### PR TITLE
選択されているセルが分かりやすいようにアイコンを表示する

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -1,5 +1,12 @@
 <template>
   <div class="audio-cell">
+    <q-icon
+      v-if="isActiveAudioCell"
+      name="arrow_right"
+      color="primary"
+      size="sm"
+      class="absolute active-arrow"
+    />
     <q-btn flat class="q-pa-none character-button" :disable="uiLocked">
       <!-- q-imgだとdisableのタイミングで点滅する -->
       <img class="q-pa-none q-ma-none" :src="characterIconUrl" />
@@ -109,6 +116,10 @@ export default defineComponent({
 
     const characterIconUrl = computed(() =>
       URL.createObjectURL(selectedCharacterInfo.value?.iconBlob)
+    );
+
+    const isActiveAudioCell = computed(
+      () => props.audioKey === store.getters.ACTIVE_AUDIO_KEY
     );
 
     const audioTextBuffer = ref(audioItem.value.text);
@@ -294,6 +305,7 @@ export default defineComponent({
       nowGenerating,
       selectedCharacterInfo,
       characterIconUrl,
+      isActiveAudioCell,
       audioTextBuffer,
       setAudioTextBuffer,
       pushAudioText,
@@ -327,6 +339,10 @@ export default defineComponent({
   display: flex;
   margin: 1rem 1rem;
   gap: 0px 1rem;
+  .active-arrow {
+    left: -5px;
+    height: 2rem;
+  }
   .character-button {
     border: solid 1px;
     border-color: global.$primary;


### PR DESCRIPTION
## 内容

どのセルが選択されているのかが少し分かりづらいかなと感じたので、アイコンを付けてみました

## スクリーンショット・動画など

https://user-images.githubusercontent.com/25514849/136706039-ee391cf0-880e-4587-bf10-69e483627936.mp4
