### PR TITLE
Bug fix: default value of hotkeySettings

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -84,6 +84,10 @@ const store = new Store<{
         exportLab: false,
       },
     },
+    // To future developers: if you are to modify the store schema with array type,
+    // for example, the hotkeySettings below,
+    // please remember to add a corresponding migration
+    // Learn more: https://github.com/sindresorhus/electron-store#migrations
     hotkeySettings: {
       type: "array",
       items: {


### PR DESCRIPTION
## 内容

When there's no `hotkeySettings` defined in `config.json`, it throws an must be array error:

![image](https://user-images.githubusercontent.com/74458240/136819800-20759291-d1fc-4492-9b94-9cf39730a7af.png)

This could happen on new installed or upgraded.

The reason is an syntax error in defining default value for it, fixed in this branch.
