### PR TITLE
「使い方」画面にgithub-markdown-cssを適用

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10265,6 +10265,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "github-markdown-css": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-4.0.0.tgz",
+      "integrity": "sha512-mH0bcIKv4XAN0mQVokfTdKo2OD5K8WJE9+lbMdM32/q0Ie5tXgVN/2o+zvToRMxSTUuiTRcLg5hzkFfOyBYreg=="
+    },
     "glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "electron-log": "^4.4.1",
     "electron-store": "^8.0.0",
     "encoding-japanese": "^1.0.30",
+    "github-markdown-css": "^4.0.0",
     "immer": "^9.0.2",
     "markdown-it": "^12.0.4",
     "quasar": "^2.0.3",

--- a/src/components/HowToUse.vue
+++ b/src/components/HowToUse.vue
@@ -6,7 +6,7 @@
       </q-toolbar>
     </q-header>
     <q-page class="relarive-absolute-wrapper scroller">
-      <div class="q-pa-md markdown" v-html="howToUse"></div>
+      <div class="q-pa-md markdown markdown-body" v-html="howToUse"></div>
     </q-page>
   </div>
 </template>
@@ -38,6 +38,8 @@ export default defineComponent({
   }
 }
 </style>
+
+<style src="github-markdown-css/github-markdown.css"></style>
 
 <style>
 .markdown img {


### PR DESCRIPTION
## 内容
「使い方」画面にgithub-markdown-cssを適用します。
https://github.com/sindresorhus/github-markdown-css

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
ref #336 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
![image](https://user-images.githubusercontent.com/44311840/136938891-cd91e6d1-a80f-4840-aaf9-73cd7435349d.png)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
追加したcssのライセンスはMIT Licenseです。