### PR TITLE
Bug fix: hotkeys on audio detail

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -287,6 +287,7 @@ export default defineComponent({
 
     setHotkeyFunctions(hotkeyMap);
 
+    // このコンポーネントは遅延評価なので`GET_HOTKEY_SETTINGS`を呼び直す
     store.dispatch("GET_HOTKEY_SETTINGS");
 
     // detail selector


### PR DESCRIPTION
## Content

As I mentioned in #334 ,there's a bug which prevents hotkeys in `AudioDteail.vue` to be triggered right after starting, for `AudioDetail.vue` is mounted later than other components, as a result, also later than the `GET_HOTKEY_SETTINGS` action in `App.vue`.

Fixed by simply adding an additional call below `setHotkeyFunctions`, I was expecting a cleverer way, though.