### PR TITLE
Linux版インストーラ: ファイルサイズとハッシュ値の名前のファイル削除を試みないように修正

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -228,6 +228,7 @@ if [ "${KEEP_ARCHIVE}" != "1" ]; then
 fi
 
 # Remove archive list
+echo "Removing archive list: list.txt"
 rm -f "list.txt"
 
 # Extract desktop entry


### PR DESCRIPTION
## 内容

Linux版インストーラの分割7zのインストール後削除処理において、
ファイルサイズとハッシュ値の名前をもつファイルの削除を試みるようになっていたので、修正します。

`~/.voicevox`を作業ディレクトリにしているため、
通常、インストールと関係のないファイルが削除されることはないと思います。

原因は、誤って`filename<TAB>size<TAB>hash`形式の変数をループに使っていたことです。

## インストール時のログ

変更前

```
Removing splitted archives
Removing VOICEVOX.AppImage.7z.001
Removing 1073741824
Removing A4E3BAC314344D8772CF4B8ADEF6FA1D
Removing VOICEVOX.AppImage.7z.002
Removing 1073741824
Removing FB5F92E5657E31EA07C6AE91CA32AAB8
Removing VOICEVOX.AppImage.7z.003
Removing 387174247
Removing 43003DDF3C620ECB7BD856107C3E3E6F
```

変更後

```
Removing splitted archives
Removing VOICEVOX.AppImage.7z.001
Removing VOICEVOX.AppImage.7z.002
Removing VOICEVOX.AppImage.7z.003
Removing archive list: list.txt
```
