### PR TITLE
再生ボタンを左に再配置

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -3,11 +3,44 @@
     <div>
       <div class="side">
         <div class="detail-selector">
-          <q-tabs vertical class="text-secondary" v-model="selectedDetail">
+          <q-tabs
+            dense
+            vertical
+            class="text-secondary"
+            v-model="selectedDetail"
+          >
             <q-tab name="accent" label="ｱｸｾﾝﾄ" />
             <q-tab name="intonation" label="ｲﾝﾄﾈｰｼｮﾝ" />
             <q-tab name="length" label="長さ" />
           </q-tabs>
+        </div>
+        <div class="play-button-wrapper">
+          <template v-if="!nowPlayingContinuously">
+            <q-btn
+              v-if="!nowPlaying && !nowGenerating"
+              fab
+              color="primary"
+              text-color="secondary"
+              icon="play_arrow"
+              @click="play"
+            ></q-btn>
+            <q-btn
+              v-else
+              fab
+              color="primary"
+              text-color="secondary"
+              icon="stop"
+              @click="stop"
+            ></q-btn>
+            <q-btn
+              round
+              aria-label="音声ファイルとして保存"
+              size="small"
+              icon="file_download"
+              @click="save()"
+              :disable="nowPlaying || nowGenerating || uiLocked"
+            ></q-btn>
+          </template>
         </div>
       </div>
 
@@ -179,30 +212,6 @@
               "
             />
           </template>
-        </div>
-      </div>
-      <div class="side">
-        <div class="detail-selector">
-          <q-tabs
-            vertical
-            :model-value="selectedDetail"
-            @update:model-value="tabAction"
-          >
-            <q-tab
-              v-if="!nowPlaying && !nowGenerating"
-              icon="play_arrow"
-              class="bg-primary text-secondary"
-              name="play"
-              :disable="nowPlaying || nowGenerating || uiLocked"
-            />
-            <q-tab
-              v-else
-              icon="stop"
-              class="bg-primary text-secondary"
-              name="stop"
-            />
-            <q-tab icon="download" name="save" :disable="uiLocked" />
-          </q-tabs>
         </div>
       </div>
     </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -242,7 +242,7 @@ export default defineComponent({
     const MAX_PORTRAIT_PANE_WIDTH = 40;
     const MIN_AUDIO_INFO_PANE_WIDTH = 160; // px
     const MAX_AUDIO_INFO_PANE_WIDTH = 250;
-    const MIN_AUDIO_DETAIL_PANE_HEIGHT = 170; // px
+    const MIN_AUDIO_DETAIL_PANE_HEIGHT = 185; // px
     const MAX_AUDIO_DETAIL_PANE_HEIGHT = 500;
 
     const portraitPaneWidth = ref(0);


### PR DESCRIPTION
## 内容

アクセントなどを選ぶタブと、再生ボタンが左右に分かれているのを、左側に戻します。
これはテキストが左に並ぶので、再生ボタンは左にあったほうがすぐ再生できるためです。
イントネーションなどの調整欄の横幅をあまり変わらないので、戻してみました。

また、タブの縦幅を少し狭くして、AudioDetailの高さを抑えます。

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/4987327/138719831-f764eac0-585c-4f0e-b973-5f222ef762bc.png)

## その他

@Patchethium さん

確か、あなたのプルリクエストで、再生ボタンを右に移動したと思います。
今回のこのrevertは、イントネーションを調整した直後（マウスカーソルが左にあることが多いです）に、すぐ再生ボタンが押せるので、左にあるほうが良いと判断したためです。
よりよいアイデアがあれば議論しましょう！

---

I think, in your pull request, you moved the play button to the right.
The reason for this revert was that I decided that it would be better to have the play button on the left, since it can be pressed immediately after tuning the intonation (the mouse cursor is often on the left).
If you have a better idea, let's discuss it!