### PR TITLE
Reinstall dialog

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -21,8 +21,8 @@ REPO_URL=${REPO_URL:-https://github.com/Hiroshiba/voicevox}
 
 # Install directory
 APP_DIR=${APP_DIR:-$HOME/.voicevox}
-# skip dialog if [ ${SKIP_DIALOG} = 1 ]
-SKIP_DIALOG=${SKIP_DIALOG:-}
+# force install if [ ${FORCE_INSTALL} = 1 ]
+FORCE_INSTALL=${FORCE_INSTALL:-}
 # keep archive if [ ${KEEP_ARCHIVE} = 1 ]
 KEEP_ARCHIVE=${KEEP_ARCHIVE:-}
 REUSE_LIST=${REUSE_LIST:-}
@@ -32,10 +32,10 @@ IGNORE_RTCOND=${IGNORE_RTCOND:-}
 DESKTOP_ENTRY_INSTALL_DIR=${DESKTOP_ENTRY_INSTALL_DIR:-$HOME/.local/share/applications}
 ICON_INSTALL_DIR=${ICON_INSTALL_DIR:-$HOME/.local/share/icons}
 
-if [ "$SKIP_DIALOG" != "1" ] && [ -f "${APP_DIR}/VOICEVOX.AppImage" ]; then
+if [ "$FORCE_INSTALL" != "1" ] && [ -f "${APP_DIR}/VOICEVOX.AppImage" ]; then
     echo "[*] VOICEVOX already installed in '${APP_DIR}/VOICEVOX.AppImage'."
     while true; do
-        read -r -p "[*] Reinstall/Update?(y/n): " yn
+        read -r -p "[*] Replace?(y/n): " yn
         case "$yn" in
             [Yy]*)
                 break


### PR DESCRIPTION
## 内容

Linux/Mac向けインストーラで、既に`VOICEVOX.AppImage`が存在する場合の対話式ダイアログを追加しました。

## 関連 Issue

ref: #396 

## スクリーンショット・動画など

```shellsession
$ ./installer_linux.sh
+-+-+-+-+-+-+-+-+
|V|O|I|C|E|V|O|X|
+-+-+-+-+-+-+-+-+-+-+-+-+-+
        |I|n|s|t|a|l|l|e|r|
+-+-+-+-+-+-+-+-+-+-+-+-+-+
|f|o|r| |L|i|n|u|x|
+-+-+-+-+-+-+-+-+-+
[*] VOICEVOX already installed in '/home/eggplants/.voicevox/VOICEVOX.AppImage'.
[*] Replace?(y/n): n
$ ./installer_linux.sh
+-+-+-+-+-+-+-+-+
|V|O|I|C|E|V|O|X|
+-+-+-+-+-+-+-+-+-+-+-+-+-+
        |I|n|s|t|a|l|l|e|r|
+-+-+-+-+-+-+-+-+-+-+-+-+-+
|f|o|r| |L|i|n|u|x|
+-+-+-+-+-+-+-+-+-+
[*] VOICEVOX already installed in '/home/eggplants/.voicevox/VOICEVOX.AppImage'.
[*] Replace?(y/n): y
[+] Checking installer prerequisites...
[-] 7z command: 7z
[+] Checking runtime prerequisites...
[-] libsndfile: OK
[+] Checking the latest version...
...
```