### PR TITLE
`installer_linux.sh`: 他OSとの互換性向上

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -117,7 +117,7 @@ echo "[-] 7z command: ${COMMAND_7Z}"
 
 echo "[+] Checking runtime prerequisites..."
 
-if ldconfig -p | grep 'libsndfile\.so' &>/dev/null; then
+if { ldconfig -p | grep 'libsndfile\.so';} &>/dev/null; then
     echo "[-] libsndfile: OK"
 elif [ -d /usr/local/Cellar/libsndfile ]; then
     echo "[-] libsndfile: OK"
@@ -242,7 +242,11 @@ for index in "${!ARCHIVE_LIST[@]}"; do
     else
         if [ "$SIZE" != "x" ]; then
             echo "[+] Verifying size == ${SIZE}..."
-            DOWNLOADED_SIZE=$(stat --printf="%s" "${FILENAME}")
+            if stat --version &>/dev/null; then
+                DOWNLOADED_SIZE=$(stat --printf="%s" "${FILENAME}")
+            else
+                DOWNLOADED_SIZE=$(stat -f%z "${FILENAME}")
+            fi
 
             if [ "$DOWNLOADED_SIZE" = "$SIZE" ]; then
                 echo "[-] Size OK"


### PR DESCRIPTION
## 内容

### `sed`の`-i`を使用しない

`installer_linux.sh`の300行目で上書き置換のために`sed -i`を用いています。
しかし、MacやBSD系OSのsedは`sed -i`でバックアップファイル拡張子を要求するために、現状の`installer_linux.sh`ではエラーが起きます。
またPOSIX sedでは`-i`自体が無いためこれまたエラーが起きます。
なので、`-i`を使わない実装に変更しました。

### `libsndfile`の存在確認方法

Macには`ldconfig`が無いため、`ldcondig -p|grep libsndfile`ではなく`[ -d /usr/local/Cellar/libsndfile ]`で調べる必要があります。

### `readarray`をなくす

`readarray`はbash 4.xから導入されたものなので、古い環境では動作しません。
特にMacのプレインストールはbash 3.2です。
そのため独自実装のものに置き換えました。
また`declare -gA`もbash 4.2以上なので、`eval "$var"'=()'`でグローバル配列を宣言しています。

```bash
_readarray(){
  [[ -z "$1" ]] && return 1
  [[ "$1" =~ [[:space:]] ]] && return 1
  var="$1"
  eval "$var"'=()'
  while IFS=$'\n' read -r r; do
    eval "$var"'+=("'"$r"'")'
  done
}
```

## 関連 Issue

なし

## スクリーンショット・動画など

なし

## その他

- Mac/*BSDで要検証
  - Mac: https://gist.github.com/eggplants/a8584927ce90671c28cfe1cb858817f3
  - 他のLinuxで動かないところやコマンドがあるか調査