### PR TITLE
onMountedでのqueryの生成を削除

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -118,7 +118,7 @@
 </template>
 
 <script lang="ts">
-import { computed, watch, defineComponent, onMounted, ref } from "vue";
+import { computed, watch, defineComponent, ref } from "vue";
 import { useStore } from "@/store";
 import { AudioItem } from "@/store/type";
 import { CharacterInfo } from "@/type/preload";
@@ -348,16 +348,6 @@ export default defineComponent({
       () => (characterInfo: CharacterInfo) =>
         URL.createObjectURL(characterInfo.iconBlob)
     );
-
-    // 初期化
-    onMounted(() => {
-      // TODO: hotfix用のコード https://github.com/Hiroshiba/voicevox/issues/139
-      if (audioItem.value.query == undefined) {
-        store.dispatch("FETCH_AND_SET_AUDIO_QUERY", {
-          audioKey: props.audioKey,
-        });
-      }
-    });
 
     return {
       characterInfos,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -561,21 +561,6 @@ export const audioStore: VoiceVoxStoreOptions<
           throw error;
         });
     },
-    FETCH_AND_SET_AUDIO_QUERY(
-      { state, dispatch },
-      { audioKey }: { audioKey: string }
-    ) {
-      const audioItem = state.audioItems[audioKey];
-      const styleId = audioItem.styleId;
-      if (styleId == undefined) throw new Error("styleId == undefined");
-
-      return dispatch("FETCH_AUDIO_QUERY", {
-        text: audioItem.text,
-        styleId: styleId,
-      }).then((audioQuery) =>
-        dispatch("SET_AUDIO_QUERY", { audioKey, audioQuery })
-      );
-    },
     GENERATE_AUDIO: createUILockAction(
       async ({ state }, { audioKey }: { audioKey: string }) => {
         const audioItem = state.audioItems[audioKey];

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -204,10 +204,6 @@ type AudioStoreTypes = {
     action(payload: { text: string; styleId: number }): Promise<AudioQuery>;
   };
 
-  FETCH_AND_SET_AUDIO_QUERY: {
-    action(payload: { audioKey: string }): void;
-  };
-
   SET_AUDIO_STYLE_ID: {
     mutation: { audioKey: string; styleId: number };
   };


### PR DESCRIPTION
## 内容

#307 でaudioItemをstateに登録する前にqueryを取得するように変更しましたが、AudioCell内のonMounted内でqueryをセットする経路がそのままだったので削除しました。

## 関連 Issue

#ref #116

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
