### PR TITLE
App.vueのscriptがtypeになっていたのをlangに修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
   </error-boundary>
 </template>
 
-<script type="ts">
+<script lang="ts">
 import { useStore } from "@/store";
 import ErrorBoundary from "@/components/ErrorBoundary.vue";
 import { defineComponent } from "vue";
@@ -13,14 +13,14 @@ export default defineComponent({
   name: "App",
 
   components: {
-    ErrorBoundary
+    ErrorBoundary,
   },
 
   setup() {
     const store = useStore();
     store.dispatch("INIT_VUEX");
-    store.dispatch("START_WAITING_ENGINE")
-  }
+    store.dispatch("START_WAITING_ENGINE");
+  },
 });
 </script>
 


### PR DESCRIPTION
## 内容

Volarがエラーを吐いていたので何かなと思ったら `lang="ts"` が `type="ts"` になっているせいでTypeScriptとして認識されていないようでした

これが原因でこのファイルだけESLintのエラーも出なくなっていたようです

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/25514849/143922347-6c2a0a73-6463-4cdb-bb35-d5e0c1840f12.png)
