### PR TITLE
installer_linux.shのメッセージを追記

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -75,6 +75,9 @@ CentOS/Fedora:
     sudo dnf install curl
 Or
     sudo yum install curl
+
+Arch Linux:
+    sudo pacman -S curl
 EOS
 fi
 
@@ -109,6 +112,10 @@ Fedora:
     sudo dnf install p7zip
 Or
     sudo yum install p7zip
+
+Arch Linux:
+    sudo pacman -S p7zip
+
 MacOS:
     brew install p7zip
 EOS
@@ -134,6 +141,10 @@ CentOS/Fedora:
     sudo dnf install libsndfile
 Or
     sudo yum install libsndfile
+
+Arch Linux
+    sudo pacman -S libsndfile
+
 MacOS:
     brew install libsndfile
 EOS


### PR DESCRIPTION
## 内容

`build/installer_linux.sh`の必要パッケージチェック失敗時のメッセージ(curl,p7zip,libsndfile)にArchLinux向け(pacman)の項目を追加
