### PR TITLE
「長さ欄を表示」ショートカットキーの初期化ができない不具合の修正とショートカットキーの重複追加防止

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -27,7 +27,6 @@ import {
 
 import log from "electron-log";
 import dayjs from "dayjs";
-import StoreConf from "conf";
 
 // silly以上のログをコンソールに出力
 log.transports.console.format = "[{h}:{i}:{s}.{ms}] [{level}] {text}";
@@ -214,11 +213,7 @@ const store = new Store<StoreOption>({
       default: "Default",
     },
   },
-  migrations: {
-    ">=0.7.3": (store) => {
-      migrateHotkeySettings(store);
-    },
-  },
+  migrations: {},
 });
 
 // engine
@@ -358,7 +353,7 @@ const updateInfos = JSON.parse(
 );
 
 // hotkeySettingsのマイグレーション
-function migrateHotkeySettings(store: StoreConf<StoreOption>) {
+function migrateHotkeySettings() {
   const COMBINATION_IS_NONE = "####";
   const emptyHotkeys = defaultHotkeySettings.map((defaultHotkey) => {
     const hotkey: HotkeySetting = {
@@ -395,6 +390,7 @@ function migrateHotkeySettings(store: StoreConf<StoreOption>) {
   });
   store.set("hotkeySettings", migratedHotkeys);
 }
+migrateHotkeySettings();
 
 let willQuit = false;
 // create window

--- a/src/background.ts
+++ b/src/background.ts
@@ -143,7 +143,7 @@ const defaultHotkeySettings: HotkeySetting[] = [
   },
 ];
 
-interface StoreType {
+interface StoreOption {
   useGpu: boolean;
   inheritAudioInfo: boolean;
   savingSetting: SavingSetting;
@@ -153,7 +153,7 @@ interface StoreType {
 }
 
 // 設定ファイル
-const store = new Store<StoreType>({
+const store = new Store<StoreOption>({
   schema: {
     useGpu: {
       type: "boolean",
@@ -367,7 +367,7 @@ const updateInfos = JSON.parse(
 );
 
 // hotkeySettingsのマイグレーション
-function migrateHotkeySettings(store: StoreConf<StoreType>) {
+function migrateHotkeySettings(store: StoreConf<StoreOption>) {
   const CONBINATION_IS_NONE = "####";
   const emptyHotkeys = defaultHotkeySettings.map((defaultHotkey) => {
     const hotkey: HotkeySetting = {

--- a/src/background.ts
+++ b/src/background.ts
@@ -142,17 +142,15 @@ const defaultHotkeySettings: HotkeySetting[] = [
   },
 ];
 
-type StoreOption = {
+// 設定ファイル
+const store = new Store<{
   useGpu: boolean;
   inheritAudioInfo: boolean;
   savingSetting: SavingSetting;
   hotkeySettings: HotkeySetting[];
   defaultStyleIds: DefaultStyleId[];
   currentTheme: string;
-};
-
-// 設定ファイル
-const store = new Store<StoreOption>({
+}>({
   schema: {
     useGpu: {
       type: "boolean",

--- a/src/background.ts
+++ b/src/background.ts
@@ -368,11 +368,11 @@ function migrateHotkeySettings() {
       const loadedHotkey = loadedHotkeys.find(
         (loadedHotkey) => loadedHotkey.action === defaultHotkey.action
       );
-      const emptyHotkey: HotkeySetting = {
+      const hotkeyWithoutCombination: HotkeySetting = {
         action: defaultHotkey.action,
         combination: COMBINATION_IS_NONE,
       };
-      return loadedHotkey || emptyHotkey;
+      return loadedHotkey || hotkeyWithoutCombination;
     }
   );
   const migratedHotkeys = hotkeysWithoutNewCombination.map((hotkey) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -20,7 +20,7 @@ import {
   DefaultStyleId,
   HotkeySetting,
   MetasJson,
-  SavingSetting,
+  StoreOption,
   ThemeConf,
   StyleInfo,
 } from "./type/preload";
@@ -142,15 +142,6 @@ const defaultHotkeySettings: HotkeySetting[] = [
     combination: "",
   },
 ];
-
-type StoreOption = {
-  useGpu: boolean;
-  inheritAudioInfo: boolean;
-  savingSetting: SavingSetting;
-  hotkeySettings: HotkeySetting[];
-  defaultStyleIds: DefaultStyleId[];
-  currentTheme: string;
-};
 
 // 設定ファイル
 const store = new Store<StoreOption>({

--- a/src/background.ts
+++ b/src/background.ts
@@ -157,22 +157,17 @@ function storeNewHotkeyforMigration(
   newHotkey: HotkeySetting
 ): void {
   const hotkeys = store.get("hotkeySettings");
-  const actionAlreadyExists = hotkeys.some(
+  const combinationExists = hotkeys.some(
+    (hotkey) => hotkey.combination === newHotkey.combination
+  );
+  if (combinationExists) {
+    newHotkey.combination = "";
+  }
+  const insertionIndex = defaultHotkeySettings.findIndex(
     (hotkey) => hotkey.action === newHotkey.action
   );
-  if (!actionAlreadyExists) {
-    const combinationExists = hotkeys.some(
-      (hotkey) => hotkey.combination === newHotkey.combination
-    );
-    if (combinationExists) {
-      newHotkey.combination = "";
-    }
-    const insertionIndex = defaultHotkeySettings.findIndex(
-      (hotkey) => hotkey.action === newHotkey.action
-    );
-    hotkeys.splice(insertionIndex, 0, newHotkey);
-    store.set("hotkeySettings", hotkeys);
-  }
+  hotkeys.splice(insertionIndex, 0, newHotkey);
+  store.set("hotkeySettings", hotkeys);
 }
 
 // 設定ファイル
@@ -248,12 +243,14 @@ const store = new Store<StoreType>({
   },
   migrations: {
     ">=0.7.3": (store) => {
-      const newHotkey: HotkeySetting = {
-        action: "長さ欄を表示",
-        combination: "3",
-      };
-
-      storeNewHotkeyforMigration(store, newHotkey);
+      const hotkeys = store.get("hotkeySettings");
+      const newHotkeys: HotkeySetting[] = defaultHotkeySettings.filter(
+        (defaultHotkey) =>
+          !hotkeys.some((hotkey) => hotkey.action === defaultHotkey.action)
+      );
+      for (const newHotkey of newHotkeys) {
+        storeNewHotkeyforMigration(store, newHotkey);
+      }
     },
   },
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -20,7 +20,7 @@ import {
   DefaultStyleId,
   HotkeySetting,
   MetasJson,
-  StoreOption,
+  SavingSetting,
   ThemeConf,
   StyleInfo,
 } from "./type/preload";
@@ -141,6 +141,15 @@ const defaultHotkeySettings: HotkeySetting[] = [
     combination: "",
   },
 ];
+
+type StoreOption = {
+  useGpu: boolean;
+  inheritAudioInfo: boolean;
+  savingSetting: SavingSetting;
+  hotkeySettings: HotkeySetting[];
+  defaultStyleIds: DefaultStyleId[];
+  currentTheme: string;
+};
 
 // 設定ファイル
 const store = new Store<StoreOption>({

--- a/src/background.ts
+++ b/src/background.ts
@@ -143,14 +143,14 @@ const defaultHotkeySettings: HotkeySetting[] = [
   },
 ];
 
-interface StoreOption {
+type StoreOption = {
   useGpu: boolean;
   inheritAudioInfo: boolean;
   savingSetting: SavingSetting;
   hotkeySettings: HotkeySetting[];
   defaultStyleIds: DefaultStyleId[];
   currentTheme: string;
-}
+};
 
 // 設定ファイル
 const store = new Store<StoreOption>({

--- a/src/background.ts
+++ b/src/background.ts
@@ -385,7 +385,11 @@ function migrateHotkeySettings() {
         (hotkey) => hotkey.combination === newHotkey.combination
       );
       if (combinationExists) {
-        return hotkey;
+        const emptyHotkey = {
+          action: newHotkey.action,
+          combination: "",
+        };
+        return emptyHotkey;
       } else {
         return newHotkey;
       }

--- a/src/background.ts
+++ b/src/background.ts
@@ -227,13 +227,21 @@ const store = new Store<{
         combination: "3",
       };
       const hotkeys = store.get("hotkeySettings");
-      const actionAlreadyExists = hotkeys.some((hotkey) => hotkey.action === newHotkey.action);
-      if(!actionAlreadyExists){
-        const combinationExists = hotkeys.some((hotkey) => hotkey.combination === newHotkey.combination);
+      
+      // 以下を関数化
+      const actionAlreadyExists = hotkeys.some(
+        (hotkey) => hotkey.action === newHotkey.action
+      );
+      if (!actionAlreadyExists) {
+        const combinationExists = hotkeys.some(
+          (hotkey) => hotkey.combination === newHotkey.combination
+        );
         if (combinationExists) {
           newHotkey.combination = "";
         }
-        const insertionIndex = defaultHotkeySettings.findIndex((hotkey) => hotkey.action === newHotkey.action);
+        const insertionIndex = defaultHotkeySettings.findIndex(
+          (hotkey) => hotkey.action === newHotkey.action
+        );
         hotkeys.splice(insertionIndex, 0, newHotkey);
         store.set("hotkeySettings", hotkeys);
       }

--- a/src/background.ts
+++ b/src/background.ts
@@ -362,28 +362,26 @@ const updateInfos = JSON.parse(
 // hotkeySettingsのマイグレーション
 function migrateHotkeySettings() {
   const COMBINATION_IS_NONE = "####";
-  const emptyHotkeys = defaultHotkeySettings.map((defaultHotkey) => {
-    const hotkey: HotkeySetting = {
-      action: defaultHotkey.action,
-      combination: COMBINATION_IS_NONE,
-    };
-    return hotkey;
-  });
   const loadedHotkeys = store.get("hotkeySettings");
-  const copiedHotkeys = emptyHotkeys.map((emptyHotkey) => {
-    return (
-      loadedHotkeys.find(
-        (loadedHotkey) => loadedHotkey.action === emptyHotkey.action
-      ) || emptyHotkey
-    );
-  });
-  const migratedHotkeys = copiedHotkeys.map((hotkey) => {
+  const hotkeysWithoutNewCombination = defaultHotkeySettings.map(
+    (defaultHotkey) => {
+      const loadedHotkey = loadedHotkeys.find(
+        (loadedHotkey) => loadedHotkey.action === defaultHotkey.action
+      );
+      const emptyHotkey: HotkeySetting = {
+        action: defaultHotkey.action,
+        combination: COMBINATION_IS_NONE,
+      };
+      return loadedHotkey || emptyHotkey;
+    }
+  );
+  const migratedHotkeys = hotkeysWithoutNewCombination.map((hotkey) => {
     if (hotkey.combination === COMBINATION_IS_NONE) {
       const newHotkey =
         defaultHotkeySettings.find(
           (defaultHotkey) => defaultHotkey.action === hotkey.action
         ) || hotkey; // ここの find が undefined を返すケースはないが、ts のエラーになるので入れた
-      const combinationExists = copiedHotkeys.some(
+      const combinationExists = hotkeysWithoutNewCombination.some(
         (hotkey) => hotkey.combination === newHotkey.combination
       );
       if (combinationExists) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -359,11 +359,11 @@ const updateInfos = JSON.parse(
 
 // hotkeySettingsのマイグレーション
 function migrateHotkeySettings(store: StoreConf<StoreOption>) {
-  const CONBINATION_IS_NONE = "####";
+  const COMBINATION_IS_NONE = "####";
   const emptyHotkeys = defaultHotkeySettings.map((defaultHotkey) => {
     const hotkey: HotkeySetting = {
       action: defaultHotkey.action,
-      combination: CONBINATION_IS_NONE,
+      combination: COMBINATION_IS_NONE,
     };
     return hotkey;
   });
@@ -376,7 +376,7 @@ function migrateHotkeySettings(store: StoreConf<StoreOption>) {
     );
   });
   const migratedHotkeys = copiedHotkeys.map((hotkey) => {
-    if (hotkey.combination === CONBINATION_IS_NONE) {
+    if (hotkey.combination === COMBINATION_IS_NONE) {
       const newHotkey =
         defaultHotkeySettings.find(
           (defaultHotkey) => defaultHotkey.action === hotkey.action

--- a/src/background.ts
+++ b/src/background.ts
@@ -93,6 +93,10 @@ const defaultHotkeySettings: HotkeySetting[] = [
     combination: "2",
   },
   {
+    action: "長さ欄を表示",
+    combination: "3",
+  },
+  {
     action: "テキスト欄を追加",
     combination: "Shift Enter",
   },
@@ -223,13 +227,16 @@ const store = new Store<{
         combination: "3",
       };
       const hotkeys = store.get("hotkeySettings");
-      hotkeys.forEach((value) => {
-        if (value.combination == newHotkey.combination) {
+      const actionAlreadyExists = hotkeys.some((hotkey) => hotkey.action === newHotkey.action);
+      if(!actionAlreadyExists){
+        const combinationExists = hotkeys.some((hotkey) => hotkey.combination === newHotkey.combination);
+        if (combinationExists) {
           newHotkey.combination = "";
         }
-      });
-      hotkeys.splice(6, 0, newHotkey);
-      store.set("hotkeySettings", hotkeys);
+        const insertionIndex = defaultHotkeySettings.findIndex((hotkey) => hotkey.action === newHotkey.action);
+        hotkeys.splice(insertionIndex, 0, newHotkey);
+        store.set("hotkeySettings", hotkeys);
+      }
     },
   },
 });

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -148,15 +148,6 @@ export type HotkeyReturnType =
   | Promise<void>
   | Promise<boolean>;
 
-export type StoreOption = {
-  useGpu: boolean;
-  inheritAudioInfo: boolean;
-  savingSetting: SavingSetting;
-  hotkeySettings: HotkeySetting[];
-  defaultStyleIds: DefaultStyleId[];
-  currentTheme: string;
-};
-
 export type MoraDataType =
   | "consonant"
   | "vowel"

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -148,6 +148,15 @@ export type HotkeyReturnType =
   | Promise<void>
   | Promise<boolean>;
 
+export type StoreOption = {
+  useGpu: boolean;
+  inheritAudioInfo: boolean;
+  savingSetting: SavingSetting;
+  hotkeySettings: HotkeySetting[];
+  defaultStyleIds: DefaultStyleId[];
+  currentTheme: string;
+};
+
 export type MoraDataType =
   | "consonant"
   | "vowel"


### PR DESCRIPTION
## 内容
タイトルの通りで、以下の2点です。
- 「長さ欄を表示」ショートカットキーの初期化ができない不具合の修正 (#541)
- ショートカットキーの重複追加防止

## 関連 Issue
ref #541 

## スクリーンショット・動画など

## その他
ショートカットキーの重複追加防止について：

保存されたショートカットキーの中に追加しようとしているキーと同じ操作名(action)がある場合はその操作が重複して追加・保存されていましたが、この場合はキーの追加をしないようにしました。
0.8 → 0.6 → 0.8 などとバージョンダウン→アップをした場合に重複が起こるかもしれません。
バージョンダウンは通常あまりしませんし、migrationsの仕様に詳しくないので重複は起こり得ないかもしれませんが…念のため入れました。