### PR TITLE
冗長な型宣言を削除

### DIFF
--- a/src/plugins/ipcMessageReceiverPlugin.ts
+++ b/src/plugins/ipcMessageReceiverPlugin.ts
@@ -15,23 +15,23 @@ export const ipcMessageReceiver: Plugin = {
     );
 
     window.electron.onReceivedIPCMsg("DETECT_MAXIMIZED", () =>
-      options.store.dispatch("DETECT_MAXIMIZED", undefined)
+      options.store.dispatch("DETECT_MAXIMIZED")
     );
 
     window.electron.onReceivedIPCMsg("DETECT_UNMAXIMIZED", () =>
-      options.store.dispatch("DETECT_UNMAXIMIZED", undefined)
+      options.store.dispatch("DETECT_UNMAXIMIZED")
     );
 
     window.electron.onReceivedIPCMsg("DETECTED_ENGINE_ERROR", () =>
-      options.store.dispatch("DETECTED_ENGINE_ERROR", undefined)
+      options.store.dispatch("DETECTED_ENGINE_ERROR")
     );
 
     window.electron.onReceivedIPCMsg("DETECT_PINNED", () => {
-      options.store.dispatch("DETECT_PINNED", undefined);
+      options.store.dispatch("DETECT_PINNED");
     });
 
     window.electron.onReceivedIPCMsg("DETECT_UNPINNED", () => {
-      options.store.dispatch("DETECT_UNPINNED", undefined);
+      options.store.dispatch("DETECT_UNPINNED");
     });
 
     window.electron.onReceivedIPCMsg("CHECK_EDITED_AND_NOT_SAVE", () => {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -3,7 +3,6 @@ import path from "path";
 import { v4 as uuidv4 } from "uuid";
 import {
   AudioItem,
-  EngineState,
   SaveResultObject,
   State,
   commandMutationsCreator,
@@ -19,11 +18,7 @@ import {
   IEngineConnectorFactoryActions,
 } from "./type";
 import { createUILockAction } from "./ui";
-import {
-  CharacterInfo,
-  Encoding as EncodingType,
-  MoraDataType,
-} from "@/type/preload";
+import { CharacterInfo } from "@/type/preload";
 import Encoding from "encoding-japanese";
 import { PromiseType } from "./vuex";
 
@@ -135,10 +130,10 @@ export const audioStore: VoiceVoxStoreOptions<
         ? state._activeAudioKey
         : undefined;
     },
-    HAVE_AUDIO_QUERY: (state) => (audioKey: string) => {
+    HAVE_AUDIO_QUERY: (state) => (audioKey) => {
       return state.audioItems[audioKey]?.query != undefined;
     },
-    IS_ACTIVE: (state) => (audioKey: string) => {
+    IS_ACTIVE: (state) => (audioKey) => {
       return state._activeAudioKey === audioKey;
     },
     IS_ENGINE_READY: (state) => {
@@ -147,48 +142,25 @@ export const audioStore: VoiceVoxStoreOptions<
   },
 
   mutations: {
-    SET_ENGINE_STATE(state, { engineState }: { engineState: EngineState }) {
+    SET_ENGINE_STATE(state, { engineState }) {
       state.engineState = engineState;
     },
-    SET_CHARACTER_INFOS(
-      state,
-      { characterInfos }: { characterInfos: CharacterInfo[] }
-    ) {
+    SET_CHARACTER_INFOS(state, { characterInfos }) {
       state.characterInfos = characterInfos;
     },
-    SET_ACTIVE_AUDIO_KEY(state, { audioKey }: { audioKey?: string }) {
+    SET_ACTIVE_AUDIO_KEY(state, { audioKey }) {
       state._activeAudioKey = audioKey;
     },
-    SET_AUDIO_NOW_PLAYING(
-      state,
-      { audioKey, nowPlaying }: { audioKey: string; nowPlaying: boolean }
-    ) {
+    SET_AUDIO_NOW_PLAYING(state, { audioKey, nowPlaying }) {
       state.audioStates[audioKey].nowPlaying = nowPlaying;
     },
-    SET_AUDIO_NOW_GENERATING(
-      state,
-      { audioKey, nowGenerating }: { audioKey: string; nowGenerating: boolean }
-    ) {
+    SET_AUDIO_NOW_GENERATING(state, { audioKey, nowGenerating }) {
       state.audioStates[audioKey].nowGenerating = nowGenerating;
     },
-    SET_NOW_PLAYING_CONTINUOUSLY(
-      state,
-      { nowPlaying }: { nowPlaying: boolean }
-    ) {
+    SET_NOW_PLAYING_CONTINUOUSLY(state, { nowPlaying }) {
       state.nowPlayingContinuously = nowPlaying;
     },
-    INSERT_AUDIO_ITEM(
-      state,
-      {
-        audioItem,
-        audioKey,
-        prevAudioKey,
-      }: {
-        audioItem: AudioItem;
-        audioKey: string;
-        prevAudioKey: string | undefined;
-      }
-    ) {
+    INSERT_AUDIO_ITEM(state, { audioItem, audioKey, prevAudioKey }) {
       const index =
         prevAudioKey !== undefined
           ? state.audioKeys.indexOf(prevAudioKey) + 1
@@ -200,16 +172,7 @@ export const audioStore: VoiceVoxStoreOptions<
         nowGenerating: false,
       };
     },
-    INSERT_AUDIO_ITEMS(
-      state,
-      {
-        prevAudioKey,
-        audioKeyItemPairs,
-      }: {
-        audioKeyItemPairs: { audioItem: AudioItem; audioKey: string }[];
-        prevAudioKey: string | undefined;
-      }
-    ) {
+    INSERT_AUDIO_ITEMS(state, { prevAudioKey, audioKeyItemPairs }) {
       const index =
         prevAudioKey !== undefined
           ? state.audioKeys.indexOf(prevAudioKey) + 1
@@ -224,108 +187,58 @@ export const audioStore: VoiceVoxStoreOptions<
         };
       }
     },
-    REMOVE_AUDIO_ITEM(state, { audioKey }: { audioKey: string }) {
+    REMOVE_AUDIO_ITEM(state, { audioKey }) {
       state.audioKeys.splice(state.audioKeys.indexOf(audioKey), 1);
       delete state.audioItems[audioKey];
       delete state.audioStates[audioKey];
     },
-    SET_AUDIO_TEXT(
-      state,
-      { audioKey, text }: { audioKey: string; text: string }
-    ) {
+    SET_AUDIO_TEXT(state, { audioKey, text }) {
       state.audioItems[audioKey].text = text;
     },
-    SET_AUDIO_SPEED_SCALE(
-      state,
-      { audioKey, speedScale }: { audioKey: string; speedScale: number }
-    ) {
+    SET_AUDIO_SPEED_SCALE(state, { audioKey, speedScale }) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
       query.speedScale = speedScale;
     },
-    SET_AUDIO_PITCH_SCALE(
-      state,
-      { audioKey, pitchScale }: { audioKey: string; pitchScale: number }
-    ) {
+    SET_AUDIO_PITCH_SCALE(state, { audioKey, pitchScale }) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
       query.pitchScale = pitchScale;
     },
-    SET_AUDIO_INTONATION_SCALE(
-      state,
-      {
-        audioKey,
-        intonationScale,
-      }: { audioKey: string; intonationScale: number }
-    ) {
+    SET_AUDIO_INTONATION_SCALE(state, { audioKey, intonationScale }) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
       query.intonationScale = intonationScale;
     },
-    SET_AUDIO_VOLUME_SCALE(
-      state,
-      { audioKey, volumeScale }: { audioKey: string; volumeScale: number }
-    ) {
+    SET_AUDIO_VOLUME_SCALE(state, { audioKey, volumeScale }) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
       query.volumeScale = volumeScale;
     },
-    SET_AUDIO_PRE_PHONEME_LENGTH(
-      state,
-      {
-        audioKey,
-        prePhonemeLength,
-      }: { audioKey: string; prePhonemeLength: number }
-    ) {
+    SET_AUDIO_PRE_PHONEME_LENGTH(state, { audioKey, prePhonemeLength }) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
       query.prePhonemeLength = prePhonemeLength;
     },
-    SET_AUDIO_POST_PHONEME_LENGTH(
-      state,
-      {
-        audioKey,
-        postPhonemeLength,
-      }: { audioKey: string; postPhonemeLength: number }
-    ) {
+    SET_AUDIO_POST_PHONEME_LENGTH(state, { audioKey, postPhonemeLength }) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
       query.postPhonemeLength = postPhonemeLength;
     },
-    SET_AUDIO_QUERY(
-      state,
-      { audioKey, audioQuery }: { audioKey: string; audioQuery: AudioQuery }
-    ) {
+    SET_AUDIO_QUERY(state, { audioKey, audioQuery }) {
       state.audioItems[audioKey].query = audioQuery;
     },
-    SET_AUDIO_STYLE_ID(
-      state,
-      { audioKey, styleId }: { audioKey: string; styleId: number }
-    ) {
+    SET_AUDIO_STYLE_ID(state, { audioKey, styleId }) {
       state.audioItems[audioKey].styleId = styleId;
     },
-    SET_ACCENT_PHRASES(
-      state,
-      {
-        audioKey,
-        accentPhrases,
-      }: { audioKey: string; accentPhrases: AccentPhrase[] }
-    ) {
+    SET_ACCENT_PHRASES(state, { audioKey, accentPhrases }) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
       query.accentPhrases = accentPhrases;
     },
     SET_SINGLE_ACCENT_PHRASE(
       state,
-      {
-        audioKey,
-        accentPhraseIndex,
-        accentPhrases,
-      }: {
-        audioKey: string;
-        accentPhraseIndex: number;
-        accentPhrases: AccentPhrase[];
-      }
+      { audioKey, accentPhraseIndex, accentPhrases }
     ) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
@@ -333,19 +246,7 @@ export const audioStore: VoiceVoxStoreOptions<
     },
     SET_AUDIO_MORA_DATA(
       state,
-      {
-        audioKey,
-        accentPhraseIndex,
-        moraIndex,
-        data,
-        type,
-      }: {
-        audioKey: string;
-        accentPhraseIndex: number;
-        moraIndex: number;
-        data: number;
-        type: MoraDataType;
-      }
+      { audioKey, accentPhraseIndex, moraIndex, data, type }
     ) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
@@ -432,10 +333,7 @@ export const audioStore: VoiceVoxStoreOptions<
         commit("REMOVE_AUDIO_ITEM", { audioKey });
       }
     },
-    async GENERATE_AUDIO_ITEM(
-      { state, getters, dispatch },
-      payload: { text?: string; styleId?: number; baseAudioItem?: AudioItem }
-    ) {
+    async GENERATE_AUDIO_ITEM({ state, getters, dispatch }, payload) {
       //引数にbaseAudioItemが与えられた場合、baseAudioItemから話速等のパラメータを引き継いだAudioItemを返す
       //baseAudioItem.queryのうち、accentPhrasesとkanaは基本設定パラメータではないので引き継がない
       //baseAudioItemのうち、textとstyleIdは別途与えられるので引き継がない
@@ -486,19 +384,16 @@ export const audioStore: VoiceVoxStoreOptions<
     },
     async REGISTER_AUDIO_ITEM(
       { dispatch, commit },
-      {
-        audioItem,
-        prevAudioKey,
-      }: { audioItem: AudioItem; prevAudioKey?: string }
+      { audioItem, prevAudioKey }
     ) {
       const audioKey = await dispatch("GENERATE_AUDIO_KEY");
       commit("INSERT_AUDIO_ITEM", { audioItem, audioKey, prevAudioKey });
       return audioKey;
     },
-    SET_ACTIVE_AUDIO_KEY({ commit }, { audioKey }: { audioKey?: string }) {
+    SET_ACTIVE_AUDIO_KEY({ commit }, { audioKey }) {
       commit("SET_ACTIVE_AUDIO_KEY", { audioKey });
     },
-    async GET_AUDIO_CACHE({ state }, { audioKey }: { audioKey: string }) {
+    async GET_AUDIO_CACHE({ state }, { audioKey }) {
       const audioItem = state.audioItems[audioKey];
       const [id] = await generateUniqueIdAndQuery(state, audioItem);
 
@@ -508,20 +403,10 @@ export const audioStore: VoiceVoxStoreOptions<
         return null;
       }
     },
-    SET_AUDIO_QUERY(
-      { commit },
-      payload: { audioKey: string; audioQuery: AudioQuery }
-    ) {
+    SET_AUDIO_QUERY({ commit }, payload) {
       commit("SET_AUDIO_QUERY", payload);
     },
-    FETCH_ACCENT_PHRASES(
-      { dispatch },
-      {
-        text,
-        styleId,
-        isKana,
-      }: { text: string; styleId: number; isKana?: boolean }
-    ) {
+    FETCH_ACCENT_PHRASES({ dispatch }, { text, styleId, isKana }) {
       return dispatch("INVOKE_ENGINE_CONNECTOR", {
         action: "accentPhrasesAccentPhrasesPost",
         payload: [
@@ -541,13 +426,7 @@ export const audioStore: VoiceVoxStoreOptions<
           throw error;
         });
     },
-    FETCH_MORA_DATA(
-      { dispatch },
-      {
-        accentPhrases,
-        styleId,
-      }: { accentPhrases: AccentPhrase[]; styleId: number }
-    ) {
+    FETCH_MORA_DATA({ dispatch }, { accentPhrases, styleId }) {
       return dispatch("INVOKE_ENGINE_CONNECTOR", {
         action: "moraDataMoraDataPost",
         payload: [{ accentPhrase: accentPhrases, speaker: styleId }],
@@ -565,15 +444,7 @@ export const audioStore: VoiceVoxStoreOptions<
     },
     async FETCH_AND_COPY_MORA_DATA(
       { dispatch },
-      {
-        accentPhrases,
-        styleId,
-        copyIndexes,
-      }: {
-        accentPhrases: AccentPhrase[];
-        styleId: number;
-        copyIndexes: number[];
-      }
+      { accentPhrases, styleId, copyIndexes }
     ) {
       const fetchedAccentPhrases: AccentPhrase[] = await dispatch(
         "FETCH_MORA_DATA",
@@ -587,10 +458,7 @@ export const audioStore: VoiceVoxStoreOptions<
       }
       return accentPhrases;
     },
-    FETCH_AUDIO_QUERY(
-      { dispatch },
-      { text, styleId }: { text: string; styleId: number }
-    ) {
+    FETCH_AUDIO_QUERY({ dispatch }, { text, styleId }) {
       return dispatch("INVOKE_ENGINE_CONNECTOR", {
         action: "audioQueryAudioQueryPost",
         payload: [{ text, speaker: styleId }],
@@ -605,7 +473,7 @@ export const audioStore: VoiceVoxStoreOptions<
         });
     },
     GENERATE_AUDIO: createUILockAction(
-      async ({ dispatch, state }, { audioKey }: { audioKey: string }) => {
+      async ({ dispatch, state }, { audioKey }) => {
         const audioItem: AudioItem = JSON.parse(
           JSON.stringify(state.audioItems[audioKey])
         );
@@ -642,15 +510,7 @@ export const audioStore: VoiceVoxStoreOptions<
     GENERATE_AND_SAVE_AUDIO: createUILockAction(
       async (
         { state, dispatch },
-        {
-          audioKey,
-          filePath,
-          encoding,
-        }: {
-          audioKey: string;
-          filePath?: string;
-          encoding?: EncodingType;
-        }
+        { audioKey, filePath, encoding }
       ): Promise<SaveResultObject> => {
         if (state.savingSetting.fixedExportEnabled) {
           filePath = path.join(
@@ -794,10 +654,7 @@ export const audioStore: VoiceVoxStoreOptions<
       }
     ),
     GENERATE_AND_SAVE_ALL_AUDIO: createUILockAction(
-      async (
-        { state, dispatch },
-        { dirPath, encoding }: { dirPath?: string; encoding?: EncodingType }
-      ) => {
+      async ({ state, dispatch }, { dirPath, encoding }) => {
         if (state.savingSetting.fixedExportEnabled) {
           dirPath = state.savingSetting.fixedExportDir;
         } else {
@@ -820,10 +677,7 @@ export const audioStore: VoiceVoxStoreOptions<
       }
     ),
     PLAY_AUDIO: createUILockAction(
-      async (
-        { state, commit, dispatch },
-        { audioKey }: { audioKey: string }
-      ) => {
+      async ({ state, commit, dispatch }, { audioKey }) => {
         const audioElem = audioElements[audioKey] as HTMLAudioElement & {
           setSinkId(deviceID: string): Promise<undefined>; // setSinkIdを認識してくれないため
         };
@@ -885,7 +739,7 @@ export const audioStore: VoiceVoxStoreOptions<
         return audioPlayPromise;
       }
     ),
-    STOP_AUDIO(_, { audioKey }: { audioKey: string }) {
+    STOP_AUDIO(_, { audioKey }) {
       const audioElem = audioElements[audioKey];
       audioElem.pause();
     },
@@ -943,7 +797,7 @@ export const audioStore: VoiceVoxStoreOptions<
         .then(() => dispatch("START_WAITING_ENGINE"))
         .catch(() => dispatch("DETECTED_ENGINE_ERROR"));
     },
-    CHECK_FILE_EXISTS(_, { file }: { file: string }) {
+    CHECK_FILE_EXISTS(_, { file }) {
       return window.electron.checkFileExists(file);
     },
   },
@@ -960,13 +814,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
   actions: {
     async COMMAND_REGISTER_AUDIO_ITEM(
       { dispatch, commit },
-      {
-        audioItem,
-        prevAudioKey,
-      }: {
-        audioItem: AudioItem;
-        prevAudioKey: string | undefined;
-      }
+      { audioItem, prevAudioKey }
     ) {
       const audioKey = await dispatch("GENERATE_AUDIO_KEY");
       commit("COMMAND_REGISTER_AUDIO_ITEM", {
@@ -976,12 +824,12 @@ export const audioCommandStore: VoiceVoxStoreOptions<
       });
       return audioKey;
     },
-    COMMAND_REMOVE_AUDIO_ITEM({ commit }, payload: { audioKey: string }) {
+    COMMAND_REMOVE_AUDIO_ITEM({ commit }, payload) {
       commit("COMMAND_REMOVE_AUDIO_ITEM", payload);
     },
     async COMMAND_CHANGE_AUDIO_TEXT(
       { state, commit, dispatch },
-      { audioKey, text }: { audioKey: string; text: string }
+      { audioKey, text }
     ) {
       const styleId = state.audioItems[audioKey].styleId;
       if (styleId == undefined) throw new Error("styleId != undefined");
@@ -1024,7 +872,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
     },
     async COMMAND_CHANGE_STYLE_ID(
       { state, dispatch, commit },
-      { audioKey, styleId }: { audioKey: string; styleId: number }
+      { audioKey, styleId }
     ) {
       const query = state.audioItems[audioKey].query;
       try {
@@ -1067,15 +915,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
     },
     async COMMAND_CHANGE_ACCENT(
       { state, dispatch, commit },
-      {
-        audioKey,
-        accentPhraseIndex,
-        accent,
-      }: {
-        audioKey: string;
-        accentPhraseIndex: number;
-        accent: number;
-      }
+      { audioKey, accentPhraseIndex, accent }
     ) {
       const query = state.audioItems[audioKey].query;
       if (query !== undefined) {
@@ -1111,18 +951,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
     },
     async COMMAND_CHANGE_ACCENT_PHRASE_SPLIT(
       { state, dispatch, commit },
-      payload: {
-        audioKey: string;
-        accentPhraseIndex: number;
-      } & (
-        | {
-            isPause: false;
-            moraIndex: number;
-          }
-        | {
-            isPause: true;
-          }
-      )
+      payload
     ) {
       const { audioKey, accentPhraseIndex } = payload;
       const query: AudioQuery | undefined = state.audioItems[audioKey].query;
@@ -1224,17 +1053,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
     },
     async COMMAND_CHANGE_SINGLE_ACCENT_PHRASE(
       { state, dispatch, commit },
-      {
-        audioKey,
-        newPronunciation,
-        accentPhraseIndex,
-        popUntilPause,
-      }: {
-        audioKey: string;
-        newPronunciation: string;
-        accentPhraseIndex: number;
-        popUntilPause: boolean;
-      }
+      { audioKey, newPronunciation, accentPhraseIndex, popUntilPause }
     ) {
       const styleId = state.audioItems[audioKey].styleId;
       if (styleId == undefined) throw new Error("styleId != undefined");
@@ -1327,59 +1146,29 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         });
       }
     },
-    COMMAND_SET_AUDIO_MORA_DATA(
-      { commit },
-      payload: {
-        audioKey: string;
-        accentPhraseIndex: number;
-        moraIndex: number;
-        data: number;
-        type: MoraDataType;
-      }
-    ) {
+    COMMAND_SET_AUDIO_MORA_DATA({ commit }, payload) {
       commit("COMMAND_SET_AUDIO_MORA_DATA", payload);
     },
-    COMMAND_SET_AUDIO_SPEED_SCALE(
-      { commit },
-      payload: { audioKey: string; speedScale: number }
-    ) {
+    COMMAND_SET_AUDIO_SPEED_SCALE({ commit }, payload) {
       commit("COMMAND_SET_AUDIO_SPEED_SCALE", payload);
     },
-    COMMAND_SET_AUDIO_PITCH_SCALE(
-      { commit },
-      payload: { audioKey: string; pitchScale: number }
-    ) {
+    COMMAND_SET_AUDIO_PITCH_SCALE({ commit }, payload) {
       commit("COMMAND_SET_AUDIO_PITCH_SCALE", payload);
     },
-    COMMAND_SET_AUDIO_INTONATION_SCALE(
-      { commit },
-      payload: { audioKey: string; intonationScale: number }
-    ) {
+    COMMAND_SET_AUDIO_INTONATION_SCALE({ commit }, payload) {
       commit("COMMAND_SET_AUDIO_INTONATION_SCALE", payload);
     },
-    COMMAND_SET_AUDIO_VOLUME_SCALE(
-      { commit },
-      payload: { audioKey: string; volumeScale: number }
-    ) {
+    COMMAND_SET_AUDIO_VOLUME_SCALE({ commit }, payload) {
       commit("COMMAND_SET_AUDIO_VOLUME_SCALE", payload);
     },
-    COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH(
-      { commit },
-      payload: { audioKey: string; prePhonemeLength: number }
-    ) {
+    COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH({ commit }, payload) {
       commit("COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH", payload);
     },
-    COMMAND_SET_AUDIO_POST_PHONEME_LENGTH(
-      { commit },
-      payload: { audioKey: string; postPhonemeLength: number }
-    ) {
+    COMMAND_SET_AUDIO_POST_PHONEME_LENGTH({ commit }, payload) {
       commit("COMMAND_SET_AUDIO_POST_PHONEME_LENGTH", payload);
     },
     COMMAND_IMPORT_FROM_FILE: createUILockAction(
-      async (
-        { state, commit, dispatch },
-        { filePath }: { filePath?: string }
-      ) => {
+      async ({ state, commit, dispatch }, { filePath }) => {
         if (!filePath) {
           filePath = await window.electron.showImportFileDialog({
             title: "セリフ読み込み",
@@ -1430,18 +1219,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
       }
     ),
     COMMAND_PUT_TEXTS: createUILockAction(
-      async (
-        { state, commit, dispatch },
-        {
-          prevAudioKey,
-          texts,
-          styleId,
-        }: {
-          prevAudioKey: string;
-          texts: string[];
-          styleId: number;
-        }
-      ) => {
+      async ({ state, commit, dispatch }, { prevAudioKey, texts, styleId }) => {
         const audioKeyItemPairs: { audioKey: string; audioItem: AudioItem }[] =
           [];
         let baseAudioItem: AudioItem | undefined = undefined;
@@ -1475,35 +1253,13 @@ export const audioCommandStore: VoiceVoxStoreOptions<
     ),
   },
   mutations: commandMutationsCreator({
-    COMMAND_REGISTER_AUDIO_ITEM(
-      draft,
-      payload: {
-        audioItem: AudioItem;
-        audioKey: string;
-        prevAudioKey: string | undefined;
-      }
-    ) {
+    COMMAND_REGISTER_AUDIO_ITEM(draft, payload) {
       audioStore.mutations.INSERT_AUDIO_ITEM(draft, payload);
     },
-    COMMAND_REMOVE_AUDIO_ITEM(draft, payload: { audioKey: string }) {
+    COMMAND_REMOVE_AUDIO_ITEM(draft, payload) {
       audioStore.mutations.REMOVE_AUDIO_ITEM(draft, payload);
     },
-    COMMAND_CHANGE_AUDIO_TEXT(
-      draft,
-      payload: { audioKey: string; text: string } & (
-        | {
-            update: "Text";
-          }
-        | {
-            update: "AccentPhrases";
-            accentPhrases: AccentPhrase[];
-          }
-        | {
-            update: "AudioQuery";
-            query: AudioQuery;
-          }
-      )
-    ) {
+    COMMAND_CHANGE_AUDIO_TEXT(draft, payload) {
       audioStore.mutations.SET_AUDIO_TEXT(draft, {
         audioKey: payload.audioKey,
         text: payload.text,
@@ -1520,22 +1276,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         });
       }
     },
-    COMMAND_CHANGE_STYLE_ID(
-      draft,
-      payload: { styleId: number; audioKey: string } & (
-        | {
-            update: "StyleId";
-          }
-        | {
-            update: "AccentPhrases";
-            accentPhrases: AccentPhrase[];
-          }
-        | {
-            update: "AudioQuery";
-            query: AudioQuery;
-          }
-      )
-    ) {
+    COMMAND_CHANGE_STYLE_ID(draft, payload) {
       audioStore.mutations.SET_AUDIO_STYLE_ID(draft, {
         audioKey: payload.audioKey,
         styleId: payload.styleId,
@@ -1552,108 +1293,46 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         });
       }
     },
-    COMMAND_CHANGE_ACCENT(
-      draft,
-      {
-        audioKey,
-        accentPhrases,
-      }: {
-        audioKey: string;
-        accentPhrases: AccentPhrase[];
-      }
-    ) {
+    COMMAND_CHANGE_ACCENT(draft, { audioKey, accentPhrases }) {
       audioStore.mutations.SET_ACCENT_PHRASES(draft, {
         audioKey,
         accentPhrases,
       });
     },
-    COMMAND_CHANGE_ACCENT_PHRASE_SPLIT(
-      draft,
-      payload: {
-        audioKey: string;
-        accentPhrases: AccentPhrase[];
-      }
-    ) {
+    COMMAND_CHANGE_ACCENT_PHRASE_SPLIT(draft, payload) {
       audioStore.mutations.SET_ACCENT_PHRASES(draft, payload);
     },
-    COMMAND_CHANGE_SINGLE_ACCENT_PHRASE(
-      draft,
-      payload: {
-        audioKey: string;
-        accentPhrases: AccentPhrase[];
-      }
-    ) {
+    COMMAND_CHANGE_SINGLE_ACCENT_PHRASE(draft, payload) {
       audioStore.mutations.SET_ACCENT_PHRASES(draft, payload);
     },
-    COMMAND_SET_AUDIO_MORA_DATA(
-      draft,
-      payload: {
-        audioKey: string;
-        accentPhraseIndex: number;
-        moraIndex: number;
-        data: number;
-        type: MoraDataType;
-      }
-    ) {
+    COMMAND_SET_AUDIO_MORA_DATA(draft, payload) {
       audioStore.mutations.SET_AUDIO_MORA_DATA(draft, payload);
     },
-    COMMAND_SET_AUDIO_SPEED_SCALE(
-      draft,
-      payload: { audioKey: string; speedScale: number }
-    ) {
+    COMMAND_SET_AUDIO_SPEED_SCALE(draft, payload) {
       audioStore.mutations.SET_AUDIO_SPEED_SCALE(draft, payload);
     },
-    COMMAND_SET_AUDIO_PITCH_SCALE(
-      draft,
-      payload: { audioKey: string; pitchScale: number }
-    ) {
+    COMMAND_SET_AUDIO_PITCH_SCALE(draft, payload) {
       audioStore.mutations.SET_AUDIO_PITCH_SCALE(draft, payload);
     },
-    COMMAND_SET_AUDIO_INTONATION_SCALE(
-      draft,
-      payload: { audioKey: string; intonationScale: number }
-    ) {
+    COMMAND_SET_AUDIO_INTONATION_SCALE(draft, payload) {
       audioStore.mutations.SET_AUDIO_INTONATION_SCALE(draft, payload);
     },
-    COMMAND_SET_AUDIO_VOLUME_SCALE(
-      draft,
-      payload: { audioKey: string; volumeScale: number }
-    ) {
+    COMMAND_SET_AUDIO_VOLUME_SCALE(draft, payload) {
       audioStore.mutations.SET_AUDIO_VOLUME_SCALE(draft, payload);
     },
-    COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH(
-      draft,
-      payload: { audioKey: string; prePhonemeLength: number }
-    ) {
+    COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH(draft, payload) {
       audioStore.mutations.SET_AUDIO_PRE_PHONEME_LENGTH(draft, payload);
     },
-    COMMAND_SET_AUDIO_POST_PHONEME_LENGTH(
-      draft,
-      payload: { audioKey: string; postPhonemeLength: number }
-    ) {
+    COMMAND_SET_AUDIO_POST_PHONEME_LENGTH(draft, payload) {
       audioStore.mutations.SET_AUDIO_POST_PHONEME_LENGTH(draft, payload);
     },
-    COMMAND_IMPORT_FROM_FILE(
-      draft,
-      {
-        audioKeyItemPairs,
-      }: { audioKeyItemPairs: { audioKey: string; audioItem: AudioItem }[] }
-    ) {
+    COMMAND_IMPORT_FROM_FILE(draft, { audioKeyItemPairs }) {
       audioStore.mutations.INSERT_AUDIO_ITEMS(draft, {
         audioKeyItemPairs,
         prevAudioKey: undefined,
       });
     },
-    COMMAND_PUT_TEXTS(
-      draft,
-      {
-        audioKeyItemPairs,
-        prevAudioKey,
-      }: {
-        audioKeyItemPairs: { audioItem: AudioItem; audioKey: string }[];
-        prevAudioKey: string;
-      }
-    ) {
+    COMMAND_PUT_TEXTS(draft, { audioKeyItemPairs, prevAudioKey }) {
       audioStore.mutations.INSERT_AUDIO_ITEMS(draft, {
         audioKeyItemPairs,
         prevAudioKey,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -80,16 +80,13 @@ export const indexStore: VoiceVoxStoreOptions<
     async GET_OSS_COMMUNITY_INFOS() {
       return await window.electron.getOssCommunityInfos();
     },
-    async SHOW_WARNING_DIALOG(
-      _,
-      { title, message }: { title: string; message: string }
-    ) {
+    async SHOW_WARNING_DIALOG(_, { title, message }) {
       return await window.electron.showWarningDialog({ title, message });
     },
-    LOG_ERROR(_, ...params: unknown[]) {
+    LOG_ERROR(_, ...params) {
       window.electron.logError(...params);
     },
-    LOG_INFO(_, ...params: unknown[]) {
+    LOG_INFO(_, ...params) {
       window.electron.logInfo(...params);
     },
     async IS_UNSET_DEFAULT_STYLE_ID(_, { speakerUuid }) {
@@ -106,7 +103,7 @@ export const indexStore: VoiceVoxStoreOptions<
     async INIT_VUEX({ dispatch }) {
       const promises = [];
 
-      promises.push(dispatch("GET_USE_GPU", undefined));
+      promises.push(dispatch("GET_USE_GPU"));
       promises.push(dispatch("GET_INHERIT_AUDIOINFO"));
       promises.push(dispatch("GET_SAVING_SETTING"));
       promises.push(dispatch("GET_HOTKEY_SETTINGS"));
@@ -114,7 +111,7 @@ export const indexStore: VoiceVoxStoreOptions<
       promises.push(dispatch("GET_ACCEPT_RETRIEVE_TELEMETRY"));
 
       Promise.all(promises).then(() => {
-        dispatch("ON_VUEX_READY", undefined);
+        dispatch("ON_VUEX_READY");
       });
     },
   },

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -37,7 +37,7 @@ export const projectStore: VoiceVoxStoreOptions<
   },
 
   mutations: {
-    SET_PROJECT_FILEPATH(state, { filePath }: { filePath?: string }) {
+    SET_PROJECT_FILEPATH(state, { filePath }) {
       state.projectFilePath = filePath;
     },
     SET_SAVED_LAST_COMMAND_UNIX_MILLISEC(state, unixMillisec) {
@@ -46,8 +46,7 @@ export const projectStore: VoiceVoxStoreOptions<
   },
 
   actions: {
-    CREATE_NEW_PROJECT: createUILockAction(
-      async (context, { confirm }: { confirm?: boolean }) => {
+    CREATE_NEW_PROJECT: createUILockAction(async (context, { confirm }) => {
         if (confirm !== false && context.getters.IS_EDITED) {
           const result: number = await window.electron.showInfoDialog({
             title: "警告",
@@ -74,13 +73,9 @@ export const projectStore: VoiceVoxStoreOptions<
         context.commit("SET_PROJECT_FILEPATH", { filePath: undefined });
         context.commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);
         context.commit("CLEAR_COMMANDS");
-      }
-    ),
+    }),
     LOAD_PROJECT_FILE: createUILockAction(
-      async (
-        context,
-        { filePath, confirm }: { filePath?: string; confirm?: boolean }
-      ) => {
+      async (context, { filePath, confirm }) => {
         if (!filePath) {
           // Select and load a project File.
           const ret = await window.electron.showProjectLoadDialog({
@@ -273,8 +268,7 @@ export const projectStore: VoiceVoxStoreOptions<
         }
       }
     ),
-    SAVE_PROJECT_FILE: createUILockAction(
-      async (context, { overwrite }: { overwrite?: boolean }) => {
+    SAVE_PROJECT_FILE: createUILockAction(async (context, { overwrite }) => {
         let filePath = context.state.projectFilePath;
         if (!overwrite || !filePath) {
           // Write the current status to a project file.
@@ -293,9 +287,7 @@ export const projectStore: VoiceVoxStoreOptions<
           audioKeys,
           audioItems,
         };
-        const buf = new TextEncoder().encode(
-          JSON.stringify(projectData)
-        ).buffer;
+      const buf = new TextEncoder().encode(JSON.stringify(projectData)).buffer;
         window.electron.writeFile({ filePath, buffer: buf });
         if (!context.state.projectFilePath) {
           context.commit("SET_PROJECT_FILEPATH", { filePath });
@@ -305,8 +297,7 @@ export const projectStore: VoiceVoxStoreOptions<
           context.getters.LAST_COMMAND_UNIX_MILLISEC
         );
         return;
-      }
-    ),
+    }),
   },
 };
 

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -47,32 +47,32 @@ export const projectStore: VoiceVoxStoreOptions<
 
   actions: {
     CREATE_NEW_PROJECT: createUILockAction(async (context, { confirm }) => {
-        if (confirm !== false && context.getters.IS_EDITED) {
-          const result: number = await window.electron.showInfoDialog({
-            title: "警告",
-            message:
-              "プロジェクトの変更が保存されていません。\n" +
-              "変更を破棄してもよろしいですか？",
-            buttons: ["破棄", "キャンセル"],
-          });
-          if (result == 1) {
-            return;
-          }
-        }
-
-        await context.dispatch("REMOVE_ALL_AUDIO_ITEM", undefined);
-
-        const audioItem: AudioItem = await context.dispatch(
-          "GENERATE_AUDIO_ITEM",
-          {}
-        );
-        await context.dispatch("REGISTER_AUDIO_ITEM", {
-          audioItem,
+      if (confirm !== false && context.getters.IS_EDITED) {
+        const result: number = await window.electron.showInfoDialog({
+          title: "警告",
+          message:
+            "プロジェクトの変更が保存されていません。\n" +
+            "変更を破棄してもよろしいですか？",
+          buttons: ["破棄", "キャンセル"],
         });
+        if (result == 1) {
+          return;
+        }
+      }
 
-        context.commit("SET_PROJECT_FILEPATH", { filePath: undefined });
-        context.commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);
-        context.commit("CLEAR_COMMANDS");
+      await context.dispatch("REMOVE_ALL_AUDIO_ITEM");
+
+      const audioItem: AudioItem = await context.dispatch(
+        "GENERATE_AUDIO_ITEM",
+        {}
+      );
+      await context.dispatch("REGISTER_AUDIO_ITEM", {
+        audioItem,
+      });
+
+      context.commit("SET_PROJECT_FILEPATH", { filePath: undefined });
+      context.commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);
+      context.commit("CLEAR_COMMANDS");
     }),
     LOAD_PROJECT_FILE: createUILockAction(
       async (context, { filePath, confirm }) => {
@@ -237,7 +237,7 @@ export const projectStore: VoiceVoxStoreOptions<
               return;
             }
           }
-          await context.dispatch("REMOVE_ALL_AUDIO_ITEM", undefined);
+          await context.dispatch("REMOVE_ALL_AUDIO_ITEM");
 
           const { audioItems, audioKeys } = obj as ProjectType;
 
@@ -269,34 +269,34 @@ export const projectStore: VoiceVoxStoreOptions<
       }
     ),
     SAVE_PROJECT_FILE: createUILockAction(async (context, { overwrite }) => {
-        let filePath = context.state.projectFilePath;
-        if (!overwrite || !filePath) {
-          // Write the current status to a project file.
-          const ret = await window.electron.showProjectSaveDialog({
-            title: "プロジェクトファイルの保存",
-          });
-          if (ret == undefined) {
-            return;
-          }
-          filePath = ret;
+      let filePath = context.state.projectFilePath;
+      if (!overwrite || !filePath) {
+        // Write the current status to a project file.
+        const ret = await window.electron.showProjectSaveDialog({
+          title: "プロジェクトファイルの保存",
+        });
+        if (ret == undefined) {
+          return;
         }
-        const appInfos = await window.electron.getAppInfos();
-        const { audioItems, audioKeys } = context.state;
-        const projectData: ProjectType = {
-          appVersion: appInfos.version,
-          audioKeys,
-          audioItems,
-        };
+        filePath = ret;
+      }
+      const appInfos = await window.electron.getAppInfos();
+      const { audioItems, audioKeys } = context.state;
+      const projectData: ProjectType = {
+        appVersion: appInfos.version,
+        audioKeys,
+        audioItems,
+      };
       const buf = new TextEncoder().encode(JSON.stringify(projectData)).buffer;
-        window.electron.writeFile({ filePath, buffer: buf });
-        if (!context.state.projectFilePath) {
-          context.commit("SET_PROJECT_FILEPATH", { filePath });
-        }
-        context.commit(
-          "SET_SAVED_LAST_COMMAND_UNIX_MILLISEC",
-          context.getters.LAST_COMMAND_UNIX_MILLISEC
-        );
-        return;
+      window.electron.writeFile({ filePath, buffer: buf });
+      if (!context.state.projectFilePath) {
+        context.commit("SET_PROJECT_FILEPATH", { filePath });
+      }
+      context.commit(
+        "SET_SAVED_LAST_COMMAND_UNIX_MILLISEC",
+        context.getters.LAST_COMMAND_UNIX_MILLISEC
+      );
+      return;
     }),
   },
 };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -1,11 +1,4 @@
-import {
-  HotkeyAction,
-  HotkeyReturnType,
-  HotkeySetting,
-  SavingSetting,
-  ThemeColorType,
-  ThemeConf,
-} from "@/type/preload";
+import { HotkeyAction, HotkeyReturnType, ThemeColorType } from "@/type/preload";
 import {
   SettingGetters,
   SettingActions,
@@ -51,13 +44,10 @@ export const settingStore: VoiceVoxStoreOptions<
     },
   },
   mutations: {
-    SET_SAVING_SETTING(
-      state,
-      { savingSetting }: { savingSetting: SavingSetting }
-    ) {
+    SET_SAVING_SETTING(state, { savingSetting }) {
       state.savingSetting = savingSetting;
     },
-    SET_HOTKEY_SETTINGS(state, { newHotkey }: { newHotkey: HotkeySetting }) {
+    SET_HOTKEY_SETTINGS(state, { newHotkey }) {
       let flag = true;
       state.hotkeySettings.forEach((hotkey) => {
         if (hotkey.action == newHotkey.action) {
@@ -67,10 +57,7 @@ export const settingStore: VoiceVoxStoreOptions<
       });
       if (flag) state.hotkeySettings.push(newHotkey);
     },
-    SET_THEME_SETTING(
-      state,
-      { currentTheme, themes }: { currentTheme: string; themes?: ThemeConf[] }
-    ) {
+    SET_THEME_SETTING(state, { currentTheme, themes }) {
       if (themes) {
         state.themeSetting.availableThemes = themes;
       }
@@ -87,7 +74,7 @@ export const settingStore: VoiceVoxStoreOptions<
         commit("SET_SAVING_SETTING", { savingSetting: savingSetting });
       });
     },
-    SET_SAVING_SETTING({ commit }, { data }: { data: SavingSetting }) {
+    SET_SAVING_SETTING({ commit }, { data }) {
       const newData = window.electron.savingSetting(data);
       newData.then((savingSetting) => {
         commit("SET_SAVING_SETTING", { savingSetting: savingSetting });
@@ -102,7 +89,7 @@ export const settingStore: VoiceVoxStoreOptions<
         });
       });
     },
-    SET_HOTKEY_SETTINGS({ state, commit }, { data }: { data: HotkeySetting }) {
+    SET_HOTKEY_SETTINGS({ state, commit }, { data }) {
       window.electron.hotkeySettings(data);
       const oldHotkey = state.hotkeySettings.find((value) => {
         return value.action == data.action;
@@ -137,10 +124,7 @@ export const settingStore: VoiceVoxStoreOptions<
         }
       });
     },
-    SET_THEME_SETTING(
-      { state, commit },
-      { currentTheme }: { currentTheme: string }
-    ) {
+    SET_THEME_SETTING({ state, commit }, { currentTheme }) {
       window.electron.theme(currentTheme);
       const theme = state.themeSetting.availableThemes.find((value) => {
         return value.name == currentTheme;

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -67,16 +67,10 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
       UNLOCK_MENUBAR(state) {
         state.dialogLockCount--;
       },
-      IS_HELP_DIALOG_OPEN(
-        state,
-        { isHelpDialogOpen }: { isHelpDialogOpen: boolean }
-      ) {
+      IS_HELP_DIALOG_OPEN(state, { isHelpDialogOpen }) {
         state.isHelpDialogOpen = isHelpDialogOpen;
       },
-      IS_SETTING_DIALOG_OPEN(
-        state,
-        { isSettingDialogOpen }: { isSettingDialogOpen: boolean }
-      ) {
+      IS_SETTING_DIALOG_OPEN(state, { isSettingDialogOpen }) {
         state.isSettingDialogOpen = isSettingDialogOpen;
       },
       IS_HOTKEY_SETTING_DIALOG_OPEN(state, { isHotkeySettingDialogOpen }) {
@@ -84,9 +78,7 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
       },
       IS_DEFAULT_STYLE_SELECT_DIALOG_OPEN(
         state,
-        {
-          isDefaultStyleSelectDialogOpen,
-        }: { isDefaultStyleSelectDialogOpen: boolean }
+        { isDefaultStyleSelectDialogOpen }
       ) {
         state.isDefaultStyleSelectDialogOpen = isDefaultStyleSelectDialogOpen;
       },
@@ -97,13 +89,10 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
         state.isAcceptRetrieveTelemetryDialogOpen =
           isAcceptRetrieveTelemetryDialogOpen;
       },
-      SET_USE_GPU(state, { useGpu }: { useGpu: boolean }) {
+      SET_USE_GPU(state, { useGpu }) {
         state.useGpu = useGpu;
       },
-      SET_INHERIT_AUDIOINFO(
-        state,
-        { inheritAudioInfo }: { inheritAudioInfo: boolean }
-      ) {
+      SET_INHERIT_AUDIOINFO(state, { inheritAudioInfo }) {
         state.inheritAudioInfo = inheritAudioInfo;
       },
       DETECT_UNMAXIMIZED(state) {
@@ -133,15 +122,10 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
       UNLOCK_MENUBAR({ commit }) {
         commit("UNLOCK_MENUBAR");
       },
-      ASYNC_UI_LOCK: createUILockAction(
-        async (_, { callback }: { callback: () => Promise<void> }) => {
-          await callback();
-        }
-      ),
-      IS_HELP_DIALOG_OPEN(
-        { state, commit },
-        { isHelpDialogOpen }: { isHelpDialogOpen: boolean }
-      ) {
+      ASYNC_UI_LOCK: createUILockAction(async (_, { callback }) => {
+        await callback();
+      }),
+      IS_HELP_DIALOG_OPEN({ state, commit }, { isHelpDialogOpen }) {
         if (state.isHelpDialogOpen === isHelpDialogOpen) return;
 
         if (isHelpDialogOpen) {
@@ -154,10 +138,7 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
 
         commit("IS_HELP_DIALOG_OPEN", { isHelpDialogOpen });
       },
-      IS_SETTING_DIALOG_OPEN(
-        { state, commit },
-        { isSettingDialogOpen }: { isSettingDialogOpen: boolean }
-      ) {
+      IS_SETTING_DIALOG_OPEN({ state, commit }, { isSettingDialogOpen }) {
         if (state.isSettingDialogOpen === isSettingDialogOpen) return;
 
         if (isSettingDialogOpen) {
@@ -234,7 +215,7 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
           useGpu: await window.electron.useGpu(),
         });
       },
-      async SET_USE_GPU({ commit }, { useGpu }: { useGpu: boolean }) {
+      async SET_USE_GPU({ commit }, { useGpu }) {
         commit("SET_USE_GPU", {
           useGpu: await window.electron.useGpu(useGpu),
         });
@@ -244,10 +225,7 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
           inheritAudioInfo: await window.electron.inheritAudioInfo(),
         });
       },
-      async SET_INHERIT_AUDIOINFO(
-        { commit },
-        { inheritAudioInfo }: { inheritAudioInfo: boolean }
-      ) {
+      async SET_INHERIT_AUDIOINFO({ commit }, { inheritAudioInfo }) {
         commit("SET_INHERIT_AUDIOINFO", {
           inheritAudioInfo: await window.electron.inheritAudioInfo(
             inheritAudioInfo

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -66,12 +66,9 @@ export function useStore<
 }
 
 export interface Dispatch<A extends ActionsBase> {
-  <T extends keyof A>(
-    type: T,
-    ...payload: Parameters<A[T]>[0] extends undefined
-      ? void[]
-      : [Parameters<A[T]>[0]]
-  ): Promise<PromiseType<ReturnType<A[T]>>>;
+  <T extends keyof A>(type: T, ...payload: Parameters<A[T]>): Promise<
+    PromiseType<ReturnType<A[T]>>
+  >;
   <T extends keyof A>(
     payloadWithType: { type: T } & (Parameters<A[T]>[0] extends Record<
       string,


### PR DESCRIPTION
## 内容

レビューをしていて、mutationやactionの引数の型は `type.ts` に定義してあるのに実装部分でも再度型宣言してあるのは冗長だと感じたので削除しました。

それから、Dispatchの型が少しおかしかったので修正しました。( `LOG_ERROR` 等で使われているスプレッドが許容されていませんでした。)
`store.dispatch()` の引数が無かった場合にundefinedを付けているところがいくつかありましたが、これはこの変更により完全に許容されなくなったので削除しています。