### PR TITLE
macOSでCmd+Qでアプリケーションを終了できるようにする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -763,9 +763,7 @@ app.on("web-contents-created", (e, contents) => {
 });
 
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
-    app.quit();
-  }
+  app.quit();
 });
 
 // Called before window closing


### PR DESCRIPTION
## 内容

タイトルの通りです。`"window-all-closed"` イベントの時にmacOSだけ例外的に終了させていなかったのを終了するようにして実現しました。

## 関連 Issue

close #546 

## スクリーンショット・動画など

なし

## その他

副作用として閉じるボタンやCmd+Wでも終了するようになります。
