### PR TITLE
macOSにおいて最小化・最大化・閉じるボタンをタイトルバーの左側に表示する

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -1,6 +1,7 @@
 <template>
   <q-bar class="bg-background q-pa-none relative-position">
-    <img src="icon.png" class="window-logo" alt="application logo" />
+    <min-max-close-buttons v-if="$q.platform.is.mac" />
+    <img v-else src="icon.png" class="window-logo" alt="application logo" />
     <menu-button
       v-for="(root, index) of menudata"
       :key="index"
@@ -28,6 +29,7 @@
 <script lang="ts">
 import { defineComponent, ref, computed, ComputedRef, watch } from "vue";
 import { useStore } from "@/store";
+import MinMaxCloseButtons from "@/components/MinMaxCloseButtons.vue";
 import MenuButton from "@/components/MenuButton.vue";
 import TitleBarButtons from "@/components/TitleBarButtons.vue";
 import { useQuasar } from "quasar";
@@ -69,6 +71,7 @@ export default defineComponent({
   name: "MenuBar",
 
   components: {
+    MinMaxCloseButtons,
     MenuButton,
     TitleBarButtons,
   },

--- a/src/components/MinMaxCloseButtons.vue
+++ b/src/components/MinMaxCloseButtons.vue
@@ -1,7 +1,8 @@
 <template>
   <q-badge
     v-if="$q.platform.is.mac"
-    color="bg-primary"
+    transparent
+    color="transparent"
     text-color="display"
     class="full-height cursor-not-allowed no-border-radius"
   >

--- a/src/components/MinMaxCloseButtons.vue
+++ b/src/components/MinMaxCloseButtons.vue
@@ -1,0 +1,133 @@
+<template>
+  <q-badge
+    v-if="$q.platform.is.mac"
+    color="bg-primary"
+    text-color="display"
+    class="full-height cursor-not-allowed no-border-radius"
+  >
+    <q-btn
+      dense
+      flat
+      round
+      icon="lens"
+      size="8.5px"
+      color="red"
+      class="title-bar-buttons"
+      @click="closeWindow()"
+    ></q-btn>
+    <q-btn
+      dense
+      flat
+      round
+      icon="lens"
+      size="8.5px"
+      color="yellow"
+      class="title-bar-buttons"
+      @click="minimizeWindow()"
+    ></q-btn>
+    <q-btn
+      dense
+      flat
+      round
+      icon="lens"
+      size="8.5px"
+      color="green"
+      class="title-bar-buttons"
+      @click="maximizeWindow()"
+    ></q-btn>
+  </q-badge>
+  <q-badge
+    v-else
+    transparent
+    color="transparent"
+    text-color="display"
+    class="
+      full-height
+      cursor-not-allowed
+      no-border-radius
+      title-bar-buttons-root
+    "
+  >
+    <q-btn
+      dense
+      flat
+      icon="minimize"
+      class="title-bar-buttons"
+      @click="minimizeWindow()"
+    ></q-btn>
+
+    <q-btn
+      v-if="!isMaximized"
+      dense
+      flat
+      icon="crop_square"
+      class="title-bar-buttons"
+      @click="maximizeWindow()"
+    ></q-btn>
+    <q-btn
+      v-else
+      dense
+      flat
+      :icon="mdiWindowRestore"
+      class="title-bar-buttons"
+      @click="maximizeWindow()"
+    >
+    </q-btn>
+
+    <q-btn
+      dense
+      flat
+      icon="close"
+      class="title-bar-buttons close"
+      @click="closeWindow()"
+    ></q-btn>
+  </q-badge>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from "vue";
+import { useStore } from "@/store";
+import { mdiWindowRestore } from "@quasar/extras/mdi-v5";
+
+export default defineComponent({
+  name: "MinMaxCloseButtons",
+  setup() {
+    const store = useStore();
+
+    const closeWindow = async () => {
+      store.dispatch("CHECK_EDITED_AND_NOT_SAVE");
+    };
+    const minimizeWindow = () => window.electron.minimizeWindow();
+    const maximizeWindow = () => window.electron.maximizeWindow();
+
+    const isMaximized = computed(() => store.state.isMaximized);
+
+    return {
+      closeWindow,
+      minimizeWindow,
+      maximizeWindow,
+      mdiWindowRestore,
+      isMaximized,
+    };
+  },
+});
+</script>
+
+<style scoped lang="scss">
+.q-badge {
+  padding: 0;
+}
+
+.title-bar-buttons-root {
+  z-index: 2000;
+}
+
+.title-bar-buttons {
+  -webkit-app-region: no-drag;
+  overflow: visible;
+}
+
+.close:hover {
+  background-color: red;
+}
+</style>

--- a/src/components/TitleBarButtons.vue
+++ b/src/components/TitleBarButtons.vue
@@ -36,35 +36,6 @@
         最前面に表示
       </q-tooltip>
     </q-btn>
-    <q-btn
-      dense
-      flat
-      round
-      icon="lens"
-      size="8.5px"
-      color="green"
-      class="title-bar-buttons"
-      @click="maximizeWindow()"
-    ></q-btn>
-    <q-btn
-      dense
-      flat
-      round
-      icon="lens"
-      size="8.5px"
-      color="yellow"
-      class="title-bar-buttons"
-      @click="minimizeWindow()"
-    ></q-btn>
-    <q-btn
-      dense
-      flat
-      icon="lens"
-      size="8.5px"
-      color="red"
-      class="title-bar-buttons"
-      @click="closeWindow()"
-    ></q-btn>
   </q-badge>
   <q-badge
     v-else
@@ -107,72 +78,29 @@
         最前面に表示
       </q-tooltip>
     </q-btn>
-    <q-btn
-      dense
-      flat
-      icon="minimize"
-      class="title-bar-buttons"
-      @click="minimizeWindow()"
-    ></q-btn>
-
-    <q-btn
-      v-if="!isMaximized"
-      dense
-      flat
-      icon="crop_square"
-      class="title-bar-buttons"
-      @click="maximizeWindow()"
-    ></q-btn>
-    <q-btn
-      v-else
-      dense
-      flat
-      :icon="mdiWindowRestore"
-      class="title-bar-buttons"
-      @click="maximizeWindow()"
-    >
-    </q-btn>
-
-    <q-btn
-      dense
-      flat
-      icon="close"
-      class="title-bar-buttons close"
-      @click="closeWindow()"
-    ></q-btn>
   </q-badge>
+  <min-max-close-buttons v-if="!$q.platform.is.mac" />
 </template>
 
 <script lang="ts">
 import { defineComponent, computed } from "vue";
 import { useStore } from "@/store";
-import { mdiWindowRestore } from "@quasar/extras/mdi-v5";
+import MinMaxCloseButtons from "@/components/MinMaxCloseButtons.vue";
 
 export default defineComponent({
   name: "TitleBarButtons",
+  components: { MinMaxCloseButtons },
   setup() {
     const store = useStore();
 
-    const closeWindow = async () => {
-      store.dispatch("CHECK_EDITED_AND_NOT_SAVE");
-    };
-    const minimizeWindow = () => window.electron.minimizeWindow();
-    const maximizeWindow = () => window.electron.maximizeWindow();
     const changePinWindow = () => {
       window.electron.changePinWindow();
     };
 
     const isPinned = computed(() => store.state.isPinned);
 
-    const isMaximized = computed(() => store.state.isMaximized);
-
     return {
-      closeWindow,
-      minimizeWindow,
-      maximizeWindow,
       changePinWindow,
-      mdiWindowRestore,
-      isMaximized,
       isPinned,
     };
   },
@@ -191,9 +119,5 @@ export default defineComponent({
 .title-bar-buttons {
   -webkit-app-region: no-drag;
   overflow: visible;
-}
-
-.close:hover {
-  background-color: red;
 }
 </style>

--- a/src/components/TitleBarButtons.vue
+++ b/src/components/TitleBarButtons.vue
@@ -110,6 +110,7 @@ export default defineComponent({
 <style scoped lang="scss">
 .q-badge {
   padding: 0;
+  margin-left: 0;
 }
 
 .title-bar-buttons-root {


### PR DESCRIPTION
## 内容

タイトルの通りです。 #554 の最初の案を採用しています。

## 関連 Issue

close #554 

## スクリーンショット・動画など

### 変更前

<img width="801" alt="before_mac_titlebar" src="https://user-images.githubusercontent.com/41382894/144737790-4c5b6f0f-5fa0-405b-8977-50a0246a3d20.png">

### 変更後

<img width="801" alt="after_mac_titlebar" src="https://user-images.githubusercontent.com/41382894/144737803-aa63e29c-b4af-47f4-a7f9-b1392fd74e83.png">

## その他

Issue #554 に他のデザイン案もあります。より良い案が見つかればそちらに変更します。
手持ちのWindows環境がないので、macOS以外に動作確認を行ったのはLinuxのみです。
Vue.js や TypeScript に不慣れなので、ナンセンスなことをおこなっていた場合はご指摘よろしくお願いします。
