### PR TITLE
vue-gtmの有効化・およびテレメトリー収集のダイアログの追加

### DIFF
--- a/src/components/AcceptRetrieveTelemetryDialog.vue
+++ b/src/components/AcceptRetrieveTelemetryDialog.vue
@@ -1,0 +1,111 @@
+<template>
+  <q-dialog
+    maximized
+    seamless
+    transition-show="jump-up"
+    transition-hide="jump-down"
+    class="accept-retrieve-telemetry-dialog"
+    v-model="modelValueComputed"
+  >
+    <q-layout container view="hHh Lpr lff" class="bg-background">
+      <q-header class="q-py-sm">
+        <q-toolbar>
+          <div class="column">
+            <q-toolbar-title class="text-display"
+              >テレメトリーの収集</q-toolbar-title
+            >
+          </div>
+
+          <q-space />
+
+          <div class="row items-center no-wrap">
+            <q-btn
+              unelevated
+              label="拒否"
+              color="background-light"
+              text-color="display-dark"
+              class="text-no-wrap q-mr-md"
+              @click="handler(false)"
+            />
+
+            <q-btn
+              unelevated
+              label="許可"
+              color="background-light"
+              text-color="display-dark"
+              class="text-no-wrap"
+              @click="handler(true)"
+            />
+          </div>
+        </q-toolbar>
+      </q-header>
+
+      <q-page-container>
+        <q-page>
+          <div class="text-body1 q-mb-lg">
+            VOICEVOXでは、利便性の向上のため、ウインドウサイズや各UIの利用率などの情報をGoogle
+            Analyticsを用いて収集、分析に使用します。
+          </div>
+          <q-card flat bordered>
+            <q-card-section>
+              <div class="text-h5">プライバシーポリシー</div>
+            </q-card-section>
+
+            <q-card-section class="text-body1">
+              <p>ダミープライバシーポリシー</p>
+            </q-card-section>
+          </q-card>
+        </q-page>
+      </q-page-container>
+    </q-layout>
+  </q-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from "vue";
+import { useStore } from "@/store";
+import { useGtm } from "@gtm-support/vue-gtm";
+
+export default defineComponent({
+  name: "AcceptRetrieveTelemetryDialog",
+
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+  },
+
+  setup(props, { emit }) {
+    const store = useStore();
+
+    const modelValueComputed = computed({
+      get: () => props.modelValue,
+      set: (val) => emit("update:modelValue", val),
+    });
+
+    const gtm = useGtm();
+    const handler = (acceptRetrieveTelemetry: boolean) => {
+      store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
+        acceptRetrieveTelemetry: acceptRetrieveTelemetry
+          ? "Accepted"
+          : "Refused",
+      });
+      gtm?.enable(acceptRetrieveTelemetry);
+
+      modelValueComputed.value = false;
+    };
+
+    return {
+      modelValueComputed,
+      handler,
+    };
+  },
+});
+</script>
+
+<style scoped lang="scss">
+.q-page {
+  padding: 3rem;
+}
+</style>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -337,12 +337,6 @@
                 </q-btn-toggle>
               </q-card-actions>
             </q-card> -->
-            <!--
-            NOTE: 現状、ElectronでGoogle Analyticsのopt-outが提供出来ない(起動時に設定が読めない)ため、
-                  設定が読める or 初期値の設定が出来るようになるまで無効にする
-            SEE: https://github.com/VOICEVOX/voicevox/pull/497#issuecomment-985721509
-            FIXME: Google Analyticsのopt-out方法の提供後有効化
-
             <q-card flat class="setting-card">
               <q-card-actions>
                 <div class="text-h5">テレメトリー</div>
@@ -367,7 +361,6 @@
                 </q-toggle>
               </q-card-actions>
             </q-card>
-            -->
           </div>
         </q-page>
       </q-page-container>
@@ -380,6 +373,7 @@ import { defineComponent, computed, ref } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
 import { SavingSetting } from "@/type/preload";
+import { useGtm } from "@gtm-support/vue-gtm";
 
 export default defineComponent({
   name: "SettingDialog",
@@ -465,17 +459,18 @@ export default defineComponent({
     );
     updateAudioOutputDevices();
 
-    // SEE: https://github.com/VOICEVOX/voicevox/pull/497#issuecomment-985721509
-    //const acceptRetrieveTelemetryComputed = computed({
-    //  get: () => store.state.acceptRetrieveTelemetry == "Accepted",
-    //  set: (acceptRetrieveTelemetry: boolean) => {
-    //    store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
-    //      acceptRetrieveTelemetry: acceptRetrieveTelemetry
-    //        ? "Accepted"
-    //        : "Refused",
-    //    });
-    //  },
-    //});
+    const gtm = useGtm();
+    const acceptRetrieveTelemetryComputed = computed({
+      get: () => store.state.acceptRetrieveTelemetry == "Accepted",
+      set: (acceptRetrieveTelemetry: boolean) => {
+        store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
+          acceptRetrieveTelemetry: acceptRetrieveTelemetry
+            ? "Accepted"
+            : "Refused",
+        });
+        gtm?.enable(acceptRetrieveTelemetry);
+      },
+    });
 
     const changeUseGPU = async (useGpu: boolean) => {
       if (store.state.useGpu === useGpu) return;
@@ -604,7 +599,7 @@ export default defineComponent({
       currentThemeNameComputed,
       currentThemeComputed,
       availableThemeNameComputed,
-      //acceptRetrieveTelemetryComputed,
+      acceptRetrieveTelemetryComputed,
     };
   },
 });

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -469,6 +469,20 @@ export default defineComponent({
             : "Refused",
         });
         gtm?.enable(acceptRetrieveTelemetry);
+
+        if (acceptRetrieveTelemetry) {
+          return;
+        }
+
+        $q.dialog({
+          title: "テレメトリーの収集の無効化",
+          message:
+            "テレメトリーの収集を完全に無効にするには、VOICEVOXを再起動する必要があります",
+          ok: {
+            flat: true,
+            textColor: "display",
+          },
+        });
       },
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,10 @@ import "@quasar/extras/material-icons/material-icons.css";
 import "quasar/dist/quasar.sass";
 import "./styles/_index.scss";
 
+// NOTE: 起動後、設定を読み込んでからvue-gtmを有効化する関係上、dataLayerの用意が間に合わず、値が欠落してしまう箇所が存在する
+//       ため、それを防止するため自前でdataLayerをあらかじめ用意する
+window.dataLayer = [];
+
 createApp(App)
   .use(store, storeKey)
   .use(router)
@@ -21,10 +25,7 @@ createApp(App)
     createGtm({
       id: process.env.VUE_APP_GTM_CONTAINER_ID ?? "GTM-DUMMY",
       vueRouter: router,
-      // NOTE: 現状、ElectronでGoogle Analyticsのopt-outが提供出来ない(起動時に設定が読めない)ため、
-      //       設定が読める or 初期値の設定が出来るようになるまで無効にする
-      // SEE: https://github.com/VOICEVOX/voicevox/pull/497#issuecomment-985721509
-      // FIXME: Google Analyticsのopt-out方法の提供後削除
+      // NOTE: 最初はgtm.jsを読まず、プライバシーポリシーに同意後に読み込む
       enabled: false,
     })
   )

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -140,6 +140,7 @@ import { QResizeObserver } from "quasar";
 import path from "path";
 import { HotkeyAction, HotkeyReturnType } from "@/type/preload";
 import { parseCombo, setHotkeyFunctions } from "@/store/setting";
+import { useGtm } from "@gtm-support/vue-gtm";
 
 export default defineComponent({
   name: "Home",
@@ -381,6 +382,9 @@ export default defineComponent({
       hotkeyActionsNative.forEach((item) => {
         document.addEventListener("keyup", item);
       });
+
+      const gtm = useGtm();
+      gtm?.enable(store.state.acceptRetrieveTelemetry === "Accepted");
     });
 
     // エンジン待機

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -113,6 +113,9 @@
     :characterInfos="characterInfos"
     v-model="isDefaultStyleSelectDialogOpenComputed"
   />
+  <accept-retrieve-telemetry-dialog
+    v-model="isAcceptRetrieveTelemetryDialogOpenComputed"
+  />
 </template>
 
 <script lang="ts">
@@ -135,6 +138,7 @@ import SettingDialog from "@/components/SettingDialog.vue";
 import HotkeySettingDialog from "@/components/HotkeySettingDialog.vue";
 import CharacterPortrait from "@/components/CharacterPortrait.vue";
 import DefaultStyleSelectDialog from "@/components/DefaultStyleSelectDialog.vue";
+import AcceptRetrieveTelemetryDialog from "@/components/AcceptRetrieveTelemetryDialog.vue";
 import { AudioItem } from "@/store/type";
 import { QResizeObserver } from "quasar";
 import path from "path";
@@ -156,6 +160,7 @@ export default defineComponent({
     HotkeySettingDialog,
     CharacterPortrait,
     DefaultStyleSelectDialog,
+    AcceptRetrieveTelemetryDialog,
   },
 
   setup() {
@@ -383,6 +388,8 @@ export default defineComponent({
         document.addEventListener("keyup", item);
       });
 
+      isAcceptRetrieveTelemetryDialogOpenComputed.value =
+        store.state.acceptRetrieveTelemetry === "Unconfirmed";
       const gtm = useGtm();
       gtm?.enable(store.state.acceptRetrieveTelemetry === "Accepted");
     });
@@ -420,6 +427,16 @@ export default defineComponent({
       set: (val) =>
         store.dispatch("IS_DEFAULT_STYLE_SELECT_DIALOG_OPEN", {
           isDefaultStyleSelectDialogOpen: val,
+        }),
+    });
+
+    const isAcceptRetrieveTelemetryDialogOpenComputed = computed({
+      get: () =>
+        !store.state.isDefaultStyleSelectDialogOpen &&
+        store.state.isAcceptRetrieveTelemetryDialogOpen,
+      set: (val) =>
+        store.dispatch("IS_ACCEPT_RETRIEVE_TELEMETRY_DIALOG_OPEN", {
+          isAcceptRetrieveTelemetryDialogOpen: val,
         }),
     });
 
@@ -470,6 +487,7 @@ export default defineComponent({
       isHotkeySettingDialogOpenComputed,
       characterInfos,
       isDefaultStyleSelectDialogOpenComputed,
+      isAcceptRetrieveTelemetryDialogOpenComputed,
       dragEventCounter,
       loadDraggedFile,
     };


### PR DESCRIPTION
## 内容

* #497 でdisableで追加したvue-gtmの有効化する処理の追加、およびテレメトリーの収集の許可・拒否を行うダイアログの追加
    * [opt-outの方法がわかった](https://github.com/VOICEVOX/voicevox/issues/487#issuecomment-986084984)ため、あらためてテレメトリーの収集をできるようにしたもの

## 関連 Issue

ref: #487

## スクリーンショット・動画など

動画: https://github.com/VOICEVOX/voicevox/issues/487#issuecomment-989877701

![image](https://user-images.githubusercontent.com/936617/145582829-1a7ff18a-f836-47af-a4ac-b6a05085b215.png)
