### PR TITLE
プライバシーポリシーを記載

### DIFF
--- a/public/privacy_policy.md
+++ b/public/privacy_policy.md
@@ -1,1 +1,15 @@
-* ダミープライバシーポリシー
+本ソフトウェアでは「Google アナリティクス」を使用しています。
+Google アナリティクスはデータの収集のために Cookie を使用しています。
+データは匿名で収集されており、個人を特定するものではありません。
+
+本ソフトウェアでは、ソフトウェアの使用状況を把握する目的で統計データを取得しています。
+取得するデータには、入力テキストなど、音声の詳細な内容がわかるようなデータは含まれておりません。
+
+データの収集機能は設定オプションで無効にすることで収集を拒否することが出来ます。
+
+Googleアナリティクスのデータ収集、処理の仕組みについては、
+[GOOGLE のサービスを使用するサイトやアプリから収集した情報の GOOGLE による使用](https://policies.google.com/technologies/partner-sites?hl=ja)をご覧ください。
+
+この規約に関しての詳細は
+[Google アナリティクス利用規約](https://marketingplatform.google.com/about/analytics/terms/jp/) や
+[Google ポリシーと規約ページ](https://policies.google.com/technologies/ads?hl=ja) をご覧ください。


### PR DESCRIPTION
## 内容

google analytics用のプライバシーポリシーを書いてみました。

ビルド時だけ入るようにすることもできるのですが、google analyticsを使うコードがOSS版に含まれている以上、プライバシーポリシーも含めてしまったほうが無難なのかなと思い、OSSに含めようとしています。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/487
