### PR TITLE
手動でCIジョブを実行できるようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
 
 env:
   VOICEVOX_ENGINE_REPO_URL: "https://github.com/Hiroshiba/voicevox_engine"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,6 +7,7 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_engine/pull/198 にならって、エディタのリポジトリでも CI の実行タイミングに `workflow_dispatch` を追加します。以下、上記PRより引用：

> リポジトリのActionsタブから個別のCIジョブのページを開くと、ブランチを指定して手動実行できるようになります。

> fork先で、実行ブランチが固定されたCIを実行するのに、実行条件を書き換えるコミットを作ったり、（Releaseのテスト以外で）Releaseを作成しなくてよくなります。

https://github.com/VOICEVOX/voicevox/pull/570#discussion_r767220139 の提案を受けて、便利なので追加したいと思いました。
