### PR TITLE
Linux用インストーラ: vvprojファイルの関連付けをする

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -41,6 +41,7 @@ IGNORE_RTCOND=${IGNORE_RTCOND:-}
 
 DESKTOP_ENTRY_INSTALL_DIR=${DESKTOP_ENTRY_INSTALL_DIR:-$HOME/.local/share/applications}
 ICON_INSTALL_DIR=${ICON_INSTALL_DIR:-$HOME/.local/share/icons}
+MIME_INSTALL_DIR=${MIME_INSTALL_DIR:-$HOME/.local/share/mime}
 
 if [ "$FORCE_INSTALL" != "1" ] && [ -f "${APP_DIR}/VOICEVOX.AppImage" ]; then
     echo "[*] VOICEVOX already installed in '${APP_DIR}/VOICEVOX.AppImage'."
@@ -338,6 +339,7 @@ VOICEVOX_INSTALLED_FILES=(
     ${DESKTOP_ENTRY_INSTALL_DIR}/voicevox.desktop
     ${ICON_INSTALL_DIR}/voicevox.png
     ${ICON_INSTALL_DIR}/hicolor/0x0/apps/voicevox.png
+    ${MIME_INSTALL_DIR}/packages/voicevox.xml
 )
 
 VOICEVOX_INSTALLED_DIR=(
@@ -400,6 +402,7 @@ chmod +x "${DESKTOP_FILE}"
 
 ESCAPED_APP_DIR=$(echo "$APP_DIR" | sed 's/\//\\\//g')
 sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U/" "${DESKTOP_FILE}" > _
+sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U/" "${DESKTOP_FILE}" > _
 mv _ "${DESKTOP_FILE}"
 
 mkdir -p "${DESKTOP_ENTRY_INSTALL_DIR}"
@@ -411,6 +414,25 @@ echo "[+] Installing icon..."
 mkdir -p "${ICON_INSTALL_DIR}"
 cp -r squashfs-root/usr/share/icons/* "${ICON_INSTALL_DIR}"
 cp squashfs-root/*.png "${ICON_INSTALL_DIR}"
+
+# Register file association
+echo "[+] Registering file association..."
+
+mkdir -p "${MIME_INSTALL_DIR}/packages"
+cat << EOS > "${MIME_INSTALL_DIR}/packages/voicevox.xml"
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="application/x-voicevox">
+        <comment>VOICEVOX Project file</comment>
+	    <comment xml:lang="ja">VOICEVOX プロジェクトファイル</comment>
+        <sub-class-of type="application/json" />
+        <glob pattern="*.vvproj" />
+		<icon name="voicevox" />
+    </mime-type>
+</mime-info>
+EOS
+
+update-mime-database "${MIME_INSTALL_DIR}"
 
 # Remove extract dir
 echo "[+] Removing temporal directory..."

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -402,7 +402,6 @@ chmod +x "${DESKTOP_FILE}"
 
 ESCAPED_APP_DIR=$(echo "$APP_DIR" | sed 's/\//\\\//g')
 sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U/" "${DESKTOP_FILE}" > _
-sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U/" "${DESKTOP_FILE}" > _
 mv _ "${DESKTOP_FILE}"
 
 mkdir -p "${DESKTOP_ENTRY_INSTALL_DIR}"

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -399,7 +399,7 @@ DESKTOP_FILE=$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -1)
 chmod +x "${DESKTOP_FILE}"
 
 ESCAPED_APP_DIR=$(echo "$APP_DIR" | sed 's/\//\\\//g')
-sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE}/" "${DESKTOP_FILE}" > _
+sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U/" "${DESKTOP_FILE}" > _
 mv _ "${DESKTOP_FILE}"
 
 mkdir -p "${DESKTOP_ENTRY_INSTALL_DIR}"

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -432,7 +432,21 @@ cat << EOS > "${MIME_INSTALL_DIR}/packages/voicevox.xml"
 </mime-info>
 EOS
 
-update-mime-database "${MIME_INSTALL_DIR}"
+# Update file association database
+echo "[+] Updating file association database..."
+if command -v update-mime-database &> /dev/null; then
+    update-mime-database "${MIME_INSTALL_DIR}"
+else
+    echo "[-] Skipped: Command 'update-mime-database' not found"
+fi
+
+# Update desktop file database
+echo "[+] Updating desktop file database..."
+if command -v update-desktop-database &> /dev/null; then
+    update-desktop-database
+else
+    echo "[-] Skipped: Command 'update-desktop-database' not found"
+fi
 
 # Remove extract dir
 echo "[+] Removing temporal directory..."

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -423,10 +423,10 @@ cat << EOS > "${MIME_INSTALL_DIR}/packages/voicevox.xml"
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
     <mime-type type="application/x-voicevox">
         <comment>VOICEVOX Project file</comment>
-	    <comment xml:lang="ja">VOICEVOX プロジェクトファイル</comment>
+        <comment xml:lang="ja">VOICEVOX プロジェクトファイル</comment>
         <sub-class-of type="application/json" />
         <glob pattern="*.vvproj" />
-		<icon name="voicevox" />
+        <icon name="voicevox" />
     </mime-type>
 </mime-info>
 EOS

--- a/vue.config.js
+++ b/vue.config.js
@@ -81,9 +81,7 @@ module.exports = {
             LINUX_EXECUTABLE_NAME !== "" ? LINUX_EXECUTABLE_NAME : undefined,
           icon: "public/icon.png",
           category: "AudioVideo",
-          mimeTypes: [
-            "application/x-voicevox"
-          ],
+          mimeTypes: ["application/x-voicevox"],
           target: [
             {
               target: "AppImage",

--- a/vue.config.js
+++ b/vue.config.js
@@ -81,6 +81,9 @@ module.exports = {
             LINUX_EXECUTABLE_NAME !== "" ? LINUX_EXECUTABLE_NAME : undefined,
           icon: "public/icon.png",
           category: "AudioVideo",
+          mimeTypes: [
+            "application/x-voicevox"
+          ],
           target: [
             {
               target: "AppImage",


### PR DESCRIPTION
## 内容

Linux用インストーラに、vvprojファイルをVOICEVOXに関連付けする処理を追加します。

- `voicevox.desktop`ファイルの実行コマンドに`%U`を追加
    - VOICEVOXの関連付け設定ができるようになる
- vue.config.jsのLinux用ビルド設定に`mimeTypes`を追加
    - `voicevox.desktop`ファイルにMimeType`application/x-voicevox`が書き出される
        - ローカルビルドして確認した
- インストール時にMimeType`application/x-voicevox`と拡張子`vvproj`の関連付け設定ファイルを、Linuxの設定ディレクトリに出力
    - デフォルトの`vvproj`関連付け先がVOICEVOXになる

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- close #575 

@eggplants さんありがとうございます！

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

- 環境: Ubuntu 20.04

### ファイルエクスプローラNautilus上の表示（ダブルクリック実行可）

<details>

![Screenshot from 2021-12-13 17-24-17](https://user-images.githubusercontent.com/27213639/145782212-7a3dc0c6-5365-4610-a635-d554318858c6.png)

</details>

### 関連付けUIの表示（デフォルト値）

<details>

![Screenshot from 2021-12-13 17-17-28](https://user-images.githubusercontent.com/27213639/145782228-91e613b8-18ed-4c31-ad60-9cab795a4430.png)

</details>

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
