### PR TITLE
Mac: vvprojファイルからVOICEVOXを正しく開けるようにする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -506,6 +506,7 @@ async function createWindow() {
           filePath: filePathOnMac,
           confirm: false,
         });
+        filePathOnMac = null;
       }
     } else {
       if (process.argv.length >= 2) {


### PR DESCRIPTION
## 内容

vvprojファイルからVOICEVOXを開くと、VOICEVOXは立ち上がりますがプロジェクト内容を開くことができていませんでした。この問題について、プロジェクト内容を開けるように修正しました。

## 関連 Issue

close #586 
ref #572 

## スクリーンショット・動画など

以下のように、vvprojファイルをダブルクリックしてVOICEVOXを開いたとき、プロジェクト内容がエディタに反映されます（コンテキストメニューからの起動でも同様です）。

https://user-images.githubusercontent.com/41382894/145824467-7c0e6f91-37c0-40ea-9827-b5e28dbe4b9d.mov

## その他

https://github.com/PickledChair/voicevox/actions/runs/1572994607 の `macos-cpu-prepackage-zip` から今回の変更を加えた Mac 向けビルドをダウンロードできます。

また「system preferenceからアプリケーション実行を許可した初回起動時にエラーが出る」という問題（ https://github.com/VOICEVOX/voicevox/pull/570#issuecomment-991601013 や  https://github.com/VOICEVOX/voicevox/issues/572#issuecomment-991875050 を参照）は、調べた限りは Mac において `process.argv` でファイルパスを得ようとした時に起こっているようだったので、今回の変更で同時に修正された可能性があります。修正されていなかった場合は、このPR内で引き続き作業します。動作確認できる方は確認をよろしくお願いいたします。

他のOSでの動作確認をまだ行っていません。後ほど Linux 版の動作を確認してみます。
