### PR TITLE
Mac: Cmdをショートカットキーの修飾キーとして使えるようにする

### DIFF
--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -322,13 +322,9 @@ export default defineComponent({
     };
 
     const confirmBtnEnabled = computed(() => {
-      const modifierKeys = ["Ctrl", "Shift", "Alt"];
-      if ($q.platform.is.mac) {
-        modifierKeys.push("Meta");
-      }
       return (
         lastRecord.value == "" ||
-        modifierKeys.indexOf(
+        ["Ctrl", "Shift", "Alt", "Meta"].indexOf(
           lastRecord.value.split(" ")[lastRecord.value.split(" ").length - 1]
         ) > -1
       );

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -322,7 +322,7 @@ export default defineComponent({
     };
 
     const confirmBtnEnabled = computed(() => {
-      let modifierKeys = ["Ctrl", "Shift", "Alt"];
+      const modifierKeys = ["Ctrl", "Shift", "Alt"];
       if ($q.platform.is.mac) {
         modifierKeys.push("Meta");
       }

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -84,7 +84,8 @@
                       getHotkeyText(props.row.action, props.row.combination)
                         .split(' ')
                         .map((hotkeyText) => {
-                          // macOS の場合のみ Meta キーが使用される。macOS の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する
+                          // Mac の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する
+                          // Windows PC では Meta キーは Windows キーだが、使用頻度低と考えられるため暫定的に Mac 対応のみを考慮している
                           return hotkeyText === 'Meta' ? 'Cmd' : hotkeyText;
                         })
                         .join(' + ')
@@ -126,7 +127,10 @@
       <q-card-section align="center">
         <template v-for="(hotkey, index) in lastRecord.split(' ')" :key="index">
           <span v-if="index !== 0"> + </span>
-          <!-- macOS の場合のみ Meta キーが使用される。macOS の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する -->
+          <!--
+          Mac の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する
+          Windows PC では Meta キーは Windows キーだが、使用頻度低と考えられるため暫定的に Mac 対応のみを考慮している
+          -->
           <q-chip :ripple="false" color="setting-item">
             {{ hotkey === "Meta" ? "Cmd" : hotkey }}
           </q-chip>
@@ -318,9 +322,13 @@ export default defineComponent({
     };
 
     const confirmBtnEnabled = computed(() => {
+      let modifierKeys = ["Ctrl", "Shift", "Alt"];
+      if ($q.platform.is.mac) {
+        modifierKeys.push("Meta");
+      }
       return (
         lastRecord.value == "" ||
-        ["Ctrl", "Shift", "Alt", "Meta"].indexOf(
+        modifierKeys.indexOf(
           lastRecord.value.split(" ")[lastRecord.value.split(" ").length - 1]
         ) > -1
       );

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -84,7 +84,7 @@
                       getHotkeyText(props.row.action, props.row.combination)
                         .split(' ')
                         .map((hotkeyText) => {
-                          return hotkeyText === 'Meta' ? 'Cmd' : hotkeyText
+                          return hotkeyText === 'Meta' ? 'Cmd' : hotkeyText;
                         })
                         .join(' + ')
                     "
@@ -126,7 +126,7 @@
         <template v-for="(hotkey, index) in lastRecord.split(' ')" :key="index">
           <span v-if="index !== 0"> + </span>
           <q-chip :ripple="false" color="setting-item">
-            {{ hotkey === 'Meta' ? 'Cmd' : hotkey }}
+            {{ hotkey === "Meta" ? "Cmd" : hotkey }}
           </q-chip>
         </template>
         <span v-if="lastRecord !== '' && confirmBtnEnabled"> +</span>

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -84,6 +84,7 @@
                       getHotkeyText(props.row.action, props.row.combination)
                         .split(' ')
                         .map((hotkeyText) => {
+                          // macOS の場合のみ Meta キーが使用される。macOS の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する
                           return hotkeyText === 'Meta' ? 'Cmd' : hotkeyText;
                         })
                         .join(' + ')
@@ -125,6 +126,7 @@
       <q-card-section align="center">
         <template v-for="(hotkey, index) in lastRecord.split(' ')" :key="index">
           <span v-if="index !== 0"> + </span>
+          <!-- macOS の場合のみ Meta キーが使用される。macOS の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する -->
           <q-chip :ripple="false" color="setting-item">
             {{ hotkey === "Meta" ? "Cmd" : hotkey }}
           </q-chip>

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -83,6 +83,9 @@
                     :label="
                       getHotkeyText(props.row.action, props.row.combination)
                         .split(' ')
+                        .map((hotkeyText) => {
+                          return hotkeyText === 'Meta' ? 'Cmd' : hotkeyText
+                        })
                         .join(' + ')
                     "
                     @click="openHotkeyDialog(props.row.action)"
@@ -123,7 +126,7 @@
         <template v-for="(hotkey, index) in lastRecord.split(' ')" :key="index">
           <span v-if="index !== 0"> + </span>
           <q-chip :ripple="false" color="setting-item">
-            {{ hotkey }}
+            {{ hotkey === 'Meta' ? 'Cmd' : hotkey }}
           </q-chip>
         </template>
         <span v-if="lastRecord !== '' && confirmBtnEnabled"> +</span>
@@ -315,7 +318,7 @@ export default defineComponent({
     const confirmBtnEnabled = computed(() => {
       return (
         lastRecord.value == "" ||
-        ["Ctrl", "Shift", "Alt"].indexOf(
+        ["Ctrl", "Shift", "Alt", "Meta"].indexOf(
           lastRecord.value.split(" ")[lastRecord.value.split(" ").length - 1]
         ) > -1
       );

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -81,7 +81,8 @@ export default defineComponent({
       if (hotkey === undefined) {
         return "";
       } else {
-        // macOS の場合のみ Meta キーが使用される。macOS の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する
+        // Mac の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する
+        // Windows PC では Meta キーは Windows キーだが、使用頻度低と考えられるため暫定的に Mac 対応のみを考慮している
         return hotkey.replaceAll(" ", "+").replaceAll("Meta", "Cmd");
       }
     };

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -81,7 +81,8 @@ export default defineComponent({
       if (hotkey === undefined) {
         return "";
       } else {
-        return hotkey.replaceAll(" ", "+");
+        // macOS の場合のみ Meta キーが使用される。macOS の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する
+        return hotkey.replaceAll(" ", "+").replaceAll("Meta", "Cmd");
       }
     };
     if (props.menudata.type === "root") {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -15,7 +15,7 @@ import {
 } from "./type";
 import Mousetrap from "mousetrap";
 import { useStore } from "@/store";
-import { Dark, setCssVar, colors, Platform } from "quasar";
+import { Dark, setCssVar, colors } from "quasar";
 
 const hotkeyFunctionCache: Record<string, () => HotkeyReturnType> = {};
 
@@ -219,11 +219,8 @@ export const parseCombo = (event: KeyboardEvent): string => {
     recordedCombo += "Shift ";
   }
   // event.metaKey は Mac キーボードでは Cmd キー、Windows キーボードでは Windows キーの押下で true になる
-  // Mac の場合のみ Meta キーを修飾キーとして取り扱う
-  if (Platform.is.mac) {
-    if (event.metaKey) {
-      recordedCombo += "Meta ";
-    }
+  if (event.metaKey) {
+    recordedCombo += "Meta ";
   }
   if (event.key === " ") {
     recordedCombo += "Space";

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -219,16 +219,17 @@ export const parseCombo = (event: KeyboardEvent): string => {
     recordedCombo += "Shift ";
   }
   // event.metaKey は Mac キーボードでは Cmd キー、Windows キーボードでは Windows キーの押下で true になる
-  // macOS の場合のみ Meta (Cmd) キーを他のキーと組み合わせられるようにする
-  if (Platform.is.mac) {
-    if (event.metaKey) {
-      recordedCombo += "Meta ";
-    }
+  if (event.metaKey) {
+    recordedCombo += "Meta ";
   }
   if (event.key === " ") {
     recordedCombo += "Space";
   } else {
-    if (["Control", "Shift", "Alt", "Meta"].indexOf(event.key) == -1) {
+    const modifierKeys = ["Control", "Shift", "Alt"];
+    if (Platform.is.mac) {
+      modifierKeys.push("Meta");
+    }
+    if (modifierKeys.indexOf(event.key) == -1) {
       recordedCombo +=
         event.key.length > 1 ? event.key : event.key.toUpperCase();
     } else {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -218,6 +218,8 @@ export const parseCombo = (event: KeyboardEvent): string => {
   if (event.shiftKey) {
     recordedCombo += "Shift ";
   }
+  // event.metaKey は Mac キーボードでは Cmd キー、Windows キーボードでは Windows キーの押下で true になる
+  // macOS の場合のみ Meta (Cmd) キーを他のキーと組み合わせられるようにする
   if (Platform.is.mac) {
     if (event.metaKey) {
       recordedCombo += "Meta ";

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -218,10 +218,13 @@ export const parseCombo = (event: KeyboardEvent): string => {
   if (event.shiftKey) {
     recordedCombo += "Shift ";
   }
+  if (event.metaKey) {
+    recordedCombo += "Meta ";
+  }
   if (event.key === " ") {
     recordedCombo += "Space";
   } else {
-    if (["Control", "Shift", "Alt"].indexOf(event.key) == -1) {
+    if (["Control", "Shift", "Alt", "Meta"].indexOf(event.key) == -1) {
       recordedCombo +=
         event.key.length > 1 ? event.key : event.key.toUpperCase();
     } else {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -15,7 +15,7 @@ import {
 } from "./type";
 import Mousetrap from "mousetrap";
 import { useStore } from "@/store";
-import { Dark, setCssVar, colors } from "quasar";
+import { Dark, setCssVar, colors, Platform } from "quasar";
 
 const hotkeyFunctionCache: Record<string, () => HotkeyReturnType> = {};
 
@@ -218,8 +218,7 @@ export const parseCombo = (event: KeyboardEvent): string => {
   if (event.shiftKey) {
     recordedCombo += "Shift ";
   }
-  const ua = window.navigator.userAgent.toLowerCase();
-  if (ua.indexOf("mac os x") !== -1) {
+  if (Platform.is.mac) {
     if (event.metaKey) {
       recordedCombo += "Meta ";
     }

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -219,8 +219,11 @@ export const parseCombo = (event: KeyboardEvent): string => {
     recordedCombo += "Shift ";
   }
   // event.metaKey は Mac キーボードでは Cmd キー、Windows キーボードでは Windows キーの押下で true になる
-  if (event.metaKey) {
-    recordedCombo += "Meta ";
+  // Mac の場合のみ Meta キーを修飾キーとして取り扱う
+  if (Platform.is.mac) {
+    if (event.metaKey) {
+      recordedCombo += "Meta ";
+    }
   }
   if (event.key === " ") {
     recordedCombo += "Space";

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -218,8 +218,11 @@ export const parseCombo = (event: KeyboardEvent): string => {
   if (event.shiftKey) {
     recordedCombo += "Shift ";
   }
-  if (event.metaKey) {
-    recordedCombo += "Meta ";
+  const ua = window.navigator.userAgent.toLowerCase();
+  if (ua.indexOf("mac os x") !== -1) {
+    if (event.metaKey) {
+      recordedCombo += "Meta ";
+    }
   }
   if (event.key === " ") {
     recordedCombo += "Space";

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -228,11 +228,7 @@ export const parseCombo = (event: KeyboardEvent): string => {
   if (event.key === " ") {
     recordedCombo += "Space";
   } else {
-    const modifierKeys = ["Control", "Shift", "Alt"];
-    if (Platform.is.mac) {
-      modifierKeys.push("Meta");
-    }
-    if (modifierKeys.indexOf(event.key) == -1) {
+    if (["Control", "Shift", "Alt", "Meta"].indexOf(event.key) == -1) {
       recordedCombo +=
         event.key.length > 1 ? event.key : event.key.toUpperCase();
     } else {


### PR DESCRIPTION
## 内容

ショートカットキーの設定について、Mac でも Shift とCtrl, Alt キーは修飾キーとして使えていましたが、Cmd キーは修飾キーとして使用できませんでした。これを使用できるようにします。

備考： Mac のショートカットキー操作は Undo 操作は Cmd + Z、保存操作は Cmd + S など、Cmd キーを多用します。Mac 対応において Cmd キーが使えるかどうかということは大きい問題だと考えています。

## 関連 Issue

ref #572 

## スクリーンショット・動画など

https://user-images.githubusercontent.com/41382894/146002019-7ee5020d-6561-4b80-8987-6ce35e887cd1.mov

## その他

Windows と Linux のショートカットキーの設定や使用には影響を与えていないと思います（Ubuntu で Windows キーを押した時などの動作を確認しました）。しかし、いくつか議論の余地がある箇所がありそうです。レビュワーのご意見によっては一旦クローズして、課題解決のための Issue を開くかもしれません。

### Meta キーの扱いについて

Mac の Cmd キーはブラウザ上では Meta キーとして扱われます。Meta キーは Windows や Ubuntu では通常 Windows キーです（ Ubuntu では Super キーと呼ぶようです）。現状、VOICEVOX では Windows や Ubuntu で Meta キーを使えないようにしているため、「Mac のみが Meta キーを修飾キーとして扱う」と仮定して実装しました。そこで、vue のコンポーネントに「 key の名前として Meta が来たら Cmd に置き換える」という処理をハードコードしてしまっています。例として以下のような箇所があります：

```vue
        <template v-for="(hotkey, index) in lastRecord.split(' ')" :key="index">
          <span v-if="index !== 0"> + </span>
          <q-chip :ripple="false" color="setting-item">
            {{ hotkey === "Meta" ? "Cmd" : hotkey }}
          </q-chip>
        </template>
```

他 OS で今後 Meta キーをどう扱うつもりなのかによっては、これは良くなさそうな気がしているので、良い案があればご提案よろしくお願いします。

また、何らかの事情により「ショートカットキーの表示名を変える」必要があるかもしれないという話題は #547 でも触れられていました。今のところ Windows と Linux で Windows キーの表示はなされないものの、今回提出した PR はそのままだとバグのもとになるかもしれないという認識はしております。姑息的な解決策としてマージしてもらうか、根本的な解決策が見出されるまでペンディングすべきか、自分には判断がつきかねたので、意見を伺うため、一応 PR として出してみました。

### OS判定コードについて

[voicevox/src/store/setting.ts](https://github.com/VOICEVOX/voicevox/blob/5e179b8d899f8da4eef67a73866deaf45e6ef5be/src/store/setting.ts) 内で OS 判定をする方法を色々調べたのですが、Web 系の技術に慣れていないため、UserAgent を使った方法しか探し出せませんでした（他に `process.platform` や `$q = useQuasar(); $q.platform.is.mac` などが使えないか試したのですがうまくいきませんでした）。より良い方法があれば教えていただければと思います。
