### PR TITLE
0.4.1のプロジェクトが0.9.3で開けないバグを修正

### DIFF
--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -154,12 +154,12 @@ export const projectStore: VoiceVoxStoreOptions<
                 }
 
                 // set phoneme length
-                if (audioItem.styleId == undefined)
-                  throw new Error("audioItem.styleId == undefined");
+                if (audioItem.characterIndex === undefined)
+                  throw new Error("audioItem.characterIndex === undefined");
                 await context
                   .dispatch("FETCH_MORA_DATA", {
                     accentPhrases: audioItem.query.accentPhrases,
-                    styleId: audioItem.styleId,
+                    styleId: audioItem.characterIndex,
                   })
                   .then((accentPhrases: AccentPhrase[]) => {
                     accentPhrases.forEach((newAccentPhrase, i) => {

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -154,6 +154,7 @@ export const projectStore: VoiceVoxStoreOptions<
                 }
 
                 // set phoneme length
+                // 0.7 未満のプロジェクトファイルは styleId ではなく characterIndex なので、ここだけ characterIndex とした
                 if (audioItem.characterIndex === undefined)
                   throw new Error("audioItem.characterIndex === undefined");
                 await context


### PR DESCRIPTION
## 内容
2点です。
- (タイトル通り) 0.4.1で保存されたプロジェクトファイル(.vvproj)が0.9.3で開けないバグを修正
- undefinedの判定を厳密化

## 関連 Issue
close #592 

## その他
0.4.1、0.5.3、0.6.1、0.7.5、0.8.2、0.9.3で保存されたプロジェクトが開発バージョンで正常に読み込まれることを確認しました。