### PR TITLE
Mac向けのショートカットキーのデフォルト設定を追加

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -67,10 +67,11 @@ protocol.registerSchemesAsPrivileged([
   { scheme: "app", privileges: { secure: true, standard: true, stream: true } },
 ]);
 
+const isMac = process.platform === "darwin";
 const defaultHotkeySettings: HotkeySetting[] = [
   {
     action: "音声書き出し",
-    combination: process.platform !== "darwin" ? "Ctrl E" : "Meta E",
+    combination: !isMac ? "Ctrl E" : "Meta E",
   },
   {
     action: "一つだけ書き出し",
@@ -118,28 +119,27 @@ const defaultHotkeySettings: HotkeySetting[] = [
   },
   {
     action: "元に戻す",
-    combination: process.platform !== "darwin" ? "Ctrl Z" : "Meta Z",
+    combination: !isMac ? "Ctrl Z" : "Meta Z",
   },
   {
     action: "やり直す",
-    combination: process.platform !== "darwin" ? "Ctrl Y" : "Shift Meta Z",
+    combination: !isMac ? "Ctrl Y" : "Shift Meta Z",
   },
   {
     action: "新規プロジェクト",
-    combination: process.platform !== "darwin" ? "Ctrl N" : "Meta N",
+    combination: !isMac ? "Ctrl N" : "Meta N",
   },
   {
     action: "プロジェクトを名前を付けて保存",
-    combination:
-      process.platform !== "darwin" ? "Ctrl Shift S" : "Shift Meta S",
+    combination: !isMac ? "Ctrl Shift S" : "Shift Meta S",
   },
   {
     action: "プロジェクトを上書き保存",
-    combination: process.platform !== "darwin" ? "Ctrl S" : "Meta S",
+    combination: !isMac ? "Ctrl S" : "Meta S",
   },
   {
     action: "プロジェクト読み込み",
-    combination: process.platform !== "darwin" ? "Ctrl O" : "Meta O",
+    combination: !isMac ? "Ctrl O" : "Meta O",
   },
   {
     action: "テキスト読み込む",
@@ -471,7 +471,7 @@ async function createWindow() {
   });
 
   win.webContents.once("did-finish-load", () => {
-    if (process.platform === "darwin") {
+    if (isMac) {
       if (filePathOnMac != null) {
         ipcMainSend(win, "LOAD_PROJECT_FILE", {
           filePath: filePathOnMac,

--- a/src/background.ts
+++ b/src/background.ts
@@ -70,7 +70,7 @@ protocol.registerSchemesAsPrivileged([
 const defaultHotkeySettings: HotkeySetting[] = [
   {
     action: "音声書き出し",
-    combination: "Ctrl E",
+    combination: process.platform !== "darwin" ? "Ctrl E" : "Meta E",
   },
   {
     action: "一つだけ書き出し",
@@ -118,27 +118,28 @@ const defaultHotkeySettings: HotkeySetting[] = [
   },
   {
     action: "元に戻す",
-    combination: "Ctrl Z",
+    combination: process.platform !== "darwin" ? "Ctrl Z" : "Meta Z",
   },
   {
     action: "やり直す",
-    combination: "Ctrl Y",
+    combination: process.platform !== "darwin" ? "Ctrl Y" : "Shift Meta Z",
   },
   {
     action: "新規プロジェクト",
-    combination: "Ctrl N",
+    combination: process.platform !== "darwin" ? "Ctrl N" : "Meta N",
   },
   {
     action: "プロジェクトを名前を付けて保存",
-    combination: "Ctrl Shift S",
+    combination:
+      process.platform !== "darwin" ? "Ctrl Shift S" : "Shift Meta S",
   },
   {
     action: "プロジェクトを上書き保存",
-    combination: "Ctrl S",
+    combination: process.platform !== "darwin" ? "Ctrl S" : "Meta S",
   },
   {
     action: "プロジェクト読み込み",
-    combination: "Ctrl O",
+    combination: process.platform !== "darwin" ? "Ctrl O" : "Meta O",
   },
   {
     action: "テキスト読み込む",


### PR DESCRIPTION
## 内容

Mac のショートカットキーは Ctrl の代わりに Cmd を使っているケースがあるなど、他の OS とデフォルトの操作体系が異なります。これを再現するために、Mac 向けのデフォルト設定を追加しました。

基本的には Mac 版 VSCode のショートカットキーを参考にしました。

## 関連 Issue

close #604 
