### PR TITLE
feat: 疑問文自動調整設定機能追加

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -274,8 +274,10 @@ const store = new Store<{
       properties: {
         enableInterrogative: {
           type: "boolean",
-          default: false,
         },
+      },
+      default: {
+        enableInterrogative: false,
       },
     },
     acceptRetrieveTelemetry: {
@@ -821,12 +823,12 @@ ipcMainHandle("SET_ACCEPT_RETRIEVE_TELEMETRY", (_, acceptRetrieveTelemetry) => {
   store.set("acceptRetrieveTelemetry", acceptRetrieveTelemetry);
 });
 
-ipcMainHandle("GET_ENABLE_INTERROGATIVE", () => {
-  return store.get("experimentalSetting.enableInterrogative");
+ipcMainHandle("GET_EXPERIMENTAL_SETTING", () => {
+  return store.get("experimentalSetting");
 });
 
-ipcMainHandle("SET_ENABLE_INTERROGATIVE", (_, enableInterrogative) => {
-  store.set("experimentalSetting.enableInterrogative", enableInterrogative);
+ipcMainHandle("SET_EXPERIMENTAL_SETTING", (_, experimentalSetting) => {
+  store.set("experimentalSetting", experimentalSetting);
 });
 
 // app callback

--- a/src/background.ts
+++ b/src/background.ts
@@ -157,6 +157,7 @@ const store = new Store<{
   toolbarSetting: ToolbarSetting;
   defaultStyleIds: DefaultStyleId[];
   currentTheme: string;
+  enableInterrogative: boolean;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
 }>({
   schema: {
@@ -266,6 +267,10 @@ const store = new Store<{
     currentTheme: {
       type: "string",
       default: "Default",
+    },
+    enableInterrogative: {
+      type: "boolean",
+      default: false,
     },
     acceptRetrieveTelemetry: {
       type: "string",
@@ -808,6 +813,14 @@ ipcMainHandle("GET_ACCEPT_RETRIEVE_TELEMETRY", () => {
 
 ipcMainHandle("SET_ACCEPT_RETRIEVE_TELEMETRY", (_, acceptRetrieveTelemetry) => {
   store.set("acceptRetrieveTelemetry", acceptRetrieveTelemetry);
+});
+
+ipcMainHandle("GET_ENABLE_INTERROGATIVE", () => {
+  return store.get("enableInterrogative");
+});
+
+ipcMainHandle("SET_ENABLE_INTERROGATIVE", (_, enableInterrogative) => {
+  store.set("enableInterrogative", enableInterrogative);
 });
 
 // app callback

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,6 +21,7 @@ import {
   SavingSetting,
   PresetConfig,
   ThemeConf,
+  ExperimentalSetting,
   AcceptRetrieveTelemetryStatus,
   ToolbarSetting,
 } from "./type/preload";
@@ -157,7 +158,7 @@ const store = new Store<{
   toolbarSetting: ToolbarSetting;
   defaultStyleIds: DefaultStyleId[];
   currentTheme: string;
-  enableInterrogative: boolean;
+  experimentalSetting: ExperimentalSetting;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
 }>({
   schema: {
@@ -268,9 +269,14 @@ const store = new Store<{
       type: "string",
       default: "Default",
     },
-    enableInterrogative: {
-      type: "boolean",
-      default: false,
+    experimentalSetting: {
+      type: "object",
+      properties: {
+        enableInterrogative: {
+          type: "boolean",
+          default: false,
+        },
+      },
     },
     acceptRetrieveTelemetry: {
       type: "string",
@@ -816,11 +822,11 @@ ipcMainHandle("SET_ACCEPT_RETRIEVE_TELEMETRY", (_, acceptRetrieveTelemetry) => {
 });
 
 ipcMainHandle("GET_ENABLE_INTERROGATIVE", () => {
-  return store.get("enableInterrogative");
+  return store.get("experimentalSetting.enableInterrogative");
 });
 
 ipcMainHandle("SET_ENABLE_INTERROGATIVE", (_, enableInterrogative) => {
-  store.set("enableInterrogative", enableInterrogative);
+  store.set("experimentalSetting.enableInterrogative", enableInterrogative);
 });
 
 // app callback

--- a/src/background.ts
+++ b/src/background.ts
@@ -274,6 +274,7 @@ const store = new Store<{
       properties: {
         enableInterrogative: {
           type: "boolean",
+          default: false,
         },
       },
       default: {

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -420,7 +420,9 @@ export default defineComponent({
     });
     const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
 
-    const enableInterrogative = computed(() => store.state.enableInterrogative);
+    const enableInterrogative = computed(
+      () => store.state.experimentalSetting.enableInterrogative
+    );
 
     const currentThemeNameComputed = computed({
       get: () => store.state.themeSetting.currentTheme,
@@ -571,7 +573,11 @@ export default defineComponent({
     };
 
     const changeEnableInterrogative = async (enableInterrogative: boolean) => {
-      if (store.state.enableInterrogative === enableInterrogative) return;
+      if (
+        store.state.experimentalSetting.enableInterrogative ===
+        enableInterrogative
+      )
+        return;
       store.dispatch("SET_ENABLE_INTERROGATIVE", { enableInterrogative });
     };
 

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -340,8 +340,10 @@
                 <div>疑問文自動調整</div>
                 <q-space />
                 <q-toggle
-                  :model-value="enableInterrogative"
-                  @update:model-value="changeEnableInterrogative($event)"
+                  :model-value="experimentalSetting.enableInterrogative"
+                  @update:model-value="
+                    changeExperimentalSetting('enableInterrogative', $event)
+                  "
                 >
                   <q-tooltip
                     :delay="500"
@@ -390,7 +392,7 @@
 import { defineComponent, computed, ref } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
-import { SavingSetting } from "@/type/preload";
+import { SavingSetting, ExperimentalSetting } from "@/type/preload";
 import { useGtm } from "@gtm-support/vue-gtm";
 
 export default defineComponent({
@@ -420,9 +422,7 @@ export default defineComponent({
     });
     const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
 
-    const enableInterrogative = computed(
-      () => store.state.experimentalSetting.enableInterrogative
-    );
+    const experimentalSetting = computed(() => store.state.experimentalSetting);
 
     const currentThemeNameComputed = computed({
       get: () => store.state.themeSetting.currentTheme,
@@ -572,13 +572,13 @@ export default defineComponent({
       store.dispatch("SET_INHERIT_AUDIOINFO", { inheritAudioInfo });
     };
 
-    const changeEnableInterrogative = async (enableInterrogative: boolean) => {
-      if (
-        store.state.experimentalSetting.enableInterrogative ===
-        enableInterrogative
-      )
-        return;
-      store.dispatch("SET_ENABLE_INTERROGATIVE", { enableInterrogative });
+    const changeExperimentalSetting = async (
+      key: keyof ExperimentalSetting,
+      data: boolean
+    ) => {
+      store.dispatch("SET_EXPERIMENTAL_SETTING", {
+        experimentalSetting: { ...experimentalSetting.value, [key]: data },
+      });
     };
 
     const restartEngineProcess = () => {
@@ -634,11 +634,11 @@ export default defineComponent({
       settingDialogOpenedComputed,
       engineMode,
       inheritAudioInfoMode,
-      enableInterrogative,
+      experimentalSetting,
       currentAudioOutputDeviceComputed,
       availableAudioOutputDevices,
       changeinheritAudioInfo,
-      changeEnableInterrogative,
+      changeExperimentalSetting,
       restartEngineProcess,
       savingSetting,
       handleSavingSettingChange,

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -306,13 +306,13 @@
                 </q-select>
               </q-card-actions>
             </q-card>
-            <!-- 今後実験的機能を追加する場合はここに追加 -->
-            <!-- FIXME: 0.9.1に間に合わなかったのでダークモード機能を一旦省きました -->
-            <!-- <q-card flat class="setting-card">
+            <q-card flat class="setting-card">
               <q-card-actions>
                 <div class="text-h5">実験的機能</div>
               </q-card-actions>
-              <q-card-actions class="q-px-md q-py-sm bg-setting-item">
+              <!-- 今後実験的機能を追加する場合はここに追加 -->
+              <!-- FIXME: 0.9.1に間に合わなかったのでダークモード機能を一旦省きました -->
+              <!-- <q-card-actions class="q-px-md q-py-sm bg-setting-item">
                 <div>Theme</div>
                 <q-space />
                 <q-btn-toggle
@@ -335,8 +335,26 @@
                     The colors in themes are not decided yet
                   </q-tooltip>
                 </q-btn-toggle>
+              </q-card-actions> -->
+              <q-card-actions class="q-px-md q-py-none bg-setting-item">
+                <div>疑問文自動調整</div>
+                <q-space />
+                <q-toggle
+                  :model-value="enableInterrogative"
+                  @update:model-value="changeEnableInterrogative($event)"
+                >
+                  <q-tooltip
+                    :delay="500"
+                    anchor="center left"
+                    self="center right"
+                    transition-show="jump-left"
+                    transition-hide="jump-right"
+                  >
+                    疑問文のアクセント句を自動調整する
+                  </q-tooltip>
+                </q-toggle>
               </q-card-actions>
-            </q-card> -->
+            </q-card>
             <q-card flat class="setting-card">
               <q-card-actions>
                 <div class="text-h5">テレメトリー</div>
@@ -401,6 +419,8 @@ export default defineComponent({
       },
     });
     const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
+
+    const enableInterrogative = computed(() => store.state.enableInterrogative);
 
     const currentThemeNameComputed = computed({
       get: () => store.state.themeSetting.currentTheme,
@@ -550,6 +570,11 @@ export default defineComponent({
       store.dispatch("SET_INHERIT_AUDIOINFO", { inheritAudioInfo });
     };
 
+    const changeEnableInterrogative = async (enableInterrogative: boolean) => {
+      if (store.state.enableInterrogative === enableInterrogative) return;
+      store.dispatch("SET_ENABLE_INTERROGATIVE", { enableInterrogative });
+    };
+
     const restartEngineProcess = () => {
       store.dispatch("RESTART_ENGINE");
     };
@@ -603,9 +628,11 @@ export default defineComponent({
       settingDialogOpenedComputed,
       engineMode,
       inheritAudioInfoMode,
+      enableInterrogative,
       currentAudioOutputDeviceComputed,
       availableAudioOutputDevices,
       changeinheritAudioInfo,
+      changeEnableInterrogative,
       restartEngineProcess,
       savingSetting,
       handleSavingSettingChange,

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -215,13 +215,13 @@ const api: Sandbox = {
     );
   },
 
-  getEnableInterrogative: async () => {
-    return await ipcRendererInvoke("GET_ENABLE_INTERROGATIVE");
+  getExperimentalSetting: async () => {
+    return await ipcRendererInvoke("GET_EXPERIMENTAL_SETTING");
   },
 
-  setEnableInterrogative: async (enableInterrogative) => {
+  setExperimentalSetting: async (enableInterrogative) => {
     return await ipcRendererInvoke(
-      "SET_ENABLE_INTERROGATIVE",
+      "SET_EXPERIMENTAL_SETTING",
       enableInterrogative
     );
   },

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -215,6 +215,17 @@ const api: Sandbox = {
     );
   },
 
+  getEnableInterrogative: async () => {
+    return await ipcRendererInvoke("GET_ENABLE_INTERROGATIVE");
+  },
+
+  setEnableInterrogative: async (enableInterrogative) => {
+    return await ipcRendererInvoke(
+      "SET_ENABLE_INTERROGATIVE",
+      enableInterrogative
+    );
+  },
+
   getDefaultHotkeySettings: async () => {
     return await ipcRendererInvoke("GET_DEFAULT_HOTKEY_SETTINGS");
   },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -576,7 +576,7 @@ export const audioStore: VoiceVoxStoreOptions<
         ? await dispatch("FETCH_AUDIO_QUERY", {
             text,
             styleId,
-            enableInterrogative: state.enableInterrogative,
+            enableInterrogative: state.experimentalSetting.enableInterrogative,
           }).catch(() => undefined)
         : undefined;
 
@@ -1327,7 +1327,8 @@ export const audioCommandStore: VoiceVoxStoreOptions<
             {
               text,
               styleId,
-              enableInterrogative: state.enableInterrogative,
+              enableInterrogative:
+                state.experimentalSetting.enableInterrogative,
             }
           );
           commit("COMMAND_CHANGE_AUDIO_TEXT", {
@@ -1340,7 +1341,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
           const newAudioQuery = await dispatch("FETCH_AUDIO_QUERY", {
             text,
             styleId,
-            enableInterrogative: state.enableInterrogative,
+            enableInterrogative: state.experimentalSetting.enableInterrogative,
           });
           commit("COMMAND_CHANGE_AUDIO_TEXT", {
             audioKey,
@@ -1384,7 +1385,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
           const query: AudioQuery = await dispatch("FETCH_AUDIO_QUERY", {
             text: text,
             styleId,
-            enableInterrogative: state.enableInterrogative,
+            enableInterrogative: state.experimentalSetting.enableInterrogative,
           });
           commit("COMMAND_CHANGE_STYLE_ID", {
             styleId,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -576,6 +576,7 @@ export const audioStore: VoiceVoxStoreOptions<
         ? await dispatch("FETCH_AUDIO_QUERY", {
             text,
             styleId,
+            enableInterrogative: state.enableInterrogative,
           }).catch(() => undefined)
         : undefined;
 
@@ -641,7 +642,13 @@ export const audioStore: VoiceVoxStoreOptions<
         text,
         styleId,
         isKana,
-      }: { text: string; styleId: number; isKana?: boolean }
+        enableInterrogative,
+      }: {
+        text: string;
+        styleId: number;
+        isKana?: boolean;
+        enableInterrogative?: boolean;
+      }
     ) {
       return dispatch("INVOKE_ENGINE_CONNECTOR", {
         action: "accentPhrasesAccentPhrasesPost",
@@ -650,6 +657,7 @@ export const audioStore: VoiceVoxStoreOptions<
             text,
             speaker: styleId,
             isKana,
+            enableInterrogative,
           },
         ],
       })
@@ -710,11 +718,21 @@ export const audioStore: VoiceVoxStoreOptions<
     },
     FETCH_AUDIO_QUERY(
       { dispatch },
-      { text, styleId }: { text: string; styleId: number }
+      {
+        text,
+        styleId,
+        enableInterrogative,
+      }: { text: string; styleId: number; enableInterrogative?: boolean }
     ) {
       return dispatch("INVOKE_ENGINE_CONNECTOR", {
         action: "audioQueryAudioQueryPost",
-        payload: [{ text, speaker: styleId }],
+        payload: [
+          {
+            text,
+            speaker: styleId,
+            enableInterrogative,
+          },
+        ],
       })
         .then(toDispatchResponse("audioQueryAudioQueryPost"))
         .catch((error) => {
@@ -1309,6 +1327,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
             {
               text,
               styleId,
+              enableInterrogative: state.enableInterrogative,
             }
           );
           commit("COMMAND_CHANGE_AUDIO_TEXT", {
@@ -1321,6 +1340,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
           const newAudioQuery = await dispatch("FETCH_AUDIO_QUERY", {
             text,
             styleId,
+            enableInterrogative: state.enableInterrogative,
           });
           commit("COMMAND_CHANGE_AUDIO_TEXT", {
             audioKey,
@@ -1364,6 +1384,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
           const query: AudioQuery = await dispatch("FETCH_AUDIO_QUERY", {
             text: text,
             styleId,
+            enableInterrogative: state.enableInterrogative,
           });
           commit("COMMAND_CHANGE_STYLE_ID", {
             styleId,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -576,7 +576,6 @@ export const audioStore: VoiceVoxStoreOptions<
         ? await dispatch("FETCH_AUDIO_QUERY", {
             text,
             styleId,
-            enableInterrogative: state.experimentalSetting.enableInterrogative,
           }).catch(() => undefined)
         : undefined;
 
@@ -637,17 +636,15 @@ export const audioStore: VoiceVoxStoreOptions<
       commit("SET_AUDIO_QUERY", payload);
     },
     FETCH_ACCENT_PHRASES(
-      { dispatch },
+      { dispatch, state },
       {
         text,
         styleId,
         isKana,
-        enableInterrogative,
       }: {
         text: string;
         styleId: number;
         isKana?: boolean;
-        enableInterrogative?: boolean;
       }
     ) {
       return dispatch("INVOKE_ENGINE_CONNECTOR", {
@@ -657,7 +654,7 @@ export const audioStore: VoiceVoxStoreOptions<
             text,
             speaker: styleId,
             isKana,
-            enableInterrogative,
+            enableInterrogative: state.experimentalSetting.enableInterrogative,
           },
         ],
       })
@@ -717,12 +714,8 @@ export const audioStore: VoiceVoxStoreOptions<
       return accentPhrases;
     },
     FETCH_AUDIO_QUERY(
-      { dispatch },
-      {
-        text,
-        styleId,
-        enableInterrogative,
-      }: { text: string; styleId: number; enableInterrogative?: boolean }
+      { dispatch, state },
+      { text, styleId }: { text: string; styleId: number }
     ) {
       return dispatch("INVOKE_ENGINE_CONNECTOR", {
         action: "audioQueryAudioQueryPost",
@@ -730,7 +723,7 @@ export const audioStore: VoiceVoxStoreOptions<
           {
             text,
             speaker: styleId,
-            enableInterrogative,
+            enableInterrogative: state.experimentalSetting.enableInterrogative,
           },
         ],
       })
@@ -1327,8 +1320,6 @@ export const audioCommandStore: VoiceVoxStoreOptions<
             {
               text,
               styleId,
-              enableInterrogative:
-                state.experimentalSetting.enableInterrogative,
             }
           );
           commit("COMMAND_CHANGE_AUDIO_TEXT", {
@@ -1341,7 +1332,6 @@ export const audioCommandStore: VoiceVoxStoreOptions<
           const newAudioQuery = await dispatch("FETCH_AUDIO_QUERY", {
             text,
             styleId,
-            enableInterrogative: state.experimentalSetting.enableInterrogative,
           });
           commit("COMMAND_CHANGE_AUDIO_TEXT", {
             audioKey,
@@ -1385,7 +1375,6 @@ export const audioCommandStore: VoiceVoxStoreOptions<
           const query: AudioQuery = await dispatch("FETCH_AUDIO_QUERY", {
             text: text,
             styleId,
-            enableInterrogative: state.experimentalSetting.enableInterrogative,
           });
           commit("COMMAND_CHANGE_STYLE_ID", {
             styleId,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -132,6 +132,7 @@ export const indexStore: VoiceVoxStoreOptions<
       promises.push(dispatch("GET_TOOLBAR_SETTING"));
       promises.push(dispatch("GET_THEME_SETTING"));
       promises.push(dispatch("GET_ACCEPT_RETRIEVE_TELEMETRY"));
+      promises.push(dispatch("GET_ENABLE_INTERROGATIVE"));
 
       Promise.all(promises).then(() => {
         dispatch("ON_VUEX_READY");

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -132,7 +132,7 @@ export const indexStore: VoiceVoxStoreOptions<
       promises.push(dispatch("GET_TOOLBAR_SETTING"));
       promises.push(dispatch("GET_THEME_SETTING"));
       promises.push(dispatch("GET_ACCEPT_RETRIEVE_TELEMETRY"));
-      promises.push(dispatch("GET_ENABLE_INTERROGATIVE"));
+      promises.push(dispatch("GET_EXPERIMENTAL_SETTING"));
 
       Promise.all(promises).then(() => {
         dispatch("ON_VUEX_READY");

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -40,6 +40,7 @@ export const settingStoreState: SettingStoreState = {
     availableThemes: [],
   },
   acceptRetrieveTelemetry: "Unconfirmed",
+  enableInterrogative: false,
 };
 
 export const settingStore: VoiceVoxStoreOptions<
@@ -83,6 +84,12 @@ export const settingStore: VoiceVoxStoreOptions<
         state.themeSetting.availableThemes = themes;
       }
       state.themeSetting.currentTheme = currentTheme;
+    },
+    SET_ENABLE_INTERROGATIVE(
+      state,
+      { enableInterrogative }: { enableInterrogative: boolean }
+    ) {
+      state.enableInterrogative = enableInterrogative;
     },
     SET_ACCEPT_RETRIEVE_TELEMETRY(state, { acceptRetrieveTelemetry }) {
       state.acceptRetrieveTelemetry = acceptRetrieveTelemetry;
@@ -199,6 +206,18 @@ export const settingStore: VoiceVoxStoreOptions<
       });
       window.electron.setAcceptRetrieveTelemetry(acceptRetrieveTelemetry);
       commit("SET_ACCEPT_RETRIEVE_TELEMETRY", { acceptRetrieveTelemetry });
+    },
+    GET_ENABLE_INTERROGATIVE({ dispatch }) {
+      window.electron.getEnableInterrogative().then((enableInterrogative) => {
+        console.log(
+          "getEnableInterrogative  enableInterrogative:" + enableInterrogative
+        );
+        dispatch("SET_ENABLE_INTERROGATIVE", { enableInterrogative });
+      });
+    },
+    SET_ENABLE_INTERROGATIVE({ commit }, { enableInterrogative }) {
+      window.electron.setEnableInterrogative(enableInterrogative);
+      commit("SET_ENABLE_INTERROGATIVE", { enableInterrogative });
     },
   },
 };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -40,7 +40,9 @@ export const settingStoreState: SettingStoreState = {
     availableThemes: [],
   },
   acceptRetrieveTelemetry: "Unconfirmed",
-  enableInterrogative: false,
+  experimentalSetting: {
+    enableInterrogative: false,
+  },
 };
 
 export const settingStore: VoiceVoxStoreOptions<
@@ -89,7 +91,7 @@ export const settingStore: VoiceVoxStoreOptions<
       state,
       { enableInterrogative }: { enableInterrogative: boolean }
     ) {
-      state.enableInterrogative = enableInterrogative;
+      state.experimentalSetting.enableInterrogative = enableInterrogative;
     },
     SET_ACCEPT_RETRIEVE_TELEMETRY(state, { acceptRetrieveTelemetry }) {
       state.acceptRetrieveTelemetry = acceptRetrieveTelemetry;

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -3,6 +3,7 @@ import {
   HotkeyReturnType,
   HotkeySetting,
   SavingSetting,
+  ExperimentalSetting,
   ThemeColorType,
   ThemeConf,
   ToolbarSetting,
@@ -87,11 +88,11 @@ export const settingStore: VoiceVoxStoreOptions<
       }
       state.themeSetting.currentTheme = currentTheme;
     },
-    SET_ENABLE_INTERROGATIVE(
+    SET_EXPERIMENTAL_SETTING(
       state,
-      { enableInterrogative }: { enableInterrogative: boolean }
+      { experimentalSetting }: { experimentalSetting: ExperimentalSetting }
     ) {
-      state.experimentalSetting.enableInterrogative = enableInterrogative;
+      state.experimentalSetting = experimentalSetting;
     },
     SET_ACCEPT_RETRIEVE_TELEMETRY(state, { acceptRetrieveTelemetry }) {
       state.acceptRetrieveTelemetry = acceptRetrieveTelemetry;
@@ -209,14 +210,14 @@ export const settingStore: VoiceVoxStoreOptions<
       window.electron.setAcceptRetrieveTelemetry(acceptRetrieveTelemetry);
       commit("SET_ACCEPT_RETRIEVE_TELEMETRY", { acceptRetrieveTelemetry });
     },
-    GET_ENABLE_INTERROGATIVE({ dispatch }) {
-      window.electron.getEnableInterrogative().then((enableInterrogative) => {
-        dispatch("SET_ENABLE_INTERROGATIVE", { enableInterrogative });
+    GET_EXPERIMENTAL_SETTING({ dispatch }) {
+      window.electron.getExperimentalSetting().then((experimentalSetting) => {
+        dispatch("SET_EXPERIMENTAL_SETTING", { experimentalSetting });
       });
     },
-    SET_ENABLE_INTERROGATIVE({ commit }, { enableInterrogative }) {
-      window.electron.setEnableInterrogative(enableInterrogative);
-      commit("SET_ENABLE_INTERROGATIVE", { enableInterrogative });
+    SET_EXPERIMENTAL_SETTING({ commit }, { experimentalSetting }) {
+      window.electron.setExperimentalSetting(experimentalSetting);
+      commit("SET_EXPERIMENTAL_SETTING", { experimentalSetting });
     },
   },
 };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -209,9 +209,6 @@ export const settingStore: VoiceVoxStoreOptions<
     },
     GET_ENABLE_INTERROGATIVE({ dispatch }) {
       window.electron.getEnableInterrogative().then((enableInterrogative) => {
-        console.log(
-          "getEnableInterrogative  enableInterrogative:" + enableInterrogative
-        );
         dispatch("SET_ENABLE_INTERROGATIVE", { enableInterrogative });
       });
     },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -220,7 +220,11 @@ type AudioStoreTypes = {
   };
 
   FETCH_AUDIO_QUERY: {
-    action(payload: { text: string; styleId: number }): Promise<AudioQuery>;
+    action(payload: {
+      text: string;
+      styleId: number;
+      enableInterrogative: boolean;
+    }): Promise<AudioQuery>;
   };
 
   SET_AUDIO_STYLE_ID: {
@@ -236,6 +240,7 @@ type AudioStoreTypes = {
       text: string;
       styleId: number;
       isKana?: boolean;
+      enableInterrogative?: boolean;
     }): Promise<AccentPhrase[]>;
   };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -681,6 +681,7 @@ export type SettingStoreState = {
   engineHost: string;
   themeSetting: ThemeSetting;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
+  enableInterrogative: boolean;
 };
 
 type SettingStoreTypes = {
@@ -730,6 +731,15 @@ type SettingStoreTypes = {
     action(payload: {
       acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
     }): void;
+  };
+
+  GET_ENABLE_INTERROGATIVE: {
+    action(): void;
+  };
+
+  SET_ENABLE_INTERROGATIVE: {
+    mutation: { enableInterrogative: boolean };
+    action(payload: { enableInterrogative: boolean }): void;
   };
 };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -18,6 +18,7 @@ import {
   SavingSetting,
   ThemeConf,
   ThemeSetting,
+  ExperimentalSetting,
   ToolbarSetting,
   UpdateInfo,
   Preset,
@@ -686,7 +687,7 @@ export type SettingStoreState = {
   engineHost: string;
   themeSetting: ThemeSetting;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
-  enableInterrogative: boolean;
+  experimentalSetting: ExperimentalSetting;
 };
 
 type SettingStoreTypes = {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -221,11 +221,7 @@ type AudioStoreTypes = {
   };
 
   FETCH_AUDIO_QUERY: {
-    action(payload: {
-      text: string;
-      styleId: number;
-      enableInterrogative: boolean;
-    }): Promise<AudioQuery>;
+    action(payload: { text: string; styleId: number }): Promise<AudioQuery>;
   };
 
   SET_AUDIO_STYLE_ID: {
@@ -241,7 +237,6 @@ type AudioStoreTypes = {
       text: string;
       styleId: number;
       isKana?: boolean;
-      enableInterrogative?: boolean;
     }): Promise<AccentPhrase[]>;
   };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -739,13 +739,13 @@ type SettingStoreTypes = {
     }): void;
   };
 
-  GET_ENABLE_INTERROGATIVE: {
+  GET_EXPERIMENTAL_SETTING: {
     action(): void;
   };
 
-  SET_ENABLE_INTERROGATIVE: {
-    mutation: { enableInterrogative: boolean };
-    action(payload: { enableInterrogative: boolean }): void;
+  SET_EXPERIMENTAL_SETTING: {
+    mutation: { experimentalSetting: ExperimentalSetting };
+    action(payload: { experimentalSetting: ExperimentalSetting }): void;
   };
 };
 

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -200,12 +200,12 @@ type IpcIHData = {
     ];
     return: void;
   };
-  GET_ENABLE_INTERROGATIVE: {
+  GET_EXPERIMENTAL_SETTING: {
     args: [];
-    return: boolean;
+    return: ExperimentalSetting;
   };
-  SET_ENABLE_INTERROGATIVE: {
-    args: [enableInterrogative: boolean];
+  SET_EXPERIMENTAL_SETTING: {
+    args: [experimentalSetting: ExperimentalSetting];
     return: void;
   };
 

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -200,6 +200,14 @@ type IpcIHData = {
     ];
     return: void;
   };
+  GET_ENABLE_INTERROGATIVE: {
+    args: [];
+    return: boolean;
+  };
+  SET_ENABLE_INTERROGATIVE: {
+    args: [enableInterrogative: boolean];
+    return: void;
+  };
 
   THEME: {
     args: [obj: { newData?: string }];

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -66,6 +66,8 @@ export interface Sandbox {
   setAcceptRetrieveTelemetry(
     acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus
   ): Promise<void>;
+  getEnableInterrogative(): Promise<boolean>;
+  setEnableInterrogative(enableInterrogative: boolean): Promise<void>;
   getDefaultHotkeySettings(): Promise<HotKeySetting[]>;
   theme(newData?: string): Promise<ThemeSetting | void>;
   vuexReady(): void;

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -222,3 +222,7 @@ export type ThemeSetting = {
   currentTheme: string;
   availableThemes: ThemeConf[];
 };
+
+export type ExperimentalSetting = {
+  enableInterrogative: boolean;
+};

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -66,8 +66,10 @@ export interface Sandbox {
   setAcceptRetrieveTelemetry(
     acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus
   ): Promise<void>;
-  getEnableInterrogative(): Promise<boolean>;
-  setEnableInterrogative(enableInterrogative: boolean): Promise<void>;
+  getExperimentalSetting(): Promise<ExperimentalSetting>;
+  setExperimentalSetting(
+    enableInterrogative: ExperimentalSetting
+  ): Promise<void>;
   getDefaultHotkeySettings(): Promise<HotKeySetting[]>;
   theme(newData?: string): Promise<ThemeSetting | void>;
   vuexReady(): void;

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -140,5 +140,6 @@ describe("store/vuex.js test", () => {
     assert.property(store.state.themeSetting, "availableThemes");
     assert.isEmpty(store.state.themeSetting.availableThemes);
     assert.equal(store.state.acceptRetrieveTelemetry, "Unconfirmed");
+    assert.equal(store.state.experimentalSetting.enableInterrogative, false);
   });
 });

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -58,6 +58,9 @@ describe("store/vuex.js test", () => {
         toolbarSetting: [],
         acceptRetrieveTelemetry: "Unconfirmed",
         engineHost: "http://127.0.0.1",
+        experimentalSetting: {
+          enableInterrogative: false,
+        },
       },
       getters: {
         ...uiStore.getters,


### PR DESCRIPTION

## 内容

Engineに疑問文自動調整機能が追加されたので、front側でその有効無効を調整できるようにする

## 関連 Issue
refs #608


## スクリーンショット・動画など

![interrogative-evidence](https://user-images.githubusercontent.com/939468/147084033-631093b5-d8e4-4528-8d3b-20eba94ebe6a.gif)


## その他
