### PR TITLE
Mac: ネイティブの三色ボタン（最小化・最大化・閉じるボタン）を使うように変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,8 @@ jobs:
       - name: Make disable dark mode for macOS
         if: startsWith(matrix.os, 'macos-')
         shell: bash
-        run: "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' "${{ matrix.artifact_path }}/${{ matrix.artifact_name }}/Contents/Info.plist"
+        run: |
+          "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' '${{ matrix.artifact_path }}/${{ matrix.artifact_name }}/Contents/Info.plist'
 
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,12 +236,6 @@ jobs:
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: npm run electron:build_pnever -- --dir
 
-      - name: Make disable dark mode for macOS
-        if: startsWith(matrix.os, 'macos-')
-        shell: bash
-        run: |
-          "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' '${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Info.plist'
-
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
         run: npm run electron:build_pnever -- --dir
 
       - name: Make disable dark mode for macOS
-        if: startsWith(matrix.os, "macos-")
+        if: startsWith(matrix.os, 'macos-')
         shell: bash
         run: "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' "${{ matrix.artifact_path }}/${{ matrix.artifact_name }}/Contents/Info.plist"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
         if: startsWith(matrix.os, 'macos-')
         shell: bash
         run: |
-          "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' '${{ matrix.artifact_path }}/${{ matrix.macos_artifact_name }}/Contents/Info.plist'
+          "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' '${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Info.plist'
 
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,6 +236,11 @@ jobs:
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: npm run electron:build_pnever -- --dir
 
+      - name: Make disable dark mode for macOS
+        if: startsWith(matrix.os, "macos-")
+        shell: bash
+        run: "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' "${{ matrix.artifact_path }}/${{ matrix.artifact_name }}/Contents/Info.plist"
+
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
         if: startsWith(matrix.os, 'macos-')
         shell: bash
         run: |
-          "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' '${{ matrix.artifact_path }}/${{ matrix.artifact_name }}/Contents/Info.plist'
+          "${{ matrix.sed_name }}" -i 's/<key>NSRequiresAquaSystemAppearance<\/key><false\/>/<key>NSRequiresAquaSystemAppearance<\/key><true\/>/' '${{ matrix.artifact_path }}/${{ matrix.macos_artifact_name }}/Contents/Info.plist'
 
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2

--- a/src/background.ts
+++ b/src/background.ts
@@ -457,7 +457,7 @@ async function createWindow() {
   }
   if (isDevelopment) win.webContents.openDevTools();
 
-  nativeTheme.themeSource = "light";
+  if (isMac) nativeTheme.themeSource = "light";
 
   win.on("maximize", () => win.webContents.send("DETECT_MAXIMIZED"));
   win.on("unmaximize", () => win.webContents.send("DETECT_UNMAXIMIZED"));

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,7 +5,15 @@ import dotenv from "dotenv";
 import treeKill from "tree-kill";
 import Store from "electron-store";
 
-import { app, protocol, BrowserWindow, dialog, Menu, shell, nativeTheme } from "electron";
+import {
+  app,
+  protocol,
+  BrowserWindow,
+  dialog,
+  Menu,
+  shell,
+  nativeTheme,
+} from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
 import installExtension, { VUEJS3_DEVTOOLS } from "electron-devtools-installer";
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -427,6 +427,8 @@ async function createWindow() {
     width: 800,
     height: 600,
     frame: false,
+    titleBarStyle: "hidden",
+    trafficLightPosition: { x: 6, y: 4 },
     minWidth: 320,
     show: false,
     webPreferences: {
@@ -449,6 +451,12 @@ async function createWindow() {
 
   win.on("maximize", () => win.webContents.send("DETECT_MAXIMIZED"));
   win.on("unmaximize", () => win.webContents.send("DETECT_UNMAXIMIZED"));
+  win.on("enter-full-screen", () =>
+    win.webContents.send("DETECT_ENTER_FULLSCREEN")
+  );
+  win.on("leave-full-screen", () =>
+    win.webContents.send("DETECT_LEAVE_FULLSCREEN")
+  );
   win.on("always-on-top-changed", () => {
     win.webContents.send(
       win.isAlwaysOnTop() ? "DETECT_PINNED" : "DETECT_UNPINNED"

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,7 +5,7 @@ import dotenv from "dotenv";
 import treeKill from "tree-kill";
 import Store from "electron-store";
 
-import { app, protocol, BrowserWindow, dialog, Menu, shell } from "electron";
+import { app, protocol, BrowserWindow, dialog, Menu, shell, nativeTheme } from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
 import installExtension, { VUEJS3_DEVTOOLS } from "electron-devtools-installer";
 
@@ -448,6 +448,8 @@ async function createWindow() {
     win.loadURL("app://./index.html#/home");
   }
   if (isDevelopment) win.webContents.openDevTools();
+
+  nativeTheme.themeSource = "light";
 
   win.on("maximize", () => win.webContents.send("DETECT_MAXIMIZED"));
   win.on("unmaximize", () => win.webContents.send("DETECT_UNMAXIMIZED"));

--- a/src/background.ts
+++ b/src/background.ts
@@ -457,6 +457,7 @@ async function createWindow() {
   }
   if (isDevelopment) win.webContents.openDevTools();
 
+  // Macではdarkモードかつウィンドウが非アクティブのときに閉じるボタンなどが見えなくなるので、lightモードに固定
   if (isMac) nativeTheme.themeSource = "light";
 
   win.on("maximize", () => win.webContents.send("DETECT_MAXIMIZED"));

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -1,6 +1,9 @@
 <template>
   <q-bar class="bg-background q-pa-none relative-position">
-    <min-max-close-buttons v-if="$q.platform.is.mac" />
+    <div
+      v-if="$q.platform.is.mac && !isFullscreen"
+      class="mac-traffic-light-space"
+    ></div>
     <img v-else src="icon.png" class="window-logo" alt="application logo" />
     <menu-button
       v-for="(root, index) of menudata"
@@ -30,7 +33,6 @@
 <script lang="ts">
 import { defineComponent, ref, computed, ComputedRef, watch } from "vue";
 import { useStore } from "@/store";
-import MinMaxCloseButtons from "@/components/MinMaxCloseButtons.vue";
 import MenuButton from "@/components/MenuButton.vue";
 import TitleBarButtons from "@/components/TitleBarButtons.vue";
 import { useQuasar } from "quasar";
@@ -75,7 +77,6 @@ export default defineComponent({
   name: "MenuBar",
 
   components: {
-    MinMaxCloseButtons,
     MenuButton,
     TitleBarButtons,
   },
@@ -91,6 +92,7 @@ export default defineComponent({
     const menubarLocked = computed(() => store.getters.MENUBAR_LOCKED);
     const projectName = computed(() => store.getters.PROJECT_NAME);
     const isEdited = computed(() => store.getters.IS_EDITED);
+    const isFullscreen = computed(() => store.getters.IS_FULLSCREEN);
 
     const createNewProject = async () => {
       if (!uiLocked.value) {
@@ -359,6 +361,7 @@ export default defineComponent({
       menubarLocked,
       projectName,
       isEdited,
+      isFullscreen,
       subMenuOpenFlags,
       reassignSubMenuOpen,
       menudata,
@@ -397,5 +400,9 @@ export default defineComponent({
   margin-right: 10%;
   text-overflow: ellipsis;
   overflow: hidden;
+}
+
+.mac-traffic-light-space {
+  margin-right: 70px;
 }
 </style>

--- a/src/plugins/ipcMessageReceiverPlugin.ts
+++ b/src/plugins/ipcMessageReceiverPlugin.ts
@@ -34,6 +34,14 @@ export const ipcMessageReceiver: Plugin = {
       options.store.dispatch("DETECT_UNPINNED");
     });
 
+    window.electron.onReceivedIPCMsg("DETECT_ENTER_FULLSCREEN", () =>
+      options.store.dispatch("DETECT_ENTER_FULLSCREEN")
+    );
+
+    window.electron.onReceivedIPCMsg("DETECT_LEAVE_FULLSCREEN", () =>
+      options.store.dispatch("DETECT_LEAVE_FULLSCREEN")
+    );
+
     window.electron.onReceivedIPCMsg("CHECK_EDITED_AND_NOT_SAVE", () => {
       options.store.dispatch("CHECK_EDITED_AND_NOT_SAVE");
     });

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -753,6 +753,7 @@ export type UiStoreState = {
   isAcceptRetrieveTelemetryDialogOpen: boolean;
   isMaximized: boolean;
   isPinned: boolean;
+  isFullscreen: boolean;
 };
 
 type UiStoreTypes = {
@@ -857,6 +858,20 @@ type UiStoreTypes = {
   DETECT_UNPINNED: {
     mutation: undefined;
     action(): void;
+  };
+
+  DETECT_ENTER_FULLSCREEN: {
+    mutation: undefined;
+    action(): void;
+  };
+
+  DETECT_LEAVE_FULLSCREEN: {
+    mutation: undefined;
+    action(): void;
+  };
+
+  IS_FULLSCREEN: {
+    getter: boolean;
   };
 
   CHECK_EDITED_AND_NOT_SAVE: {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -38,6 +38,7 @@ export const uiStoreState: UiStoreState = {
   isAcceptRetrieveTelemetryDialogOpen: false,
   isMaximized: false,
   isPinned: false,
+  isFullscreen: false,
 };
 
 export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
@@ -51,6 +52,9 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
       },
       SHOULD_SHOW_PANES(_, getters) {
         return getters.ACTIVE_AUDIO_KEY != undefined;
+      },
+      IS_FULLSCREEN(state) {
+        return state.isFullscreen;
       },
     },
 
@@ -117,6 +121,12 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
       },
       DETECT_UNPINNED(state) {
         state.isPinned = false;
+      },
+      DETECT_ENTER_FULLSCREEN(state) {
+        state.isFullscreen = true;
+      },
+      DETECT_LEAVE_FULLSCREEN(state) {
+        state.isFullscreen = false;
       },
     },
 
@@ -265,6 +275,12 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
       },
       async DETECT_UNPINNED({ commit }) {
         commit("DETECT_UNPINNED");
+      },
+      async DETECT_ENTER_FULLSCREEN({ commit }) {
+        commit("DETECT_ENTER_FULLSCREEN");
+      },
+      async DETECT_LEAVE_FULLSCREEN({ commit }) {
+        commit("DETECT_LEAVE_FULLSCREEN");
       },
       async CHECK_EDITED_AND_NOT_SAVE({ getters }) {
         if (getters.IS_EDITED) {

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -246,6 +246,16 @@ type IpcSOData = {
     return: void;
   };
 
+  DETECT_ENTER_FULLSCREEN: {
+    args: [];
+    return: void;
+  };
+
+  DETECT_LEAVE_FULLSCREEN: {
+    args: [];
+    return: void;
+  };
+
   CHECK_EDITED_AND_NOT_SAVE: {
     args: [];
     return: void;

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -52,6 +52,7 @@ describe("store/vuex.js test", () => {
           availableThemes: [],
         },
         isPinned: false,
+        isFullscreen: false,
         presetItems: {},
         presetKeys: [],
         hotkeySettings: [],


### PR DESCRIPTION
## 内容

Mac 版の三色ボタンを自前のもの（`<min-max-close-buttons />`）から OS ネイティブのものに変更します。

Mac 版の三色ボタンはこれまでネイティブのものではなく、挙動を真似たものを自前で用意していました。しかし、マウスオーバーしたときにボタンの役割を説明する模様が表示されないなど、ネイティブのボタンに比べて機能が欠けていたり異なっていたりしました。

## 関連 Issue

ref #572 

## スクリーンショット・動画など

https://user-images.githubusercontent.com/41382894/147450662-9144f742-0e12-48c6-ad8e-ff43c1161825.mov

## その他

- フルスクリーンにした時は三色ボタンが画面外に移動するため、三色ボタンのためにメニューバーに空けたスペースが余分になってしまいます。かといってスペースを除去するだけだとデザイン的に寂しくなったので、他の OS 版と同様に VOICEVOX アイコンを表示するようにしています。
- 今回の変更が採用される場合、`<min-max-close-buttons />` の Mac 向けの条件分岐が余分になります。これを削除するかどうか迷っています。
  - 今回の変更に伴って、閉じるボタンを押した時の終了処理に致命的な影響はなさそうでしたが、Mac 版と他の OS 版でやや異なる手順を踏むようになりました（具体的には、今までの仕様では閉じるボタンで直接 `CHECK_EDITED_AND_NOT_SAVE` イベントを起こしますが、今回の変更で Mac 版だけ、まず electron のアプリ終了関連のイベントが呼ばれます。`before-quit` イベントの中で結局 `CHECK_EDITED_AND_NOT_SAVE` イベントを起こしているので問題ないようになっています）。
  - 今回は問題ないものの、将来的に終了処理まわりで何らかの変更が入った時に Mac 版で挙動がおかしくなるケースがありうるため、その時の臨時の対応策として Mac 版の三色ボタンを自前で用意する手段も残しておいた方が良いのかもしれないと思いました（他の OS 版と同じコンポーネントを使うので、姑息的に同じ挙動を実現しやすくなります）。
  - そのまま残しておいても問題ないと思いますが、後からソースコードを読んだときに使われていないコードが入っていることで混乱するなど、デメリットが大きそうであれば該当部分をコメントアウトするなどの対応をとりたいと思います。
