### PR TITLE
Mac: ネイティブUI部分の日本語化

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,6 +396,15 @@ jobs:
           asar pack "${{ matrix.app_asar_dir }}/app" "${{ matrix.app_asar_dir }}/app.asar"
           rm -rf "${{ matrix.app_asar_dir }}/app"
 
+      # NOTE: Normally, you should be able to set the language settings for macOS
+      #       by setting mac.electronLaunguages in the electronBuilder section of
+      #       vue.config.js. However, for some reason, it doesn't work.
+      #       As a workaround, you can manually create a directory for language settings.
+      - name: Make .lproj files in Resources directory of VOICEVOX.app
+        if: startsWith(matrix.artifact_name, 'macos-')
+        shell: bash
+        run: mkdir prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
+
       - name: Merge VOICEVOX ENGINE into prepackage/
         if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'linux-')
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,15 +396,6 @@ jobs:
           asar pack "${{ matrix.app_asar_dir }}/app" "${{ matrix.app_asar_dir }}/app.asar"
           rm -rf "${{ matrix.app_asar_dir }}/app"
 
-      # NOTE: Normally, you should be able to set the language settings for macOS
-      #       by setting mac.electronLaunguages in the electronBuilder section of
-      #       vue.config.js. However, for some reason, it doesn't work.
-      #       As a workaround, you can manually create a directory for language settings.
-      - name: Make .lproj directories in Resources directory of VOICEVOX.app
-        if: startsWith(matrix.artifact_name, 'macos-')
-        shell: bash
-        run: mkdir prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
-
       - name: Merge VOICEVOX ENGINE into prepackage/
         if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'linux-')
         shell: bash
@@ -448,6 +439,13 @@ jobs:
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Plugin).app/Contents/MacOS/VOICEVOX Helper (Plugin)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Renderer).app/Contents/MacOS/VOICEVOX Helper (Renderer)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper.app/Contents/MacOS/VOICEVOX Helper"
+
+      # NOTE: actions/upload-artifact@v2 does not upload `**.lproj` directories, which are an empty directory.
+      #       Make `ja.lproj` directory because it is necessary for Japanese localization on macOS.
+      - name: Make .lproj directories in Resources directory of VOICEVOX.app
+        if: startsWith(matrix.artifact_name, 'macos-')
+        shell: bash
+        run: mkdir -p prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
 
       - name: Set BUILD_IDENTIFIER env var
         if: startsWith(matrix.artifact_name, 'linux-') # linux
@@ -610,6 +608,13 @@ jobs:
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Plugin).app/Contents/MacOS/VOICEVOX Helper (Plugin)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Renderer).app/Contents/MacOS/VOICEVOX Helper (Renderer)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper.app/Contents/MacOS/VOICEVOX Helper"
+
+      # NOTE: actions/upload-artifact@v2 does not upload `**.lproj` directories, which are an empty directory.
+      #       Make `ja.lproj` directory because it is necessary for Japanese localization on macOS.
+      - name: Make .lproj directories in Resources directory of VOICEVOX.app
+        if: endsWith(matrix.artifact_name, '-dmg')
+        shell: bash
+        run: mkdir -p prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
 
       - name: Show disk space (debug info)
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,6 +236,15 @@ jobs:
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: npm run electron:build_pnever -- --dir
 
+      # NOTE: Normally, you should be able to set the language settings for macOS
+      #       by setting mac.electronLaunguages in the electronBuilder section of
+      #       vue.config.js. However, for some reason, it doesn't work.
+      #       As a workaround, you can manually create a directory for language settings.
+      - name: Make .lproj files in Resources directory of VOICEVOX.app
+        if: startsWith(matrix.os, 'macos-')
+        shell: bash
+        run: mkdir "${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Resources/ja.lproj" "${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Resources/en.lproj"
+
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2
         with:
@@ -395,15 +404,6 @@ jobs:
           # Repack asar
           asar pack "${{ matrix.app_asar_dir }}/app" "${{ matrix.app_asar_dir }}/app.asar"
           rm -rf "${{ matrix.app_asar_dir }}/app"
-
-      # NOTE: Normally, you should be able to set the language settings for macOS
-      #       by setting mac.electronLaunguages in the electronBuilder section of
-      #       vue.config.js. However, for some reason, it doesn't work.
-      #       As a workaround, you can manually create a directory for language settings.
-      - name: Make .lproj files in Resources directory of VOICEVOX.app
-        if: startsWith(matrix.artifact_name, 'macos-')
-        shell: bash
-        run: mkdir prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
 
       - name: Merge VOICEVOX ENGINE into prepackage/
         if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'linux-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,15 +236,6 @@ jobs:
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: npm run electron:build_pnever -- --dir
 
-      # NOTE: Normally, you should be able to set the language settings for macOS
-      #       by setting mac.electronLaunguages in the electronBuilder section of
-      #       vue.config.js. However, for some reason, it doesn't work.
-      #       As a workaround, you can manually create a directory for language settings.
-      - name: Make .lproj directories in Resources directory of VOICEVOX.app
-        if: startsWith(matrix.os, 'macos-')
-        shell: bash
-        run: mkdir "${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Resources/ja.lproj" "${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Resources/en.lproj"
-
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2
         with:
@@ -404,6 +395,15 @@ jobs:
           # Repack asar
           asar pack "${{ matrix.app_asar_dir }}/app" "${{ matrix.app_asar_dir }}/app.asar"
           rm -rf "${{ matrix.app_asar_dir }}/app"
+
+      # NOTE: Normally, you should be able to set the language settings for macOS
+      #       by setting mac.electronLaunguages in the electronBuilder section of
+      #       vue.config.js. However, for some reason, it doesn't work.
+      #       As a workaround, you can manually create a directory for language settings.
+      - name: Make .lproj directories in Resources directory of VOICEVOX.app
+        if: startsWith(matrix.artifact_name, 'macos-')
+        shell: bash
+        run: mkdir prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
 
       - name: Merge VOICEVOX ENGINE into prepackage/
         if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'linux-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
       #       by setting mac.electronLaunguages in the electronBuilder section of
       #       vue.config.js. However, for some reason, it doesn't work.
       #       As a workaround, you can manually create a directory for language settings.
-      - name: Make .lproj files in Resources directory of VOICEVOX.app
+      - name: Make .lproj directories in Resources directory of VOICEVOX.app
         if: startsWith(matrix.os, 'macos-')
         shell: bash
         run: mkdir "${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Resources/ja.lproj" "${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Resources/en.lproj"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,16 +236,6 @@ jobs:
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: npm run electron:build_pnever -- --dir
 
-      - name: Confirm ja.lproj directory existing
-        if: startsWith(matrix.os, 'macos-')
-        shell: bash
-        run: |
-          if [ -d "${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Resources/ja.lproj" ]; then
-            echo "ja.lproj dir exists."
-          else
-            echo "ja.lproj dir does not exist."
-          fi
-
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2
         with:
@@ -347,16 +337,6 @@ jobs:
         with:
           name: ${{ matrix.noengine_artifact_name }}
           path: ./prepackage
-
-      - name: Confirm ja.lproj directory existing
-        if: startsWith(matrix.artifact_name, 'macos-')
-        shell: bash
-        run: |
-          if [ -d "${{ matrix.app_asar_dir }}/ja.lproj" ]; then
-            echo "ja.lproj dir exists."
-          else
-            echo "ja.lproj dir does not exist."
-          fi
 
       # Download VOICEVOX ENGINE
       - name: Create directory voicevox_engine/download

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,6 +236,16 @@ jobs:
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: npm run electron:build_pnever -- --dir
 
+      - name: Confirm ja.lproj directory existing
+        if: startsWith(matrix.os, 'macos-')
+        shell: bash
+        run: |
+          if [ -d "${{ matrix.artifact_path }}/VOICEVOX.app/Contents/Resources/ja.lproj" ]; then
+            echo "ja.lproj dir exists."
+          else
+            echo "ja.lproj dir does not exist."
+          fi
+
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2
         with:
@@ -337,6 +347,16 @@ jobs:
         with:
           name: ${{ matrix.noengine_artifact_name }}
           path: ./prepackage
+
+      - name: Confirm ja.lproj directory existing
+        if: startsWith(matrix.artifact_name, 'macos-')
+        shell: bash
+        run: |
+          if [ -d "${{ matrix.app_asar_dir }}/ja.lproj" ]; then
+            echo "ja.lproj dir exists."
+          else
+            echo "ja.lproj dir does not exist."
+          fi
 
       # Download VOICEVOX ENGINE
       - name: Create directory voicevox_engine/download

--- a/vue.config.js
+++ b/vue.config.js
@@ -100,6 +100,7 @@ module.exports = {
               arch: ["x64"],
             },
           ],
+          electronLanguages: ["ja", "en"],
         },
         dmg: {
           icon: "public/icon-dmg.icns",

--- a/vue.config.js
+++ b/vue.config.js
@@ -100,7 +100,6 @@ module.exports = {
               arch: ["x64"],
             },
           ],
-          electronLanguages: ["ja", "en"],
         },
         dmg: {
           icon: "public/icon-dmg.icns",


### PR DESCRIPTION
## 内容

Mac 版でネイティブ UI の部分（閉じるボタンにマウスオーバーして表示されるポップアップや、保存ダイアログなど）が英語になる問題がありました。日本語になるように修正します。

（この問題の原因と対策についての詳細は https://github.com/VOICEVOX/voicevox/issues/624#issuecomment-1002880923 に書きました。）

## 関連 Issue

close #624 

## その他

~~`actions/upload_artifact@v2` が空のディレクトリ `ja.lproj` をアップロードできる簡単な方法があれば、そちらの方が良い解決法だと思うので、詳しい方がいらっしゃれば教えていただければとても助かります。~~

`actions/upload_artifact@v2` のアップロード機能は [@actions/artifact](https://github.com/actions/toolkit/tree/main/packages/artifact) の `uploadArtifact` 関数の仕様に依存しているのですが、この関数がアップロード項目としてファイルのみをサポートしているため、原理的に無理のようです。アップロード結果の `artifactItems` について以下のように書かれています：

> A list of all files that describe what is uploaded if there are no errors encountered. Usually this will be equal to the inputted files with the exception of empty directories (will not be uploaded)

cf. https://github.com/actions/toolkit/tree/main/packages/artifact#upload-an-artifact