### PR TITLE
起動時に一瞬真っ白になるのを防ぐ

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -6,10 +6,19 @@
 
     <q-page-container>
       <q-page class="main-row-panes">
-        <div v-if="engineState === 'STARTING'" class="waiting-engine">
+        <div
+          v-if="!readyUserOperation || engineState === 'STARTING'"
+          class="waiting-engine"
+        >
           <div>
             <q-spinner color="primary" size="2.5rem" />
-            <div>エンジン起動中・・・</div>
+            <div class="q-mt-xs">
+              {{
+                engineState === "STARTING"
+                  ? "エンジン起動中・・・"
+                  : "データ準備中・・・"
+              }}
+            </div>
           </div>
         </div>
         <q-splitter
@@ -379,6 +388,7 @@ export default defineComponent({
       audioCellRefs[audioKey].focusTextField();
     };
 
+    // Electronのデフォルトのundo/redoを無効化
     const disableDefaultUndoRedo = (event: KeyboardEvent) => {
       // ctrl+z, ctrl+shift+z, ctrl+y
       if (
@@ -389,7 +399,8 @@ export default defineComponent({
       }
     };
 
-    // プロジェクトを初期化
+    // ソフトウェアを初期化
+    const readyUserOperation = ref(false);
     onMounted(async () => {
       await store.dispatch("START_WAITING_ENGINE");
       await store.dispatch("LOAD_CHARACTER");
@@ -404,6 +415,7 @@ export default defineComponent({
         );
       }
       isDefaultStyleSelectDialogOpenComputed.value = isUnsetDefaultStyleIds;
+
       const audioItem: AudioItem = await store.dispatch(
         "GENERATE_AUDIO_ITEM",
         {}
@@ -423,6 +435,8 @@ export default defineComponent({
         store.state.acceptRetrieveTelemetry === "Unconfirmed";
       const gtm = useGtm();
       gtm?.enable(store.state.acceptRetrieveTelemetry === "Accepted");
+
+      readyUserOperation.value = true;
     });
 
     // エンジン待機
@@ -524,6 +538,7 @@ export default defineComponent({
       audioDetailPaneHeight,
       audioDetailPaneMinHeight,
       audioDetailPaneMaxHeight,
+      readyUserOperation,
       engineState,
       isHelpDialogOpenComputed,
       isSettingDialogOpenComputed,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -7,7 +7,7 @@
     <q-page-container>
       <q-page class="main-row-panes">
         <div
-          v-if="!readyUserOperation || engineState === 'STARTING'"
+          v-if="!isCompletedInitialStartup || engineState === 'STARTING'"
           class="waiting-engine"
         >
           <div>
@@ -400,7 +400,7 @@ export default defineComponent({
     };
 
     // ソフトウェアを初期化
-    const readyUserOperation = ref(false);
+    const isCompletedInitialStartup = ref(false);
     onMounted(async () => {
       await store.dispatch("START_WAITING_ENGINE");
       await store.dispatch("LOAD_CHARACTER");
@@ -436,7 +436,7 @@ export default defineComponent({
       const gtm = useGtm();
       gtm?.enable(store.state.acceptRetrieveTelemetry === "Accepted");
 
-      readyUserOperation.value = true;
+      isCompletedInitialStartup.value = true;
     });
 
     // エンジン待機
@@ -538,7 +538,7 @@ export default defineComponent({
       audioDetailPaneHeight,
       audioDetailPaneMinHeight,
       audioDetailPaneMaxHeight,
-      readyUserOperation,
+      isCompletedInitialStartup,
       engineState,
       isHelpDialogOpenComputed,
       isSettingDialogOpenComputed,


### PR DESCRIPTION
## 内容

起動時に一瞬真っ白になるのを防ぎます。
エンジン起動が完了するとインジケータが消えていたのですが、実際はエンジン起動後にキャラクターロードが完了したあとにUIが表示されるので、その間真っ白になっていたのが原因でした。

なので、キャラクターロードなどが完了したあとにUIが表示されるようにしました。

## 関連 Issue

close #637 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

engineState以外にisCompletedInitialStartupという制御変数を設けました。
engineStateはエンジン再起動時にも参照されます。
