### PR TITLE
複数エンジン対応: RESTART_ENGINEを関数に切り出し（リファクタリング）

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -380,6 +380,60 @@ async function runEngine() {
   });
 }
 
+async function restartEngine() {
+  await new Promise<void>((resolve, reject) => {
+    log.info(
+      `Restarting ENGINE (last exit code: ${engineProcess.exitCode}, signal: ${engineProcess.signalCode})`
+    );
+
+    // エンジンのプロセスがすでに終了している、またはkillされている場合
+    const engineExited = engineProcess.exitCode !== null;
+    const engineKilled = engineProcess.signalCode !== null;
+
+    if (engineExited || engineKilled) {
+      log.info(
+        "ENGINE process is not started yet or already killed. Starting ENGINE..."
+      );
+
+      runEngine();
+      resolve();
+      return;
+    }
+
+    // エンジンエラー時のエラーウィンドウ抑制用。
+    willQuitEngine = true;
+
+    // 「killに使用するコマンドが終了するタイミング」と「OSがプロセスをkillするタイミング」が違うので単純にtreeKillのコールバック関数でrunEngine()を実行すると失敗します。
+    // closeイベントはexitイベントよりも後に発火します。
+    const restartEngineOnProcessClosedCallback = () => {
+      log.info("ENGINE process killed. Restarting ENGINE...");
+
+      runEngine();
+      resolve();
+    };
+    engineProcess.once("close", restartEngineOnProcessClosedCallback);
+
+    // treeKillのコールバック関数はコマンドが終了した時に呼ばれます。
+    log.info(`Killing current ENGINE process (PID=${engineProcess.pid})...`);
+    treeKill(engineProcess.pid, (error) => {
+      // error変数の値がundefined以外であればkillコマンドが失敗したことを意味します。
+      if (error != null) {
+        log.error("Failed to kill ENGINE");
+        log.error(error);
+
+        // killに失敗したとき、closeイベントが発生せず、once listenerが消費されない
+        // listenerを削除してENGINEの意図しない再起動を防止
+        engineProcess.removeListener(
+          "close",
+          restartEngineOnProcessClosedCallback
+        );
+
+        reject();
+      }
+    });
+  });
+}
+
 // temp dir
 const tempDir = path.join(app.getPath("temp"), "VOICEVOX");
 if (!fs.existsSync(tempDir)) {
@@ -717,61 +771,9 @@ ipcMainHandle("LOG_INFO", (_, ...params) => {
  * エンジンを再起動する。
  * エンジンの起動が開始したらresolve、起動が失敗したらreject。
  */
-ipcMainHandle(
-  "RESTART_ENGINE",
-  () =>
-    new Promise<void>((resolve, reject) => {
-      log.info(
-        `Restarting ENGINE (last exit code: ${engineProcess.exitCode}, signal: ${engineProcess.signalCode})`
-      );
-
-      // エンジンのプロセスがすでに終了している、またはkillされている場合
-      const engineExited = engineProcess.exitCode !== null;
-      const engineKilled = engineProcess.signalCode !== null;
-
-      if (engineExited || engineKilled) {
-        log.info(
-          "ENGINE process is not started yet or already killed. Starting ENGINE..."
-        );
-
-        runEngine();
-        resolve();
-        return;
-      }
-
-      // エンジンエラー時のエラーウィンドウ抑制用。
-      willQuitEngine = true;
-
-      // 「killに使用するコマンドが終了するタイミング」と「OSがプロセスをkillするタイミング」が違うので単純にtreeKillのコールバック関数でrunEngine()を実行すると失敗します。
-      // closeイベントはexitイベントよりも後に発火します。
-      const restartEngineOnProcessClosedCallback = () => {
-        log.info("ENGINE process killed. Restarting ENGINE...");
-
-        runEngine();
-        resolve();
-      };
-      engineProcess.once("close", restartEngineOnProcessClosedCallback);
-
-      // treeKillのコールバック関数はコマンドが終了した時に呼ばれます。
-      log.info(`Killing current ENGINE process (PID=${engineProcess.pid})...`);
-      treeKill(engineProcess.pid, (error) => {
-        // error変数の値がundefined以外であればkillコマンドが失敗したことを意味します。
-        if (error != null) {
-          log.error("Failed to kill ENGINE");
-          log.error(error);
-
-          // killに失敗したとき、closeイベントが発生せず、once listenerが消費されない
-          // listenerを削除してENGINEの意図しない再起動を防止
-          engineProcess.removeListener(
-            "close",
-            restartEngineOnProcessClosedCallback
-          );
-
-          reject();
-        }
-      });
-    })
-);
+ipcMainHandle("RESTART_ENGINE", async () => {
+  await restartEngine();
+});
 
 ipcMainHandle("SAVING_SETTING", (_, { newData }) => {
   if (newData !== undefined) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -59,7 +59,10 @@ if (isDevelopment) {
 let win: BrowserWindow;
 
 // 多重起動防止
-if (!isDevelopment && !app.requestSingleInstanceLock()) app.quit();
+if (!isDevelopment && !app.requestSingleInstanceLock()) {
+  log.info("VOICEVOX already running. Cancelling launch");
+  app.quit();
+}
 
 process.on("uncaughtException", (error) => {
   log.error(error);

--- a/src/background.ts
+++ b/src/background.ts
@@ -339,7 +339,6 @@ async function runEngine() {
     store.set("inheritAudioInfo", true);
   }
   const useGpu = store.get("useGpu");
-  // const inheritAudioInfo = store.get("inheritAudioInfo");
 
   log.info(`Starting ENGINE`);
   log.info(`ENGINE mode: ${useGpu ? "GPU" : "CPU"}`);

--- a/src/background.ts
+++ b/src/background.ts
@@ -891,6 +891,7 @@ app.on("web-contents-created", (e, contents) => {
 });
 
 app.on("window-all-closed", () => {
+  log.info("All windows closed. Quitting app");
   app.quit();
 });
 
@@ -967,6 +968,7 @@ if (isDevelopment) {
   if (process.platform === "win32") {
     process.on("message", (data) => {
       if (data === "graceful-exit") {
+        log.info("Received graceful-exit");
         app.quit();
       }
     });

--- a/src/background.ts
+++ b/src/background.ts
@@ -339,7 +339,7 @@ async function runEngine() {
     store.set("inheritAudioInfo", true);
   }
   const useGpu = store.get("useGpu");
-  const inheritAudioInfo = store.get("inheritAudioInfo");
+  // const inheritAudioInfo = store.get("inheritAudioInfo");
 
   log.info(`Starting ENGINE`);
   log.info(`ENGINE mode: ${useGpu ? "GPU" : "CPU"}`);

--- a/src/background.ts
+++ b/src/background.ts
@@ -341,7 +341,8 @@ async function runEngine() {
   const useGpu = store.get("useGpu");
   const inheritAudioInfo = store.get("inheritAudioInfo");
 
-  log.info(`Starting ENGINE in ${useGpu ? "GPU" : "CPU"} mode`);
+  log.info(`Starting ENGINE`);
+  log.info(`ENGINE mode: ${useGpu ? "GPU" : "CPU"}`);
 
   // エンジンプロセスの起動
   const enginePath = path.resolve(
@@ -350,21 +351,24 @@ async function runEngine() {
   );
   const args = useGpu ? ["--use_gpu"] : [];
 
+  log.info(`ENGINE path: ${enginePath}`);
+  log.info(`ENGINE args: ${JSON.stringify(args)}`);
+
   engineProcess = spawn(enginePath, args, {
     cwd: path.dirname(enginePath),
   });
 
   engineProcess.stdout?.on("data", (data) => {
-    log.info("ENGINE: " + data.toString("utf-8"));
+    log.info(`ENGINE: ${data.toString("utf-8")}`);
   });
 
   engineProcess.stderr?.on("data", (data) => {
-    log.error("ENGINE: " + data.toString("utf-8"));
+    log.error(`ENGINE: ${data.toString("utf-8")}`);
   });
 
   engineProcess.on("close", (code, signal) => {
-    log.info(`ENGINE: terminated due to receipt of signal ${signal}`);
-    log.info(`ENGINE: exited with code ${code}`);
+    log.info(`ENGINE: process terminated due to receipt of signal ${signal}`);
+    log.info(`ENGINE: process exited with code ${code}`);
 
     if (!willQuitEngine) {
       ipcMainSend(win, "DETECTED_ENGINE_ERROR");


### PR DESCRIPTION
## 内容

background側（メインプロセス）のRESTART_ENGINEを関数に切り出します。

複数エンジン対応時に、再起動するエンジンを指定する引数を追加、全エンジンを再起動する関数を作成するつもりです。

## 関連 Issue

- ref #609

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
