### PR TITLE
zipファイルをreleaseにアップロードする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -843,7 +843,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }} # == github.event.release.tag_name
           file_glob: true
-          file: artifact/*.targz
+          file: artifact/*.tar.gz
 
       # zip
       - name: Upload zip to Release assets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,6 +273,7 @@ jobs:
             voicevox_engine_asset_name: linux-nvidia
             linux_executable_name: voicevox
             targz_name: VOICEVOX
+            zip_name: voicevox-linux-nvidia
             app_asar_dir: prepackage/resources
           # Linux CPU
           - artifact_name: linux-cpu-prepackage
@@ -280,23 +281,26 @@ jobs:
             voicevox_engine_asset_name: linux-cpu
             linux_executable_name: voicevox
             targz_name: VOICEVOX-CPU
+            zip_name: voicevox-linux-cpu
             app_asar_dir: prepackage/resources
           # Windows NVIDIA GPU
           - artifact_name: windows-nvidia-prepackage
             noengine_artifact_name: windows-noengine-prepackage
             voicevox_engine_asset_name: windows-nvidia
+            zip_name: voicevox-windows-nvidia
             app_asar_dir: prepackage/resources
           # Windows CPU
           - artifact_name: windows-cpu-prepackage
             noengine_artifact_name: windows-noengine-cpu-prepackage
             voicevox_engine_asset_name: windows-cpu
+            zip_name: voicevox-windows-cpu
             app_asar_dir: prepackage/resources
           # macOS CPU
           - artifact_name: macos-cpu-prepackage
             noengine_artifact_name: macos-noengine-cpu-prepackage
             voicevox_engine_asset_name: macos-x64
             macos_executable_name: VOICEVOX
-            zip_name: voicevox-cpu-macos-x64
+            zip_name: voicevox-macos-cpu
             app_asar_dir: prepackage/VOICEVOX.app/Contents/Resources
 
     runs-on: ${{ matrix.os }}
@@ -455,48 +459,13 @@ jobs:
         run: |
           echo "BUILD_IDENTIFIER=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
-      # Create tar.gz for Linux
-      #
-      # Due to GitHub Actions limitation (https://github.com/actions/upload-artifact/issues/38),
-      # file permissions are lost in actions/upload-artifact.
-      # To distribute binaries (voicevox, run) with execute permission,
-      # we need to pack all the files in tarball (tar.gz) before uploading.
-      # https://github.com/actions/upload-artifact/blob/11e311c8b504ea40cbed20583a64d75b4735cff3/README.md#maintaining-file-permissions-and-case-sensitive-files
-      #
-      # voicevox-x.x.x.tar.gz
-      # - VOICEVOX/
-      #   - voicevox
-      #   - run
-      #
-      - name: Create Linux tar.gz
-        if: startsWith(matrix.artifact_name, 'linux-') # linux
-        shell: bash
-        run: |
-          mv prepackage VOICEVOX
-          tar cf "${{ matrix.targz_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz" VOICEVOX/
-
-      - name: Show disk space (debug info)
-        if: startsWith(matrix.artifact_name, 'linux-') # linux
-        shell: bash
-        run: |
-          df -h
-
-      - name: Upload Linux tar.gz artifact
-        if: startsWith(matrix.artifact_name, 'linux-') # linux
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.artifact_name }}-targz
-          path: "${{ matrix.targz_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz"
-
-      - name: Create macOS zip
-        if: startsWith(matrix.artifact_name, 'macos-')
+      - name: Create zip
         shell: bash
         run: |
           mv prepackage VOICEVOX
           zip "${{ matrix.zip_name }}.zip" -r VOICEVOX
 
-      - name: Upload macOS zip artifact
-        if: startsWith(matrix.artifact_name, 'macos-')
+      - name: Upload zip artifact
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}-zip
@@ -751,8 +720,12 @@ jobs:
             appimage_7z_name: VOICEVOX.AppImage
           - artifact_name: linux-cpu-appimage
             appimage_7z_name: VOICEVOX-CPU.AppImage
+          - artifact_name: linux-nvidia-prepackage-zip
+          - artifact_name: linux-cpu-prepackage-zip
           - artifact_name: windows-nvidia-nsis-web
           - artifact_name: windows-cpu-nsis-web
+          - artifact_name: windows-nvidia-prepackage-zip
+          - artifact_name: windows-cpu-prepackage-zip
           - artifact_name: macos-cpu-dmg
           - artifact_name: macos-cpu-prepackage-zip
 
@@ -853,9 +826,9 @@ jobs:
           file_glob: true
           file: artifact/*.dmg
 
-      # macOS zip
-      - name: Upload macOS zip to Release assets
-        if: startsWith(matrix.artifact_name, 'macos-') && endsWith(matrix.artifact_name, '-zip')
+      # zip
+      - name: Upload zip to Release assets
+        if: endsWith(matrix.artifact_name, '-zip')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,35 +272,33 @@ jobs:
             noengine_artifact_name: linux-noengine-prepackage
             voicevox_engine_asset_name: linux-nvidia
             linux_executable_name: voicevox
-            targz_name: VOICEVOX
-            zip_name: voicevox-linux-nvidia
+            compressed_artifact_name: voicevox-linux-nvidia
             app_asar_dir: prepackage/resources
           # Linux CPU
           - artifact_name: linux-cpu-prepackage
             noengine_artifact_name: linux-noengine-cpu-prepackage
             voicevox_engine_asset_name: linux-cpu
             linux_executable_name: voicevox
-            targz_name: VOICEVOX-CPU
-            zip_name: voicevox-linux-cpu
+            compressed_artifact_name: voicevox-linux-cpu
             app_asar_dir: prepackage/resources
           # Windows NVIDIA GPU
           - artifact_name: windows-nvidia-prepackage
             noengine_artifact_name: windows-noengine-prepackage
             voicevox_engine_asset_name: windows-nvidia
-            zip_name: voicevox-windows-nvidia
+            compressed_artifact_name: voicevox-windows-nvidia
             app_asar_dir: prepackage/resources
           # Windows CPU
           - artifact_name: windows-cpu-prepackage
             noengine_artifact_name: windows-noengine-cpu-prepackage
             voicevox_engine_asset_name: windows-cpu
-            zip_name: voicevox-windows-cpu
+            compressed_artifact_name: voicevox-windows-cpu
             app_asar_dir: prepackage/resources
           # macOS CPU
           - artifact_name: macos-cpu-prepackage
             noengine_artifact_name: macos-noengine-cpu-prepackage
             voicevox_engine_asset_name: macos-x64
             macos_executable_name: VOICEVOX
-            zip_name: voicevox-macos-cpu
+            compressed_artifact_name: voicevox-macos-cpu
             app_asar_dir: prepackage/VOICEVOX.app/Contents/Resources
 
     runs-on: ${{ matrix.os }}
@@ -454,22 +452,37 @@ jobs:
         run: mkdir -p prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
 
       - name: Set BUILD_IDENTIFIER env var
-        if: startsWith(matrix.artifact_name, 'linux-') # linux
         shell: bash
         run: |
           echo "BUILD_IDENTIFIER=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
-      - name: Create zip
+      - name: Create Linux tar.gz
+        if: startsWith(matrix.artifact_name, 'linux-')
         shell: bash
         run: |
           mv prepackage VOICEVOX
-          zip "${{ matrix.zip_name }}.zip" -r VOICEVOX
+          tar cfz "${{ matrix.compressed_artifact_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz" VOICEVOX/
 
-      - name: Upload zip artifact
+      - name: Upload Linux tar.gz artifact
+        if: startsWith(matrix.artifact_name, 'linux-')
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.artifact_name }}-targz
+          path: "${{ matrix.compressed_artifact_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz"
+
+      - name: Create Windows & Mac zip
+        if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'macos-')
+        shell: bash
+        run: |
+          mv prepackage VOICEVOX
+          zip "${{ matrix.compressed_artifact_name }}-${{ env.BUILD_IDENTIFIER }}.zip" -r VOICEVOX
+
+      - name: Upload Windows & Mac zip artifact
+        if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'macos-')
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}-zip
-          path: "${{ matrix.zip_name }}.zip"
+          path: "${{ matrix.compressed_artifact_name }}-${{ env.BUILD_IDENTIFIER }}.zip"
 
 
   build-distributable:
@@ -711,8 +724,8 @@ jobs:
         artifact_name:
           - linux-nvidia-appimage
           - linux-cpu-appimage
-          - linux-nvidia-prepackage-zip
-          - linux-cpu-prepackage-zip
+          - linux-nvidia-prepackage-targz
+          - linux-cpu-prepackage-targz
           - windows-nvidia-nsis-web
           - windows-cpu-nsis-web
           - windows-nvidia-prepackage-zip
@@ -821,6 +834,16 @@ jobs:
           tag: ${{ github.ref }} # == github.event.release.tag_name
           file_glob: true
           file: artifact/*.dmg
+
+      # targz
+      - name: Upload targz to Release assets
+        if: endsWith(matrix.artifact_name, '-targz')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }} # == github.event.release.tag_name
+          file_glob: true
+          file: artifact/*.targz
 
       # zip
       - name: Upload zip to Release assets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -711,8 +711,12 @@ jobs:
         artifact_name:
           - linux-nvidia-appimage
           - linux-cpu-appimage
+          - linux-nvidia-prepackage-zip
+          - linux-cpu-prepackage-zip
           - windows-nvidia-nsis-web
           - windows-cpu-nsis-web
+          - windows-nvidia-prepackage-zip
+          - windows-cpu-prepackage-zip
           - macos-cpu-dmg
           - macos-cpu-prepackage-zip
         include:
@@ -720,14 +724,6 @@ jobs:
             appimage_7z_name: VOICEVOX.AppImage
           - artifact_name: linux-cpu-appimage
             appimage_7z_name: VOICEVOX-CPU.AppImage
-          - artifact_name: linux-nvidia-prepackage-zip
-          - artifact_name: linux-cpu-prepackage-zip
-          - artifact_name: windows-nvidia-nsis-web
-          - artifact_name: windows-cpu-nsis-web
-          - artifact_name: windows-nvidia-prepackage-zip
-          - artifact_name: windows-cpu-prepackage-zip
-          - artifact_name: macos-cpu-dmg
-          - artifact_name: macos-cpu-prepackage-zip
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## 内容

今までzip版は、artifactからダウンロードしてからgoogle driveにアップロードしていました。
結構煩雑で時間がかかっていたので、zipファイルが2GB未満になったのもあって、releasesにアップロードすることにしたいです。

## 関連 Issue

close #636 
close #638 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->


## その他

zipファイルの容量は大体1.8GBで、github releasesの制限の2GBギリギリです。
electronのアップデートなどでいつかこの制限を越してしまう可能性はあります。
超してしまったら悲しみつつgoogle driveにアップロードする運用に戻すことにして、2GB未満の間はreleasesにアップロードとしたいと思います。
