### PR TITLE
保存確認ダイアログの×ボタンをキャンセル扱いにする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -696,11 +696,11 @@ ipcMainHandle(
     return dialog
       .showMessageBox(win, {
         type: "info",
-        buttons: buttons,
-        title: title,
-        message: message,
+        buttons,
+        title,
+        message,
         noLink: true,
-        cancelId: cancelId,
+        cancelId,
       })
       .then((value) => {
         return value.response;
@@ -711,16 +711,16 @@ ipcMainHandle(
 ipcMainHandle("SHOW_WARNING_DIALOG", (_, { title, message }) => {
   return dialog.showMessageBox(win, {
     type: "warning",
-    title: title,
-    message: message,
+    title,
+    message,
   });
 });
 
 ipcMainHandle("SHOW_ERROR_DIALOG", (_, { title, message }) => {
   return dialog.showMessageBox(win, {
     type: "error",
-    title: title,
-    message: message,
+    title,
+    message,
   });
 });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -690,19 +690,23 @@ ipcMainHandle("SHOW_PROJECT_LOAD_DIALOG", async (_, { title }) => {
   return result.filePaths;
 });
 
-ipcMainHandle("SHOW_INFO_DIALOG", (_, { title, message, buttons }) => {
-  return dialog
-    .showMessageBox(win, {
-      type: "info",
-      buttons: buttons,
-      title: title,
-      message: message,
-      noLink: true,
-    })
-    .then((value) => {
-      return value.response;
-    });
-});
+ipcMainHandle(
+  "SHOW_INFO_DIALOG",
+  (_, { title, message, buttons, cancelId }) => {
+    return dialog
+      .showMessageBox(win, {
+        type: "info",
+        buttons: buttons,
+        title: title,
+        message: message,
+        noLink: true,
+        cancelId: cancelId,
+      })
+      .then((value) => {
+        return value.response;
+      });
+  }
+);
 
 ipcMainHandle("SHOW_WARNING_DIALOG", (_, { title, message }) => {
   return dialog.showMessageBox(win, {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -103,8 +103,13 @@ const api: Sandbox = {
     return ipcRendererInvoke("SHOW_PROJECT_LOAD_DIALOG", { title });
   },
 
-  showInfoDialog: ({ title, message, buttons }) => {
-    return ipcRendererInvoke("SHOW_INFO_DIALOG", { title, message, buttons });
+  showInfoDialog: ({ title, message, buttons, cancelId }) => {
+    return ipcRendererInvoke("SHOW_INFO_DIALOG", {
+      title,
+      message,
+      buttons,
+      cancelId,
+    });
   },
 
   showWarningDialog: ({ title, message }) => {

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -56,6 +56,7 @@ export const projectStore: VoiceVoxStoreOptions<
               "プロジェクトの変更が保存されていません。\n" +
               "変更を破棄してもよろしいですか？",
             buttons: ["破棄", "キャンセル"],
+            cancelId: 1,
           });
           if (result == 1) {
             return;
@@ -239,6 +240,7 @@ export const projectStore: VoiceVoxStoreOptions<
                 "プロジェクトをロードすると現在のプロジェクトは破棄されます。\n" +
                 "変更を破棄してもよろしいですか？",
               buttons: ["破棄", "キャンセル"],
+              cancelId: 1,
             });
             if (result == 1) {
               return;

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -343,6 +343,7 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
               "プロジェクトの変更が保存されていません。\n" +
               "変更を破棄してもよろしいですか？",
             buttons: ["破棄", "キャンセル"],
+            cancelId: 1,
           });
           if (result == 1) {
             return;

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -68,7 +68,14 @@ type IpcIHData = {
   };
 
   SHOW_INFO_DIALOG: {
-    args: [obj: { title: string; message: string; buttons: string[] }];
+    args: [
+      obj: {
+        title: string;
+        message: string;
+        buttons: string[];
+        cancelId?: number;
+      }
+    ];
     return: number;
   };
 

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -25,6 +25,7 @@ export interface Sandbox {
     title: string;
     message: string;
     buttons: string[];
+    cancelId?: number;
   }): Promise<number>;
   showWarningDialog(obj: {
     title: string;


### PR DESCRIPTION
## 内容

ソフトウェアを閉じようとしたときに出てくる確認ダイアログを閉じると、キャンセルではなく破棄の扱いになります。
これはデフォルトで一番左のボタンをキャンセルボタンだとみなすためです。

キャンセルボタンの番号を指定可能にし、キャンセルされるようにしました。

## 関連 Issue

close #662 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
