### PR TITLE
プリセットのUIを変更

### DIFF
--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -4,11 +4,11 @@
 
 #### CPU 版
 
-Windows・Mac・Linux 搭載の PC に対応しています。
+Windows／Mac／Linux 搭載の PC に対応しています。
 
 #### GPU 版
 
-Windows・Linux と Nvidia 製 GPU 搭載の PC に対応しています。
+Windows／Linux と Nvidia 製 GPU 搭載の PC に対応しています。
 
 ## インストールに関する質問
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -299,6 +299,7 @@ const store = new Store<{
     experimentalSetting: {
       type: "object",
       properties: {
+        enablePreset: { type: "boolean", default: false },
         enableInterrogative: {
           type: "boolean",
           default: false,
@@ -309,6 +310,7 @@ const store = new Store<{
         },
       },
       default: {
+        enablePreset: false,
         enableInterrogative: false,
         enableReorderCell: false,
       },

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -373,7 +373,27 @@
                 </q-btn-toggle>
               </q-card-actions> -->
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
-                <div>疑問文自動調整</div>
+                <div>プリセット機能</div>
+                <q-space />
+                <q-toggle
+                  :model-value="experimentalSetting.enablePreset"
+                  @update:model-value="
+                    changeExperimentalSetting('enablePreset', $event)
+                  "
+                >
+                  <q-tooltip
+                    :delay="500"
+                    anchor="center left"
+                    self="center right"
+                    transition-show="jump-left"
+                    transition-hide="jump-right"
+                  >
+                    プリセット機能を有効にする
+                  </q-tooltip>
+                </q-toggle>
+              </q-card-actions>
+              <q-card-actions class="q-px-md q-py-none bg-setting-item">
+                <div>疑問文を自動調整</div>
                 <q-space />
                 <q-toggle
                   :model-value="experimentalSetting.enableInterrogative"
@@ -388,7 +408,7 @@
                     transition-show="jump-left"
                     transition-hide="jump-right"
                   >
-                    疑問文のアクセント句を自動調整する
+                    疑問文のとき語尾の音高を自動的に上げる
                   </q-tooltip>
                 </q-toggle>
               </q-card-actions>

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -239,11 +239,8 @@ const api: Sandbox = {
     return await ipcRendererInvoke("GET_EXPERIMENTAL_SETTING");
   },
 
-  setExperimentalSetting: async (enableInterrogative) => {
-    return await ipcRendererInvoke(
-      "SET_EXPERIMENTAL_SETTING",
-      enableInterrogative
-    );
+  setExperimentalSetting: async (setting) => {
+    return await ipcRendererInvoke("SET_EXPERIMENTAL_SETTING", setting);
   },
 
   getDefaultHotkeySettings: async () => {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -318,7 +318,7 @@ export const audioStore: VoiceVoxStoreOptions<
       if (query == undefined) throw new Error("query == undefined");
       query.postPhonemeLength = postPhonemeLength;
     },
-    SET_AUDIO_PRESET(
+    SET_AUDIO_PRESET_KEY(
       state,
       {
         audioKey,
@@ -2157,7 +2157,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         presetKey: string | undefined;
       }
     ) => {
-      audioStore.mutations.SET_AUDIO_PRESET(draft, { audioKey, presetKey });
+      audioStore.mutations.SET_AUDIO_PRESET_KEY(draft, { audioKey, presetKey });
       audioStore.mutations.APPLY_AUDIO_PRESET(draft, { audioKey });
     },
     COMMAND_APPLY_AUDIO_PRESET(draft, payload: { audioKey: string }) {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -42,6 +42,7 @@ export const settingStoreState: SettingStoreState = {
   },
   acceptRetrieveTelemetry: "Unconfirmed",
   experimentalSetting: {
+    enablePreset: false,
     enableInterrogative: false,
     enableReorderCell: false,
   },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -334,7 +334,7 @@ type AudioStoreTypes = {
     action(payload: { audioKey: string }): void;
   };
 
-  SET_AUDIO_PRESET: {
+  SET_AUDIO_PRESET_KEY: {
     mutation: {
       audioKey: string;
       presetKey: string | undefined;

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -76,9 +76,7 @@ export interface Sandbox {
     acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus
   ): Promise<void>;
   getExperimentalSetting(): Promise<ExperimentalSetting>;
-  setExperimentalSetting(
-    enableInterrogative: ExperimentalSetting
-  ): Promise<void>;
+  setExperimentalSetting(setting: ExperimentalSetting): Promise<void>;
   getDefaultHotkeySettings(): Promise<HotKeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
   theme(newData?: string): Promise<ThemeSetting | void>;
@@ -244,6 +242,7 @@ export type ThemeSetting = {
 };
 
 export type ExperimentalSetting = {
+  enablePreset: boolean;
   enableInterrogative: boolean;
   enableReorderCell: boolean;
 };

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -63,6 +63,7 @@ describe("store/vuex.js test", () => {
         acceptRetrieveTelemetry: "Unconfirmed",
         engineHost: "http://127.0.0.1",
         experimentalSetting: {
+          enablePreset: false,
           enableInterrogative: false,
           enableReorderCell: false,
         },
@@ -147,6 +148,7 @@ describe("store/vuex.js test", () => {
     assert.property(store.state.themeSetting, "availableThemes");
     assert.isEmpty(store.state.themeSetting.availableThemes);
     assert.equal(store.state.acceptRetrieveTelemetry, "Unconfirmed");
+    assert.equal(store.state.experimentalSetting.enablePreset, false);
     assert.equal(store.state.experimentalSetting.enableInterrogative, false);
     assert.equal(store.state.experimentalSetting.enableReorderCell, false);
   });


### PR DESCRIPTION
## 内容

プリセットのUIを変更しました。

* プリセット→パラメータの適用ボタンを無くし、データの流れを一方向にしました
  * パラメータ→プリセット→他のテキスト欄
* 再登録ボタンを表示し、パラメータ変更時に現れるようにしました
  * これで編集中のパラメータをプリセットに反映されるには更に操作が必要だとわかるようになった･･･はず！
* プリセットを実験的機能に変更
  * 再適用の挙動など、まだ最も良い状態ではないかもと感じたので、実験的機能にして将来の変更に備えます

## 関連 Issue

ref #428 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/4987327/151417165-2b791555-08e7-4e6a-87b0-f2b5250bd13f.png)

## その他

いろいろ考えた思考回路を少し残してみたので参考になりますと幸いです

* プリセットUIの最大の問題は、どっちを編集しているのかがわからない点
  * プリセット欄を常時表示する以上必ず問題になる
    * パラメータ変更時にプリセット欄が外れる場合 → プリセット値を変えたいのになぜ勝手に外れるんだ
    * はずれない場合 → プリセット値を設定したのに反映されてない
      * こっちはパラメータ変更時に見た目を変えてプリセットを設定していないことを伝える手もある
        * 見た目の変更が何を意味するのかわからないかもしれない（未保存）
        * そもそもそのUIがスクロール範囲外に行って見えてないこともある
* 「適用」が設定→プリセットなのかプリセット→設定なのかわからない
  * 「登録」は設定→プリセットっぽさがあるので、その逆だと考えると理解できる
  * 「適用」はできる限り使わないようにした
* プリセットの変更をしているわけではないことがわかるUIにする
  * 再登録ボタン、再適用ボタンで区切る方法
    * これはセルとプリセットが結びついていることがわかりにくくなってしまう
  * 再登録ボタンだけにし、変更が入ったタイミングで再登録ボタンを表示する
    * これでプリセットに登録するには操作が必要だということがわかる･･･はず！
