### PR TITLE
アクセント句の選択色を青系統に変更

### DIFF
--- a/public/themes/dark.json
+++ b/public/themes/dark.json
@@ -15,6 +15,7 @@
     "markdown-background": "#0D1117",
     "markdown-hyperlink": "#58A6FF",
     "pause-hovered": "#333A44",
-    "active-point-focus": "#FFEDEC"
+    "active-point-focus": "#EEF3FF",
+    "active-point-focus-hover": "#F7FAFF"
   }
 }

--- a/public/themes/default.json
+++ b/public/themes/default.json
@@ -15,6 +15,7 @@
     "markdown-background": "#FFFFFF",
     "markdown-hyperlink": "#0969DA",
     "pause-hovered": "#CCDDFF",
-    "active-point-focus": "#FFEDEC"
+    "active-point-focus": "#EEF3FF",
+    "active-point-focus-hover": "#F7FAFF"
   }
 }

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -856,7 +856,7 @@ $pitch-label-height: 24px;
 
     .mora-table-hover:hover {
       cursor: pointer;
-      background-color: rgba(colors.$active-point-focus-rgb, 0.5);
+      background-color: colors.$active-point-focus-hover;
     }
 
     .mora-table-focus {

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -39,3 +39,6 @@ $pause-hovered-rgb: var(--color-pause-hovered-rgb);
 
 $active-point-focus: var(--color-active-point-focus);
 $active-point-focus-rgb: var(--color-active-point-focus-rgb);
+
+$active-point-focus-hover: var(--color-active-point-focus-hover);
+$active-point-focus-hover-rgb: var(--color-active-point-focus-hover-rgb);

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -228,7 +228,8 @@ export type ThemeColorType =
   | "markdown-background"
   | "markdown-hyperlink"
   | "pause-hovered"
-  | "active-point-focus";
+  | "active-point-focus"
+  | "active-point-focus-hover";
 
 export type ThemeConf = {
   name: string;


### PR DESCRIPTION
## 内容

ユーザーには落ち着いて調整作業をできる環境を提供したいので、選択色を赤色系統から青色に変更してみました。

![image](https://user-images.githubusercontent.com/4987327/151427722-33596142-be84-44c4-aa11-81942dd3e66f.png)

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

次リリース前にマージしたいと思います