### PR TITLE
読点を含んだ読み仮名修正に対応

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1632,9 +1632,13 @@ export const audioCommandStore: VoiceVoxStoreOptions<
 
       let newAccentPhrasesSegment: AccentPhrase[] | undefined = undefined;
 
-      // ひらがな(U+3041~U+3094)とカタカナ(U+30A1~U+30F4)と全角長音(U+30FC)のみで構成される場合、
-      // 「読み仮名」としてこれを処理する
-      const kanaRegex = /^[\u3041-\u3094\u30A1-\u30F4\u30FC]+$/;
+      // 以下の文字のみで構成される場合、「読み仮名」としてこれを処理する
+      //  * ひらがな(U+3041~U+3094)
+      //  * カタカナ(U+30A1~U+30F4)
+      //  * 全角長音(U+30FC)
+      //  * 読点(U+3001)
+      //  * クエスチョン(U+FF1F)
+      const kanaRegex = /^[\u3041-\u3094\u30A1-\u30F4\u30FC\u3001\uFF1F]+$/;
       if (kanaRegex.test(newPronunciation)) {
         // ひらがなが混ざっている場合はカタカナに変換
         const katakana = newPronunciation.replace(/[\u3041-\u3094]/g, (s) => {
@@ -1650,10 +1654,17 @@ export const audioCommandStore: VoiceVoxStoreOptions<
           .replace(/(?<=[ン]ー*)ー/g, "ン")
           .replace(/(?<=[ッ]ー*)ー/g, "ッ");
 
-        // アクセントを末尾につけaccent phraseの生成をリクエスト
+        // アクセントを各句の末尾につける
+        // 文中に「？、」「、」がある場合は、そこで句切りとみなす
+        const pureKatakanaWithAccent = pureKatakana.replace(
+          /(？、|、|[^？、]$|？$)/g,
+          "'$1"
+        );
+
+        // accent phraseの生成をリクエスト
         // 判別できない読み仮名が混じっていた場合400エラーが帰るのでfallback
         newAccentPhrasesSegment = await dispatch("FETCH_ACCENT_PHRASES", {
-          text: pureKatakana + "'",
+          text: pureKatakanaWithAccent,
           styleId,
           isKana: true,
         }).catch(

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1657,7 +1657,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         // アクセントを各句の末尾につける
         // 文中に「？、」「、」がある場合は、そこで句切りとみなす
         const pureKatakanaWithAccent = pureKatakana.replace(
-          /(？、|、|[^？、]$|？$)/g,
+          /(？、|、|(?<=[^？、])$|？$)/g,
           "'$1"
         );
 


### PR DESCRIPTION
## 内容
読み仮名の修正に「、」や「？、」を含んでいるときでも `is_kana=true` としての修正を可能にする
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #691 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

