### PR TITLE
AudioDetailの疑似疑問文化されている句に「？」を表示する

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -150,7 +150,13 @@
               @mouseleave="handleHoverText(false, accentPhraseIndex, moraIndex)"
               @click="handleChangeVoicing(mora, accentPhraseIndex, moraIndex)"
             >
-              {{ getHoveredText(mora, accentPhraseIndex, moraIndex) }}
+              {{
+                getHoveredText(mora, accentPhraseIndex, moraIndex) +
+                (accentPhrase.isInterrogative &&
+                moraIndex === accentPhrase.moras.length - 1
+                  ? "？"
+                  : "")
+              }}
               <q-popup-edit
                 v-if="selectedDetail == 'accent' && !uiLocked"
                 :model-value="pronunciationByPhrase[accentPhraseIndex]"
@@ -529,6 +535,9 @@ export default defineComponent({
         accentPhrase.moras.forEach((mora) => {
           textString += mora.text;
         });
+        if (accentPhrase.isInterrogative) {
+          textString += "？";
+        }
         if (accentPhrase.pauseMora) {
           textString += "、";
         }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1541,6 +1541,8 @@ export const audioCommandStore: VoiceVoxStoreOptions<
             ],
             accent: accentPhrases[accentPhraseIndex].accent,
             pauseMora: accentPhrases[accentPhraseIndex + 1].pauseMora,
+            isInterrogative:
+              accentPhrases[accentPhraseIndex + 1].isInterrogative,
           };
           accentPhrases.splice(accentPhraseIndex, 2, newAccentPhrase);
         };
@@ -1559,6 +1561,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
                 ? moraIndex + 1
                 : accentPhrases[accentPhraseIndex].accent,
             pauseMora: undefined,
+            isInterrogative: false,
           };
           const newAccentPhrase2: AccentPhrase = {
             moras: accentPhrases[accentPhraseIndex].moras.slice(moraIndex + 1),
@@ -1567,6 +1570,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
                 ? accentPhrases[accentPhraseIndex].accent - moraIndex - 1
                 : 1,
             pauseMora: accentPhrases[accentPhraseIndex].pauseMora,
+            isInterrogative: accentPhrases[accentPhraseIndex].isInterrogative,
           };
           accentPhrases.splice(
             accentPhraseIndex,


### PR DESCRIPTION
## 内容
疑問文化されているアクセント句の末尾に「？」を挿入する。
merge/split時に後方の疑問文フラグが消えてしまうバグも同時に修正

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #670 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
![image](https://user-images.githubusercontent.com/8027142/152684244-851905a3-5c81-4af5-87ef-bb75893d4234.png)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

