### PR TITLE
stateに間違えてstoreが入っている状態を修正

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,7 +14,12 @@ import {
   VoiceVoxStoreOptions,
 } from "./type";
 import { commandStoreState, commandStore } from "./command";
-import { audioStoreState, audioStore, audioCommandStore } from "./audio";
+import {
+  audioStoreState,
+  audioStore,
+  audioCommandStore,
+  audioCommandStoreState,
+} from "./audio";
 import { projectStoreState, projectStore } from "./project";
 import { uiStoreState, uiStore } from "./ui";
 import { settingStoreState, settingStore } from "./setting";
@@ -156,7 +161,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...commandStoreState,
     ...projectStoreState,
     ...settingStoreState,
-    ...audioCommandStore,
+    ...audioCommandStoreState,
     ...indexStoreState,
     ...presetStoreState,
     ...proxyStoreState,


### PR DESCRIPTION
## 内容

vuex loggerの出力を見ていたらstateに入っているのが`audioCommandStoreState`ではなく`audioCommandStore`だったので修正

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
