### PR TITLE
fix: Mac において Cmd + V 等のショートカットキーを利用可能にする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -621,6 +621,7 @@ if (!isDevelopment && !isMac) {
   Menu.setApplicationMenu(null);
 }
 
+// create menu (only for macOS)
 function createMenu() {
   const template: Electron.MenuItemConstructorOptions[] = [
     {
@@ -1025,6 +1026,7 @@ app.on("ready", async () => {
   }
 
   createWindow().then(() => runEngine());
+  // For macOS, set the native menu to enable shortcut keys such as 'Cmd + V'.
   if (isMac) {
     createMenu();
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -617,29 +617,29 @@ async function createWindow() {
   });
 }
 
-if (!isDevelopment && !isMac) {
-  Menu.setApplicationMenu(null);
-}
+const menuTemplateForMac: Electron.MenuItemConstructorOptions[] = [
+  {
+    label: "VOICEVOX",
+    submenu: [{ role: "quit" }],
+  },
+  {
+    label: "Edit",
+    submenu: [
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      { role: "selectAll" },
+    ],
+  },
+];
 
-// create menu (only for macOS)
-function createMenu() {
-  const template: Electron.MenuItemConstructorOptions[] = [
-    {
-      label: "VOICEVOX",
-      submenu: [{ role: "quit" }],
-    },
-    {
-      label: "Edit",
-      submenu: [
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "selectAll" },
-      ],
-    },
-  ];
-
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+// For macOS, set the native menu to enable shortcut keys such as 'Cmd + V'.
+if (isMac) {
+  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplateForMac));
+} else {
+  if (!isDevelopment) {
+    Menu.setApplicationMenu(null);
+  }
 }
 
 // プロセス間通信
@@ -1026,10 +1026,6 @@ app.on("ready", async () => {
   }
 
   createWindow().then(() => runEngine());
-  // For macOS, set the native menu to enable shortcut keys such as 'Cmd + V'.
-  if (isMac) {
-    createMenu();
-  }
 });
 
 app.on("second-instance", () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -617,8 +617,28 @@ async function createWindow() {
   });
 }
 
-if (!isDevelopment) {
+if (!isDevelopment && !isMac) {
   Menu.setApplicationMenu(null);
+}
+
+function createMenu() {
+  const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: "VOICEVOX",
+      submenu: [{ role: "quit" }],
+    },
+    {
+      label: "Edit",
+      submenu: [
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "selectAll" },
+      ],
+    },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
 // プロセス間通信
@@ -1005,6 +1025,9 @@ app.on("ready", async () => {
   }
 
   createWindow().then(() => runEngine());
+  if (isMac) {
+    createMenu();
+  }
 });
 
 app.on("second-instance", () => {


### PR DESCRIPTION
## 内容

Mac 版において、テキスト欄で一部のショートカットキーが使用できない状態になっていました。
https://github.com/VOICEVOX/voicevox/issues/675#issuecomment-1024902466 で説明した通り、これを解決する最も簡便な方法は、使用したいショートカットキーと紐づいている Mac のネイティブメニューを設定することのようでした。そのため、Mac 環境でのみ Electron のネイティブメニューを最低限設定するように変更しました。

今回、

- `Cmd + X`
- `Cmd + C`
- `Cmd + V`
- `Cmd + A`

の４つのショートカットキーを利用可能なようにしました。

## 関連 Issue

close #675 

## スクリーンショット・動画など

Mac のネイティブメニューとして以下のものが追加されます（`fn D` と `fn E` は自動で追加されていました）。

<img width="305" alt="voicevox_native_menu" src="https://user-images.githubusercontent.com/41382894/154836545-44064ce4-8c05-4d20-8fbf-828fcdc17334.png">

