### PR TITLE
デフォルトスタイル選択ダイアログの仕様変更

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -385,9 +385,6 @@ export default defineComponent({
       textfield.value.focus();
     };
 
-    // キャラクター選択
-    const isOpenedCharacterList = ref(false);
-
     return {
       characterInfos,
       audioItem,
@@ -420,7 +417,6 @@ export default defineComponent({
       textfield,
       focusTextField,
       blurCell,
-      isOpenedCharacterList,
     };
   },
 });

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -300,7 +300,7 @@ export default defineComponent({
           },
           {
             type: "button",
-            label: "デフォルトスタイル変更",
+            label: "デフォルトスタイル",
             onClick() {
               store.dispatch("IS_DEFAULT_STYLE_SELECT_DIALOG_OPEN", {
                 isDefaultStyleSelectDialogOpen: true,

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -300,7 +300,7 @@ export default defineComponent({
           },
           {
             type: "button",
-            label: "デフォルトスタイル・試聴",
+            label: "デフォルトスタイル変更",
             onClick() {
               store.dispatch("IS_DEFAULT_STYLE_SELECT_DIALOG_OPEN", {
                 isDefaultStyleSelectDialogOpen: true,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -112,21 +112,27 @@ export const indexStore: VoiceVoxStoreOptions<
       return await window.electron.isUnsetDefaultStyleId(speakerUuid);
     },
     async LOAD_DEFAULT_STYLE_IDS({ commit, state }) {
-      const storeDefaultStyleIds = await window.electron.getDefaultStyleIds();
-      if (storeDefaultStyleIds.length === 0) {
-        const characterInfos = await state.characterInfos;
-        if (characterInfos == undefined)
-          throw new Error("state.characterInfos == undefined");
-        const defaultStyleIds = characterInfos.map<DefaultStyleId>((info) => ({
+      let defaultStyleIds = await window.electron.getDefaultStyleIds();
+
+      if (!state.characterInfos) throw new Error("characterInfos is undefined");
+
+      // デフォルトスタイルが設定されていない場合は0をセットする
+      // FIXME: 保存しているものとstateのものが異なってしまうので良くない。デフォルトスタイルが未設定の場合はAudioCellsを表示しないようにすべき
+      const unsetCharacterInfos = state.characterInfos.filter(
+        (characterInfo) =>
+          !defaultStyleIds.some(
+            (styleId) => styleId.speakerUuid == characterInfo.metas.speakerUuid
+          )
+      );
+      defaultStyleIds = [
+        ...defaultStyleIds,
+        ...unsetCharacterInfos.map<DefaultStyleId>((info) => ({
           speakerUuid: info.metas.speakerUuid,
           defaultStyleId: info.metas.styles[0].styleId,
-        }));
-        commit("SET_DEFAULT_STYLE_IDS", { defaultStyleIds });
-      } else {
-        commit("SET_DEFAULT_STYLE_IDS", {
-          defaultStyleIds: storeDefaultStyleIds,
-        });
-      }
+        })),
+      ];
+
+      commit("SET_DEFAULT_STYLE_IDS", { defaultStyleIds });
     },
     async SET_DEFAULT_STYLE_IDS({ commit }, defaultStyleIds) {
       commit("SET_DEFAULT_STYLE_IDS", { defaultStyleIds });

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -408,13 +408,15 @@ export default defineComponent({
       await store.dispatch("LOAD_CHARACTER");
       await store.dispatch("LOAD_DEFAULT_STYLE_IDS");
 
+      // スタイルが複数あって未選択なキャラがいる場合はデフォルトスタイル選択ダイアログを表示
       let isUnsetDefaultStyleIds = false;
       if (characterInfos.value == undefined) throw new Error();
       for (const info of characterInfos.value) {
-        isUnsetDefaultStyleIds ||= await store.dispatch(
-          "IS_UNSET_DEFAULT_STYLE_ID",
-          { speakerUuid: info.metas.speakerUuid }
-        );
+        isUnsetDefaultStyleIds ||=
+          info.metas.styles.length > 1 &&
+          (await store.dispatch("IS_UNSET_DEFAULT_STYLE_ID", {
+            speakerUuid: info.metas.speakerUuid,
+          }));
       }
       isDefaultStyleSelectDialogOpenComputed.value = isUnsetDefaultStyleIds;
 


### PR DESCRIPTION
## 内容

デフォルトスタイル選択ダイアログは、デフォルトスタイルを選ぶ役割と、サンプルボイスを聞いてもらう役割がありました。
後者の目的を果たすために全キャラクターを別ページで表示していましたが、キャラクター数が多くなると使えるようになるまでのステップが増えてしまうという課題がありました。

- https://github.com/VOICEVOX/voicevox/issues/614

そこで「キャラクター並び替えダイアログ」を別途作って、そちらでサンプルボイスを再生可能にする予定です。
そのプルリクエストも用意していますが、変更量が大きくなってしまったので、デフォルトスタイル選択の仕様変更だけを切り分けてプルリクエストにしました。

## 関連 Issue

ref https://github.com/VOICEVOX/voicevox/issues/614

## その他

スタイル数が１のキャラクターはデフォルトスタイル選択ダイアログに出さない仕様にしています。
