### PR TITLE
Audio Storeのリファクタリング

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -903,15 +903,20 @@ export const audioStore: VoiceVoxStoreOptions<
           });
       }
     ),
-    GENERATE_AUDIO: createUILockAction(
-      async ({ dispatch, state }, { audioKey }: { audioKey: string }) => {
+    async GENERATE_AUDIO(
+      { dispatch, state },
+      { audioKey }: { audioKey: string }
+    ) {
+      const audioItem: AudioItem = JSON.parse(
+        JSON.stringify(state.audioItems[audioKey])
+      );
+      return dispatch("GENERATE_AUDIO_FROM_AUDIO_ITEM", { audioItem });
+    },
+    GENERATE_AUDIO_FROM_AUDIO_ITEM: createUILockAction(
+      async ({ dispatch, state }, { audioItem }: { audioItem: AudioItem }) => {
         const engineInfo = state.engineInfos[0]; // TODO: 複数エンジン対応
         if (!engineInfo)
           throw new Error(`No such engineInfo registered: index == 0`);
-
-        const audioItem: AudioItem = JSON.parse(
-          JSON.stringify(state.audioItems[audioKey])
-        );
 
         const [id, audioQuery] = await generateUniqueIdAndQuery(
           state,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1254,9 +1254,7 @@ export const audioStore: VoiceVoxStoreOptions<
         { state, commit, dispatch },
         { audioKey }: { audioKey: string }
       ) => {
-        const audioElem = audioElements[audioKey] as HTMLAudioElement & {
-          setSinkId(deviceID: string): Promise<undefined>; // setSinkIdを認識してくれないため
-        };
+        const audioElem = audioElements[audioKey];
         audioElem.pause();
 
         // 音声用意

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -661,8 +661,17 @@ export const audioStore: VoiceVoxStoreOptions<
     ) {
       commit("SET_AUDIO_PLAY_START_POINT", { startPoint });
     },
-    async GET_AUDIO_CACHE({ state }, { audioKey }: { audioKey: string }) {
+    async GET_AUDIO_CACHE(
+      { state, dispatch },
+      { audioKey }: { audioKey: string }
+    ) {
       const audioItem = state.audioItems[audioKey];
+      return dispatch("GET_AUDIO_CACHE_FROM_AUDIO_ITEM", { audioItem });
+    },
+    async GET_AUDIO_CACHE_FROM_AUDIO_ITEM(
+      { state },
+      { audioItem }: { audioItem: AudioItem }
+    ) {
       const [id] = await generateUniqueIdAndQuery(state, audioItem);
 
       if (Object.prototype.hasOwnProperty.call(audioBlobCache, id)) {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -200,6 +200,10 @@ type AudioStoreTypes = {
     action(payload: { audioKey: string }): Promise<Blob | null>;
   };
 
+  GET_AUDIO_CACHE_FROM_AUDIO_ITEM: {
+    action(payload: { audioItem: AudioItem }): Promise<Blob | null>;
+  };
+
   SET_AUDIO_TEXT: {
     mutation: { audioKey: string; text: string };
   };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -299,7 +299,11 @@ type AudioStoreTypes = {
   };
 
   GENERATE_AUDIO: {
-    action(payload: { audioKey: string }): Blob | null;
+    action(payload: { audioKey: string }): Promise<Blob | null>;
+  };
+
+  GENERATE_AUDIO_FROM_AUDIO_ITEM: {
+    action(payload: { audioItem: AudioItem }): Blob | null;
   };
 
   CONNECT_AUDIO: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -340,6 +340,14 @@ type AudioStoreTypes = {
     action(payload: { audioKey: string }): boolean;
   };
 
+  PLAY_AUDIO_BLOB: {
+    action(payload: {
+      audioBlob: Blob;
+      audioElem: HTMLAudioElement;
+      audioKey?: string;
+    }): boolean;
+  };
+
   STOP_AUDIO: {
     action(payload: { audioKey: string }): void;
   };

--- a/src/type/globals.d.ts
+++ b/src/type/globals.d.ts
@@ -1,2 +1,8 @@
 // Include global variables to build immer source code
 export * from "immer/src/types/globals";
+
+declare global {
+  interface HTMLAudioElement {
+    setSinkId(deviceID: string): Promise<undefined>; // setSinkIdを認識してくれないため
+  }
+}


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
辞書実装の中で、アクセント調整のプレビュー再生機能を作るときにaudio storeの機能が使えると便利そうだったので、それ用にリファクタと関数分けを行いました。
AudioItemをstateに持たせたくないながら、再生はしたいというときのためのリファクタリングです。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- ref #709

