### PR TITLE
AquesTalk記法等のための関数切り出しとリファクタリング

### DIFF
--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -60,3 +60,32 @@ export const getToolbarButtonName = (tag: ToolbarButtonTagType): string => {
   };
   return tag2NameObj[tag];
 };
+
+export const createKanaRegex = (includeSeparation?: boolean): RegExp => {
+  // 以下の文字のみで構成される場合、「読み仮名」としてこれを処理する
+  // includeSeparationがtrueの時は、読点(U+3001)とクエスチョン(U+FF1F)も含む
+  //  * ひらがな(U+3041~U+3094)
+  //  * カタカナ(U+30A1~U+30F4)
+  //  * 全角長音(U+30FC)
+  if (includeSeparation) {
+    return /^[\u3041-\u3094\u30A1-\u30F4\u30FC\u3001\uFF1F]+$/;
+  }
+  return /^[\u3041-\u3094\u30A1-\u30F4\u30FC]+$/;
+};
+
+export const convertHiraToKana = (text: string): string => {
+  return text.replace(/[\u3041-\u3094]/g, (s) => {
+    return String.fromCharCode(s.charCodeAt(0) + 0x60);
+  });
+};
+
+export const convertLongVowel = (text: string): string => {
+  return text
+    .replace(/(?<=[アカサタナハマヤラワャァガザダバパ]ー*)ー/g, "ア")
+    .replace(/(?<=[イキシチニヒミリィギジヂビピ]ー*)ー/g, "イ")
+    .replace(/(?<=[ウクスツヌフムユルュゥヴグズヅブプ]ー*)ー/g, "ウ")
+    .replace(/(?<=[エケセテネヘメレェゲゼデベペ]ー*)ー/g, "エ")
+    .replace(/(?<=[オコソトノホモヨロヲョォゴゾドボポ]ー*)ー/g, "オ")
+    .replace(/(?<=[ン]ー*)ー/g, "ン")
+    .replace(/(?<=[ッ]ー*)ー/g, "ッ");
+};


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
ひらがなやカタカナのみの正規表現生成や、ひらがなtoカタカナの関数や、長音置き換えなどを関数として切り出しました。
辞書のために、読みをカタカナorひらがなで書く必要がありますが、そのための検証機能として利用するために、これらを関数として切り出す必要がありました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- ref #709

