### PR TITLE
辞書の編集UIを追加

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -153,7 +153,17 @@
                 </div>
               </div>
             </div>
-            <div class="row q-px-md save-and-delete-buttons">
+            <div class="row q-px-md save-delete-reset-buttons">
+              <q-btn
+                v-show="!!selectedId"
+                outline
+                text-color="display"
+                class="text-no-wrap text-bold q-mr-sm"
+                @click="resetWord"
+                :disable="uiLocked || !isWordChanged"
+                >リセット</q-btn
+              >
+              <q-space />
               <q-btn
                 outline
                 text-color="display"
@@ -553,6 +563,26 @@ export default defineComponent({
         await loadingDictProcess();
       });
     };
+    const resetWord = () => {
+      $q.dialog({
+        title: "単語の変更をリセットしますか？",
+        message: "単語の変更は破棄されてリセットされます。",
+        persistent: true,
+        focus: "cancel",
+        ok: {
+          label: "リセット",
+          flat: true,
+          textColor: "display",
+        },
+        cancel: {
+          label: "キャンセル",
+          flat: true,
+          textColor: "display",
+        },
+      }).onOk(() => {
+        selectWord(selectedId.value);
+      });
+    };
     const discardOrNotDialog = (okCallback: () => void) => {
       if (isWordChanged.value) {
         $q.dialog({
@@ -605,6 +635,7 @@ export default defineComponent({
       isDeletable,
       saveWord,
       deleteWord,
+      resetWord,
       discardOrNotDialog,
     };
   },
@@ -715,7 +746,7 @@ export default defineComponent({
   }
 }
 
-.save-and-delete-buttons {
+.save-delete-reset-buttons {
   // menubar-height + header-height + window-border-width
   // 46(surface input) + 58(yomi input) + 38(accent title) + 18(accent desc) + 130(accent)
   height: calc(
@@ -726,6 +757,5 @@ export default defineComponent({
 
   display: flex;
   align-items: flex-end;
-  justify-content: flex-end;
 }
 </style>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -413,7 +413,7 @@ export default defineComponent({
           ],
         });
       } else {
-        await store
+        selectedId.value = await store
           .dispatch("INVOKE_ENGINE_CONNECTOR", {
             engineKey: engineInfo.key,
             action: "addUserDictWordUserDictWordPost",

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -331,6 +331,7 @@ export default defineComponent({
           accentPhraseTable.value.offsetWidth;
     };
     const convertHankakuToZenkaku = (text: string) => {
+      // "!"から"~"までの範囲の文字(数字やアルファベット)を全角に置き換える
       return text.replace(/[\u0021-\u007e]/g, (s) => {
         return String.fromCharCode(s.charCodeAt(0) + 0xfee0);
       });

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -38,9 +38,15 @@
                 :key="key"
                 tag="label"
                 v-ripple
+                clickable
+                @click="selectWord(key)"
+                :active="selectedId === key"
+                active-class="active-word"
               >
                 <q-item-section>
-                  <q-item-label>{{ value.surface }}</q-item-label>
+                  <q-item-label class="text-display">{{
+                    value.surface
+                  }}</q-item-label>
                   <q-item-label caption>{{ value.yomi }}</q-item-label>
                 </q-item-section>
               </q-item>
@@ -214,8 +220,15 @@ export default defineComponent({
     const surfaceInput = ref<QInput>();
     const yomiInput = ref<QInput>();
 
+    const selectedId = ref("");
     const surface = ref("");
     const yomi = ref("");
+    const selectWord = (id: string) => {
+      selectedId.value = id;
+      surface.value = userDict.value[id].surface;
+      setYomi(userDict.value[id].yomi, userDict.value[id].accentType);
+    };
+
     const kanaRegex = createKanaRegex();
     const isOnlyHiraOrKana = ref(true);
     const accentPhrase = ref<AccentPhrase | undefined>();
@@ -229,7 +242,7 @@ export default defineComponent({
         accentPhraseTable.value.scrollWidth ==
           accentPhraseTable.value.offsetWidth;
     };
-    const setYomi = async (text: string) => {
+    const setYomi = async (text: string, accent?: number) => {
       // テキスト長が0の時にエラー表示にならないように、テキスト長を考慮する
       isOnlyHiraOrKana.value = !text.length || kanaRegex.test(text);
       // 文字列が変更されていない場合は、アクセントフレーズに変更を加えない
@@ -251,7 +264,10 @@ export default defineComponent({
             styleId: 0,
             isKana: true,
           })
-        )[0];
+        ).map((v) => {
+          if (accent !== undefined) v.accent = accent;
+          return v;
+        })[0];
       } else {
         accentPhrase.value = undefined;
       }
@@ -358,8 +374,10 @@ export default defineComponent({
       loadingDict,
       surfaceInput,
       yomiInput,
+      selectedId,
       surface,
       yomi,
+      selectWord,
       isOnlyHiraOrKana,
       setYomi,
       accentPhrase,
@@ -392,6 +410,10 @@ export default defineComponent({
   );
   width: 100%;
   overflow-y: scroll;
+}
+
+.active-word {
+  background: rgba(colors.$primary-rgb, 0.4);
 }
 
 .loading-dict {

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -23,16 +23,41 @@
             />
           </q-toolbar>
         </q-header>
-        <q-page>
-          <div />
+        <q-page class="row">
+          <div v-if="loadingDict" class="loading-dict">
+            <div>
+              <q-spinner color="primary" size="2.5rem" />
+              <div class="q-mt-xs">読み込み中・・・</div>
+            </div>
+          </div>
+          <div class="col-4 word-list-col">
+            <div class="text-h5 q-pa-sm">単語一覧</div>
+            <q-list class="word-list">
+              <q-item
+                v-for="(value, key) in userDict"
+                :key="key"
+                tag="label"
+                v-ripple
+              >
+                <q-item-section>
+                  <q-item-label>{{ value.surface }}</q-item-label>
+                  <q-item-label caption>{{ value.yomi }}</q-item-label>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </div>
+          <div class="col-8" />
         </q-page>
       </q-page-container>
     </q-layout>
   </q-dialog>
 </template>
 
-<script>
-import { computed, defineComponent } from "vue";
+<script lang="ts">
+import { computed, defineComponent, ref, watch } from "vue";
+import { useStore } from "@/store";
+import { toDispatchResponse } from "@/store/audio";
+import { UserDictWord } from "@/openapi";
 
 export default defineComponent({
   name: "DictionaryManageDialog",
@@ -45,14 +70,75 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
+    const store = useStore();
+
     const dictionaryManageDialogOpenedComputed = computed({
       get: () => props.modelValue,
       set: (val) => emit("update:modelValue", val),
     });
+    const loadingDict = ref(false);
+    const userDict = ref<{ [key: string]: UserDictWord }>({});
+
+    watch(dictionaryManageDialogOpenedComputed, async (newValue) => {
+      if (newValue) {
+        const engineInfo = store.state.engineInfos[0]; // TODO: 複数エンジン対応
+        if (!engineInfo)
+          throw new Error(`No such engineInfo registered: index == 0`);
+        loadingDict.value = true;
+        userDict.value = await store
+          .dispatch("INVOKE_ENGINE_CONNECTOR", {
+            engineKey: engineInfo.key,
+            action: "getUserDictWordsUserDictGet",
+            payload: [],
+          })
+          .then(toDispatchResponse("getUserDictWordsUserDictGet"));
+        loadingDict.value = false;
+      }
+    });
 
     return {
       dictionaryManageDialogOpenedComputed,
+      userDict,
+      loadingDict,
     };
   },
 });
 </script>
+
+<style lang="scss" scoped>
+@use '@/styles/colors' as colors;
+@use '@/styles/variables' as vars;
+
+.word-list-col {
+  border-right: solid 1px colors.$setting-item;
+}
+
+.word-list {
+  // menubar-height + header-height + window-border-width
+  // 46(title)
+  height: calc(
+    100vh - #{vars.$menubar-height + vars.$header-height +
+      vars.$window-border-width + 46px}
+  );
+  width: 100%;
+  overflow-y: scroll;
+}
+
+.loading-dict {
+  background-color: rgba(colors.$display-dark-rgb, 0.15);
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+
+  > div {
+    color: colors.$display-dark;
+    background: colors.$background-light;
+    border-radius: 6px;
+    padding: 14px;
+  }
+}
+</style>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -376,7 +376,7 @@ export default defineComponent({
             },
           ],
         })
-        .then(toDispatchResponse("getUserDictWordsUserDictGet"));
+        .then(toDispatchResponse("addUserDictWordUserDictWordPost"));
     };
     const discardOrNotDialog = (okCallback: () => void) => {
       if (isWordChanged.value) {

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -152,6 +152,14 @@
                 :disable="uiLocked || !isWordChanged"
                 >保存</q-btn
               >
+              <q-btn
+                outline
+                text-color="warning"
+                class="text-no-wrap text-bold q-mr-sm"
+                @click="deleteWord"
+                :disable="uiLocked || isDeletable"
+                >削除</q-btn
+              >
             </div>
           </div>
         </q-page>
@@ -485,6 +493,52 @@ export default defineComponent({
       }
       await loadingDictProcess();
     };
+    const isDeletable = computed(() => !!selectedId.value);
+    const deleteWord = () => {
+      $q.dialog({
+        title: "登録された単語を削除しますか？",
+        message: "削除された単語は復旧できません。",
+        persistent: true,
+        focus: "cancel",
+        ok: {
+          label: "削除",
+          flat: true,
+          textColor: "warning",
+        },
+        cancel: {
+          label: "キャンセル",
+          flat: true,
+          textColor: "display",
+        },
+      }).onOk(async () => {
+        if (!engineInfo)
+          throw new Error(`No such engineInfo registered: index == 0`);
+        try {
+          await store.dispatch("INVOKE_ENGINE_CONNECTOR", {
+            engineKey: engineInfo.key,
+            action: "deleteUserDictWordUserDictWordWordUuidDelete",
+            payload: [
+              {
+                wordUuid: selectedId.value,
+              },
+            ],
+          });
+        } catch {
+          $q.dialog({
+            title: "単語の削除に失敗しました",
+            message: "エンジンの再起動をお試しください。",
+            ok: {
+              label: "閉じる",
+              flat: true,
+              textColor: "display",
+            },
+          });
+          return;
+        }
+        resetSelect();
+        await loadingDictProcess();
+      });
+    };
     const discardOrNotDialog = (okCallback: () => void) => {
       if (isWordChanged.value) {
         $q.dialog({
@@ -533,7 +587,9 @@ export default defineComponent({
       play,
       stop,
       isWordChanged,
+      isDeletable,
       saveWord,
+      deleteWord,
       discardOrNotDialog,
     };
   },

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -228,6 +228,7 @@ export default defineComponent({
     const userDict = ref<Record<string, UserDictWord>>({});
 
     const loadingDictProcess = async () => {
+      // FIXME: エンジン周りに蜜結合なので、他のユーザー辞書操作系も含めてvuexに移動させる。
       engineInfo = store.state.engineInfos[0]; // TODO: 複数エンジン対応
       if (!engineInfo)
         throw new Error(`No such engineInfo registered: index == 0`);
@@ -324,6 +325,7 @@ export default defineComponent({
     // スクロールしなければならないほど長いアクセント句はセンタリングしないようにする
     // computedにすると、ダイアログを表示した際にしか動作しないので、refにして変更時に代入する
     const centeringAccentPhrase = ref(true);
+    // FIXME: CSSで完結させる
     const computeCenteringAccentPhrase = () => {
       centeringAccentPhrase.value =
         !!accentPhraseTable.value &&

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -136,6 +136,16 @@
                 </div>
               </div>
             </div>
+            <div class="row q-px-md save-and-delete-buttons">
+              <q-btn
+                outline
+                text-color="display"
+                class="text-no-wrap text-bold q-mr-sm"
+                @click="saveWord"
+                :disable="uiLocked || !savable"
+                >保存</q-btn
+              >
+            </div>
           </div>
         </q-page>
       </q-page-container>
@@ -317,6 +327,28 @@ export default defineComponent({
       audioElem.pause();
     };
 
+    const savable = computed(
+      () => surface.value && yomi.value && accentPhrase.value
+    );
+    const saveWord = async () => {
+      if (!engineInfo)
+        throw new Error(`No such engineInfo registered: index == 0`);
+      if (!accentPhrase.value) throw new Error(`accentPhrase === undefined`);
+      await store
+        .dispatch("INVOKE_ENGINE_CONNECTOR", {
+          engineKey: engineInfo.key,
+          action: "addUserDictWordUserDictWordPost",
+          payload: [
+            {
+              surface: surface.value,
+              pronunciation: yomi.value,
+              accentType: accentPhrase.value.accent,
+            },
+          ],
+        })
+        .then(toDispatchResponse("getUserDictWordsUserDictGet"));
+    };
+
     return {
       dictionaryManageDialogOpenedComputed,
       uiLocked,
@@ -336,6 +368,8 @@ export default defineComponent({
       changeAccent,
       play,
       stop,
+      savable,
+      saveWord,
     };
   },
 });
@@ -435,5 +469,19 @@ export default defineComponent({
       z-index: vars.$detail-view-splitter-cell-z-index;
     }
   }
+}
+
+.save-and-delete-buttons {
+  // menubar-height + header-height + window-border-width
+  // 46(surface input) + 58(yomi input) + 38(accent title) + 18(accent desc) + 130(accent)
+  height: calc(
+    100vh - #{vars.$menubar-height + vars.$header-height +
+      vars.$window-border-width + 46px + 58px + 38px + 18px + 130px}
+  );
+  padding: 20px;
+
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
 }
 </style>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -8,7 +8,7 @@
     v-model="dictionaryManageDialogOpenedComputed"
   >
     <q-layout container view="hHh Lpr fFf" class="bg-background">
-      <q-page-container class="root">
+      <q-page-container>
         <q-header class="q-pa-sm">
           <q-toolbar>
             <q-toolbar-title class="text-display">辞書管理</q-toolbar-title>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -72,6 +72,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const store = useStore();
 
+    let engineInfo: EngineInfo | undefined;
     const dictionaryManageDialogOpenedComputed = computed({
       get: () => props.modelValue,
       set: (val) => emit("update:modelValue", val),
@@ -81,7 +82,7 @@ export default defineComponent({
 
     watch(dictionaryManageDialogOpenedComputed, async (newValue) => {
       if (newValue) {
-        const engineInfo = store.state.engineInfos[0]; // TODO: 複数エンジン対応
+        engineInfo = store.state.engineInfos[0]; // TODO: 複数エンジン対応
         if (!engineInfo)
           throw new Error(`No such engineInfo registered: index == 0`);
         loadingDict.value = true;

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -235,7 +235,7 @@ export default defineComponent({
     const selectWord = (id: string) => {
       selectedId.value = id;
       surface.value = userDict.value[id].surface;
-      setYomi(userDict.value[id].yomi, userDict.value[id].accentType);
+      setYomi(userDict.value[id].yomi);
     };
 
     const kanaRegex = createKanaRegex();
@@ -251,7 +251,7 @@ export default defineComponent({
         accentPhraseTable.value.scrollWidth ==
           accentPhraseTable.value.offsetWidth;
     };
-    const setYomi = async (text: string, accent?: number) => {
+    const setYomi = async (text: string) => {
       // テキスト長が0の時にエラー表示にならないように、テキスト長を考慮する
       isOnlyHiraOrKana.value = !text.length || kanaRegex.test(text);
       // 文字列が変更されていない場合は、アクセントフレーズに変更を加えない
@@ -273,10 +273,13 @@ export default defineComponent({
             styleId: 0,
             isKana: true,
           })
-        ).map((v) => {
-          if (accent !== undefined) v.accent = accent;
-          return v;
-        })[0];
+        )[0];
+        if (
+          selectedId.value &&
+          userDict.value[selectedId.value].yomi === text
+        ) {
+          accentPhrase.value.accent = computeDisplayAccent();
+        }
       } else {
         accentPhrase.value = undefined;
       }
@@ -359,6 +362,14 @@ export default defineComponent({
       if (!accentPhrase.value) throw new Error();
       let accent = accentPhrase.value.accent;
       accent = accent === accentPhrase.value.moras.length ? 0 : accent;
+      return accent;
+    };
+    // computeの逆
+    // 辞書から得たaccentが0の場合に、自動で追加される「ワ」の位置にアクセントを表示させるように処理する
+    const computeDisplayAccent = () => {
+      if (!accentPhrase.value || !selectedId.value) throw new Error();
+      let accent = userDict.value[selectedId.value].accentType;
+      accent = accent === 0 ? accentPhrase.value.moras.length : accent;
       return accent;
     };
 

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -442,7 +442,7 @@ export default defineComponent({
           });
         } catch {
           $q.dialog({
-            title: "辞書の更新に失敗しました",
+            title: "単語の更新に失敗しました",
             message: "エンジンの再起動をお試しください。",
             ok: {
               label: "閉じる",
@@ -469,7 +469,7 @@ export default defineComponent({
             .then(toDispatchResponse("addUserDictWordUserDictWordPost"));
         } catch {
           $q.dialog({
-            title: "辞書の登録に失敗しました",
+            title: "単語の登録に失敗しました",
             message: "エンジンの再起動をお試しください。",
             ok: {
               label: "閉じる",

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -51,6 +51,16 @@
                 </q-item-section>
               </q-item>
             </q-list>
+            <div class="q-ma-sm">
+              <q-btn
+                outline
+                text-color="display"
+                class="text-no-wrap text-bold new-word-button"
+                @click="discardOrNotDialog(newWord)"
+                :disable="uiLocked"
+                >新規登録</q-btn
+              >
+            </div>
           </div>
           <div class="col-8 no-wrap text-no-wrap">
             <div class="row q-pl-md q-mt-md">
@@ -263,6 +273,10 @@ export default defineComponent({
       selectedId.value = id;
       surface.value = userDict.value[id].surface;
       setYomi(userDict.value[id].yomi, true);
+    };
+    const newWord = () => {
+      resetSelect();
+      surfaceInput.value?.focus();
     };
 
     const kanaRegex = createKanaRegex();
@@ -577,6 +591,7 @@ export default defineComponent({
       surface,
       yomi,
       selectWord,
+      newWord,
       isOnlyHiraOrKana,
       setSurface,
       setYomi,
@@ -605,11 +620,11 @@ export default defineComponent({
 }
 
 .word-list {
-  // menubar-height + header-height + window-border-width
-  // 46(title)
+  // menubar-height + header-height + window-border-width +
+  // 46(title) + 52(new word button)
   height: calc(
     100vh - #{vars.$menubar-height + vars.$header-height +
-      vars.$window-border-width + 46px}
+      vars.$window-border-width + 46px + 52px}
   );
   width: 100%;
   overflow-y: scroll;
@@ -617,6 +632,10 @@ export default defineComponent({
 
 .active-word {
   background: rgba(colors.$primary-rgb, 0.4);
+}
+
+.new-word-button {
+  width: 100%;
 }
 
 .loading-dict {

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -380,11 +380,14 @@ export default defineComponent({
       if (selectedId.value === "") {
         return surface.value && yomi.value && accentPhrase.value;
       }
-      const dictData = userDict.value[selectedId.value];
+      // 一旦代入することで、userDictそのものが更新された時もcomputedするようにする
+      const dict = userDict.value;
+      const dictData = dict[selectedId.value];
       return (
-        dictData.surface !== surface.value ||
-        dictData.yomi !== yomi.value ||
-        dictData.accentType !== computeRegisteredAccent()
+        dictData &&
+        (dictData.surface !== surface.value ||
+          dictData.yomi !== yomi.value ||
+          dictData.accentType !== computeRegisteredAccent())
       );
     });
     const saveWord = async () => {

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -46,7 +46,7 @@
               </q-item>
             </q-list>
           </div>
-          <div class="col-8">
+          <div class="col-8 no-wrap text-no-wrap">
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <form @submit.stop="yomiInput.focus()">
@@ -412,7 +412,7 @@ export default defineComponent({
 
   display: flex;
   overflow-x: scroll;
-  width: calc(66vw - 110px);
+  width: calc(66vw - 140px);
 
   .mora-table {
     display: inline-grid;

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -235,11 +235,14 @@ export default defineComponent({
         await loadingDictProcess();
       }
     });
-    const closeDialogProcess = () => {
-      dictionaryManageDialogOpenedComputed.value = false;
+    const resetSelect = () => {
       selectedId.value = "";
       surface.value = "";
       setYomi("");
+    };
+    const closeDialogProcess = () => {
+      dictionaryManageDialogOpenedComputed.value = false;
+      resetSelect();
     };
 
     const surfaceInput = ref<QInput>();

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -1,0 +1,58 @@
+<template>
+  <q-dialog
+    maximized
+    seamless
+    transition-show="jump-up"
+    transition-hide="jump-down"
+    class="setting-dialog"
+    v-model="dictionaryManageDialogOpenedComputed"
+  >
+    <q-layout container view="hHh Lpr fFf" class="bg-background">
+      <q-page-container class="root">
+        <q-header class="q-pa-sm">
+          <q-toolbar>
+            <q-toolbar-title class="text-display">辞書管理</q-toolbar-title>
+            <q-space />
+            <!-- close button -->
+            <q-btn
+              round
+              flat
+              icon="close"
+              color="display"
+              @click="dictionaryManageDialogOpenedComputed = false"
+            />
+          </q-toolbar>
+        </q-header>
+        <q-page>
+          <div />
+        </q-page>
+      </q-page-container>
+    </q-layout>
+  </q-dialog>
+</template>
+
+<script>
+import { computed, defineComponent } from "vue";
+
+export default defineComponent({
+  name: "DictionaryManageDialog",
+
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+  },
+
+  setup(props, { emit }) {
+    const dictionaryManageDialogOpenedComputed = computed({
+      get: () => props.modelValue,
+      set: (val) => emit("update:modelValue", val),
+    });
+
+    return {
+      dictionaryManageDialogOpenedComputed,
+    };
+  },
+});
+</script>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -65,34 +65,32 @@
           <div class="col-8 no-wrap text-no-wrap">
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
-              <form @submit.stop="yomiInput.focus()">
-                <q-input
-                  ref="surfaceInput"
-                  class="word-input"
-                  v-model="surface"
-                  @blur="setSurface(surface)"
-                  dense
-                  :disable="uiLocked"
-                />
-              </form>
+              <q-input
+                ref="surfaceInput"
+                class="word-input"
+                v-model="surface"
+                @blur="setSurface(surface)"
+                @keydown="yomiFocusWhenEnter"
+                dense
+                :disable="uiLocked"
+              />
             </div>
             <div class="row q-pl-md q-pt-sm">
               <div class="text-h6">読み</div>
-              <form @submit.stop="yomiInput.blur()">
-                <q-input
-                  ref="yomiInput"
-                  class="word-input"
-                  v-model="yomi"
-                  @blur="setYomi(yomi)"
-                  dense
-                  :error="!isOnlyHiraOrKana"
-                  :disable="uiLocked"
-                >
-                  <template v-slot:error>
-                    読みに使える文字はひらがなとカタカナのみです。
-                  </template>
-                </q-input>
-              </form>
+              <q-input
+                ref="yomiInput"
+                class="word-input"
+                v-model="yomi"
+                @blur="setYomi(yomi)"
+                @keydown="setYomiWhenEnter"
+                dense
+                :error="!isOnlyHiraOrKana"
+                :disable="uiLocked"
+              >
+                <template v-slot:error>
+                  読みに使える文字はひらがなとカタカナのみです。
+                </template>
+              </q-input>
             </div>
             <div class="row q-pl-md q-pt-sm text-h6">アクセント調整</div>
             <div class="row q-pl-md accent-desc">
@@ -291,6 +289,20 @@ export default defineComponent({
 
     const surfaceInput = ref<QInput>();
     const yomiInput = ref<QInput>();
+    const yomiFocusWhenEnter = (event: KeyboardEvent) => {
+      // keyCodeは非推奨で、keyが推奨だが、
+      // key === "Enter"はIMEのEnterも拾ってしまうので、keyCodeを用いている
+      if (event.keyCode === 13) {
+        yomiInput.value?.focus();
+      }
+    };
+    const setYomiWhenEnter = (event: KeyboardEvent) => {
+      // keyCodeは非推奨で、keyが推奨だが、
+      // key === "Enter"はIMEのEnterも拾ってしまうので、keyCodeを用いている
+      if (event.keyCode === 13) {
+        setYomi(yomi.value);
+      }
+    };
 
     const selectedId = ref("");
     const surface = ref("");
@@ -633,6 +645,8 @@ export default defineComponent({
       loadingDict,
       surfaceInput,
       yomiInput,
+      yomiFocusWhenEnter,
+      setYomiWhenEnter,
       selectedId,
       surface,
       yomi,

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -19,11 +19,7 @@
               flat
               icon="close"
               color="display"
-              @click="
-                discardOrNotDialog(
-                  () => (dictionaryManageDialogOpenedComputed = false)
-                )
-              "
+              @click="discardOrNotDialog(closeDialogProcess)"
             />
           </q-toolbar>
         </q-header>
@@ -220,6 +216,12 @@ export default defineComponent({
         loadingDict.value = false;
       }
     });
+    const closeDialogProcess = () => {
+      dictionaryManageDialogOpenedComputed.value = false;
+      selectedId.value = "";
+      surface.value = "";
+      setYomi("");
+    };
 
     const surfaceInput = ref<QInput>();
     const yomiInput = ref<QInput>();
@@ -406,6 +408,7 @@ export default defineComponent({
       nowGenerating,
       nowPlaying,
       userDict,
+      closeDialogProcess,
       loadingDict,
       surfaceInput,
       yomiInput,

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -167,7 +167,7 @@
                 text-color="warning"
                 class="text-no-wrap text-bold q-mr-sm"
                 @click="deleteWord"
-                :disable="uiLocked || isDeletable"
+                :disable="uiLocked || !isDeletable"
                 >削除</q-btn
               >
             </div>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -235,13 +235,29 @@ export default defineComponent({
         throw new Error(`No such engineInfo registered: index == 0`);
       loadingDict.value = true;
       try {
-        userDict.value = await store
+        const engineDict = await store
           .dispatch("INVOKE_ENGINE_CONNECTOR", {
             engineKey: engineInfo.key,
             action: "getUserDictWordsUserDictGet",
             payload: [],
           })
           .then(toDispatchResponse("getUserDictWordsUserDictGet"));
+        // 50音順にソートするために、一旦arrayにする
+        const dictArray = Object.keys(engineDict).map((k) => {
+          return { key: k, ...engineDict[k] };
+        });
+        dictArray.sort((a, b) => {
+          if (a.yomi > b.yomi) {
+            return 1;
+          } else {
+            return -1;
+          }
+        });
+        const dictEntries: [string, UserDictWord][] = dictArray.map((v) => {
+          const { key, ...newV } = v;
+          return [key, newV];
+        });
+        userDict.value = Object.fromEntries(dictEntries);
       } catch {
         loadingDict.value = false;
         $q.dialog({

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -227,7 +227,7 @@ export default defineComponent({
     const nowPlaying = ref(false);
 
     const loadingDict = ref(false);
-    const userDict = ref<{ [key: string]: UserDictWord }>({});
+    const userDict = ref<Record<string, UserDictWord>>({});
 
     const loadingDictProcess = async () => {
       engineInfo = store.state.engineInfos[0]; // TODO: 複数エンジン対応

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -60,6 +60,7 @@
                   ref="surfaceInput"
                   class="word-input"
                   v-model="surface"
+                  @blur="setSurface(surface)"
                   dense
                   :disable="uiLocked"
                 />
@@ -265,6 +266,17 @@ export default defineComponent({
         !!accentPhraseTable.value &&
         accentPhraseTable.value.scrollWidth ==
           accentPhraseTable.value.offsetWidth;
+    };
+    const convertHankakuToZenkaku = (text: string) => {
+      return text.replace(/[\u0021-\u007e]/g, (s) => {
+        return String.fromCharCode(s.charCodeAt(0) + 0xfee0);
+      });
+    };
+    const setSurface = (text: string) => {
+      // surfaceを全角化する
+      // 入力は半角でも問題ないが、登録時に全角に変換され、isWordChangedの判断がおかしくなることがあるので、
+      // 入力後に自動で変換するようにする
+      surface.value = convertHankakuToZenkaku(text);
     };
     const setYomi = async (text: string, changeWord?: boolean) => {
       // テキスト長が0の時にエラー表示にならないように、テキスト長を考慮する
@@ -509,6 +521,7 @@ export default defineComponent({
       yomi,
       selectWord,
       isOnlyHiraOrKana,
+      setSurface,
       setYomi,
       accentPhrase,
       accentPhraseTable,

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -235,7 +235,7 @@ export default defineComponent({
     const selectWord = (id: string) => {
       selectedId.value = id;
       surface.value = userDict.value[id].surface;
-      setYomi(userDict.value[id].yomi);
+      setYomi(userDict.value[id].yomi, true);
     };
 
     const kanaRegex = createKanaRegex();
@@ -251,19 +251,22 @@ export default defineComponent({
         accentPhraseTable.value.scrollWidth ==
           accentPhraseTable.value.offsetWidth;
     };
-    const setYomi = async (text: string) => {
+    const setYomi = async (text: string, changeWord?: boolean) => {
       // テキスト長が0の時にエラー表示にならないように、テキスト長を考慮する
       isOnlyHiraOrKana.value = !text.length || kanaRegex.test(text);
-      // 文字列が変更されていない場合は、アクセントフレーズに変更を加えない
+      // 読みが変更されていない場合は、アクセントフレーズに変更を加えない
+      // ただし、読みが同じで違う単語が存在する場合が考えられるので、changeWordフラグを考慮する
       // 「ワ」が自動挿入されるので、それを考慮してsliceしている
       if (
         text ==
-        accentPhrase.value?.moras
-          .map((v) => v.text)
-          .join("")
-          .slice(0, -1)
-      )
+          accentPhrase.value?.moras
+            .map((v) => v.text)
+            .join("")
+            .slice(0, -1) &&
+        !changeWord
+      ) {
         return;
+      }
       if (isOnlyHiraOrKana.value && text.length) {
         text = convertHiraToKana(text);
         text = convertLongVowel(text);

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -200,20 +200,23 @@ export default defineComponent({
     const loadingDict = ref(false);
     const userDict = ref<{ [key: string]: UserDictWord }>({});
 
+    const loadingDictProcess = async () => {
+      engineInfo = store.state.engineInfos[0]; // TODO: 複数エンジン対応
+      if (!engineInfo)
+        throw new Error(`No such engineInfo registered: index == 0`);
+      loadingDict.value = true;
+      userDict.value = await store
+        .dispatch("INVOKE_ENGINE_CONNECTOR", {
+          engineKey: engineInfo.key,
+          action: "getUserDictWordsUserDictGet",
+          payload: [],
+        })
+        .then(toDispatchResponse("getUserDictWordsUserDictGet"));
+      loadingDict.value = false;
+    };
     watch(dictionaryManageDialogOpenedComputed, async (newValue) => {
       if (newValue) {
-        engineInfo = store.state.engineInfos[0]; // TODO: 複数エンジン対応
-        if (!engineInfo)
-          throw new Error(`No such engineInfo registered: index == 0`);
-        loadingDict.value = true;
-        userDict.value = await store
-          .dispatch("INVOKE_ENGINE_CONNECTOR", {
-            engineKey: engineInfo.key,
-            action: "getUserDictWordsUserDictGet",
-            payload: [],
-          })
-          .then(toDispatchResponse("getUserDictWordsUserDictGet"));
-        loadingDict.value = false;
+        await loadingDictProcess();
       }
     });
     const closeDialogProcess = () => {

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -307,6 +307,15 @@ export default defineComponent({
               });
             },
           },
+          {
+            type: "button",
+            label: "辞書管理",
+            onClick() {
+              store.dispatch("IS_DICTIONARY_MANAGE_DIALOG_OPEN", {
+                isDictionaryManageDialogOpen: true,
+              });
+            },
+          },
           { type: "separator" },
           {
             type: "button",

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2289,7 +2289,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
 };
 
 // FIXME: ProxyStoreのactionとVuexの組み合わせでReturnValueの型付けが中途半端になり、Promise<any>になってしまっている
-const toDispatchResponse =
+export const toDispatchResponse =
   <T extends keyof IEngineConnectorFactoryActions>(_: T) =>
   (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -832,6 +832,7 @@ export type UiStoreState = {
   isToolbarSettingDialogOpen: boolean;
   isAcceptRetrieveTelemetryDialogOpen: boolean;
   isAcceptTermsDialogOpen: boolean;
+  isDictionaryManageDialogOpen: boolean;
   isMaximized: boolean;
   isPinned: boolean;
   isFullscreen: boolean;
@@ -902,6 +903,11 @@ type UiStoreTypes = {
   IS_ACCEPT_TERMS_DIALOG_OPEN: {
     mutation: { isAcceptTermsDialogOpen: boolean };
     action(payload: { isAcceptTermsDialogOpen: boolean }): void;
+  };
+
+  IS_DICTIONARY_MANAGE_DIALOG_OPEN: {
+    mutation: { isDictionaryManageDialogOpen: boolean };
+    action(payload: { isDictionaryManageDialogOpen: boolean }): void;
   };
 
   ON_VUEX_READY: {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -40,6 +40,7 @@ export const uiStoreState: UiStoreState = {
   isDefaultStyleSelectDialogOpen: false,
   isAcceptRetrieveTelemetryDialogOpen: false,
   isAcceptTermsDialogOpen: false,
+  isDictionaryManageDialogOpen: false,
   isMaximized: false,
   isPinned: false,
   isFullscreen: false,
@@ -103,6 +104,14 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
         }: { isDefaultStyleSelectDialogOpen: boolean }
       ) {
         state.isDefaultStyleSelectDialogOpen = isDefaultStyleSelectDialogOpen;
+      },
+      IS_DICTIONARY_MANAGE_DIALOG_OPEN(
+        state,
+        {
+          isDictionaryManageDialogOpen,
+        }: { isDictionaryManageDialogOpen: boolean }
+      ) {
+        state.isDictionaryManageDialogOpen = isDictionaryManageDialogOpen;
       },
       IS_ACCEPT_RETRIEVE_TELEMETRY_DIALOG_OPEN(
         state,
@@ -263,6 +272,25 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
 
         commit("IS_DEFAULT_STYLE_SELECT_DIALOG_OPEN", {
           isDefaultStyleSelectDialogOpen,
+        });
+      },
+      async IS_DICTIONARY_MANAGE_DIALOG_OPEN(
+        { state, commit },
+        { isDictionaryManageDialogOpen }
+      ) {
+        if (state.isDictionaryManageDialogOpen === isDictionaryManageDialogOpen)
+          return;
+
+        if (isDictionaryManageDialogOpen) {
+          commit("LOCK_UI");
+          commit("LOCK_MENUBAR");
+        } else {
+          commit("UNLOCK_UI");
+          commit("UNLOCK_MENUBAR");
+        }
+
+        commit("IS_DICTIONARY_MANAGE_DIALOG_OPEN", {
+          isDictionaryManageDialogOpen,
         });
       },
       async IS_ACCEPT_RETRIEVE_TELEMETRY_DIALOG_OPEN(

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -130,6 +130,7 @@
     :characterInfos="characterInfos"
     v-model="isDefaultStyleSelectDialogOpenComputed"
   />
+  <dictionary-manage-dialog v-model="isDictionaryManageDialogOpenComputed" />
   <accept-retrieve-telemetry-dialog
     v-model="isAcceptRetrieveTelemetryDialogOpenComputed"
   />
@@ -160,6 +161,7 @@ import CharacterPortrait from "@/components/CharacterPortrait.vue";
 import DefaultStyleSelectDialog from "@/components/DefaultStyleSelectDialog.vue";
 import AcceptRetrieveTelemetryDialog from "@/components/AcceptRetrieveTelemetryDialog.vue";
 import AcceptTermsDialog from "@/components/AcceptTermsDialog.vue";
+import DictionaryManageDialog from "@/components/DictionaryManageDialog.vue";
 import { AudioItem } from "@/store/type";
 import { QResizeObserver } from "quasar";
 import path from "path";
@@ -184,6 +186,7 @@ export default defineComponent({
     DefaultStyleSelectDialog,
     AcceptRetrieveTelemetryDialog,
     AcceptTermsDialog,
+    DictionaryManageDialog,
   },
 
   setup() {
@@ -487,6 +490,15 @@ export default defineComponent({
         }),
     });
 
+    // 辞書管理
+    const isDictionaryManageDialogOpenComputed = computed({
+      get: () => store.state.isDictionaryManageDialogOpen,
+      set: (val) =>
+        store.dispatch("IS_DICTIONARY_MANAGE_DIALOG_OPEN", {
+          isDictionaryManageDialogOpen: val,
+        }),
+    });
+
     const isAcceptRetrieveTelemetryDialogOpenComputed = computed({
       get: () =>
         !store.state.isAcceptTermsDialogOpen &&
@@ -549,6 +561,7 @@ export default defineComponent({
       isToolbarSettingDialogOpenComputed,
       characterInfos,
       isDefaultStyleSelectDialogOpenComputed,
+      isDictionaryManageDialogOpenComputed,
       isAcceptRetrieveTelemetryDialogOpenComputed,
       isAcceptTermsDialogOpenComputed,
       dragEventCounter,

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -36,6 +36,7 @@ describe("store/vuex.js test", () => {
         isHotkeySettingDialogOpen: false,
         isToolbarSettingDialogOpen: false,
         isDefaultStyleSelectDialogOpen: false,
+        isDictionaryManageDialogOpen: false,
         isAcceptRetrieveTelemetryDialogOpen: false,
         isAcceptTermsDialogOpen: false,
         isMaximized: false,
@@ -137,6 +138,7 @@ describe("store/vuex.js test", () => {
     assert.equal(store.state.isSettingDialogOpen, false);
     assert.equal(store.state.isHotkeySettingDialogOpen, false);
     assert.equal(store.state.isDefaultStyleSelectDialogOpen, false);
+    assert.equal(store.state.isDictionaryManageDialogOpen, false);
     assert.equal(store.state.isAcceptRetrieveTelemetryDialogOpen, false);
     assert.equal(store.state.isAcceptTermsDialogOpen, false);
     assert.equal(store.state.isMaximized, false);


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り。
詳細として、以下のことが可能です
- 登録単語の一覧化
  - 50音順にソートして表示されます
- 単語の新規登録
- 単語の編集
  - 新規登録と編集では、表記、読み、アクセント位置の調整が可能です
- 単語の削除
- 編集した単語パラメータのリセット
- 登録した・登録する単語のプレビュー再生機能

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #709 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
<img width="794" alt="スクリーンショット 2022-02-27 23 41 16" src="https://user-images.githubusercontent.com/34832037/155886939-e94a97bc-c46e-4213-b6d5-0cf5fcdb16a8.png">
<img width="793" alt="スクリーンショット 2022-02-27 23 41 36" src="https://user-images.githubusercontent.com/34832037/155886951-e7774502-85ab-43b3-87d8-f1a9b1cb53db.png">
