### PR TITLE
辞書登録UIのデザインちょっと修正

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -321,7 +321,7 @@ export default defineComponent({
           },
           {
             type: "button",
-            label: "辞書管理",
+            label: "読み方＆アクセント辞書",
             onClick() {
               store.dispatch("IS_DICTIONARY_MANAGE_DIALOG_OPEN", {
                 isDictionaryManageDialogOpen: true,

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -68,6 +68,13 @@ img {
   background-color: colors.$background;
 }
 
+// 無効時の色
+.q-btn {
+  &.disabled {
+    opacity: 0.6 !important;
+  }
+}
+
 // ダイアログ
 .q-dialog,
 #q-loading {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -516,7 +516,7 @@ export default defineComponent({
         }),
     });
 
-    // 辞書管理
+    // 読み方＆アクセント辞書
     const isDictionaryManageDialogOpenComputed = computed({
       get: () => store.state.isDictionaryManageDialogOpen,
       set: (val) =>


### PR DESCRIPTION
## 内容

辞書登録UIを、左を操作しているときと右を操作しているときのステートが違うことをわかりやすくしてみました。
消去・編集・追加ボタンは左に、リセット・保存・キャンセルボタンは右にあります。


## スクリーンショット・動画など


https://user-images.githubusercontent.com/4987327/155902095-873c3b0d-433e-454f-bee5-70d44cec44c8.mp4



## その他

@y-chan （共有のためのメンションです）
