### PR TITLE
Hotfix: バイナリでエンジン設定が読み出せず、エンジンが起動しない問題の原因を修正 (#721)

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -59,29 +59,6 @@ if (isDevelopment) {
   );
 }
 
-const engineInfos: EngineInfo[] = (() => {
-  const defaultEngineInfosEnv = process.env.DEFAULT_ENGINE_INFOS;
-
-  if (defaultEngineInfosEnv) {
-    return JSON.parse(defaultEngineInfosEnv) as EngineInfo[];
-  }
-
-  // FIXME: electron builderでは、.envファイルが読み込まれないらしいのでフォールバック
-  // .envから情報を取得するようにするべき
-  // https://github.com/VOICEVOX/voicevox/issues/721
-  const isMac = process.platform === "darwin";
-  const isLinux = process.platform === "linux";
-  return [
-    {
-      key: "074fc39e-678b-4c13-8916-ffca8d505d1d",
-      executionEnabled: true,
-      executionFilePath: isMac || isLinux ? "./run" : "run.exe",
-      host: "http://127.0.0.1:50021",
-    },
-  ];
-  // return [];
-})();
-
 let win: BrowserWindow;
 
 // 多重起動防止
@@ -101,11 +78,23 @@ process.on("unhandledRejection", (reason) => {
 const appDirPath = path.dirname(app.getPath("exe"));
 const envPath = path.join(appDirPath, ".env");
 dotenv.config({ path: envPath });
+
 protocol.registerSchemesAsPrivileged([
   { scheme: "app", privileges: { secure: true, standard: true, stream: true } },
 ]);
 
 const isMac = process.platform === "darwin";
+
+const engineInfos: EngineInfo[] = (() => {
+  const defaultEngineInfosEnv = process.env.DEFAULT_ENGINE_INFOS;
+
+  if (defaultEngineInfosEnv) {
+    return JSON.parse(defaultEngineInfosEnv) as EngineInfo[];
+  }
+
+  return [];
+})();
+
 const defaultHotkeySettings: HotkeySetting[] = [
   {
     action: "音声書き出し",

--- a/src/background.ts
+++ b/src/background.ts
@@ -74,7 +74,7 @@ process.on("unhandledRejection", (reason) => {
   log.error(reason);
 });
 
-// .envから設定を読み込み
+// .envから設定をprocess.envに読み込み
 const appDirPath = path.dirname(app.getPath("exe"));
 const envPath = path.join(appDirPath, ".env");
 dotenv.config({ path: envPath });

--- a/src/background.ts
+++ b/src/background.ts
@@ -74,7 +74,7 @@ process.on("unhandledRejection", (reason) => {
   log.error(reason);
 });
 
-// 設定
+// .envから設定を読み込み
 const appDirPath = path.dirname(app.getPath("exe"));
 const envPath = path.join(appDirPath, ".env");
 dotenv.config({ path: envPath });


### PR DESCRIPTION
## 内容

0.11.0でエンジン起動が終わらない問題 #721 の原因を修正します。

dotenvが.envから設定をprocess.envに読み出す（`dotenv.config()`）前に、
`engineInfos`の初期化処理をしていたため、electron builderでビルドしたバイナリで、
`process.env.DEFAULT_ENGINE_INFOS`が`undefined`になり、エンジン設定`engineInfos`が空リストになっていました。

`engineInfos`の初期化処理を`dotenv.config()`の後に移動して、修正します。

ローカルで`npm run electron:build_pnever`で（エンジンなしで）ビルドして、.envを0.11.0エンジンが起動するように差し替えて、エンジンが起動・接続できることを確認しました。

一応ビルドを回しています。

- <https://github.com/aoirint/voicevox/releases/tag/0.11.1-aoirint-1>

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- close #721
- ref #722

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など



<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
