### PR TITLE
複数エンジン対応: `DEFAULT_ENGINE_INFOS`に登録されたエンジンのプロセスをすべて起動する（Promise版）

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1200,7 +1200,7 @@ app.on("before-quit", (event) => {
   log.info("Interrupt app quit to kill ENGINE processes");
   event.preventDefault();
 
-  const numEngineProcess = processKillPromises.length;
+  const numEngineProcess = processKillPromises.length; // assert == engineProcessContainers.length
   let numEngineProcessKilled = 0;
 
   // 非同期的にすべてのエンジンプロセスをキル

--- a/src/background.ts
+++ b/src/background.ts
@@ -1223,7 +1223,7 @@ app.on("before-quit", (event) => {
 
     // アプリケーションの終了を再試行する
     log.info("All ENGINE process kill operations done. Attempting to quit app again");
-    app.quit(); // attempt to quit app again
+    app.quit();
   })();
 });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -488,7 +488,18 @@ function killEngineAll({
           onAllKilled?.();
         }
       },
-      onError: (message) => onError?.(engineKey, message),
+      onError: (message) => {
+        onError?.(engineKey, message);
+
+        // エディタを終了するため、エラーが起きてもエンジンプロセスをキルできたとみなして次のエンジンプロセスをキルする
+        numEngineProcessKilled++;
+        log.info(
+          `ENGINE ${engineKey}: process kill errored, but assume to have been killed`
+        );
+        log.info(
+          `ENGINE ${numEngineProcessKilled} / ${numEngineProcess} processes killed`
+        );
+      },
     });
   }
 }
@@ -514,6 +525,7 @@ function killEngine({
   if (engineProcess == undefined) {
     // nop if no process started (already killed or not started yet)
     log.info(`ENGINE ${engineKey}: Process not started`);
+    onKilled?.();
     return;
   }
 
@@ -543,6 +555,7 @@ function killEngine({
     }
   } else {
     log.info(`ENGINE ${engineKey}: Process already closed`);
+    onKilled?.();
   }
 }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -499,6 +499,10 @@ function killEngineAll({
         log.info(
           `ENGINE ${numEngineProcessKilled} / ${numEngineProcess} processes killed`
         );
+
+        if (numEngineProcessKilled === numEngineProcess) {
+          onAllKilled?.();
+        }
       },
     });
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1181,12 +1181,12 @@ app.on("before-quit", (event) => {
       event.preventDefault();
     },
     onAllKilled: () => {
-      // executed asynchronously to catch all process closed event
-      log.info("All ENGINE killed. Quitting app");
+      // executed asynchronously
+      log.info("All ENGINE process killed. Quitting app");
       app.quit(); // attempt to quit app again
     },
     onError: (engineKey, message) => {
-      console.error(
+      log.error(
         `ENGINE ${engineKey}: Error during killing process: ${message}`
       );
     },

--- a/src/background.ts
+++ b/src/background.ts
@@ -515,6 +515,8 @@ function killEngine({
   onKilled?: VoidFunction;
   onError?: (error: unknown) => void;
 }) {
+  // この関数では、結果を通知するためonKilledまたはonErrorを同期または非同期で必ず呼び出さなければならない
+
   const engineProcessContainer = engineProcessContainers[engineKey];
   if (!engineProcessContainer) {
     onError?.(`No such engineProcessContainer: key == ${engineKey}`);

--- a/src/background.ts
+++ b/src/background.ts
@@ -1167,7 +1167,9 @@ app.on("before-quit", (event) => {
       app.quit(); // attempt to quit app again
     },
     onError: (engineKey, message) => {
-      console.error(`ENGINE ${engineKey}: Error during killing process: ${message}`);
+      console.error(
+        `ENGINE ${engineKey}: Error during killing process: ${message}`
+      );
     },
   });
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -538,10 +538,11 @@ function killEngine({
     try {
       engineProcess.pid != undefined && treeKill(engineProcess.pid);
     } catch (error: unknown) {
+      log.error(`ENGINE ${engineKey}: Error during killing process`);
       onError?.(error);
     }
   } else {
-    log.info("ENGINE process already closed");
+    log.info(`ENGINE ${engineKey}: Process already closed`);
   }
 }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -506,7 +506,7 @@ function killEngine({
 }) {
   const engineProcessContainer = engineProcessContainers[engineKey];
   if (!engineProcessContainer) {
-    onError?.(`No such engineProcessContainer: ${engineKey}`);
+    onError?.(`No such engineProcessContainer: key == ${engineKey}`);
     return;
   }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -356,7 +356,7 @@ type EngineProcessContainer = {
 const engineProcessContainers: Record<string, EngineProcessContainer> = {};
 
 async function runEngineAll() {
-  log.info(`Starting ${engineInfos.length} engines...`);
+  log.info(`Starting ${engineInfos.length} engine/s...`);
 
   for (const engineInfo of engineInfos) {
     log.info(`ENGINE ${engineInfo.key}: Start launching`);

--- a/src/background.ts
+++ b/src/background.ts
@@ -1177,7 +1177,7 @@ app.on("before-quit", (event) => {
   killEngineAll({
     onFirstKillStart: () => {
       // executed synchronously to cancel before-quit event
-      log.info("Interrupt app quit to kill ENGINE");
+      log.info("Interrupt app quit to kill ENGINE processes");
       event.preventDefault();
     },
     onAllKilled: () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -378,6 +378,8 @@ async function runEngine(engineKey: string) {
     return;
   }
 
+  log.info(`Starting ENGINE ${engineKey} process`);
+
   if (!(engineKey in engineProcessContainers)) {
     engineProcessContainers[engineKey] = {
       willQuitEngine: false,
@@ -407,8 +409,7 @@ async function runEngine(engineKey: string) {
   }
   const useGpu = store.get("useGpu");
 
-  log.info(`Starting ENGINE`);
-  log.info(`ENGINE mode: ${useGpu ? "GPU" : "CPU"}`);
+  log.info(`ENGINE ${engineKey} mode: ${useGpu ? "GPU" : "CPU"}`);
 
   // エンジンプロセスの起動
   const enginePath = path.resolve(
@@ -417,8 +418,8 @@ async function runEngine(engineKey: string) {
   );
   const args = useGpu ? ["--use_gpu"] : [];
 
-  log.info(`ENGINE path: ${enginePath}`);
-  log.info(`ENGINE args: ${JSON.stringify(args)}`);
+  log.info(`ENGINE ${engineKey} path: ${enginePath}`);
+  log.info(`ENGINE ${engineKey} args: ${JSON.stringify(args)}`);
 
   const engineProcess = spawn(enginePath, args, {
     cwd: path.dirname(enginePath),
@@ -426,16 +427,16 @@ async function runEngine(engineKey: string) {
   engineProcessContainer.engineProcess = engineProcess;
 
   engineProcess.stdout?.on("data", (data) => {
-    log.info(`ENGINE: ${data.toString("utf-8")}`);
+    log.info(`ENGINE ${engineKey} STDOUT: ${data.toString("utf-8")}`);
   });
 
   engineProcess.stderr?.on("data", (data) => {
-    log.error(`ENGINE: ${data.toString("utf-8")}`);
+    log.error(`ENGINE ${engineKey} STDERR: ${data.toString("utf-8")}`);
   });
 
   engineProcess.on("close", (code, signal) => {
-    log.info(`ENGINE: process terminated due to receipt of signal ${signal}`);
-    log.info(`ENGINE: process exited with code ${code}`);
+    log.info(`ENGINE ${engineKey} process terminated due to receipt of signal ${signal}`);
+    log.info(`ENGINE ${engineKey} process exited with code ${code}`);
 
     if (!engineProcessContainer.willQuitEngine) {
       ipcMainSend(win, "DETECTED_ENGINE_ERROR");

--- a/src/background.ts
+++ b/src/background.ts
@@ -515,7 +515,7 @@ function killEngine({
   onKilled?: VoidFunction;
   onError?: (error: unknown) => void;
 }) {
-  // この関数では、結果を通知するためonKilledまたはonErrorを同期または非同期で必ず呼び出さなければならない
+  // この関数では、呼び出し元に結果を通知するためonKilledまたはonErrorを同期または非同期で必ず呼び出さなければならない
 
   const engineProcessContainer = engineProcessContainers[engineKey];
   if (!engineProcessContainer) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -351,7 +351,7 @@ const store = new Store<{
 type EngineProcessContainer = {
   willQuitEngine: boolean;
   engineProcess?: ChildProcess;
-}
+};
 
 const engineProcessContainers: Record<string, EngineProcessContainer> = {};
 
@@ -365,20 +365,22 @@ async function runEngineAll() {
 }
 
 async function runEngine(engineKey: string) {
-  const engineInfo = engineInfos.find((engineInfo) => engineInfo.key === engineKey)
-  if (!engineInfo) throw new Error(`No such engineInfo registered: index == 0`);
+  const engineInfo = engineInfos.find(
+    (engineInfo) => engineInfo.key === engineKey
+  );
+  if (!engineInfo) throw new Error(`No such engineInfo registered: key == ${engineKey}`);
 
   if (!engineInfo.executionEnabled) {
-    log.info("Skipped engineInfo execution: disabled");
+    log.info(`ENGINE ${engineKey}: Skipped engineInfo execution: disabled`);
     return;
   }
 
   if (!engineInfo.executionFilePath) {
-    log.info("Skipped engineInfo execution: empty executionFilePath");
+    log.info(`ENGINE ${engineKey}: Skipped engineInfo execution: empty executionFilePath`);
     return;
   }
 
-  log.info(`Starting ENGINE ${engineKey} process`);
+  log.info(`ENGINE ${engineKey}: Starting process`);
 
   if (!(engineKey in engineProcessContainers)) {
     engineProcessContainers[engineKey] = {
@@ -435,8 +437,10 @@ async function runEngine(engineKey: string) {
   });
 
   engineProcess.on("close", (code, signal) => {
-    log.info(`ENGINE ${engineKey} process terminated due to receipt of signal ${signal}`);
-    log.info(`ENGINE ${engineKey} process exited with code ${code}`);
+    log.info(
+      `ENGINE ${engineKey}: Process terminated due to receipt of signal ${signal}`
+    );
+    log.info(`ENGINE ${engineKey}: Process exited with code ${code}`);
 
     if (!engineProcessContainer.willQuitEngine) {
       ipcMainSend(win, "DETECTED_ENGINE_ERROR");


### PR DESCRIPTION
## 内容

#741 の別バージョンの実装になります。こちらでは、エディタが管理していないエンジンを利用していたとき、エディタが終了しないという #741 の不具合を修正しています。

マージの想定としては、不具合のある #741 → このPR または、このPRのみをマージすることを想定しています。

#654 や #741 では、エンジンプロセスをキルする処理をコールバックを使って書いていましたが、Promiseで実装し直してみました。

アプリケーションのウインドウがすべて閉じられ、app.quitが呼び出されたとき、before-quitイベントが発火します。

before-quitイベントのハンドラでは、event.preventDefaultを同期的に呼び出すことでアプリケーションの終了を回避することができます。

実装では、キルしなければならないエンジンプロセスが1つ以上ある場合、before-quitイベントを同期的にキャンセルし、エンジンプロセス終了後に非同期にapp.quitを再呼び出ししています。これにより、エンジンプロセスが生存したままエディタが終了することを防ぎ、エンジンプロセスの終了を待機してからエディタが終了するようにしています。

https://github.com/VOICEVOX/voicevox/pull/654 や https://github.com/VOICEVOX/voicevox/pull/741 では、エンジンプロセスのキルを非同期に実行しつつ、before-quitイベントを同期的にキャンセルする関数を実装するため、
可読性が落ちるのを承知でコールバックを使っていましたが、戻り値を工夫すればPromiseで書けることに気づいたので書き直してみました。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
