### PR TITLE
キャラクター並び替えUI: speakerUuidが異なる場合にstyleIdの重複を許容する

### DIFF
--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -65,7 +65,7 @@
                 ]"
                 @click="
                   selectCharacter(speakerUuid);
-                  togglePlayOrStop(selectedStyles[speakerUuid], 0);
+                  togglePlayOrStop(speakerUuid, selectedStyles[speakerUuid], 0);
                 "
               >
                 <div class="character-item-inner">
@@ -124,6 +124,8 @@
                       outline
                       :icon="
                         playing != undefined &&
+                        selectedStyles[speakerUuid] != undefined &&
+                        speakerUuid === playing.speakerUuid &&
                         selectedStyles[speakerUuid].styleId ===
                           playing.styleId &&
                         voiceSampleIndex === playing.index
@@ -137,6 +139,7 @@
                       @click.stop="
                         selectCharacter(speakerUuid);
                         togglePlayOrStop(
+                          speakerUuid,
                           selectedStyles[speakerUuid],
                           voiceSampleIndex
                         );
@@ -236,21 +239,14 @@ export default defineComponent({
     const sampleCharacterOrder = ref<string[]>([]);
 
     // 選択中のスタイル
-    const selectedStyleIndexes = ref(
-      Object.fromEntries(
-        props.characterInfos.map((characterInfo) => [
-          characterInfo.metas.speakerUuid,
-          0,
-        ])
-      )
-    );
+    const selectedStyleIndexes = ref<Record<string, number>>({});
     const selectedStyles = computed(() => {
       const map: { [key: string]: StyleInfo } = {};
       props.characterInfos.forEach((characterInfo) => {
+        const selectedStyleIndex: number | undefined =
+          selectedStyleIndexes.value[characterInfo.metas.speakerUuid];
         map[characterInfo.metas.speakerUuid] =
-          characterInfo.metas.styles[
-            selectedStyleIndexes.value[characterInfo.metas.speakerUuid]
-          ];
+          characterInfo.metas.styles[selectedStyleIndex ?? 0];
       });
       return map;
     });
@@ -315,18 +311,23 @@ export default defineComponent({
     const isHoverableItem = ref(true);
 
     // 音声再生
-    const playing = ref<{ styleId: number; index: number }>();
+    const playing =
+      ref<{ speakerUuid: string; styleId: number; index: number }>();
 
     const audio = new Audio();
     audio.volume = 0.5;
     audio.onended = () => stop();
 
-    const play = ({ styleId, voiceSamplePaths }: StyleInfo, index: number) => {
+    const play = (
+      speakerUuid: string,
+      { styleId, voiceSamplePaths }: StyleInfo,
+      index: number
+    ) => {
       if (audio.src !== "") stop();
 
       audio.src = voiceSamplePaths[index];
       audio.play();
-      playing.value = { styleId, index };
+      playing.value = { speakerUuid, styleId, index };
     };
     const stop = () => {
       if (audio.src === "") return;
@@ -337,13 +338,18 @@ export default defineComponent({
     };
 
     // 再生していたら停止、再生していなかったら再生
-    const togglePlayOrStop = (styleInfo: StyleInfo, index: number) => {
+    const togglePlayOrStop = (
+      speakerUuid: string,
+      styleInfo: StyleInfo,
+      index: number
+    ) => {
       if (
         playing.value === undefined ||
+        speakerUuid !== playing.value.speakerUuid ||
         styleInfo.styleId !== playing.value.styleId ||
         index !== playing.value.index
       ) {
-        play(styleInfo, index);
+        play(speakerUuid, styleInfo, index);
       } else {
         stop();
       }
@@ -353,14 +359,17 @@ export default defineComponent({
     const rollStyleIndex = (speakerUuid: string, diff: number) => {
       // 0 <= index <= length に収める
       const length = characterInfosMap.value[speakerUuid].metas.styles.length;
-      let styleIndex = selectedStyleIndexes.value[speakerUuid] + diff;
+      const selectedStyleIndex: number | undefined =
+        selectedStyleIndexes.value[speakerUuid];
+
+      let styleIndex = (selectedStyleIndex ?? 0) + diff;
       styleIndex = styleIndex < 0 ? length - 1 : styleIndex % length;
       selectedStyleIndexes.value[speakerUuid] = styleIndex;
 
       // 音声を再生する。同じstyleIndexだったら停止する。
       const selectedStyleInfo =
         characterInfosMap.value[speakerUuid].metas.styles[styleIndex];
-      togglePlayOrStop(selectedStyleInfo, 0);
+      togglePlayOrStop(speakerUuid, selectedStyleInfo, 0);
     };
 
     // ドラッグ中かどうか


### PR DESCRIPTION
## 内容

キャラクター並び替えUI（CharacterOrderDialog）について、`speakerUuid`が異なるキャラクターが重複した`styleId`を持つことを許容する実装にします。

複数エンジン対応時に、スタイル付きのキャラクターを一意に識別する方法については、
`engineId`と`styleId`の2つをユニークキーにする方針 https://github.com/VOICEVOX/voicevox/issues/609#issuecomment-1000940773 がありますが、
簡易な修正で済むため、キャラクター並び替えUIについては、いったん`speakerUuid`と`styleId`で一意に識別するように実装してみました。

また、`props.characerInfos`が初回setup呼び出し後に書き換えられたとき、書き換えによって追加されたキャラクターのサンプルボイスを再生できない現象を修正します。

この現象は、`selectedStyleIndexes`は初回setup呼び出し時に計算された初期値（またはその後に変更された値）を保持するため、`props.characterInfos`書き換え時に`selectedStyles`が再計算されないことで発生します。

`selectedStyleIndexes`に初期値を与える実装を削除し、`selectedStyleIndexes[speakerUuid]`が`undefined`のとき、`selectedStyleIndex=0`（0番目のスタイル）とする実装にして修正します。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- ref #609 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
