### PR TITLE
キャラクター並び替えダイアログ: スタイルごとにアイコンを変える

### DIFF
--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -71,7 +71,9 @@
                 <div class="character-item-inner">
                   <img
                     :src="
-                      characterInfosMap[speakerUuid].metas.styles[0].iconPath
+                      characterInfosMap[speakerUuid].metas.styles[
+                        selectedStyleIndexes[speakerUuid] ?? 0
+                      ].iconPath
                     "
                     class="style-icon"
                   />


### PR DESCRIPTION
## 内容

キャラクター並び替えダイアログ（CharacterOrderDialog）について、スタイルを切り替えたときに、アイコンをスタイルに対応するものに切り替えるようにします。

複数エンジン対応中に気になったのでPRを作成しました。
（キャラクター並び替えダイアログではデフォルトスタイルが変更されないので、意図的にアイコンを切り替えていないのかも・・・？　その場合はCloseしてください）

これまでの実装では、常に0番目のスタイルのアイコンが表示されていました。

<https://github.com/VOICEVOX/voicevox/pull/754> の変更と互換性があります。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
