### PR TITLE
CPU/GPUモードの状態をタイトルに追加

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -22,7 +22,8 @@
         (isEdited ? "*" : "") +
         (projectName !== undefined ? projectName + " - " : "") +
         "VOICEVOX" +
-        (currentVersion ? " - Ver. " + currentVersion : "")
+        (currentVersion ? " - Ver. " + currentVersion + " - " : "") +
+        (useGpu ? "GPU" : "CPU")
       }}
     </div>
     <q-space />
@@ -91,6 +92,7 @@ export default defineComponent({
     const uiLocked = computed(() => store.getters.UI_LOCKED);
     const menubarLocked = computed(() => store.getters.MENUBAR_LOCKED);
     const projectName = computed(() => store.getters.PROJECT_NAME);
+    const useGpu = store.state.useGpu;
     const isEdited = computed(() => store.getters.IS_EDITED);
     const isFullscreen = computed(() => store.getters.IS_FULLSCREEN);
 
@@ -398,6 +400,7 @@ export default defineComponent({
       subMenuOpenFlags,
       reassignSubMenuOpen,
       menudata,
+      useGpu,
     };
   },
 });


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

windowのタイトルにCPU/GPUモードの状態を載せます。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #694 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

- windows 10 `npm run electron:serve`
  - タイトルに `CPU` の文字列を追加

![image](https://user-images.githubusercontent.com/6399740/158129291-35b259d0-8035-4173-8d9c-b33df8ed11bc.png)

対応GPUを有する実機がないため、別ブランチでダミーを仕込んで実験済み https://github.com/o108minmin/voicevox/commit/f3e9499c1a0f351a484856a00b447e1dcc31c98b

## その他

- GPUモードで
- このリポジトリには初commitになります
  - [README: 貢献者の方へ](https://github.com/VOICEVOX/voicevox#%E8%B2%A2%E7%8C%AE%E8%80%85%E3%81%AE%E6%96%B9%E3%81%B8) セクションを読んで下記は確認しましたが、他に不足があればご指摘お願いします
    - [x] ユニットテスト/e2eテストの結果が、自分のcommit前後で差分がないこと
    - [x] コードフォーマットの実施
    - [x] typosの実施