### PR TITLE
#752 に基づく「※単語は全角と半角は区別しません。」という注意書き追加

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,7 +90,6 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-          <div class="text-h5">単語登録</div>
             <div class="row q-pl-md q-mt-md">
             単語は全角と半角は区別しません。
               <div class="text-h6">単語</div>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,7 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-          <div class="row q-pl-md accent-desc">全角表示となりますが単語は全角と半角は区別しません。</div>
+          
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input
@@ -102,6 +102,7 @@
                 dense
                 :disable="uiLocked"
               />
+              <div class="row q-pl-md accent-desc">全角表示となりますが単語は全角と半角は区別しません。</div>
             </div>
             <div class="row q-pl-md q-pt-sm">
               <div class="text-h6">読み</div>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,7 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-          <div class="row q-pl-md q-mt-md accent-desc">
+          <div class="row q-pl-md accent-desc">
             全角表示となりますが単語は全角と半角は区別しません。
             </div>
             <div class="row q-pl-md q-mt-md">

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,7 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-            <div class="row q-pl-md accent-desc">単語は全角と半角は区別されません。</div>
+            <div class="text-h6">※単語は全角と半角は区別しません。</div>
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,7 +90,9 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-          <div class="row q-pl-md q-pt-sm text-h6">単語登録</div><div class="row q-pl-md accent-desc">全角表示となりますが単語は全角と半角は区別しません。</div>
+          <div class="row q-pl-md q-mt-md accent-desc">
+            全角表示となりますが単語は全角と半角は区別しません。
+            </div>
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -91,10 +91,8 @@
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
           <div class="text-h5">単語登録</div>
-           <div class="row q-pl-md accent-desc">
-             単語は全角と半角は区別しません。
-            </div><div class="text-p">単語は全角と半角は区別しません。</div>
             <div class="row q-pl-md q-mt-md">
+            単語は全角と半角は区別しません。
               <div class="text-h6">単語</div>
               <q-input
                 ref="surfaceInput"

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,6 +90,10 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
+          <div class="row q-pl-md q-pt-sm text-h6">単語登録</div>
+            <div class="row q-pl-md accent-desc">
+              単語を登録する際、全角になりますが、単語は全角と半角は区別されません。
+            </div>
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,8 +90,10 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-            <div class="text-h6">※単語は全角と半角は区別しません。</div>
+
             <div class="row q-pl-md q-mt-md">
+            <div class="text-h5">単語登録</div>
+            <div class="row q-pl-md accent-desc">単語は全角と半角は区別しません。</div>
               <div class="text-h6">単語</div>
               <q-input
                 ref="surfaceInput"

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,10 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-          <div class="row q-pl-md q-pt-sm text-h6">単語登録</div>
-            <div class="row q-pl-md accent-desc">
-              単語を登録する際、全角になりますが、単語は全角と半角は区別されません。
-            </div>
+            <div class="row q-pl-md accent-desc">単語を登録する際、全角になりますが、単語は全角と半角は区別されません。</div>
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,11 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-          
-          <div class="row q-pl-md q-pt-sm text-h6">単語登録</div>
-          <div class="row q-pl-md accent-desc">
-              全角表示となりますが単語は全角と半角は区別しません。
-            </div>
+          <div class="row q-pl-md q-pt-sm text-h6">単語登録</div><div class="row q-pl-md accent-desc">全角表示となりますが単語は全角と半角は区別しません。</div>
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,7 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-            <div class="row q-pl-md accent-desc">単語を登録する際、全角になりますが、単語は全角と半角は区別されません。</div>
+            <div class="row q-pl-md accent-desc">単語は全角と半角は区別されません。</div>
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -102,8 +102,8 @@
                 dense
                 :disable="uiLocked"
               />
-              全角表示となりますが単語は全角と半角は区別しません。
             </div>
+            全角表示となりますが単語は全角と半角は区別しません。
             <div class="row q-pl-md q-pt-sm">
               <div class="text-h6">読み</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,7 +90,11 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-          ※単語は全角と半角は区別しません。
+          
+          <div class="row q-pl-md q-pt-sm text-h6">単語登録</div>
+          <div class="row q-pl-md accent-desc">
+              全角表示となりますが単語は全角と半角は区別しません。
+            </div>
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -93,7 +93,7 @@
 
             <div class="row q-pl-md q-mt-md">
             <div class="text-h5">単語登録</div>
-            <div class="row q-pl-md accent-desc">単語は全角と半角は区別しません。</div>
+            <div class="row q-pl-md">単語は全角と半角は区別しません。</div>
               <div class="text-h6">単語</div>
               <q-input
                 ref="surfaceInput"

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -102,7 +102,7 @@
                 dense
                 :disable="uiLocked"
               />
-              <div class="text-h6">全角表示となりますが単語は全角と半角は区別しません。</div>
+              全角表示となりますが単語は全角と半角は区別しません。
             </div>
             <div class="row q-pl-md q-pt-sm">
               <div class="text-h6">読み</div>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,7 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-            <div class="row q-pl-md q-mt-md">単語は全角と半角は区別しません。
+            <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input
                 ref="surfaceInput"
@@ -118,6 +118,9 @@
                   読みに使える文字はひらがなとカタカナのみです。
                 </template>
               </q-input>
+            </div>
+            <div class="row q-pl-md accent-desc">
+              ※単語は全角と半角は区別しません。
             </div>
             <div class="row q-pl-md q-pt-sm text-h6">アクセント調整</div>
             <div class="row q-pl-md accent-desc">

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,8 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-            <div class="row q-pl-md q-mt-md">
-            単語は全角と半角は区別しません。
+            <div class="row q-pl-md q-mt-md">単語は全角と半角は区別しません。
               <div class="text-h6">単語</div>
               <q-input
                 ref="surfaceInput"

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,10 +90,11 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-
+          <div class="text-h5">単語登録</div>
+           <div class="row q-pl-md accent-desc">
+             単語は全角と半角は区別しません。
+            </div><div class="text-p">単語は全角と半角は区別しません。</div>
             <div class="row q-pl-md q-mt-md">
-            <div class="text-h5">単語登録</div>
-            <div class="row q-pl-md">単語は全角と半角は区別しません。</div>
               <div class="text-h6">単語</div>
               <q-input
                 ref="surfaceInput"

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,9 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
-          <div class="row q-pl-md accent-desc">
-            全角表示となりますが単語は全角と半角は区別しません。
-            </div>
+          <div class="row q-pl-md accent-desc">全角表示となりますが単語は全角と半角は区別しません。</div>
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -102,7 +102,7 @@
                 dense
                 :disable="uiLocked"
               />
-              <div class="row q-pl-md accent-desc">全角表示となりますが単語は全角と半角は区別しません。</div>
+              <div class="text-h6">全角表示となりますが単語は全角と半角は区別しません。</div>
             </div>
             <div class="row q-pl-md q-pt-sm">
               <div class="text-h6">読み</div>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -90,6 +90,7 @@
 
           <!-- 右側のpane -->
           <div v-if="wordEditing" class="col-8 no-wrap text-no-wrap">
+          ※単語は全角と半角は区別しません。
             <div class="row q-pl-md q-mt-md">
               <div class="text-h6">単語</div>
               <q-input
@@ -118,9 +119,6 @@
                   読みに使える文字はひらがなとカタカナのみです。
                 </template>
               </q-input>
-            </div>
-            <div class="row q-pl-md accent-desc">
-              ※単語は全角と半角は区別しません。
             </div>
             <div class="row q-pl-md q-pt-sm text-h6">アクセント調整</div>
             <div class="row q-pl-md accent-desc">


### PR DESCRIPTION
## 内容
OpenJTalk（Mecab）「辞書に登録する単語は全角でなければならない」という仕様が
ユーザー目線からするとちょっと分かりにくいため、「※単語は全角と半角は区別しません。」という注意書き追加しました。

経緯はここ：https://github.com/VOICEVOX/voicevox/issues/752

## 関連 Issue
close #752


## スクリーンショット・動画など

<img width="912" alt="スクリーンショット 2022-03-14 16 14 33" src="https://user-images.githubusercontent.com/91584669/158330656-8c57d416-a21e-44e1-871e-d2789220b17c.png">


## その他
https://twitter.com/Apple_Yuk/status/1503268871222226946
