### PR TITLE
辞書ダイアログからengineInfoを取り除く

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -218,7 +218,6 @@
 <script lang="ts">
 import { computed, defineComponent, nextTick, ref, watch } from "vue";
 import { useStore } from "@/store";
-import { toDispatchResponse } from "@/store/audio";
 import { AccentPhrase, AudioQuery, UserDictWord } from "@/openapi";
 import {
   convertHiraToKana,
@@ -226,7 +225,6 @@ import {
   createKanaRegex,
 } from "@/store/utility";
 import AudioAccent from "@/components/AudioAccent.vue";
-import { EngineInfo } from "@/type/preload";
 import { QInput, useQuasar } from "quasar";
 import { AudioItem } from "@/store/type";
 
@@ -244,7 +242,6 @@ export default defineComponent({
     const store = useStore();
     const $q = useQuasar();
 
-    let engineInfo: EngineInfo | undefined;
     const dictionaryManageDialogOpenedComputed = computed({
       get: () => props.modelValue,
       set: (val) => emit("update:modelValue", val),
@@ -257,37 +254,10 @@ export default defineComponent({
     const userDict = ref<Record<string, UserDictWord>>({});
 
     const loadingDictProcess = async () => {
-      // FIXME: エンジン周りに蜜結合なので、他のユーザー辞書操作系も含めてvuexに移動させる。
-      engineInfo = store.state.engineInfos[0]; // TODO: 複数エンジン対応
-      if (!engineInfo)
-        throw new Error(`No such engineInfo registered: index == 0`);
       loadingDict.value = true;
       try {
-        const engineDict = await store
-          .dispatch("INVOKE_ENGINE_CONNECTOR", {
-            engineKey: engineInfo.key,
-            action: "getUserDictWordsUserDictGet",
-            payload: [],
-          })
-          .then(toDispatchResponse("getUserDictWordsUserDictGet"));
-        // 50音順にソートするために、一旦arrayにする
-        const dictArray = Object.keys(engineDict).map((k) => {
-          return { key: k, ...engineDict[k] };
-        });
-        dictArray.sort((a, b) => {
-          if (a.yomi > b.yomi) {
-            return 1;
-          } else {
-            return -1;
-          }
-        });
-        const dictEntries: [string, UserDictWord][] = dictArray.map((v) => {
-          const { key, ...newV } = v;
-          return [key, newV];
-        });
-        userDict.value = Object.fromEntries(dictEntries);
+        userDict.value = await store.dispatch("LOAD_USER_DICT");
       } catch {
-        loadingDict.value = false;
         $q.dialog({
           title: "辞書の取得に失敗しました",
           message: "エンジンの再起動をお試しください。",
@@ -505,23 +475,15 @@ export default defineComponent({
       );
     });
     const saveWord = async () => {
-      if (!engineInfo)
-        throw new Error(`No such engineInfo registered: index == 0`);
       if (!accentPhrase.value) throw new Error(`accentPhrase === undefined`);
       const accent = computeRegisteredAccent();
       if (selectedId.value) {
         try {
-          await store.dispatch("INVOKE_ENGINE_CONNECTOR", {
-            engineKey: engineInfo.key,
-            action: "rewriteUserDictWordUserDictWordWordUuidPut",
-            payload: [
-              {
-                wordUuid: selectedId.value,
-                surface: surface.value,
-                pronunciation: yomi.value,
-                accentType: accent,
-              },
-            ],
+          await store.dispatch("REWIRTE_WORD", {
+            wordUuid: selectedId.value,
+            surface: surface.value,
+            pronunciation: yomi.value,
+            accentType: accent,
           });
         } catch {
           $q.dialog({
@@ -537,19 +499,11 @@ export default defineComponent({
         }
       } else {
         try {
-          await store
-            .dispatch("INVOKE_ENGINE_CONNECTOR", {
-              engineKey: engineInfo.key,
-              action: "addUserDictWordUserDictWordPost",
-              payload: [
-                {
-                  surface: surface.value,
-                  pronunciation: yomi.value,
-                  accentType: accent,
-                },
-              ],
-            })
-            .then(toDispatchResponse("addUserDictWordUserDictWordPost"));
+          await store.dispatch("ADD_WORD", {
+            surface: surface.value,
+            pronunciation: yomi.value,
+            accentType: accent,
+          });
         } catch {
           $q.dialog({
             title: "単語の登録に失敗しました",
@@ -584,17 +538,9 @@ export default defineComponent({
           textColor: "display",
         },
       }).onOk(async () => {
-        if (!engineInfo)
-          throw new Error(`No such engineInfo registered: index == 0`);
         try {
-          await store.dispatch("INVOKE_ENGINE_CONNECTOR", {
-            engineKey: engineInfo.key,
-            action: "deleteUserDictWordUserDictWordWordUuidDelete",
-            payload: [
-              {
-                wordUuid: selectedId.value,
-              },
-            ],
+          await store.dispatch("DELETE_WORD", {
+            wordUuid: selectedId.value,
           });
         } catch {
           $q.dialog({

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -479,7 +479,7 @@ export default defineComponent({
       const accent = computeRegisteredAccent();
       if (selectedId.value) {
         try {
-          await store.dispatch("REWIRTE_WORD", {
+          await store.dispatch("REWRITE_WORD", {
             wordUuid: selectedId.value,
             surface: surface.value,
             pronunciation: yomi.value,

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -1,0 +1,107 @@
+import { UserDictWord } from "@/openapi";
+import {
+  DictionaryGetters,
+  DictionaryActions,
+  DictionaryMutations,
+  DictionaryStoreState,
+  VoiceVoxStoreOptions,
+} from "@/store/type";
+import { toDispatchResponse } from "./audio";
+
+export const dictionaryStoreState: DictionaryStoreState = {};
+
+export const dictionaryStore: VoiceVoxStoreOptions<
+  DictionaryGetters,
+  DictionaryActions,
+  DictionaryMutations
+> = {
+  getters: {},
+  mutations: {},
+  actions: {
+    LOAD_USER_DICT: async ({ state, dispatch }) => {
+      const engineInfo = state.engineInfos[0]; // TODO: 複数エンジン対応
+      if (!engineInfo)
+        throw new Error(`No such engineInfo registered: index == 0`);
+      const engineDict = await dispatch("INVOKE_ENGINE_CONNECTOR", {
+        engineKey: engineInfo.key,
+        action: "getUserDictWordsUserDictGet",
+        payload: [],
+      }).then(toDispatchResponse("getUserDictWordsUserDictGet"));
+
+      // 50音順にソートするために、一旦arrayにする
+      const dictArray = Object.keys(engineDict).map((k) => {
+        return { key: k, ...engineDict[k] };
+      });
+      dictArray.sort((a, b) => {
+        if (a.yomi > b.yomi) {
+          return 1;
+        } else {
+          return -1;
+        }
+      });
+      const dictEntries: [string, UserDictWord][] = dictArray.map((v) => {
+        const { key, ...newV } = v;
+        return [key, newV];
+      });
+      return Object.fromEntries(dictEntries);
+    },
+
+    ADD_WORD: async (
+      { state, dispatch },
+      { surface, pronunciation, accentType }
+    ) => {
+      const engineInfo = state.engineInfos[0]; // TODO: 複数エンジン対応
+      if (!engineInfo)
+        throw new Error(`No such engineInfo registered: index == 0`);
+      await dispatch("INVOKE_ENGINE_CONNECTOR", {
+        engineKey: engineInfo.key,
+        action: "addUserDictWordUserDictWordPost",
+        payload: [
+          {
+            surface,
+            pronunciation,
+            accentType,
+          },
+        ],
+      }).then(toDispatchResponse("addUserDictWordUserDictWordPost"));
+    },
+
+    REWIRTE_WORD: async (
+      { state, dispatch },
+      { wordUuid, surface, pronunciation, accentType }
+    ) => {
+      const engineInfo = state.engineInfos[0]; // TODO: 複数エンジン対応
+      if (!engineInfo)
+        throw new Error(`No such engineInfo registered: index == 0`);
+      await dispatch("INVOKE_ENGINE_CONNECTOR", {
+        engineKey: engineInfo.key,
+        action: "rewriteUserDictWordUserDictWordWordUuidPut",
+        payload: [
+          {
+            wordUuid,
+            surface,
+            pronunciation,
+            accentType,
+          },
+        ],
+      }).then(toDispatchResponse("rewriteUserDictWordUserDictWordWordUuidPut"));
+    },
+
+    DELETE_WORD: async ({ state, dispatch }, { wordUuid }) => {
+      const engineInfo = state.engineInfos[0]; // TODO: 複数エンジン対応
+      if (!engineInfo)
+        throw new Error(`No such engineInfo registered: index == 0`);
+      await dispatch("INVOKE_ENGINE_CONNECTOR", {
+        engineKey: engineInfo.key,
+        action: "deleteUserDictWordUserDictWordWordUuidDelete",
+        payload: [
+          {
+            wordUuid,
+          },
+        ],
+      }).then(
+        toDispatchResponse("deleteUserDictWordUserDictWordWordUuidDelete")
+      );
+    },
+  },
+};

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -66,7 +66,7 @@ export const dictionaryStore: VoiceVoxStoreOptions<
       }).then(toDispatchResponse("addUserDictWordUserDictWordPost"));
     },
 
-    REWIRTE_WORD: async (
+    REWRITE_WORD: async (
       { state, dispatch },
       { wordUuid, surface, pronunciation, accentType }
     ) => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -24,6 +24,7 @@ import { projectStoreState, projectStore } from "./project";
 import { uiStoreState, uiStore } from "./ui";
 import { settingStoreState, settingStore } from "./setting";
 import { presetStoreState, presetStore } from "./preset";
+import { dictionaryStoreState, dictionaryStore } from "./dictionary";
 import { proxyStore, proxyStoreState } from "./proxy";
 import { DefaultStyleId } from "@/type/preload";
 
@@ -194,6 +195,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...audioCommandStoreState,
     ...indexStoreState,
     ...presetStoreState,
+    ...dictionaryStoreState,
     ...proxyStoreState,
   },
 
@@ -204,6 +206,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...projectStore.getters,
     ...settingStore.getters,
     ...presetStore.getters,
+    ...dictionaryStore.getters,
     ...audioCommandStore.getters,
     ...indexStore.getters,
     ...proxyStore.getters,
@@ -217,6 +220,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...settingStore.mutations,
     ...audioCommandStore.mutations,
     ...presetStore.mutations,
+    ...dictionaryStore.mutations,
     ...indexStore.mutations,
     ...proxyStore.mutations,
   },
@@ -229,6 +233,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...settingStore.actions,
     ...audioCommandStore.actions,
     ...presetStore.actions,
+    ...dictionaryStore.actions,
     ...indexStore.actions,
     ...proxyStore.actions,
   },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -6,7 +6,7 @@ import {
   StoreOptions,
 } from "./vuex";
 import { Patch } from "immer";
-import { AccentPhrase, AudioQuery } from "@/openapi";
+import { AccentPhrase, AudioQuery, UserDictWord } from "@/openapi";
 import { createCommandMutationTree, PayloadRecipeTree } from "./command";
 import {
   CharacterInfo,
@@ -1064,6 +1064,40 @@ export type PresetMutations = StoreType<PresetStoreTypes, "mutation">;
 export type PresetActions = StoreType<PresetStoreTypes, "action">;
 
 /*
+  Dictionary Store Types
+*/
+
+export type DictionaryStoreState = Record<string, unknown>;
+
+type DictionaryStoreTypes = {
+  LOAD_USER_DICT: {
+    action(): Promise<Record<string, UserDictWord>>;
+  };
+  ADD_WORD: {
+    action(payload: {
+      surface: string;
+      pronunciation: string;
+      accentType: number;
+    }): Promise<void>;
+  };
+  REWIRTE_WORD: {
+    action(payload: {
+      wordUuid: string;
+      surface: string;
+      pronunciation: string;
+      accentType: number;
+    }): Promise<void>;
+  };
+  DELETE_WORD: {
+    action(payload: { wordUuid: string }): Promise<void>;
+  };
+};
+
+export type DictionaryGetters = StoreType<DictionaryStoreTypes, "getter">;
+export type DictionaryMutations = StoreType<DictionaryStoreTypes, "mutation">;
+export type DictionaryActions = StoreType<DictionaryStoreTypes, "action">;
+
+/*
  * Setting Store Types
  */
 
@@ -1108,6 +1142,7 @@ export type State = AudioStoreState &
   SettingStoreState &
   UiStoreState &
   PresetStoreState &
+  DictionaryStoreState &
   ProxyStoreState;
 
 type AllStoreTypes = AudioStoreTypes &
@@ -1118,6 +1153,7 @@ type AllStoreTypes = AudioStoreTypes &
   SettingStoreTypes &
   UiStoreTypes &
   PresetStoreTypes &
+  DictionaryStoreTypes &
   ProxyStoreTypes;
 
 export type AllGetters = StoreType<AllStoreTypes, "getter">;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1064,8 +1064,8 @@ export type PresetMutations = StoreType<PresetStoreTypes, "mutation">;
 export type PresetActions = StoreType<PresetStoreTypes, "action">;
 
 /*
-  Dictionary Store Types
-*/
+ * Dictionary Store Types
+ */
 
 export type DictionaryStoreState = Record<string, unknown>;
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1080,7 +1080,7 @@ type DictionaryStoreTypes = {
       accentType: number;
     }): Promise<void>;
   };
-  REWIRTE_WORD: {
+  REWRITE_WORD: {
     action(payload: {
       wordUuid: string;
       surface: string;

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -10,6 +10,7 @@ import { settingStore } from "@/store/setting";
 import { presetStore } from "@/store/preset";
 import { assert } from "chai";
 import { proxyStore } from "@/store/proxy";
+import { dictionaryStore } from "@/store/dictionary";
 const isDevelopment = process.env.NODE_ENV == "development";
 // TODO: Swap external files to Mock
 
@@ -89,6 +90,7 @@ describe("store/vuex.js test", () => {
         ...indexStore.getters,
         ...presetStore.getters,
         ...proxyStore.getters,
+        ...dictionaryStore.getters,
       },
       mutations: {
         ...uiStore.mutations,
@@ -100,6 +102,7 @@ describe("store/vuex.js test", () => {
         ...indexStore.mutations,
         ...presetStore.mutations,
         ...proxyStore.mutations,
+        ...dictionaryStore.mutations,
       },
       actions: {
         ...uiStore.actions,
@@ -111,6 +114,7 @@ describe("store/vuex.js test", () => {
         ...indexStore.actions,
         ...presetStore.actions,
         ...proxyStore.actions,
+        ...dictionaryStore.actions,
       },
       plugins: isDevelopment ? [createLogger()] : undefined,
       strict: process.env.NODE_ENV !== "production",


### PR DESCRIPTION
## 内容

辞書ダイアログコンポーネントからエンジンの情報を取り除いて、vuex側で呼ぶようにしました。

## 関連 Issue

ref #724
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
