### PR TITLE
アクセント句分割の当たり判定を広げる

### DIFF
--- a/src/components/AudioAccent.vue
+++ b/src/components/AudioAccent.vue
@@ -37,7 +37,7 @@
       'grid-column': `1 / span ${accentPhrase.moras.length * 2 - 1}`,
     }"
   >
-    <svg :viewBox="`0 0 ${accentPhrase.moras.length * 40 - 10} 50`">
+    <svg :viewBox="`0 0 ${accentPhrase.moras.length * 40 - 20} 50`">
       <polyline :points="accentLine" />
     </svg>
   </div>
@@ -53,8 +53,8 @@
       ]"
       :style="{ 'grid-column': `${moraIndex * 2 + 1} / span 1` }"
     >
-      <svg width="29" height="50" viewBox="0 0 29 50">
-        <line x1="14" y1="0" x2="14" y2="50" stroke-width="1" />
+      <svg width="19" height="50" viewBox="0 0 19 50">
+        <line x1="9" y1="0" x2="9" y2="50" stroke-width="1" />
       </svg>
     </div>
   </template>
@@ -99,7 +99,7 @@ export default defineComponent({
       const accent = previewAccentSlider.state.currentValue.value ?? 0;
       return [...Array(props.accentPhrase.moras.length).keys()].map(
         (index) =>
-          `${index * 40 + 15} ${
+          `${index * 40 + 10} ${
             index + 1 == accent || (index != 0 && index < accent) ? 5 : 45
           }`
       );
@@ -132,8 +132,7 @@ div {
       right: 0;
       bottom: 0;
       > div {
-        padding-left: 10px;
-        padding-right: 5px;
+        padding-left: 5px;
       }
     }
   }

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -802,15 +802,15 @@ $pitch-label-height: 24px;
       div {
         padding: 0px;
         &.text-cell {
-          min-width: 30px;
-          max-width: 30px;
+          min-width: 20px;
+          max-width: 20px;
           grid-row-start: 3;
           text-align: center;
           color: colors.$display;
         }
         &.text-cell-hovered {
-          min-width: 30px;
-          max-width: 30px;
+          min-width: 20px;
+          max-width: 20px;
           grid-row-start: 3;
           text-align: center;
           color: colors.$display;
@@ -818,8 +818,8 @@ $pitch-label-height: 24px;
           cursor: pointer;
         }
         &.splitter-cell {
-          min-width: 10px;
-          max-width: 10px;
+          min-width: 20px;
+          max-width: 20px;
           grid-row: 3 / span 1;
           z-index: vars.$detail-view-splitter-cell-z-index;
         }
@@ -833,14 +833,14 @@ $pitch-label-height: 24px;
           grid-row: 1 / span 3;
         }
         &.splitter-cell-be-split-pause {
-          min-width: 10px;
-          max-width: 10px;
+          min-width: 20px;
+          max-width: 20px;
         }
         &.accent-cell {
           grid-row: 2 / span 1;
           div {
-            min-width: 30px + 10px;
-            max-width: 30px + 10px;
+            min-width: 20px + 20px;
+            max-width: 20px + 20px;
             display: inline-block;
             cursor: pointer;
           }

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -54,22 +54,22 @@
 
             <q-btn
               v-if="pageIndex + 1 < showCharacterInfos.length"
+              v-show="canNext"
               unelevated
               label="次へ"
               color="background-light"
               text-color="display-dark"
               class="text-no-wrap"
-              :disable="!canNext"
               @click="nextPage"
             />
             <q-btn
               v-else
+              v-show="canNext"
               unelevated
               label="完了"
               color="background-light"
               text-color="display-dark"
               class="text-no-wrap"
-              :disable="!canNext"
               @click="closeDialog"
             />
           </div>


### PR DESCRIPTION
## 内容

アクセント句分割の当たり判定を広げてみました。いくつか方法はあると思うのですが、もっとも単純に「文字部分の範囲を削り、分割部分の判定を増やす」という方法を試してみました。全体の表示幅に影響が出ないよう調整しました。

## 関連 Issue

ref #453

## スクリーンショット・動画など

### 旧
![image](https://user-images.githubusercontent.com/73807432/160222157-3bfdd34f-6953-460c-9600-564d82f50d38.png)

### 新
![image](https://user-images.githubusercontent.com/73807432/160222251-a1b67b9f-aeb5-4671-9f18-931851e5a116.png)

## その他
提案の確認用なので merge せずに閉じても構いません。
