### PR TITLE
アクセントからイントネーションを再設定する機能

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -172,6 +172,10 @@ const defaultHotkeySettings: HotkeySetting[] = [
     action: "テキスト読み込む",
     combination: "",
   },
+  {
+    action: "イントネーションをリセット",
+    combination: !isMac ? "Ctrl G" : "Meta G",
+  },
 ];
 
 const defaultToolbarButtonSetting: ToolbarSetting = [

--- a/src/background.ts
+++ b/src/background.ts
@@ -174,7 +174,7 @@ const defaultHotkeySettings: HotkeySetting[] = [
   },
   {
     action: "イントネーションをリセット",
-    combination: !isMac ? "Ctrl G" : "Meta G",
+    combination: "R",
   },
 ];
 

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -287,7 +287,7 @@ export default defineComponent({
         "イントネーションをリセット",
         () => {
           if (!uiLocked.value && store.getters.ACTIVE_AUDIO_KEY) {
-            store.dispatch("COMMAND_RESET_MORA_PITCH", {
+            store.dispatch("COMMAND_RESET_MORA_PITCH_AND_LENGTH", {
               audioKey: store.getters.ACTIVE_AUDIO_KEY,
             });
           }

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -287,7 +287,7 @@ export default defineComponent({
         "イントネーションをリセット",
         () => {
           if (!uiLocked.value && store.getters.ACTIVE_AUDIO_KEY) {
-            store.dispatch("COMMAND_RESET_MORA_FROM_ACCENT_PHRASE", {
+            store.dispatch("COMMAND_RESET_MORA_PITCH", {
               audioKey: store.getters.ACTIVE_AUDIO_KEY,
             });
           }

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -283,6 +283,16 @@ export default defineComponent({
           }
         },
       ],
+      [
+        "イントネーションをリセット",
+        () => {
+          if (!uiLocked.value && store.getters.ACTIVE_AUDIO_KEY) {
+            store.dispatch("COMMAND_RESET_MORA_FROM_ACCENT_PHRASE", {
+              audioKey: store.getters.ACTIVE_AUDIO_KEY,
+            });
+          }
+        },
+      ],
     ]);
     // このコンポーネントは遅延評価なので手動でバインディングを行う
     setHotkeyFunctions(hotkeyMap, true);

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -789,6 +789,27 @@ export const audioStore: VoiceVoxStoreOptions<
       }
       return accentPhrases;
     },
+    FETCH_MORA_PITCH({ dispatch, state }, { accentPhrases, styleId }) {
+      const engineInfo = state.engineInfos[0]; // TODO: 複数エンジン対応
+      if (!engineInfo)
+        throw new Error(`No such engineInfo registered: index == 0`);
+
+      return dispatch("INVOKE_ENGINE_CONNECTOR", {
+        engineKey: engineInfo.key,
+        action: "moraPitchMoraPitchPost",
+        payload: [{ accentPhrase: accentPhrases, speaker: styleId }],
+      })
+        .then(toDispatchResponse("moraPitchMoraPitchPost"))
+        .catch((error) => {
+          window.electron.logError(
+            error,
+            `Failed to fetch MoraPitch for the accentPhrases "${JSON.stringify(
+              accentPhrases
+            )}".`
+          );
+          throw error;
+        });
+    },
     FETCH_AUDIO_QUERY(
       { dispatch, state },
       { text, styleId }: { text: string; styleId: number }
@@ -1816,7 +1837,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
       if (query == undefined) throw new Error("query == undefined");
 
       try {
-        const newAccentPhases = await dispatch("FETCH_MORA_DATA", {
+        const newAccentPhases = await dispatch("FETCH_MORA_PITCH", {
           accentPhrases: query.accentPhrases,
           styleId,
         });

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -789,27 +789,6 @@ export const audioStore: VoiceVoxStoreOptions<
       }
       return accentPhrases;
     },
-    FETCH_MORA_PITCH({ dispatch, state }, { accentPhrases, styleId }) {
-      const engineInfo = state.engineInfos[0]; // TODO: 複数エンジン対応
-      if (!engineInfo)
-        throw new Error(`No such engineInfo registered: index == 0`);
-
-      return dispatch("INVOKE_ENGINE_CONNECTOR", {
-        engineKey: engineInfo.key,
-        action: "moraPitchMoraPitchPost",
-        payload: [{ accentPhrase: accentPhrases, speaker: styleId }],
-      })
-        .then(toDispatchResponse("moraPitchMoraPitchPost"))
-        .catch((error) => {
-          window.electron.logError(
-            error,
-            `Failed to fetch MoraPitch for the accentPhrases "${JSON.stringify(
-              accentPhrases
-            )}".`
-          );
-          throw error;
-        });
-    },
     FETCH_AUDIO_QUERY(
       { dispatch, state },
       { text, styleId }: { text: string; styleId: number }
@@ -1837,7 +1816,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
       if (query == undefined) throw new Error("query == undefined");
 
       try {
-        const newAccentPhases = await dispatch("FETCH_MORA_PITCH", {
+        const newAccentPhases = await dispatch("FETCH_MORA_DATA", {
           accentPhrases: query.accentPhrases,
           styleId,
         });

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1808,10 +1808,7 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         });
       }
     },
-    async COMMAND_RESET_MORA_FROM_ACCENT_PHRASE(
-      { state, dispatch, commit },
-      { audioKey }
-    ) {
+    async COMMAND_RESET_MORA_PITCH({ state, dispatch, commit }, { audioKey }) {
       const styleId = state.audioItems[audioKey].styleId;
       if (styleId == undefined) throw new Error("styleId == undefined");
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1808,7 +1808,10 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         });
       }
     },
-    async COMMAND_RESET_MORA_PITCH({ state, dispatch, commit }, { audioKey }) {
+    async COMMAND_RESET_MORA_PITCH_AND_LENGTH(
+      { state, dispatch, commit },
+      { audioKey }
+    ) {
       const styleId = state.audioItems[audioKey].styleId;
       if (styleId == undefined) throw new Error("styleId == undefined");
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1808,6 +1808,33 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         });
       }
     },
+    async COMMAND_RESET_MORA_FROM_ACCENT_PHRASE(
+      { state, dispatch, commit },
+      { audioKey }
+    ) {
+      const styleId = state.audioItems[audioKey].styleId;
+      if (styleId == undefined) throw new Error("styleId == undefined");
+
+      const query = state.audioItems[audioKey].query;
+      if (query == undefined) throw new Error("query == undefined");
+
+      try {
+        const newAccentPhases = await dispatch("FETCH_MORA_DATA", {
+          accentPhrases: query.accentPhrases,
+          styleId,
+        });
+
+        commit("COMMAND_CHANGE_ACCENT", {
+          audioKey,
+          accentPhrases: newAccentPhases,
+        });
+      } catch (error) {
+        commit("COMMAND_CHANGE_ACCENT", {
+          audioKey,
+          accentPhrases: query.accentPhrases,
+        });
+      }
+    },
     COMMAND_SET_AUDIO_MORA_DATA(
       { commit },
       payload: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -462,7 +462,7 @@ type AudioCommandStoreTypes = {
     }): void;
   };
 
-  COMMAND_RESET_MORA_FROM_ACCENT_PHRASE: {
+  COMMAND_RESET_MORA_PITCH: {
     action(payload: { audioKey: string }): void;
   };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -462,7 +462,7 @@ type AudioCommandStoreTypes = {
     }): void;
   };
 
-  COMMAND_RESET_MORA_PITCH: {
+  COMMAND_RESET_MORA_PITCH_AND_LENGTH: {
     action(payload: { audioKey: string }): void;
   };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -290,13 +290,6 @@ type AudioStoreTypes = {
     }): Promise<AccentPhrase[]>;
   };
 
-  FETCH_MORA_PITCH: {
-    action(payload: {
-      accentPhrases: AccentPhrase[];
-      styleId: number;
-    }): Promise<AccentPhrase[]>;
-  };
-
   FETCH_AND_COPY_MORA_DATA: {
     action(payload: {
       accentPhrases: AccentPhrase[];

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -462,6 +462,10 @@ type AudioCommandStoreTypes = {
     }): void;
   };
 
+  COMMAND_RESET_MORA_FROM_ACCENT_PHRASE: {
+    action(payload: { audioKey: string }): void;
+  };
+
   COMMAND_SET_AUDIO_MORA_DATA: {
     mutation: {
       audioKey: string;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -290,6 +290,13 @@ type AudioStoreTypes = {
     }): Promise<AccentPhrase[]>;
   };
 
+  FETCH_MORA_PITCH: {
+    action(payload: {
+      accentPhrases: AccentPhrase[];
+      styleId: number;
+    }): Promise<AccentPhrase[]>;
+  };
+
   FETCH_AND_COPY_MORA_DATA: {
     action(payload: {
       accentPhrases: AccentPhrase[];

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -198,7 +198,8 @@ export type HotkeyAction =
   | "プロジェクトを名前を付けて保存"
   | "プロジェクトを上書き保存"
   | "プロジェクト読み込み"
-  | "テキスト読み込む";
+  | "テキスト読み込む"
+  | "イントネーションをリセット";
 
 export type HotkeyCombo = string;
 


### PR DESCRIPTION
## 内容
アクセント句の内容からイントネーション（moraのpitch）を再設定する機能を追加しました。

ショートカットには仮に `Ctrl + G` を割り当てています。
イントネーションタブを開いていないと実行時のユーザへのフィードバックがないので、意図せず誤爆しないように微妙に押しづらいものを選択した、程度の意図なのでよりふさわしいものがありそうです。

## 関連 Issue
issueの粒度的に使ってみてUIを追加するかどうか？まで含んでいる気がしたのでcloseしないようrefにしておきます
ref #524 

## スクリーンショット・動画など
![Animation](https://user-images.githubusercontent.com/241973/161279042-c8018c8a-267d-473b-8faf-bc097f6366e1.gif)

## その他
音素長をリセットしないように `/mora_pitch` を使いましたが、 `/mora_data` を使えば音素長も一緒にリセットします
イントネーションをリセット、に音素長も含まれるかどうか判断できなかったので、とりあえずpitchのみリセットするようにしました