### PR TITLE
.envのエンジンへのパスは\区切りではなく/区切りだとわかりやすくする

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
-DEFAULT_ENGINE_INFOS=[{"key":"074fc39e-678b-4c13-8916-ffca8d505d1d","executionEnabled":true,"executionFilePath":"C:/path/to/run.exe","host":"http://127.0.0.1:50021"}]
+DEFAULT_ENGINE_INFOS=[{"key":"074fc39e-678b-4c13-8916-ffca8d505d1d","executionEnabled":true,"executionFilePath":"run.exe","host":"http://127.0.0.1:50021"}]
 VUE_APP_GTM_CONTAINER_ID=GTM-DUMMY

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
-DEFAULT_ENGINE_INFOS=[{"key":"074fc39e-678b-4c13-8916-ffca8d505d1d","executionEnabled":true,"executionFilePath":"run.exe","host":"http://127.0.0.1:50021"}]
+DEFAULT_ENGINE_INFOS=[{"key":"074fc39e-678b-4c13-8916-ffca8d505d1d","executionEnabled":true,"executionFilePath":"C:/path/to/run.exe","host":"http://127.0.0.1:50021"}]
 VUE_APP_GTM_CONTAINER_ID=GTM-DUMMY

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ npm ci
 ## 実行
 
 `.env.production`をコピーして`.env`を作成し、`DEFAULT_ENGINE_INFOS`内の`executionFilePath`に`voicevox_engine`があるパスを指定します。
-とりあえず [製品版 VOICEVOX](https://voicevox.hiroshiba.jp/) のディレクトリのパスを指定すれば動きます。
+[製品版 VOICEVOX](https://voicevox.hiroshiba.jp/) のディレクトリのパスを指定すれば動きます。
+Windowsの場合でもパスの区切り文字は`\`ではなく`/`なのでご注意ください。
 
 ```bash
 npm run electron:serve


### PR DESCRIPTION
## 内容

.envに書くエンジンのパスは、\じゃだめで/区切りである必要があるかもしれません。
（もし\区切りだと、`[00:28:09.365] [error] SyntaxError: Unexpected token P in JSON at position 95`といったエラーが表示されるとのことです）

それがちょっとでもわかりやすいように、例のパスを/区切りにしてみました。

## その他
