### PR TITLE
設定画面の項目の詳細情報をヘルプとして表示する

### DIFF
--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -67,20 +67,29 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-sm bg-setting-item">
                 <div>パラメータの引き継ぎ</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      テキスト欄を追加する際、現在の話速等のパラメータを引き継ぎます
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-toggle
                   :model-value="inheritAudioInfoMode"
                   @update:model-value="changeinheritAudioInfo($event)"
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    テキスト欄を追加する際、現在の話速等のパラメータを引き継ぎます
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-sm bg-setting-item">
@@ -807,6 +816,10 @@ export default defineComponent({
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;
+
+.help-hover-icon {
+  margin-left: 6px;
+}
 
 .hotkey-table {
   width: 100%;

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -34,6 +34,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-sm bg-setting-item">
                 <div>エンジンモード</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      GPUモードの利用には NVIDIA&trade; GPU が必要です
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-btn-toggle
                   padding="xs md"
@@ -48,15 +66,6 @@
                     { label: 'GPU', value: 'switchGPU' },
                   ]"
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    GPUモードの利用には NVIDIA&trade; GPU が必要です
-                  </q-tooltip>
                 </q-btn-toggle>
               </q-card-actions>
             </q-card>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -221,6 +221,24 @@
 
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>上書き防止</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      上書きせずにファイルを連番で保存します
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-toggle
                   :model-value="savingSetting.avoidOverwrite"
@@ -228,15 +246,6 @@
                     handleSavingSettingChange('avoidOverwrite', $event)
                   "
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    上書きせずにファイルを連番で保存します
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -557,21 +557,30 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>ソフトウェア利用状況のデータ収集を許可する</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      各UIの利用率などのデータを送信してVOICEVOXの改善に役立てます。テキストデータ・音声データは送信しません。
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-toggle
                   name="enabled"
                   align="left"
                   v-model="acceptRetrieveTelemetryComputed"
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    各UIの利用率などのデータを送信してVOICEVOXの改善に役立てます。テキストデータ・音声データは送信しません。
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
             </q-card>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -491,6 +491,24 @@
               </q-card-actions> -->
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>プリセット機能</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      プリセット機能を有効にする
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-toggle
                   :model-value="experimentalSetting.enablePreset"
@@ -498,15 +516,6 @@
                     changeExperimentalSetting('enablePreset', $event)
                   "
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    プリセット機能を有効にする
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -503,6 +503,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-grey-3">
                 <div>音声のサンプリングレート</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      再生・保存時の音声のサンプリングレートを変更します（サンプリングレートを上げても音声の品質は上がりません。）
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-select
                   borderless
@@ -519,15 +537,6 @@
                     handleSavingSettingChange('outputSamplingRate', $event)
                   "
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    再生・保存時の音声のサンプリングレートを変更します（サンプリングレートを上げても音声の品質は上がりません。）
-                  </q-tooltip>
                 </q-select>
               </q-card-actions>
             </q-card>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -354,7 +354,25 @@
                 </q-toggle>
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-sm bg-setting-item">
-                <div>テキストを貼り付け時に行われる分割の挙動を変えます</div>
+                <div>分割の挙動</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      テキストを貼り付け時に行われる分割の挙動を変えます
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-btn-toggle
                   padding="xs md"

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -163,6 +163,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-sm bg-setting-item">
                 <div>文字コード</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      文字コードを選ぶことができます
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-btn-toggle
                   padding="xs md"

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -520,6 +520,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>疑問文を自動調整</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      疑問文のとき語尾の音高を自動的に上げる
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-toggle
                   :model-value="experimentalSetting.enableInterrogativeUpspeak"
@@ -530,15 +548,6 @@
                     )
                   "
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    疑問文のとき語尾の音高を自動的に上げる
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
             </q-card>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -250,6 +250,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>txtファイルを書き出し</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      テキストをtxtファイルとして書き出します
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-toggle
                   :model-value="savingSetting.exportText"
@@ -257,15 +275,6 @@
                     handleSavingSettingChange('exportText', $event)
                   "
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    テキストをtxtファイルとして書き出します
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -279,6 +279,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>labファイルを書き出し</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      リップシンク用のlabファイルを書き出します
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-toggle
                   name="enabled"
@@ -288,15 +306,6 @@
                     handleSavingSettingChange('exportLab', $event)
                   "
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    リップシンク用のlabファイルを書き出します
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-sm bg-setting-item">

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -156,6 +156,25 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>書き出し先を固定</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                      v-if="!savingSetting.fixedExportEnabled"
+                    >
+                      音声ファイルを設定したフォルダに書き出す
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-input
                   dense
@@ -197,16 +216,6 @@
                     handleSavingSettingChange('fixedExportEnabled', $event)
                   "
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                    v-if="!savingSetting.fixedExportEnabled"
-                  >
-                    音声ファイルを設定したフォルダに書き出す
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
 

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -94,6 +94,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-sm bg-setting-item">
                 <div>再生位置を追従</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      再生位置を追従し、自動でスクロールするモードを選ぶことができます
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <div class="scroll-mode-toggle">
                   <q-radio

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -379,6 +379,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>音声をステレオ化</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      音声データをモノラルからステレオに変換してから再生・保存を行います
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-toggle
                   name="enabled"
@@ -388,15 +406,6 @@
                     handleSavingSettingChange('outputStereo', $event)
                   "
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    音声データをモノラルからステレオに変換してから再生・保存を行います
-                  </q-tooltip>
                 </q-toggle>
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -473,6 +473,24 @@
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>再生デバイス</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      音声の再生デバイスを変更し再生を行います
+                    </q-tooltip>
+                  </q-icon>
+                </div>
                 <q-space />
                 <q-select
                   dense
@@ -481,15 +499,6 @@
                   :options="availableAudioOutputDevices"
                   class="col-7"
                 >
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    音声の再生デバイスを変更し再生を行います
-                  </q-tooltip>
                 </q-select>
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-grey-3">


### PR DESCRIPTION
## 内容

設定画面の項目にて，トグルボタンにカーソルを当てるとその項目の詳細が表示されるようになっていた状態から，項目ごとに（？）アイコンを追加して詳細情報を表示するようにし，設定の項目についてわかりやすいUIに変更しました．

## 関連 Issue

close #647 

## スクリーンショット・動画など

https://user-images.githubusercontent.com/40142697/161590143-4cd29f04-3367-4f6f-91c1-e6841210e744.mp4

## その他
