### PR TITLE
ウィンドウ位置・splitterの位置を記憶できるようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8428,6 +8428,15 @@
       "integrity": "sha512-qKD5Pbq+QMk4nea4lMuncUMhpEiQwaJyCW7MrvissnRcBDENhVfDmAqQYRQ3X525oTzhar9Zh1cK0L2d1UKYcw==",
       "dev": true
     },
+    "electron-window-state": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.3.tgz",
+      "integrity": "sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==",
+      "requires": {
+        "jsonfile": "^4.0.0",
+        "mkdirp": "^0.5.1"
+      }
+    },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -10081,8 +10090,7 @@
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-      "dev": true
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -11740,7 +11748,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -12847,8 +12854,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.3",
@@ -12955,7 +12961,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dayjs": "1.10.7",
     "electron-log": "4.4.1",
     "electron-store": "8.0.0",
+    "electron-window-state": "5.0.3",
     "encoding-japanese": "1.0.30",
     "immer": "9.0.2",
     "lodash.debounce": "4.0.8",

--- a/src/background.ts
+++ b/src/background.ts
@@ -39,6 +39,7 @@ import {
 
 import log from "electron-log";
 import dayjs from "dayjs";
+import windowStateKeeper from "electron-window-state";
 
 // silly以上のログをコンソールに出力
 log.transports.console.format = "[{h}:{i}:{s}.{ms}] [{level}] {text}";
@@ -737,9 +738,16 @@ let willQuit = false;
 let filePathOnMac: string | null = null;
 // create window
 async function createWindow() {
+  const mainWindowState = windowStateKeeper({
+    defaultWidth: 800,
+    defaultHeight: 600,
+  });
+
   win = new BrowserWindow({
-    width: 800,
-    height: 600,
+    x: mainWindowState.x,
+    y: mainWindowState.y,
+    width: mainWindowState.width,
+    height: mainWindowState.height,
     frame: false,
     titleBarStyle: "hidden",
     trafficLightPosition: { x: 6, y: 4 },
@@ -752,6 +760,8 @@ async function createWindow() {
     },
     icon: path.join(__static, "icon.png"),
   });
+
+  mainWindowState.manage(win);
 
   if (process.env.WEBPACK_DEV_SERVER_URL) {
     await win.loadURL(

--- a/src/background.ts
+++ b/src/background.ts
@@ -772,8 +772,6 @@ async function createWindow() {
     icon: path.join(__static, "icon.png"),
   });
 
-  mainWindowState.manage(win);
-
   if (process.env.WEBPACK_DEV_SERVER_URL) {
     await win.loadURL(
       (process.env.WEBPACK_DEV_SERVER_URL as string) + "#/home"
@@ -832,6 +830,8 @@ async function createWindow() {
       }
     }
   });
+
+  mainWindowState.manage(win);
 }
 
 const menuTemplateForMac: Electron.MenuItemConstructorOptions[] = [

--- a/src/background.ts
+++ b/src/background.ts
@@ -35,6 +35,7 @@ import {
   ToolbarSetting,
   ActivePointScrollMode,
   EngineInfo,
+  SplitterPosition,
 } from "./type/preload";
 
 import log from "electron-log";
@@ -207,6 +208,7 @@ const store = new Store<{
   experimentalSetting: ExperimentalSetting;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
   acceptTerms: AcceptTermsStatus;
+  splitterPosition: SplitterPosition;
 }>({
   schema: {
     useGpu: {
@@ -357,6 +359,15 @@ const store = new Store<{
       type: "string",
       enum: ["Unconfirmed", "Accepted", "Rejected"],
       default: "Unconfirmed",
+    },
+    splitterPosition: {
+      type: "object",
+      properties: {
+        portraitPainWidth: { type: "number" },
+        audioInfoPainWidth: { type: "number" },
+        audioDetailPainHeight: { type: "number" },
+      },
+      default: {},
     },
   },
   migrations: {},
@@ -1170,6 +1181,14 @@ ipcMainHandle("GET_EXPERIMENTAL_SETTING", () => {
 
 ipcMainHandle("SET_EXPERIMENTAL_SETTING", (_, experimentalSetting) => {
   store.set("experimentalSetting", experimentalSetting);
+});
+
+ipcMainHandle("GET_SPLITTER_POSITION", () => {
+  return store.get("splitterPosition");
+});
+
+ipcMainHandle("SET_SPLITTER_POSITION", (_, splitterPosition) => {
+  store.set("splitterPosition", splitterPosition);
 });
 
 // app callback

--- a/src/background.ts
+++ b/src/background.ts
@@ -363,9 +363,9 @@ const store = new Store<{
     splitterPosition: {
       type: "object",
       properties: {
-        portraitPainWidth: { type: "number" },
-        audioInfoPainWidth: { type: "number" },
-        audioDetailPainHeight: { type: "number" },
+        portraitPaneWidth: { type: "number" },
+        audioInfoPaneWidth: { type: "number" },
+        audioDetailPaneHeight: { type: "number" },
       },
       default: {},
     },

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -263,6 +263,14 @@ const api: Sandbox = {
     return await ipcRendererInvoke("SET_EXPERIMENTAL_SETTING", setting);
   },
 
+  getSplitterPosition: async () => {
+    return await ipcRendererInvoke("GET_SPLITTER_POSITION");
+  },
+
+  setSplitterPosition: async (splitterPosition) => {
+    return await ipcRendererInvoke("SET_SPLITTER_POSITION", splitterPosition);
+  },
+
   getDefaultHotkeySettings: async () => {
     return await ipcRendererInvoke("GET_DEFAULT_HOTKEY_SETTINGS");
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -177,6 +177,7 @@ export const indexStore: VoiceVoxStoreOptions<
       promises.push(dispatch("GET_ACCEPT_RETRIEVE_TELEMETRY"));
       promises.push(dispatch("GET_ACCEPT_TERMS"));
       promises.push(dispatch("GET_EXPERIMENTAL_SETTING"));
+      promises.push(dispatch("GET_SPLITTER_POSITION"));
 
       await Promise.all(promises).then(() => {
         dispatch("ON_VUEX_READY");

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -46,6 +46,11 @@ export const settingStoreState: SettingStoreState = {
     enablePreset: false,
     enableInterrogativeUpspeak: false,
   },
+  splitterPosition: {
+    audioDetailPainHeight: undefined,
+    audioInfoPainWidth: undefined,
+    portraitPainWidth: undefined,
+  },
 };
 
 export const settingStore: VoiceVoxStoreOptions<
@@ -101,6 +106,9 @@ export const settingStore: VoiceVoxStoreOptions<
     },
     SET_ACCEPT_TERMS(state, { acceptTerms }) {
       state.acceptTerms = acceptTerms;
+    },
+    SET_SPLITTER_POSITION(state, { splitterPosition }) {
+      state.splitterPosition = splitterPosition;
     },
   },
   actions: {
@@ -236,6 +244,15 @@ export const settingStore: VoiceVoxStoreOptions<
     SET_EXPERIMENTAL_SETTING({ commit }, { experimentalSetting }) {
       window.electron.setExperimentalSetting(experimentalSetting);
       commit("SET_EXPERIMENTAL_SETTING", { experimentalSetting });
+    },
+    GET_SPLITTER_POSITION({ dispatch }) {
+      window.electron.getSplitterPosition().then((splitterPosition) => {
+        dispatch("SET_SPLITTER_POSITION", { splitterPosition });
+      });
+    },
+    SET_SPLITTER_POSITION({ commit }, { splitterPosition }) {
+      window.electron.setSplitterPosition(splitterPosition);
+      commit("SET_SPLITTER_POSITION", { splitterPosition });
     },
   },
 };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -47,9 +47,9 @@ export const settingStoreState: SettingStoreState = {
     enableInterrogativeUpspeak: false,
   },
   splitterPosition: {
-    audioDetailPainHeight: undefined,
-    audioInfoPainWidth: undefined,
-    portraitPainWidth: undefined,
+    audioDetailPaneHeight: undefined,
+    audioInfoPaneWidth: undefined,
+    portraitPaneWidth: undefined,
   },
 };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -25,6 +25,7 @@ import {
   Preset,
   ActivePointScrollMode,
   EngineInfo,
+  SplitterPosition,
 } from "@/type/preload";
 import { IEngineConnectorFactory } from "@/infrastructures/EngineConnector";
 import { QVueGlobals } from "quasar";
@@ -767,6 +768,7 @@ export type SettingStoreState = {
   themeSetting: ThemeSetting;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
   experimentalSetting: ExperimentalSetting;
+  splitterPosition: SplitterPosition;
 };
 
 type SettingStoreTypes = {
@@ -834,6 +836,15 @@ type SettingStoreTypes = {
   SET_EXPERIMENTAL_SETTING: {
     mutation: { experimentalSetting: ExperimentalSetting };
     action(payload: { experimentalSetting: ExperimentalSetting }): void;
+  };
+
+  GET_SPLITTER_POSITION: {
+    action(): void;
+  };
+
+  SET_SPLITTER_POSITION: {
+    mutation: { splitterPosition: SplitterPosition };
+    action(payload: { splitterPosition: SplitterPosition }): void;
   };
 };
 

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -269,7 +269,7 @@ type IpcIHData = {
 
   SET_SPLITTER_POSITION: {
     args: [splitterPosition: import("@/type/preload").SplitterPosition];
-    return: import("@/type/preload").SplitterPosition;
+    return: void;
   };
 
   THEME: {

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -262,6 +262,16 @@ type IpcIHData = {
     return: void;
   };
 
+  GET_SPLITTER_POSITION: {
+    args: [];
+    return: import("@/type/preload").SplitterPosition;
+  };
+
+  SET_SPLITTER_POSITION: {
+    args: [splitterPosition: import("@/type/preload").SplitterPosition];
+    return: import("@/type/preload").SplitterPosition;
+  };
+
   THEME: {
     args: [obj: { newData?: string }];
     return: import("@/type/preload").ThemeSetting | void;

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -82,6 +82,8 @@ export interface Sandbox {
   setAcceptTerms(acceptTerms: AcceptTermsStatus): Promise<void>;
   getExperimentalSetting(): Promise<ExperimentalSetting>;
   setExperimentalSetting(setting: ExperimentalSetting): Promise<void>;
+  getSplitterPosition(): Promise<SplitterPosition>;
+  setSplitterPosition(splitterPosition: SplitterPosition): Promise<void>;
   getDefaultHotkeySettings(): Promise<HotKeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
   theme(newData?: string): Promise<ThemeSetting | void>;
@@ -264,4 +266,10 @@ export type ThemeSetting = {
 export type ExperimentalSetting = {
   enablePreset: boolean;
   enableInterrogativeUpspeak: boolean;
+};
+
+export type SplitterPosition = {
+  portraitPainWidth: number | undefined;
+  audioInfoPainWidth: number | undefined;
+  audioDetailPainHeight: number | undefined;
 };

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -269,7 +269,7 @@ export type ExperimentalSetting = {
 };
 
 export type SplitterPosition = {
-  portraitPainWidth: number | undefined;
-  audioInfoPainWidth: number | undefined;
-  audioDetailPainHeight: number | undefined;
+  portraitPaneWidth: number | undefined;
+  audioInfoPaneWidth: number | undefined;
+  audioDetailPaneHeight: number | undefined;
 };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -400,21 +400,29 @@ export default defineComponent({
         const clamp = (value: number, min: number, max: number) =>
           Math.max(Math.min(value, max), min);
 
-        portraitPaneWidth.value =
-          splitterPosition.portraitPainWidth ?? DEFAULT_PORTRAIT_PANE_WIDTH;
-        audioInfoPaneWidth.value =
-          splitterPosition.audioInfoPainWidth ?? MIN_AUDIO_INFO_PANE_WIDTH;
+        // 設定ファイルを書き換えれば異常な値が入り得るのですべてclampしておく
+        portraitPaneWidth.value = clamp(
+          splitterPosition.portraitPainWidth ?? DEFAULT_PORTRAIT_PANE_WIDTH,
+          MIN_PORTRAIT_PANE_WIDTH,
+          MAX_PORTRAIT_PANE_WIDTH
+        );
+
+        audioInfoPaneWidth.value = clamp(
+          splitterPosition.audioInfoPainWidth ?? MIN_AUDIO_INFO_PANE_WIDTH,
+          MIN_AUDIO_INFO_PANE_WIDTH,
+          MAX_AUDIO_INFO_PANE_WIDTH
+        );
         audioInfoPaneMinWidth.value = MIN_AUDIO_INFO_PANE_WIDTH;
         audioInfoPaneMaxWidth.value = MAX_AUDIO_INFO_PANE_WIDTH;
+
         audioDetailPaneMinHeight.value = MIN_AUDIO_DETAIL_PANE_HEIGHT;
         changeAudioDetailPaneMaxHeight(
           resizeObserverRef.value?.$el.parentElement.clientHeight
         );
-        const defaultAudioDetailPainHeight =
-          splitterPosition.audioDetailPainHeight ??
-          MIN_AUDIO_DETAIL_PANE_HEIGHT;
+
         audioDetailPaneHeight.value = clamp(
-          defaultAudioDetailPainHeight,
+          splitterPosition.audioDetailPainHeight ??
+            MIN_AUDIO_DETAIL_PANE_HEIGHT,
           audioDetailPaneMinHeight.value,
           audioDetailPaneMaxHeight.value
         );

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -329,17 +329,17 @@ export default defineComponent({
 
     const updatePortraitPane = async (width: number) => {
       portraitPaneWidth.value = width;
-      await updateSplitterPosition("portraitPainWidth", width);
+      await updateSplitterPosition("portraitPaneWidth", width);
     };
 
     const updateAudioInfoPane = async (width: number) => {
       audioInfoPaneWidth.value = width;
-      await updateSplitterPosition("audioInfoPainWidth", width);
+      await updateSplitterPosition("audioInfoPaneWidth", width);
     };
 
     const updateAudioDetailPane = async (height: number) => {
       audioDetailPaneHeight.value = height;
-      await updateSplitterPosition("audioDetailPainHeight", height);
+      await updateSplitterPosition("audioDetailPaneHeight", height);
     };
 
     // component
@@ -407,14 +407,14 @@ export default defineComponent({
 
         // 設定ファイルを書き換えれば異常な値が入り得るのですべてclampしておく
         portraitPaneWidth.value = clamp(
-          splitterPosition.value.portraitPainWidth ??
+          splitterPosition.value.portraitPaneWidth ??
             DEFAULT_PORTRAIT_PANE_WIDTH,
           MIN_PORTRAIT_PANE_WIDTH,
           MAX_PORTRAIT_PANE_WIDTH
         );
 
         audioInfoPaneWidth.value = clamp(
-          splitterPosition.value.audioInfoPainWidth ??
+          splitterPosition.value.audioInfoPaneWidth ??
             MIN_AUDIO_INFO_PANE_WIDTH,
           MIN_AUDIO_INFO_PANE_WIDTH,
           MAX_AUDIO_INFO_PANE_WIDTH
@@ -428,7 +428,7 @@ export default defineComponent({
         );
 
         audioDetailPaneHeight.value = clamp(
-          splitterPosition.value.audioDetailPainHeight ??
+          splitterPosition.value.audioDetailPaneHeight ??
             MIN_AUDIO_DETAIL_PANE_HEIGHT,
           audioDetailPaneMinHeight.value,
           audioDetailPaneMaxHeight.value

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -310,14 +310,20 @@ export default defineComponent({
       }
     };
 
+    const splitterPosition = computed<SplitterPosition>(
+      () => store.state.splitterPosition
+    );
+
     const updateSplitterPosition = async (
       propertyName: keyof SplitterPosition,
       newValue: number
     ) => {
-      const position = await window.electron.getSplitterPosition();
-      await window.electron.setSplitterPosition({
-        ...position,
+      const newSplitterPosition = {
+        ...splitterPosition.value,
         [propertyName]: newValue,
+      };
+      store.dispatch("SET_SPLITTER_POSITION", {
+        splitterPosition: newSplitterPosition,
       });
     };
 
@@ -392,23 +398,24 @@ export default defineComponent({
     const shouldShowPanes = computed<boolean>(
       () => store.getters.SHOULD_SHOW_PANES
     );
-    watch(shouldShowPanes, async (val, old) => {
+    watch(shouldShowPanes, (val, old) => {
       if (val === old) return;
 
       if (val) {
-        const splitterPosition = await window.electron.getSplitterPosition();
         const clamp = (value: number, min: number, max: number) =>
           Math.max(Math.min(value, max), min);
 
         // 設定ファイルを書き換えれば異常な値が入り得るのですべてclampしておく
         portraitPaneWidth.value = clamp(
-          splitterPosition.portraitPainWidth ?? DEFAULT_PORTRAIT_PANE_WIDTH,
+          splitterPosition.value.portraitPainWidth ??
+            DEFAULT_PORTRAIT_PANE_WIDTH,
           MIN_PORTRAIT_PANE_WIDTH,
           MAX_PORTRAIT_PANE_WIDTH
         );
 
         audioInfoPaneWidth.value = clamp(
-          splitterPosition.audioInfoPainWidth ?? MIN_AUDIO_INFO_PANE_WIDTH,
+          splitterPosition.value.audioInfoPainWidth ??
+            MIN_AUDIO_INFO_PANE_WIDTH,
           MIN_AUDIO_INFO_PANE_WIDTH,
           MAX_AUDIO_INFO_PANE_WIDTH
         );
@@ -421,7 +428,7 @@ export default defineComponent({
         );
 
         audioDetailPaneHeight.value = clamp(
-          splitterPosition.audioDetailPainHeight ??
+          splitterPosition.value.audioDetailPainHeight ??
             MIN_AUDIO_DETAIL_PANE_HEIGHT,
           audioDetailPaneMinHeight.value,
           audioDetailPaneMaxHeight.value

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -176,7 +176,11 @@ import DictionaryManageDialog from "@/components/DictionaryManageDialog.vue";
 import { AudioItem } from "@/store/type";
 import { QResizeObserver } from "quasar";
 import path from "path";
-import { HotkeyAction, HotkeyReturnType } from "@/type/preload";
+import {
+  HotkeyAction,
+  HotkeyReturnType,
+  SplitterPosition,
+} from "@/type/preload";
 import { parseCombo, setHotkeyFunctions } from "@/store/setting";
 
 export default defineComponent({
@@ -306,34 +310,30 @@ export default defineComponent({
       }
     };
 
-    const updatePortraitPane = async (width: number) => {
-      portraitPaneWidth.value = width;
-
+    const updateSplitterPosition = async (
+      propertyName: keyof SplitterPosition,
+      newValue: number
+    ) => {
       const position = await window.electron.getSplitterPosition();
       window.electron.setSplitterPosition({
         ...position,
-        portraitPainWidth: width,
+        [propertyName]: newValue,
       });
+    };
+
+    const updatePortraitPane = async (width: number) => {
+      portraitPaneWidth.value = width;
+      await updateSplitterPosition("portraitPainWidth", width);
     };
 
     const updateAudioInfoPane = async (width: number) => {
       audioInfoPaneWidth.value = width;
-
-      const position = await window.electron.getSplitterPosition();
-      window.electron.setSplitterPosition({
-        ...position,
-        audioInfoPainWidth: width,
-      });
+      await updateSplitterPosition("audioInfoPainWidth", width);
     };
 
     const updateAudioDetailPane = async (height: number) => {
       audioDetailPaneHeight.value = height;
-
-      const position = await window.electron.getSplitterPosition();
-      window.electron.setSplitterPosition({
-        ...position,
-        audioDetailPainHeight: height,
-      });
+      await updateSplitterPosition("audioDetailPainHeight", height);
     };
 
     // component

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -315,7 +315,7 @@ export default defineComponent({
       newValue: number
     ) => {
       const position = await window.electron.getSplitterPosition();
-      window.electron.setSplitterPosition({
+      await window.electron.setSplitterPosition({
         ...position,
         [propertyName]: newValue,
       });

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -81,9 +81,9 @@ describe("store/vuex.js test", () => {
           enableInterrogativeUpspeak: false,
         },
         splitterPosition: {
-          audioDetailPainHeight: 200,
-          audioInfoPainWidth: 20,
-          portraitPainWidth: 50,
+          audioDetailPaneHeight: 200,
+          audioInfoPaneWidth: 20,
+          portraitPaneWidth: 50,
         },
       },
       getters: {
@@ -180,10 +180,10 @@ describe("store/vuex.js test", () => {
     );
     assert.propertyVal(
       store.state.splitterPosition,
-      "audioDetailPainHeight",
+      "audioDetailPaneHeight",
       200
     );
-    assert.propertyVal(store.state.splitterPosition, "audioInfoPainWidth", 20);
-    assert.propertyVal(store.state.splitterPosition, "portraitPainWidth", 50);
+    assert.propertyVal(store.state.splitterPosition, "audioInfoPaneWidth", 20);
+    assert.propertyVal(store.state.splitterPosition, "portraitPaneWidth", 50);
   });
 });

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -80,6 +80,11 @@ describe("store/vuex.js test", () => {
           enablePreset: false,
           enableInterrogativeUpspeak: false,
         },
+        splitterPosition: {
+          audioDetailPainHeight: 200,
+          audioInfoPainWidth: 20,
+          portraitPainWidth: 50,
+        },
       },
       getters: {
         ...uiStore.getters,
@@ -173,5 +178,12 @@ describe("store/vuex.js test", () => {
       store.state.experimentalSetting.enableInterrogativeUpspeak,
       false
     );
+    assert.propertyVal(
+      store.state.splitterPosition,
+      "audioDetailPainHeight",
+      200
+    );
+    assert.propertyVal(store.state.splitterPosition, "audioInfoPainWidth", 20);
+    assert.propertyVal(store.state.splitterPosition, "portraitPainWidth", 50);
   });
 });


### PR DESCRIPTION
## 内容
### 概要
ウィンドウ位置とスプリッターの位置を記憶できるようにしました。
ウィンドウ位置は [electron-window-state](https://github.com/mawie81/electron-window-state) を利用し、
スプリッターの位置は electron-store の設定ファイルに保存するようにしました。

### ウィンドウ位置の記憶
- `config.json` と同じディレクトリに `window-state.json` というファイルが作成され、そこに記録されます。
- 表示していたディスプレイを外した場合の復帰処理は electron-window-state が面倒見てくれるのでこちらのコード内には入っていません。
- 最大化やフルスクリーン状態も記憶して復帰してくれます。
- ただし、その復帰処理の[ライブラリ内バグ](https://github.com/mawie81/electron-window-state/issues/68)で「複数モニタにまたがるようにウィンドウを配置して終了→起動した場合、復帰できず初期位置に戻る」という現象が起こります。。。
   - もしこれが許容し難い場合はこのライブラリを使わず自前で実装が必要と思います（自前でもそんなに重くはなさそうです）

### スプリッター位置の記憶
- 設定ファイルへの保存タイミングは、スプリッターをつまんで動かして離したタイミングです。
- ユーザが設定ファイルを編集してとんでもない値にした場合でも表示が壊れないようにしています。

## 関連 Issue
close #195

## スクリーンショット・動画など
![Animation](https://user-images.githubusercontent.com/241973/162623102-1c10c842-c438-4762-9b44-a324f2b45d6c.gif)

----

EDITED:

### 動作確認
両OSでウィンドウ位置の保存と、マルチモニタでの復帰、windowsで最大化・macでフルスクリーン状態が復元されることを確認しています。（linuxは確認できてないです、すみません）
- windows10
- Intel mac (Monterey)