### PR TITLE
書き出しファイル名をカスタマイズ可能にする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -234,6 +234,10 @@ const store = new Store<{
           enum: ["UTF-8", "Shift_JIS"],
           default: "UTF-8",
         },
+        fileNamePattern: {
+          type: "string",
+          default: "",
+        },
         fixedExportEnabled: { type: "boolean", default: false },
         avoidOverwrite: { type: "boolean", default: false },
         fixedExportDir: { type: "string", default: "" },
@@ -245,6 +249,7 @@ const store = new Store<{
       },
       default: {
         fileEncoding: "UTF-8",
+        fileNamePattern: "",
         fixedExportEnabled: false,
         avoidOverwrite: false,
         fixedExportDir: "",

--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -37,9 +37,8 @@
           </div>
         </div>
         <div class="text-body2 text-ellipsis">
-          出力例）{{ exampleFileName }}
+          出力例）{{ previewFileName }}
         </div>
-
         <div class="row full-width q-my-md">
           <q-btn
             v-for="tagString in tagStrings"
@@ -101,27 +100,29 @@ export default defineComponent({
       context.emit("update:openDialog", isOpen);
 
     const store = useStore();
-
     const patternInput = ref<QInput>();
+    const maxLength = 128;
+    const tagStrings = Object.values(replaceTagIdToTagString);
 
     const savingSetting = computed(() => store.state.savingSetting);
 
     const currentFileNamePattern = ref(savingSetting.value.fileNamePattern);
-    const sanitizedPattern = computed(() =>
+    const sanitizedFileNamePattern = computed(() =>
       sanitizeFileName(currentFileNamePattern.value)
     );
-    const includesInvalidChar = computed(
-      () => currentFileNamePattern.value !== sanitizedPattern.value
+
+    const hasInvalidChar = computed(
+      () => currentFileNamePattern.value !== sanitizedFileNamePattern.value
     );
-    const notIncludesIndexTag = computed(
+    const hasNotIndexTagString = computed(
       () =>
         !currentFileNamePattern.value.includes(replaceTagIdToTagString["index"])
     );
     const invalidChar = computed(() => {
-      if (!includesInvalidChar.value) return "";
+      if (!hasInvalidChar.value) return "";
 
       const a = currentFileNamePattern.value;
-      const b = sanitizedPattern.value;
+      const b = sanitizedFileNamePattern.value;
 
       let diffAt = "";
       for (let i = 0; i < a.length; i++) {
@@ -144,16 +145,16 @@ export default defineComponent({
           `使用できない文字が含まれています：「${invalidChar.value}」`
         );
       }
-      if (notIncludesIndexTag.value) {
+      if (hasNotIndexTagString.value) {
         result.push(`$${replaceTagIdToTagString["index"]}$は必須です`);
       }
       return result.join(", ");
     });
     const hasError = computed(() => errorMessage.value !== "");
-    const exampleFileName = computed(() =>
+
+    const previewFileName = computed(() =>
       buildFileNameFromRawData(currentFileNamePattern.value + ".wav")
     );
-    const maxLength = 128;
 
     const removeExtension = (str: string) => {
       return str.replace(/\.wav$/, "");
@@ -169,8 +170,6 @@ export default defineComponent({
       );
       patternInput.value?.focus();
     };
-
-    const tagStrings = Object.values(replaceTagIdToTagString);
 
     const insertTagToCurrentPosition = (tag: string) => {
       const elem = patternInput.value?.getNativeElement() as HTMLInputElement;
@@ -219,7 +218,7 @@ export default defineComponent({
       currentFileNamePattern,
       errorMessage,
       hasError,
-      exampleFileName,
+      previewFileName,
     };
   },
 });

--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -9,8 +9,8 @@
         <div class="text-h6">出力ファイル名パターン</div>
       </q-card-section>
       <q-card-actions class="setting-card q-px-md q-py-sm">
-        <div>
-          <div>
+        <div class="row full-width justify-between">
+          <div class="col">
             <q-input
               dense
               outlined
@@ -22,49 +22,54 @@
               :error-message="`ファイル名に使用できない文字が含まれています：「${invalidChar}」`"
               v-model="currentFileNamePattern"
               ref="patternInput"
-            />
+            >
+              <template v-slot:after>
+                <q-btn
+                  label="デフォルトにリセット"
+                  unelevated
+                  color="background-light"
+                  text-color="display-dark"
+                  class="text-no-wrap q-mr-sm"
+                  @click="resetToDefault"
+                />
+              </template>
+            </q-input>
           </div>
-          <div class="text-body2">出力例）{{ exampleFileName }}</div>
+        </div>
+        <div class="text-body2 text-ellipsis">
+          出力例）{{ exampleFileName }}
+        </div>
+
+        <div class="row full-width q-my-md">
           <q-btn
-            label="デフォルトにリセット"
+            v-for="tag in tags"
+            :key="tag"
+            :label="`$${tag}$`"
             unelevated
             color="background-light"
             text-color="display-dark"
-            class="text-no-wrap text-bold q-mr-sm"
-            @click="resetToDefault"
+            class="text-no-wrap q-mr-sm"
+            @click="insertTagToCurrentPosition(`$${tag}$`)"
           />
-          <div>
-            <q-btn
-              v-for="tag in tags"
-              :key="tag"
-              :label="`$${tag}$`"
-              unelevated
-              color="background-light"
-              text-color="display-dark"
-              class="text-no-wrap text-bold q-mr-sm"
-              @click="insertTagToCurrentPosition(`$${tag}$`)"
-            />
-          </div>
-          <div>
-            <q-space />
-            <q-btn
-              label="キャンセル"
-              unelevated
-              color="background-light"
-              text-color="display-dark"
-              class="text-no-wrap text-bold q-mr-sm"
-              @click="updateOpenDialog(false)"
-            />
-            <q-btn
-              label="確定"
-              unelevated
-              color="background-light"
-              text-color="display-dark"
-              class="text-no-wrap text-bold q-mr-sm"
-              :disable="isInvalidPattern"
-              @click="submit"
-            />
-          </div>
+        </div>
+        <div class="row full-width justify-end">
+          <q-btn
+            label="キャンセル"
+            unelevated
+            color="background-light"
+            text-color="display-dark"
+            class="text-no-wrap text-bold q-mr-sm col-2"
+            @click="updateOpenDialog(false)"
+          />
+          <q-btn
+            label="確定"
+            unelevated
+            color="background-light"
+            text-color="display-dark"
+            class="text-no-wrap text-bold q-mr-sm col-2"
+            :disable="isInvalidPattern || currentFileNamePattern.length === 0"
+            @click="submit"
+          />
         </div>
       </q-card-actions>
     </q-card>
@@ -204,6 +209,12 @@ export default defineComponent({
   width: 100%;
   min-width: 475px;
   background: colors.$setting-item;
+}
+
+.text-ellipsis {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .dialog-card {

--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -1,0 +1,213 @@
+<template>
+  <q-dialog
+    :model-value="openDialog"
+    @update:model-value="updateOpenDialog"
+    @before-show="initializeInput"
+  >
+    <q-card class="q-pa-md dialog-card">
+      <q-card-section>
+        <div class="text-h6">出力ファイル名パターン</div>
+      </q-card-section>
+      <q-card-actions class="setting-card q-px-md q-py-sm">
+        <div>
+          <div>
+            <q-input
+              dense
+              outlined
+              bg-color="background-light"
+              label="ファイル名パターン"
+              suffix=".wav"
+              :maxlength="maxLength"
+              :error="isInvalidPattern"
+              :error-message="`ファイル名に使用できない文字が含まれています：「${invalidChar}」`"
+              v-model="currentFileNamePattern"
+              ref="patternInput"
+            />
+          </div>
+          <div class="text-body2">出力例）{{ exampleFileName }}</div>
+          <q-btn
+            label="デフォルトにリセット"
+            unelevated
+            color="background-light"
+            text-color="display-dark"
+            class="text-no-wrap text-bold q-mr-sm"
+            @click="resetToDefault"
+          />
+          <div>
+            <q-btn
+              v-for="tag in tags"
+              :key="tag"
+              :label="`$${tag}$`"
+              unelevated
+              color="background-light"
+              text-color="display-dark"
+              class="text-no-wrap text-bold q-mr-sm"
+              @click="insertTagToCurrentPosition(`$${tag}$`)"
+            />
+          </div>
+          <div>
+            <q-space />
+            <q-btn
+              label="キャンセル"
+              unelevated
+              color="background-light"
+              text-color="display-dark"
+              class="text-no-wrap text-bold q-mr-sm"
+              @click="updateOpenDialog(false)"
+            />
+            <q-btn
+              label="確定"
+              unelevated
+              color="background-light"
+              text-color="display-dark"
+              class="text-no-wrap text-bold q-mr-sm"
+              :disable="isInvalidPattern"
+              @click="submit"
+            />
+          </div>
+        </div>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed, ref } from "vue";
+import { QInput } from "quasar";
+import { useStore } from "@/store";
+import {
+  buildFileNameFromRawData,
+  DEFAULT_FILE_NAME_TEMPLATE,
+  replaceTagMap,
+  sanitizeFileName,
+} from "@/store/utility";
+
+export default defineComponent({
+  name: "FileNamePatternDialog",
+
+  props: {
+    openDialog: Boolean,
+  },
+
+  emits: ["update:openDialog"],
+
+  setup(props, context) {
+    const updateOpenDialog = (isOpen: boolean) =>
+      context.emit("update:openDialog", isOpen);
+
+    const store = useStore();
+
+    const patternInput = ref<QInput>();
+
+    const savingSetting = computed(() => store.state.savingSetting);
+
+    const currentFileNamePattern = ref(savingSetting.value.fileNamePattern);
+    const sanitizedPattern = computed(() =>
+      sanitizeFileName(currentFileNamePattern.value)
+    );
+    const isInvalidPattern = computed(
+      () => currentFileNamePattern.value !== sanitizedPattern.value
+    );
+    const invalidChar = computed(() => {
+      if (!isInvalidPattern.value) return "";
+
+      const a = currentFileNamePattern.value;
+      const b = sanitizedPattern.value;
+
+      let diffAt = "";
+      for (let i = 0; i < a.length; i++) {
+        if (b[i] !== a[i]) {
+          diffAt = a[i];
+          break;
+        }
+      }
+
+      return diffAt;
+    });
+    const exampleFileName = computed(() =>
+      buildFileNameFromRawData(currentFileNamePattern.value + ".wav")
+    );
+    const maxLength = 128;
+
+    const removeExtension = (str: string) => {
+      return str.replace(/\.wav$/, "");
+    };
+
+    const initializeInput = () => {
+      const pattern = savingSetting.value.fileNamePattern;
+      currentFileNamePattern.value = removeExtension(pattern);
+    };
+    const resetToDefault = () => {
+      currentFileNamePattern.value = removeExtension(
+        DEFAULT_FILE_NAME_TEMPLATE
+      );
+    };
+
+    const tags = computed(() => [...replaceTagMap.values()]);
+
+    const insertTagToCurrentPosition = (tag: string) => {
+      const elem = patternInput.value?.getNativeElement() as HTMLInputElement;
+      if (elem) {
+        const text = elem.value;
+
+        if (text.length + tag.length > maxLength) {
+          return;
+        }
+
+        const from = elem.selectionStart ?? 0;
+        const to = elem.selectionEnd ?? 0;
+        const newText = text.substring(0, from) + tag + text.substring(to);
+        currentFileNamePattern.value = newText;
+
+        // キャレットの位置を挿入した後の位置にずらす
+        // QInputの内容が更新されてから動かすために50ms待つ
+        setTimeout(() => {
+          elem.selectionStart = from + tag.length;
+          elem.selectionEnd = from + tag.length;
+        }, 50);
+      }
+    };
+
+    const submit = async () => {
+      await store.dispatch("SET_SAVING_SETTING", {
+        data: {
+          ...savingSetting.value,
+          fileNamePattern: currentFileNamePattern.value + ".wav",
+        },
+      });
+      updateOpenDialog(false);
+    };
+
+    return {
+      patternInput,
+      tags,
+      maxLength,
+      updateOpenDialog,
+      resetToDefault,
+      insertTagToCurrentPosition,
+      submit,
+      initializeInput,
+      savingSetting,
+      currentFileNamePattern,
+      isInvalidPattern,
+      invalidChar,
+      exampleFileName,
+    };
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@use '@/styles/colors' as colors;
+
+.setting-card {
+  width: 100%;
+  min-width: 475px;
+  background: colors.$setting-item;
+}
+
+.dialog-card {
+  width: 700px;
+  max-width: 80vw;
+}
+</style>

--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -6,7 +6,10 @@
   >
     <q-card class="q-pa-md dialog-card">
       <q-card-section>
-        <div class="text-h6">出力ファイル名パターン</div>
+        <div class="text-h5">書き出しファイル名パターン</div>
+        <div class="text-body2 text-grey-8">
+          「$キャラ$」のようなタグを使って書き出すファイル名をカスタマイズできます
+        </div>
       </q-card-section>
       <q-card-actions class="setting-card q-px-md q-py-sm">
         <div class="row full-width justify-between">

--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -42,14 +42,14 @@
 
         <div class="row full-width q-my-md">
           <q-btn
-            v-for="tag in tags"
-            :key="tag"
-            :label="`$${tag}$`"
+            v-for="tagString in tagStrings"
+            :key="tagString"
+            :label="`$${tagString}$`"
             unelevated
             color="background-light"
             text-color="display-dark"
             class="text-no-wrap q-mr-sm"
-            @click="insertTagToCurrentPosition(`$${tag}$`)"
+            @click="insertTagToCurrentPosition(`$${tagString}$`)"
           />
         </div>
         <div class="row full-width justify-end">
@@ -83,7 +83,7 @@ import { useStore } from "@/store";
 import {
   buildFileNameFromRawData,
   DEFAULT_FILE_NAME_TEMPLATE,
-  replaceTagMap,
+  replaceTagIdToTagString,
   sanitizeFileName,
 } from "@/store/utility";
 
@@ -115,9 +115,7 @@ export default defineComponent({
     );
     const notIncludesIndexTag = computed(
       () =>
-        !currentFileNamePattern.value.includes(
-          replaceTagMap.get("index") as string
-        )
+        !currentFileNamePattern.value.includes(replaceTagIdToTagString["index"])
     );
     const invalidChar = computed(() => {
       if (!includesInvalidChar.value) return "";
@@ -147,7 +145,7 @@ export default defineComponent({
         );
       }
       if (notIncludesIndexTag.value) {
-        result.push(`$${replaceTagMap.get("index")}$は必須です`);
+        result.push(`$${replaceTagIdToTagString["index"]}$は必須です`);
       }
       return result.join(", ");
     });
@@ -172,7 +170,7 @@ export default defineComponent({
       patternInput.value?.focus();
     };
 
-    const tags = [...replaceTagMap.values()];
+    const tagStrings = Object.values(replaceTagIdToTagString);
 
     const insertTagToCurrentPosition = (tag: string) => {
       const elem = patternInput.value?.getNativeElement() as HTMLInputElement;
@@ -210,7 +208,7 @@ export default defineComponent({
 
     return {
       patternInput,
-      tags,
+      tagStrings,
       maxLength,
       updateOpenDialog,
       resetToDefault,

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -347,7 +347,7 @@
               />
 
               <q-card-actions class="q-px-md q-py-sm bg-setting-item">
-                <div>ファイル名パターン</div>
+                <div>書き出しファイル名パターン</div>
                 <div>
                   <q-icon
                     name="help_outline"
@@ -362,7 +362,7 @@
                       transition-show="jump-left"
                       transition-hide="jump-right"
                     >
-                      書き出すファイル名のパターンを指定する
+                      書き出すファイル名のパターンをカスタマイズする
                     </q-tooltip>
                   </q-icon>
                 </div>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -342,6 +342,41 @@
                 </q-toggle>
               </q-card-actions>
 
+              <file-name-pattern-dialog
+                v-model:open-dialog="showsFilePatternEditDialog"
+              />
+
+              <q-card-actions class="q-px-md q-py-none bg-setting-item">
+                <div>ファイル名パターン</div>
+                <div>
+                  <q-icon
+                    name="help_outline"
+                    color="grey-8"
+                    size="sm"
+                    class="help-hover-icon"
+                  >
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      書き出すファイル名のパターンを指定する
+                    </q-tooltip>
+                  </q-icon>
+                </div>
+                <q-space />
+                <q-btn
+                  label="ファイル名パターンを編集する"
+                  unelevated
+                  color="background-light"
+                  text-color="display-dark"
+                  class="text-no-wrap text-bold q-mr-sm"
+                  @click="showsFilePatternEditDialog = true"
+                />
+              </q-card-actions>
+
               <q-card-actions class="q-px-md q-py-none bg-setting-item">
                 <div>上書き防止</div>
                 <div>
@@ -679,9 +714,14 @@ import {
   ActivePointScrollMode,
   SplitTextWhenPasteType,
 } from "@/type/preload";
+import FileNamePatternDialog from "./FileNamePatternDialog.vue";
 
 export default defineComponent({
   name: "SettingDialog",
+
+  components: {
+    FileNamePatternDialog,
+  },
 
   props: {
     modelValue: {
@@ -953,6 +993,8 @@ export default defineComponent({
       store.dispatch("SET_SPLIT_TEXT_WHEN_PASTE", { splitTextWhenPaste });
     };
 
+    const showsFilePatternEditDialog = ref(false);
+
     return {
       settingDialogOpenedComputed,
       engineMode,
@@ -974,6 +1016,7 @@ export default defineComponent({
       acceptRetrieveTelemetryComputed,
       splitTextWhenPaste,
       changeSplitTextWhenPaste,
+      showsFilePatternEditDialog,
     };
   },
 });

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -293,7 +293,6 @@
                       self="center right"
                       transition-show="jump-left"
                       transition-hide="jump-right"
-                      v-if="!savingSetting.fixedExportEnabled"
                     >
                       音声ファイルを設定したフォルダに書き出す
                     </q-tooltip>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -346,7 +346,7 @@
                 v-model:open-dialog="showsFilePatternEditDialog"
               />
 
-              <q-card-actions class="q-px-md q-py-none bg-setting-item">
+              <q-card-actions class="q-px-md q-py-sm bg-setting-item">
                 <div>ファイル名パターン</div>
                 <div>
                   <q-icon
@@ -367,12 +367,15 @@
                   </q-icon>
                 </div>
                 <q-space />
+                <div class="q-px-sm text-ellipsis">
+                  {{ savingSetting.fileNamePattern }}
+                </div>
                 <q-btn
-                  label="ファイル名パターンを編集する"
+                  label="編集"
                   unelevated
                   color="background-light"
                   text-color="display-dark"
-                  class="text-no-wrap text-bold q-mr-sm"
+                  class="text-no-wrap q-mr-sm"
                   @click="showsFilePatternEditDialog = true"
                 />
               </q-card-actions>
@@ -1051,6 +1054,12 @@ export default defineComponent({
 
 .scroll-mode-button-selected {
   background: colors.$primary;
+}
+
+.text-ellipsis {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .scroll-mode-button:hover {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -29,11 +29,11 @@ import {
 import Encoding from "encoding-japanese";
 import { PromiseType } from "./vuex";
 import {
+  buildFileNameFromRawData,
   buildProjectFileName,
   convertHiraToKana,
   convertLongVowel,
   createKanaRegex,
-  sanitizeFileName,
 } from "./utility";
 
 async function generateUniqueIdAndQuery(
@@ -100,78 +100,6 @@ function parseTextFile(
     audioItems.push({ text: splittedText, styleId: lastStyleId });
   }
   return audioItems;
-}
-
-type ReplaceTag =
-  | "index"
-  | "characterName"
-  | "styleName"
-  | "rawStyleName"
-  | "text";
-type Replacer = { [P in ReplaceTag]?: string };
-type VariablesForFileName = {
-  index: number;
-  characterName: string;
-  styleName: string | undefined;
-  text: string;
-};
-
-const replaceTagMap: Map<ReplaceTag, string> = new Map([
-  ["index", "連番"],
-  ["characterName", "キャラ"],
-  ["styleName", "（スタイル）"],
-  ["text", "テキスト"],
-  ["rawStyleName", "スタイル"],
-]);
-
-const DEFAULT_TEMPLATE = "$連番$_$キャラ$$（スタイル）$_$テキスト$.wav";
-const DEFAULT_FILE_NAME_VARIABLES: VariablesForFileName = {
-  index: 1,
-  characterName: "四国めたん",
-  text: "おはようこんにちはこんばんは",
-  styleName: "ノーマル",
-};
-
-function replaceTag(template: string, replacer: Replacer): string {
-  let result = `${template}`;
-
-  replaceTagMap.forEach((target, key) => {
-    const replacedText = replacer[key] ?? "";
-    result = result.replaceAll(`$${target}$`, replacedText);
-  });
-
-  return result;
-}
-
-export function buildFileNameFromRawData(
-  fileNamePattern = DEFAULT_TEMPLATE,
-  vars: VariablesForFileName = DEFAULT_FILE_NAME_VARIABLES
-): string {
-  let pattern = fileNamePattern;
-  if (pattern.length === 0) {
-    // ファイル名指定のオプションが初期値("")ならデフォルトテンプレートを使う
-    pattern = DEFAULT_TEMPLATE;
-  }
-
-  let text = sanitizeFileName(vars.text);
-  if (text.length > 10) {
-    text = text.substring(0, 9) + "…";
-  }
-
-  const characterName = sanitizeFileName(vars.characterName);
-
-  const index = (vars.index + 1).toString().padStart(3, "0");
-
-  // デフォルトのスタイルだとstyleIdが定義されていないのでstyleNameがundefinedになるケースが存在する
-  const styleName = sanitizeFileName(vars.styleName ?? "");
-
-  return replaceTag(pattern, {
-    index,
-    characterName,
-    rawStyleName: styleName,
-    styleName: styleName.length !== 0 ? `（${styleName}）` : "",
-    text,
-  });
 }
 
 function buildFileName(state: State, audioKey: string) {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -34,6 +34,7 @@ import {
   convertHiraToKana,
   convertLongVowel,
   createKanaRegex,
+  currentDateString,
 } from "./utility";
 
 async function generateUniqueIdAndQuery(
@@ -130,6 +131,7 @@ function buildFileName(state: State, audioKey: string) {
     index,
     styleName,
     text: audioItem.text,
+    date: currentDateString(),
   });
 }
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1049,7 +1049,6 @@ export const audioStore: VoiceVoxStoreOptions<
           let tail = 1;
           const name = filePath.slice(0, filePath.length - 4);
           while (await dispatch("CHECK_FILE_EXISTS", { file: filePath })) {
-            console.log({ checked: filePath });
             filePath = name + "[" + tail.toString() + "]" + ".wav";
             tail += 1;
           }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -133,6 +133,47 @@ function buildFileName(state: State, audioKey: string) {
   });
 }
 
+/**
+ * 出力予定のファイル名のリストを受け取り、
+ * audioKeyとファイル名の対応関係に変換して返す。
+ * 重複するファイル名は末尾に数値を付与してファイル名が重複しないように処理する。
+ *
+ * @param dirPath 出力ディレクトリのパス
+ * @param builtFileNameMap { key: ファイル名、value: audioKeyの配列 }が格納されたObject
+ * @returns (key: audioKey, value: 重複解決済みのファイル名) のMap
+ */
+async function resolveDuplicatedFilename(
+  dirPath: string,
+  builtFileNameMap: Record<string, string[]>
+): Promise<Map<string, string>> {
+  const result: Map<string, string> = new Map();
+
+  for (const [filename, audioKeys] of Object.entries(builtFileNameMap)) {
+    let tail = 1;
+    const alreadyResolvedFilePath = new Set();
+
+    for (const audioKey of audioKeys) {
+      let filePath = path.join(dirPath, filename);
+
+      const name = filePath.slice(0, filePath.length - 4);
+      while (
+        (await window.electron.checkFileExists(filePath)) ||
+        alreadyResolvedFilePath.has(filePath)
+      ) {
+        filePath = name + "[" + tail.toString() + "]" + ".wav";
+        tail += 1;
+      }
+
+      alreadyResolvedFilePath.add(filePath);
+
+      const fileName = path.basename(filePath);
+      result.set(audioKey, fileName);
+    }
+  }
+
+  return result;
+}
+
 const audioBlobCache: Record<string, Blob> = {};
 const audioElements: Record<string, HTMLAudioElement> = {};
 
@@ -985,7 +1026,8 @@ export const audioStore: VoiceVoxStoreOptions<
           encoding?: EncodingType;
         }
       ): Promise<SaveResultObject> => {
-        if (state.savingSetting.fixedExportEnabled) {
+        // filePathが外から与えられた場合は既にパスが決定しているので再度生成しない
+        if (state.savingSetting.fixedExportEnabled && filePath === undefined) {
           filePath = path.join(
             state.savingSetting.fixedExportDir,
             buildFileName(state, audioKey)
@@ -1098,11 +1140,27 @@ export const audioStore: VoiceVoxStoreOptions<
         }
         if (dirPath) {
           const _dirPath = dirPath;
+
+          // 連続出力ではすべての出力が1つのファイルに上書きされて嬉しい人はいないと思うので、
+          // 重複防止設定のON/OFFに関わらず重複を防止する
+          const builtFileNameMap: Record<string, string[]> = {};
+          state.audioKeys.forEach((audioKey) => {
+            const builtName = buildFileName(state, audioKey);
+            const value = builtFileNameMap[builtName] ?? [];
+            builtFileNameMap[builtName] = [...value, audioKey];
+          });
+
+          const audioKeyToFileNameMap = await resolveDuplicatedFilename(
+            _dirPath,
+            builtFileNameMap
+          );
+
           const promises = state.audioKeys.map((audioKey) => {
-            const name = buildFileName(state, audioKey);
+            // audioKeysからMapを作成しており必ず対応する値が存在するのでキャスト
+            const fileName = audioKeyToFileNameMap.get(audioKey) as string;
             return dispatch("GENERATE_AND_SAVE_AUDIO", {
               audioKey,
-              filePath: path.join(_dirPath, name),
+              filePath: path.join(_dirPath, fileName),
               encoding,
             });
           });

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -24,6 +24,7 @@ const hotkeyFunctionCache: Record<string, () => HotkeyReturnType> = {};
 export const settingStoreState: SettingStoreState = {
   savingSetting: {
     fileEncoding: "UTF-8",
+    fileNamePattern: "",
     fixedExportEnabled: false,
     fixedExportDir: "",
     avoidOverwrite: false,

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -50,13 +50,15 @@ type ReplaceTag =
   | "characterName"
   | "styleName"
   | "rawStyleName"
-  | "text";
+  | "text"
+  | "date";
 type Replacer = { [P in ReplaceTag]?: string };
 type VariablesForFileName = {
   index: number;
   characterName: string;
   styleName: string | undefined;
   text: string;
+  date: string;
 };
 
 export const replaceTagMap: Map<ReplaceTag, string> = new Map([
@@ -65,6 +67,7 @@ export const replaceTagMap: Map<ReplaceTag, string> = new Map([
   ["styleName", "（スタイル）"],
   ["text", "テキスト"],
   ["rawStyleName", "スタイル"],
+  ["date", "日付"],
 ]);
 
 export const DEFAULT_FILE_NAME_TEMPLATE =
@@ -74,7 +77,13 @@ const DEFAULT_FILE_NAME_VARIABLES: VariablesForFileName = {
   characterName: "四国めたん",
   text: "おはようこんにちはこんばんは",
   styleName: "ノーマル",
+  date: currentDateString(),
 };
+
+export function currentDateString(): string {
+  const date = new Date();
+  return `${date.getFullYear()}${date.getMonth()}${date.getDate()}`;
+}
 
 function replaceTag(template: string, replacer: Replacer): string {
   let result = `${template}`;
@@ -109,12 +118,15 @@ export function buildFileNameFromRawData(
   // デフォルトのスタイルだとstyleIdが定義されていないのでstyleNameがundefinedになるケースが存在する
   const styleName = sanitizeFileName(vars.styleName ?? "");
 
+  const date = currentDateString();
+
   return replaceTag(pattern, {
     index,
     characterName,
     rawStyleName: styleName,
     styleName: styleName.length !== 0 ? `（${styleName}）` : "",
     text,
+    date,
   });
 }
 

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -53,7 +53,6 @@ type ReplaceTagId =
   | "text"
   | "date";
 type Replacer = { [P in ReplaceTagId]?: string };
-type ReplaceTagString = string;
 type VariablesForFileName = {
   index: number;
   characterName: string;
@@ -63,7 +62,7 @@ type VariablesForFileName = {
 };
 
 export const replaceTagIdToTagString: {
-  [key in ReplaceTagId]: ReplaceTagString;
+  [key in ReplaceTagId]: string;
 } = {
   index: "連番",
   characterName: "キャラ",
@@ -72,7 +71,7 @@ export const replaceTagIdToTagString: {
   rawStyleName: "スタイル",
   date: "日付",
 };
-const replaceTagStringToTagId: { [key in ReplaceTagString]: ReplaceTagId } =
+const replaceTagStringToTagId: { [tagString: string]: ReplaceTagId } =
   Object.entries(replaceTagIdToTagString).reduce(
     (prev, [k, v]) => ({ ...prev, [v]: k }),
     {}

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -75,7 +75,7 @@ export const DEFAULT_FILE_NAME_TEMPLATE =
 const DEFAULT_FILE_NAME_VARIABLES: VariablesForFileName = {
   index: 0,
   characterName: "四国めたん",
-  text: "おはようこんにちはこんばんは",
+  text: "テキストテキストテキスト",
   styleName: "ノーマル",
   date: currentDateString(),
 };

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -59,7 +59,7 @@ type VariablesForFileName = {
   text: string;
 };
 
-const replaceTagMap: Map<ReplaceTag, string> = new Map([
+export const replaceTagMap: Map<ReplaceTag, string> = new Map([
   ["index", "連番"],
   ["characterName", "キャラ"],
   ["styleName", "（スタイル）"],
@@ -67,7 +67,8 @@ const replaceTagMap: Map<ReplaceTag, string> = new Map([
   ["rawStyleName", "スタイル"],
 ]);
 
-const DEFAULT_TEMPLATE = "$連番$_$キャラ$$（スタイル）$_$テキスト$.wav";
+export const DEFAULT_FILE_NAME_TEMPLATE =
+  "$連番$_$キャラ$$（スタイル）$_$テキスト$.wav";
 const DEFAULT_FILE_NAME_VARIABLES: VariablesForFileName = {
   index: 0,
   characterName: "四国めたん",
@@ -87,13 +88,13 @@ function replaceTag(template: string, replacer: Replacer): string {
 }
 
 export function buildFileNameFromRawData(
-  fileNamePattern = DEFAULT_TEMPLATE,
+  fileNamePattern = DEFAULT_FILE_NAME_TEMPLATE,
   vars: VariablesForFileName = DEFAULT_FILE_NAME_VARIABLES
 ): string {
   let pattern = fileNamePattern;
   if (pattern.length === 0) {
     // ファイル名指定のオプションが初期値("")ならデフォルトテンプレートを使う
-    pattern = DEFAULT_TEMPLATE;
+    pattern = DEFAULT_FILE_NAME_TEMPLATE;
   }
 
   let text = sanitizeFileName(vars.text);

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -142,6 +142,7 @@ export type SplitTextWhenPasteType = "PERIOD_AND_NEW_LINE" | "NEW_LINE" | "OFF";
 export type SavingSetting = {
   exportLab: boolean;
   fileEncoding: Encoding;
+  fileNamePattern: string;
   fixedExportEnabled: boolean;
   fixedExportDir: string;
   avoidOverwrite: boolean;

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -46,6 +46,7 @@ describe("store/vuex.js test", () => {
         savedLastCommandUnixMillisec: null,
         savingSetting: {
           fileEncoding: "UTF-8",
+          fileNamePattern: "",
           fixedExportEnabled: false,
           fixedExportDir: "",
           avoidOverwrite: false,
@@ -161,6 +162,7 @@ describe("store/vuex.js test", () => {
     assert.propertyVal(store.state.savingSetting, "fixedExportDir", "");
     assert.propertyVal(store.state.savingSetting, "avoidOverwrite", false);
     assert.propertyVal(store.state.savingSetting, "exportLab", false);
+    assert.propertyVal(store.state.savingSetting, "fileNamePattern", "");
     assert.equal(store.state.isPinned, false);
     assert.isObject(store.state.presetItems);
     assert.isEmpty(store.state.presetItems);


### PR DESCRIPTION
## 内容
書き出すファイル名をユーザが自由に組み立てられるようになる機能を追加しました。
文字列にタグを指定すると実際のデータに置き換えられて出力されます。
`$キャラ$.wav` のような指定にして音声を一括出力しようとした場合の重複解消ロジックが重めだったので、
コード差分の少ない「$連番$を必須にする」ことで対処しています。

## 関連 Issue
close #569

## スクリーンショット・動画など
### ダイアログの動作
![Animation](https://user-images.githubusercontent.com/241973/163704914-11212f6e-5670-414a-84bf-1757294fe3cc.gif)

### 出力
（テキストにタグが入るようにしていても悪いことはできないようになっています）
![Animation3](https://user-images.githubusercontent.com/241973/163705133-c738f1fa-6489-46d7-902a-532189c4daf7.gif)
