### PR TITLE
イントネーション欄の文字横幅をそろえる

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -838,8 +838,7 @@ $pitch-label-height: 24px;
 
       div {
         padding: 0px;
-        &.text-cell,
-        &.text-cell-hovered {
+        &.text-cell {
           min-width: 20px;
           max-width: 20px;
           grid-row-start: 3;

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -142,7 +142,14 @@
             :key="moraIndex"
           >
             <div
-              :class="getHoveredClass(mora.vowel, accentPhraseIndex, moraIndex)"
+              class="text-cell"
+              :class="{
+                'text-cell-hovered': isHovered(
+                  mora.vowel,
+                  accentPhraseIndex,
+                  moraIndex
+                ),
+              }"
               :style="{
                 'grid-column': `${moraIndex * 2 + 1} / span 1`,
               }"
@@ -658,7 +665,7 @@ export default defineComponent({
 
     const unvoicableVowels = ["U", "I", "i", "u"];
 
-    const getHoveredClass = (
+    const isHovered = (
       vowel: string,
       accentPhraseIndex: number,
       moraIndex: number
@@ -679,8 +686,7 @@ export default defineComponent({
           }
         }
       }
-      if (isHover) return "text-cell-hovered";
-      else return "text-cell";
+      return isHover;
     };
 
     const getHoveredText = (
@@ -769,7 +775,7 @@ export default defineComponent({
       handleChangePronounce,
       handleHoverText,
       handleLengthHoverText,
-      getHoveredClass,
+      isHovered,
       getHoveredText,
       shiftKeyFlag,
       handleChangeVoicing,

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -826,19 +826,16 @@ $pitch-label-height: 24px;
 
       div {
         padding: 0px;
-        &.text-cell {
-          min-width: 20px;
-          max-width: 20px;
-          grid-row-start: 3;
-          text-align: center;
-          color: colors.$display;
-        }
+        &.text-cell,
         &.text-cell-hovered {
           min-width: 20px;
           max-width: 20px;
           grid-row-start: 3;
           text-align: center;
+          white-space: nowrap;
           color: colors.$display;
+        }
+        &.text-cell-hovered {
           font-weight: bold;
           cursor: pointer;
         }
@@ -872,8 +869,8 @@ $pitch-label-height: 24px;
         }
         &.pitch-cell {
           grid-row: 1 / span 2;
-          min-width: 30px;
-          max-width: 30px;
+          min-width: 20px;
+          max-width: 20px;
           display: inline-block;
           position: relative;
         }

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -851,6 +851,7 @@ $pitch-label-height: 24px;
           .text-cell-inner {
             position: absolute;
             transform: translateX(-50%);
+            z-index: 10;
           }
         }
         &.text-cell-hovered {

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -153,7 +153,9 @@
                   handleChangeVoicing(mora, accentPhraseIndex, moraIndex)
               "
             >
-              {{ getHoveredText(mora, accentPhraseIndex, moraIndex) }}
+              <span class="text-cell-inner">
+                {{ getHoveredText(mora, accentPhraseIndex, moraIndex) }}
+              </span>
               <q-popup-edit
                 v-if="selectedDetail == 'accent' && !uiLocked"
                 :model-value="pronunciationByPhrase[accentPhraseIndex]"
@@ -197,7 +199,11 @@
             />
           </template>
           <template v-if="accentPhrase.pauseMora">
-            <div class="text-cell">{{ accentPhrase.pauseMora.text }}</div>
+            <div class="text-cell">
+              <span class="text-cell-inner">
+                {{ accentPhrase.pauseMora.text }}
+              </span>
+            </div>
             <div
               @click.stop="
                 uiLocked || toggleAccentPhraseSplit(accentPhraseIndex, true)
@@ -834,6 +840,12 @@ $pitch-label-height: 24px;
           text-align: center;
           white-space: nowrap;
           color: colors.$display;
+          position: relative;
+
+          .text-cell-inner {
+            position: absolute;
+            transform: translateX(-50%);
+          }
         }
         &.text-cell-hovered {
           font-weight: bold;

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -141,8 +141,8 @@ div {
   .q-slider {
     height: calc(100% - #{$value-label-height + 12px});
     margin-top: $value-label-height + 12px;
-    min-width: 30px;
-    max-width: 30px;
+    min-width: 20px;
+    max-width: 20px;
     :deep(.q-slider__track-container--v) {
       margin-left: -1.5px;
       width: 3px;


### PR DESCRIPTION
## 内容

以前 Split の当たり判定を広げる修正を行いました (#772) が、その際に生じていた

- 複数文字のモーラ（「シャ」など）が改行されてしまう
- イントネーションタブとアクセントタブで文字とスライダーの表示位置がずれている

という二つの問題を修正しました。

## 関連 Issue

fix #777 
ref #772

## スクリーンショット・動画など

修正前画像は #777 を参照してください。

### 修正後
![image](https://user-images.githubusercontent.com/73807432/164884956-3a76e1b5-bbf0-4036-8457-a800665fc772.png)

## その他
### 文字の overflow について
改行されないように表示している点について、 `white-space: nowrap;` によって無理やり狭いスペースに押し込めている都合上、特に複数文字のモーラの右側部分に「文字が表示されているが当たり判定としては split」というスペースができてしまっています。

![image](https://user-images.githubusercontent.com/73807432/164884868-14fb2f77-cefe-4a69-9fe9-1ec83699f3b4.png)
（「ショ」の直後の split にカーソルを合わせています。）

- 読みを変更する場合どの文字を押してもいい
- ハイライトでどちらの機能が起動するかわかる

ことから緊急性は低いと思われますが、余裕があれば修正したほうが良いかもしれません。

### 文字の中央揃えについて
`text-align: center` はしているものの、overflow していることにより文字がグリッド先頭部分ぞろえになってしまっています。そのため、スライダーに対して複数文字モーラの表示位置が右に若干ずれています。これを中央に表示できれば、表示は両側にはみ出ることになるので、上で述べた当たり判定に関しても被る量が減り、使用感が改善されるかもしれません。