### PR TITLE
.envのDEFAULT_ENGINE_INFOSを改行して定義

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,9 @@
-DEFAULT_ENGINE_INFOS=[{"key":"074fc39e-678b-4c13-8916-ffca8d505d1d","executionEnabled":true,"executionFilePath":"run.exe","host":"http://127.0.0.1:50021"}]
+DEFAULT_ENGINE_INFOS=`[
+    {
+        "key": "074fc39e-678b-4c13-8916-ffca8d505d1d",
+        "executionEnabled": true,
+        "executionFilePath": "run.exe",
+        "host": "http://127.0.0.1:50021"
+    }
+]`
 VUE_APP_GTM_CONTAINER_ID=GTM-DUMMY

--- a/package-lock.json
+++ b/package-lock.json
@@ -3272,6 +3272,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "dotenv": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -7970,10 +7976,9 @@
       }
     },
     "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -15488,6 +15493,14 @@
         "js-yaml": "^3.13.1",
         "json5": "^2.1.2",
         "lazy-val": "^1.0.4"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+          "dev": true
+        }
       }
     },
     "read-installed": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ajv": "8.6.2",
     "core-js": "3.12.1",
     "dayjs": "1.10.7",
+    "dotenv": "16.0.0",
     "electron-log": "4.4.1",
     "electron-store": "8.0.0",
     "encoding-japanese": "1.0.30",

--- a/src/background.ts
+++ b/src/background.ts
@@ -76,8 +76,7 @@ process.on("unhandledRejection", (reason) => {
 
 // .envから設定をprocess.envに読み込み
 const appDirPath = path.dirname(app.getPath("exe"));
-const envPath = path.join(appDirPath, ".env");
-dotenv.config({ path: envPath });
+dotenv.config({ override: true });
 
 protocol.registerSchemesAsPrivileged([
   { scheme: "app", privileges: { secure: true, standard: true, stream: true } },


### PR DESCRIPTION
## 内容

- Jsonを1行で書いてあるのは見づらかったので改行するようにしました。
- 開発環境だと `envPath` はnode_modulesの中を指していてうまく読めていなかったので修正しました。
- 本番環境でも `dotenv` が使われているっぽいのにdependenciesに入っていなかったので追加しました。

## 関連 Issue

## スクリーンショット・動画など

## その他
