### PR TITLE
Fix: LinuxとmacOSの配布パッケージを動作可能にする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -79,7 +79,12 @@ process.on("unhandledRejection", (reason) => {
 
 // .envから設定をprocess.envに読み込み
 const appDirPath = path.dirname(app.getPath("exe"));
-dotenv.config({ override: true });
+if (isDevelopment) {
+  dotenv.config({ override: true });
+} else {
+  const envPath = path.join(appDirPath, ".env");
+  dotenv.config({ path: envPath });
+}
 
 protocol.registerSchemesAsPrivileged([
   { scheme: "app", privileges: { secure: true, standard: true, stream: true } },

--- a/src/background.ts
+++ b/src/background.ts
@@ -79,6 +79,12 @@ process.on("unhandledRejection", (reason) => {
 
 // .envから設定をprocess.envに読み込み
 const appDirPath = path.dirname(app.getPath("exe"));
+
+// NOTE: 開発版では、カレントディレクトリにある .env ファイルを読み込む。
+//       一方、配布パッケージ版では .env ファイルが実行ファイルと同じディレクトリに配置されているが、
+//       Linux・macOS ではそのディレクトリはカレントディレクトリとはならないため、.env ファイルの
+//       パスを明示的に指定する必要がある。Windows の配布パッケージ版でもこの設定で起動できるため、
+//       全 OS で共通の条件分岐とした。
 if (isDevelopment) {
   dotenv.config({ override: true });
 } else {


### PR DESCRIPTION
## 内容

#794 の検証用のリリース https://github.com/VOICEVOX/voicevox/releases/tag/0.12.2-preview を Linux と macOS で試したところ、`.env` を見つけられずエンジンが起動できないことがわかりました（ #794 の変更で、起動時に `.env` がカレントディレクトリにある想定になったためと考えられます。一方で、配布パッケージではカレントディレクトリがどこであったとしても、`.env` が実行ファイルと同じディレクトリにあることを想定しています。Linux の AppImage については詳しくないのですが、少なくとも macOS の App bundle では、カレントディレクトリは実行ファイルのあるディレクトリにはならないです）。

以上の問題を解決するため、配布パッケージの実行時にはこれまで通り `appDirPath` にある `.env` を読みに行くように条件分岐を加えました。

https://github.com/PickledChair/voicevox/releases/tag/0.12.0-pickledchair-0 に試験的にリリースを公開しています。手元の環境で Linux と macOS 双方での動作を確認しました。

## 関連 PR

#794 
