### PR TITLE
テキストの「読み込み」及び「繋げて書き出し」で「キャラ名(スタイル名)」を利用可能に

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -75,6 +75,7 @@ function parseTextFile(
     const styleId = defaultStyleId.defaultStyleId;
     uuid2StyleIds.set(speakerUuid, styleId);
   }
+  // setup default characters
   for (const characterInfo of userOrderedCharacterInfos) {
     const uuid = characterInfo.metas.speakerUuid;
     const styleId = uuid2StyleIds.get(uuid);
@@ -82,6 +83,18 @@ function parseTextFile(
     if (styleId == undefined)
       throw new Error(`styleId is undefined. speakerUuid: ${uuid}`);
     characters.set(speakerName, styleId);
+  }
+  // setup characters with style name
+  for (const characterInfo of userOrderedCharacterInfos) {
+    for (const style of characterInfo.metas.styles) {
+      if (style.styleName === undefined) {
+        continue;
+      }
+      characters.set(
+        `${characterInfo.metas.speakerName}(${style.styleName})`,
+        style.styleId
+      );
+    }
   }
   if (!characters.size) return [];
 
@@ -1302,7 +1315,14 @@ export const audioStore: VoiceVoxStoreOptions<
 
         for (const characterInfo of getters.USER_ORDERED_CHARACTER_INFOS) {
           for (const style of characterInfo.metas.styles) {
-            characters.set(style.styleId, characterInfo.metas.speakerName);
+            if (style.styleName === undefined) {
+              continue;
+            } else {
+              characters.set(
+                style.styleId,
+                `${characterInfo.metas.speakerName}(${style.styleName})`
+              );
+            }
           }
         }
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -87,11 +87,8 @@ function parseTextFile(
   // setup characters with style name
   for (const characterInfo of userOrderedCharacterInfos) {
     for (const style of characterInfo.metas.styles) {
-      if (style.styleName === undefined) {
-        continue;
-      }
       characters.set(
-        `${characterInfo.metas.speakerName}(${style.styleName})`,
+        `${characterInfo.metas.speakerName}(${style.styleName || "ノーマル"})`,
         style.styleId
       );
     }
@@ -1315,14 +1312,12 @@ export const audioStore: VoiceVoxStoreOptions<
 
         for (const characterInfo of getters.USER_ORDERED_CHARACTER_INFOS) {
           for (const style of characterInfo.metas.styles) {
-            if (style.styleName === undefined) {
-              continue;
-            } else {
-              characters.set(
-                style.styleId,
-                `${characterInfo.metas.speakerName}(${style.styleName})`
-              );
-            }
+            characters.set(
+              style.styleId,
+              `${characterInfo.metas.speakerName}(${
+                style.styleName || "ノーマル"
+              })`
+            );
           }
         }
 


### PR DESCRIPTION
## 内容
<!--
プルリクエストの内容説明を端的に記載してください。
-->
「テキスト読み込み」とテキストを繋げて書き込み」機能で「キャラ名」だけでなく「キャラ名(スタイル名)」を扱えるようにする。

*「テキスト読み込み」機能：「キャラ名」のみ指定された場合デフォルトスタイルを採用し、「キャラ名(スタイル名)」が指定された場合、該当スタイルを採用する。
*「テキストを繋げて書き込み」機能：常に「キャラ名(スタイル名)」で出力する。


## 関連 Issue
ref #802
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

### テキスト読み込み例

![テキスト読み込み 例1](https://user-images.githubusercontent.com/101532773/167873552-87830e34-e016-4c42-9b66-a931626867e4.png)

![テキスト読み込み 例2](https://user-images.githubusercontent.com/101532773/167873587-e7e32085-b3ee-46d3-98b9-335eac114ca9.png)

### テキストを繋げて書き込み例

![テキストを繋げて書き込み 例](https://user-images.githubusercontent.com/101532773/167873651-dd69f8d2-f1a0-4253-b4ee-d27a5fe62487.png)

## その他
