### PR TITLE
話者切り替え時にinitialize speakerを叩く

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -612,6 +612,36 @@ export const audioStore: VoiceVoxStoreOptions<
       audioElements[audioKey] = new Audio();
       return audioKey;
     },
+    /**
+     * 指定した話者（スタイルID）に対してエンジン側の初期化を行い、即座に音声合成ができるようにする。
+     * 初期化済みだった場合は何もしない。
+     */
+    async SETUP_ENGINE_SPEAKER({ state, dispatch }, { styleId }) {
+      const engineInfo = state.engineInfos[0]; // TODO: 複数エンジン対応
+      if (!engineInfo)
+        throw new Error(`No such engineInfo registered: index == 0`);
+
+      // FIXME: なぜかbooleanではなくstringが返ってくる。
+      // おそらくエンジン側のresponse_modelをBaseModel継承にしないといけない。
+      const isInitialized: string = await dispatch("INVOKE_ENGINE_CONNECTOR", {
+        engineKey: engineInfo.key,
+        action: "isInitializedSpeakerIsInitializedSpeakerGet",
+        payload: [{ speaker: styleId }],
+      });
+      if (isInitialized !== "true" && isInitialized !== "false")
+        throw new Error(`Failed to get isInitialized.`);
+
+      if (isInitialized === "false") {
+        await dispatch("ASYNC_UI_LOCK", {
+          callback: () =>
+            dispatch("INVOKE_ENGINE_CONNECTOR", {
+              engineKey: engineInfo.key,
+              action: "initializeSpeakerInitializeSpeakerPost",
+              payload: [{ speaker: styleId }],
+            }),
+        });
+      }
+    },
     REMOVE_ALL_AUDIO_ITEM({ commit, state }) {
       for (const audioKey of [...state.audioKeys]) {
         commit("REMOVE_AUDIO_ITEM", { audioKey });
@@ -1636,6 +1666,8 @@ export const audioCommandStore: VoiceVoxStoreOptions<
     ) {
       const query = state.audioItems[audioKey].query;
       try {
+        await dispatch("SETUP_ENGINE_SPEAKER", { styleId });
+
         if (query !== undefined) {
           const accentPhrases = query.accentPhrases;
           const newAccentPhrases: AccentPhrase[] = await dispatch(

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -145,6 +145,10 @@ type AudioStoreTypes = {
     action(): string;
   };
 
+  SETUP_ENGINE_SPEAKER: {
+    action(payload: { styleId: number }): void;
+  };
+
   SET_ACTIVE_AUDIO_KEY: {
     mutation: { audioKey?: string };
     action(payload: { audioKey?: string }): void;


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/813

の解決です。
キャラクター切り替え時にinitialize speakerを別途叩くようにし、UI_LOCKをすることでユーザーが処理中であることを気づけるようにしました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/817 のマージが先

close #813 

## スクリーンショット・動画など

https://user-images.githubusercontent.com/4987327/170884121-5a1d8345-60a5-4c76-b33f-6c670098f47a.mp4

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

キャラクターロード中に真ん中にインジケータなどを表示したり、
キャラクターを裏で全部ロードするPromiseを動かしたりしても良さそうです。

- [ ] これらは別途issueにしたいと思います。