### PR TITLE
デフォルトスタイル選択画面で音声が再生できなくなっていた

### DIFF
--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -149,7 +149,11 @@
                             style.styleId === playing.styleId &&
                             voiceSampleIndex === playing.index
                               ? stop()
-                              : play(style, voiceSampleIndex)
+                              : play(
+                                  characterInfo.metas.speakerUuid,
+                                  style,
+                                  voiceSampleIndex
+                                )
                           "
                         />
                         <q-radio


### PR DESCRIPTION
## 内容

タイトル通りです。
デフォルトスタイル選択したときに勝手に流れる部分はそのまま再生されるので、hotfixは出さない予定です。
とりあえず0.12に向けてPRします。

## 関連 Issue

fix #835

## その他

VSCodeのVolarだとちゃんと型エラーが出ていました。
Vueテンプレート部分も型検査をテストしても良いかもしれない。
