### PR TITLE
再生中、イントネーションなどのタブ移動がショートカットキーで無効になっている

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -275,25 +275,19 @@ export default defineComponent({
       [
         "ｱｸｾﾝﾄ欄を表示",
         () => {
-          if (!uiLocked.value) {
-            selectedDetail.value = "accent";
-          }
+          selectedDetail.value = "accent";
         },
       ],
       [
         "ｲﾝﾄﾈｰｼｮﾝ欄を表示",
         () => {
-          if (!uiLocked.value) {
-            selectedDetail.value = "pitch";
-          }
+          selectedDetail.value = "pitch";
         },
       ],
       [
         "長さ欄を表示",
         () => {
-          if (!uiLocked.value) {
-            selectedDetail.value = "length";
-          }
+          selectedDetail.value = "length";
         },
       ],
       [


### PR DESCRIPTION
## 内容
AudioDetailのタブ（アクセント・イントネーション・長さ）について
再生中にホットキーで移動できない問題を修正しました。（クリックでは移動可能）


不要だと思われるuiLockedのチェックを削除しました。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #590

## その他。
初PRです。不手際等ありましたらお知らせください。