### PR TITLE
音声生成中は音声停止ボタンを無効にする

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -26,6 +26,7 @@
               text-color="display-dark"
               icon="stop"
               @click="stop"
+              :disable="nowGenerating"
             ></q-btn>
           </template>
         </div>


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

メイン画面で音声再生ボタンを押した後、音声生成が終わるまで音声停止ボタンが無効になるようにしました。

音声再生/停止ボタンがある箇所はメイン画面と「読み方＆アクセント辞書」画面の2箇所で、それぞれ[AudioDetail.vue](https://github.com/VOICEVOX/voicevox/blob/b6abc60a284cfd3ade1c273d3950f32d91a7d171/src/components/AudioDetail.vue#L22)と[DictionaryManageDialog.vue](https://github.com/VOICEVOX/voicevox/blob/b6abc60a284cfd3ade1c273d3950f32d91a7d171/src/components/DictionaryManageDialog.vue#L134)で定義されています。
元々「読み方＆アクセント辞書」画面の音声停止ボタンは音声生成中は無効になる仕様なのですが、メイン画面の音声停止ボタンでは無効になっていませんでした。
今回の修正でメイン画面の音声停止ボタンに足りなかった記述を追加し、2つの画面の音声停止ボタンの仕様を統一しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #696