### PR TITLE
コード署名する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   VOICEVOX_RESOURCE_VERSION: 0.12.1
   VOICEVOX_EDITOR_VERSION:
     |- # releaseタグ名か、workflow_dispatchでのバージョン名か、999.999.999が入る
-    ${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}
+    ${{ github.event.release.tag_name || github.event.inputs.version || '999.999.999' }}
 
 jobs:
   build-noengine-prepackage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,17 +8,29 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      version:
+        description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
+        required: true
+      prerelease:
+        description: "プレリリースかどうか"
+        type: boolean
+        default: true
+      code_signing:
+        description: "コード署名する"
+        type: boolean
 
 env:
   VOICEVOX_ENGINE_REPO_URL: "https://github.com/VOICEVOX/voicevox_engine"
   VOICEVOX_ENGINE_VERSION: 0.12.2
   VOICEVOX_RESOURCE_VERSION: 0.12.1
   VOICEVOX_EDITOR_VERSION:
-    |- # releaseのときはタグが、それ以外は999.999.999がバージョン名に
-    ${{ github.event.release.tag_name != '' && github.event.release.tag_name || '999.999.999' }}
+    |- # releaseタグ名か、workflow_dispatchでのバージョン名か、999.999.999が入る
+    ${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}
 
 jobs:
   build-noengine-prepackage:
+    environment: ${{ github.event.inputs.code_signing && 'code_signing' }} # コード署名用のenvironment
     env:
       CYPRESS_CACHE_FOLDER: ~/.npm/cypress_cache
       ELECTRON_CACHE: .cache/electron
@@ -246,6 +258,26 @@ jobs:
         run: |
           df -h
 
+      # redirect用のブランチ戻す
+      # redirect用のブランチ戻す
+      # redirect用のブランチ戻す
+      # redirect用のブランチ戻す
+      # redirect用のブランチ戻す
+      # redirect用のブランチ戻す
+
+      # build electronでコード署名するには環境変数を指定が必要だけど、
+      # コード署名しない場合に環境変数を定義するとエラーになるので、動的に環境変数を足す
+      - name: Define Code Signing Envs
+        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing
+        shell: bash
+        run: |
+          # 複数行の文字列を環境変数に代入
+          echo 'CSC_LINK<<EOF' >> $GITHUB_ENV
+          echo "${{ secrets.CERT_BASE64 }}" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+          echo 'CSC_KEY_PASSWORD=${{ secrets.CERT_PASSWORD }}' >> $GITHUB_ENV
+
       # Build result will be exported to ${{ matrix.artifact_path }}
       - name: Build Electron
         shell: bash
@@ -255,6 +287,13 @@ jobs:
           LINUX_EXECUTABLE_NAME: ${{ matrix.linux_executable_name }}
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: npm run electron:build_pnever -- --dir
+
+      - name: Reset Code Signing Envs
+        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing
+        shell: bash
+        run: |
+          echo 'CSC_LINK=' >> $GITHUB_ENV
+          echo 'CSC_KEY_PASSWORD=' >> $GITHUB_ENV
 
       - name: Upload NoEngine Prepackage
         uses: actions/upload-artifact@v2
@@ -504,8 +543,9 @@ jobs:
           path: "${{ matrix.compressed_artifact_name }}-${{ env.VOICEVOX_EDITOR_VERSION }}.zip"
 
   build-distributable:
-    if: github.event.release.tag_name != '' # If release
+    if: (github.event.release.tag_name || github.event.inputs.version) != '' # If release
     needs: [build-engine-prepackage]
+    environment: ${{ github.event.inputs.code_signing && 'code_signing' }} # コード署名用のenvironment
     env:
       CYPRESS_CACHE_FOLDER: ~/.npm/cypress_cache
       ELECTRON_CACHE: .cache/electron
@@ -677,6 +717,19 @@ jobs:
         run: |
           df -h
 
+      # build electronでコード署名するには環境変数を指定が必要だけど、
+      # コード署名しない場合に環境変数を定義するとエラーになるので、動的に環境変数を足す
+      - name: Define Code Signing Envs
+        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing
+        shell: bash
+        run: |
+          # 複数行の文字列を環境変数に代入
+          echo 'CSC_LINK<<EOF' >> $GITHUB_ENV
+          echo "${{ secrets.CERT_BASE64 }}" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+          echo 'CSC_KEY_PASSWORD=${{ secrets.CERT_PASSWORD }}' >> $GITHUB_ENV
+
       # NOTE: prepackage can be removed before splitting nsis-web archive
       - name: Build Electron
         if: endsWith(matrix.artifact_name, '-nsis-web') || endsWith(matrix.artifact_name, '-appimage') # windows and linux
@@ -693,6 +746,13 @@ jobs:
         env:
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: npm run electron:build_pnever -- --prepackaged "prepackage/VOICEVOX.app"
+
+      - name: Reset Code Signing Envs
+        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing
+        shell: bash
+        run: |
+          echo 'CSC_LINK=' >> $GITHUB_ENV
+          echo 'CSC_KEY_PASSWORD=' >> $GITHUB_ENV
 
       - name: Show disk space (debug info)
         shell: bash
@@ -743,7 +803,7 @@ jobs:
             nsis-web-artifact/*
 
   upload-distributable-to-release:
-    if: github.event.release.tag_name != '' # If release
+    if: (github.event.release.tag_name || github.event.inputs.version) != '' # If release
     needs: [build-distributable]
     strategy:
       fail-fast: false
@@ -832,7 +892,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }} # == github.event.release.tag_name
+          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           file_glob: true
           file: artifact/*.7z.*
 
@@ -842,7 +902,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }} # == github.event.release.tag_name
+          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           file_glob: true
           file: artifact/*.7z.*
 
@@ -851,7 +911,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }} # == github.event.release.tag_name
+          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           file_glob: true
           file: artifact/*.exe
 
@@ -861,7 +921,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }} # == github.event.release.tag_name
+          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           file_glob: true
           file: artifact/*.dmg
 
@@ -871,7 +931,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }} # == github.event.release.tag_name
+          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           file_glob: true
           file: artifact/*.tar.gz
 
@@ -881,6 +941,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }} # == github.event.release.tag_name
+          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           file_glob: true
           file: artifact/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,7 +268,7 @@ jobs:
       # build electronでコード署名するには環境変数を指定が必要だけど、
       # コード署名しない場合に環境変数を定義するとエラーになるので、動的に環境変数を足す
       - name: Define Code Signing Envs
-        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing
+        if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing
         shell: bash
         run: |
           # 複数行の文字列を環境変数に代入
@@ -289,7 +289,7 @@ jobs:
         run: npm run electron:build_pnever -- --dir
 
       - name: Reset Code Signing Envs
-        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing
+        if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing
         shell: bash
         run: |
           echo 'CSC_LINK=' >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-noengine-prepackage:
-    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment
+    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment（false時の挙動は2022年7月10日時点で未定義動作）
     env:
       CYPRESS_CACHE_FOLDER: ~/.npm/cypress_cache
       ELECTRON_CACHE: .cache/electron
@@ -261,7 +261,7 @@ jobs:
       # build electronでコード署名するには環境変数を指定が必要だけど、
       # コード署名しない場合に環境変数を定義するとエラーになるので、動的に環境変数を足す
       - name: Define Code Signing Envs
-        if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing
+        if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing == 'true'
         shell: bash
         run: |
           # 複数行の文字列を環境変数に代入
@@ -282,7 +282,7 @@ jobs:
         run: npm run electron:build_pnever -- --dir
 
       - name: Reset Code Signing Envs
-        if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing
+        if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing == 'true'
         shell: bash
         run: |
           echo 'CSC_LINK=' >> $GITHUB_ENV
@@ -538,7 +538,7 @@ jobs:
   build-distributable:
     if: (github.event.release.tag_name || github.event.inputs.version) != '' # If release
     needs: [build-engine-prepackage]
-    environment: ${{ github.event.inputs.code_signing && 'code_signing' }} # コード署名用のenvironment
+    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment
     env:
       CYPRESS_CACHE_FOLDER: ~/.npm/cypress_cache
       ELECTRON_CACHE: .cache/electron
@@ -713,7 +713,7 @@ jobs:
       # build electronでコード署名するには環境変数を指定が必要だけど、
       # コード署名しない場合に環境変数を定義するとエラーになるので、動的に環境変数を足す
       - name: Define Code Signing Envs
-        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing
+        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing == 'true'
         shell: bash
         run: |
           # 複数行の文字列を環境変数に代入
@@ -741,7 +741,7 @@ jobs:
         run: npm run electron:build_pnever -- --prepackaged "prepackage/VOICEVOX.app"
 
       - name: Reset Code Signing Envs
-        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing
+        if: endsWith(matrix.artifact_name, '-nsis-web') && github.event.inputs.code_signing == 'true'
         shell: bash
         run: |
           echo 'CSC_LINK=' >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -886,6 +886,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          prerelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: artifact/*.7z.*
 
@@ -896,6 +897,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          prerelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: artifact/*.7z.*
 
@@ -905,6 +907,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          prerelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: artifact/*.exe
 
@@ -915,6 +918,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          prerelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: artifact/*.dmg
 
@@ -925,6 +929,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          prerelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: artifact/*.tar.gz
 
@@ -935,5 +940,6 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          prerelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: artifact/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-noengine-prepackage:
-    environment: ${{ github.event.inputs.code_signing && 'code_signing' }} # コード署名用のenvironment
+    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment
     env:
       CYPRESS_CACHE_FOLDER: ~/.npm/cypress_cache
       ELECTRON_CACHE: .cache/electron

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,13 +258,6 @@ jobs:
         run: |
           df -h
 
-      # redirect用のブランチ戻す
-      # redirect用のブランチ戻す
-      # redirect用のブランチ戻す
-      # redirect用のブランチ戻す
-      # redirect用のブランチ戻す
-      # redirect用のブランチ戻す
-
       # build electronでコード署名するには環境変数を指定が必要だけど、
       # コード署名しない場合に環境変数を定義するとエラーになるので、動的に環境変数を足す
       - name: Define Code Signing Envs


### PR DESCRIPTION
## 内容

VOICEVOX.exeやwindowsインストーラーを、electron-builderの仕組みを使ってコード署名します。

証明書.pfxファイルをbase64エンコードしたものをsecret.CERT_BASE64に登録し、
証明書のパスワードをsecret.CERT_PASSWORDに登録して、
workflow_dispatchで「コード署名する」にチェックを入れてbuild.ymlを起動すれば、
core.dllが署名されます。

もしくはcode_signingenvironmentを作成し、同様にCERT_BASE64とCERT_PASSWORDを登録して実行しても署名できます。
（こちらのフローは、OSSリポジトリ上でビルドする場合を想定しています。）

「コード署名する」にチェックを入れずにビルドしたり、releaseを作ってビルドした場合は署名用のコードが実行されないので、メンテナー以外の方は今まで通りにテストビルドができます。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/pull/430
- https://github.com/VOICEVOX/voicevox_core/pull/164

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

実際にこちらでビルドを試しています。
https://github.com/Hiroshiba/voicevox/runs/7216557572?check_suite_focus=true
