### PR TITLE
単語の優先度を設定可能にする

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -247,7 +247,7 @@ import AudioAccent from "@/components/AudioAccent.vue";
 import { QInput, useQuasar } from "quasar";
 import { AudioItem } from "@/store/type";
 
-const default_dict_priority = 5;
+const defaultDictPriority = 5;
 
 export default defineComponent({
   name: "DictionaryManageDialog",
@@ -483,7 +483,7 @@ export default defineComponent({
       return accent;
     };
 
-    const wordPriority = ref(default_dict_priority);
+    const wordPriority = ref(defaultDictPriority);
 
     // 操作（ステートの移動）
     const isWordChanged = computed(() => {
@@ -638,7 +638,7 @@ export default defineComponent({
       selectedId.value = "";
       surface.value = "";
       setYomi("");
-      wordPriority.value = default_dict_priority;
+      wordPriority.value = defaultDictPriority;
       editWord();
     };
     const editWord = () => {
@@ -665,7 +665,7 @@ export default defineComponent({
       selectedId.value = "";
       surface.value = "";
       setYomi("");
-      wordPriority.value = default_dict_priority;
+      wordPriority.value = defaultDictPriority;
     };
     // 単語が選択されているだけの状態
     const toWordSelectedState = () => {

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -118,7 +118,7 @@
               </q-input>
             </div>
             <div class="row q-pl-md q-pt-sm text-h6">アクセント調整</div>
-            <div class="row q-pl-md accent-desc">
+            <div class="row q-pl-md desc-row">
               語尾のアクセントを考慮するため、「が」が自動で挿入されます。
             </div>
             <div class="row q-px-md" style="height: 130px">
@@ -775,7 +775,7 @@ export default defineComponent({
   }
 }
 
-.accent-desc {
+.desc-row {
   color: rgba(colors.$display-rgb, 0.5);
   font-size: 12px;
 }

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -175,6 +175,30 @@
                 </div>
               </div>
             </div>
+            <div class="row q-pl-md q-pt-sm text-h6">単語優先度</div>
+            <div class="row q-pl-md desc-row">
+              単語を登録しても反映されないと感じた場合、優先度の数値を上げてみてください。
+            </div>
+            <div
+              class="row q-px-md"
+              :style="{
+                justifyContent: 'center',
+              }"
+            >
+              <q-slider
+                v-model="wordPriority"
+                snap
+                dense
+                marker-labels
+                color="primary-light"
+                :min="0"
+                :max="10"
+                :step="1"
+                :style="{
+                  width: '80%',
+                }"
+              />
+            </div>
             <div class="row q-px-md save-delete-reset-buttons">
               <q-space />
               <q-btn
@@ -222,6 +246,8 @@ import {
 import AudioAccent from "@/components/AudioAccent.vue";
 import { QInput, useQuasar } from "quasar";
 import { AudioItem } from "@/store/type";
+
+const default_dict_priority = 5;
 
 export default defineComponent({
   name: "DictionaryManageDialog",
@@ -457,6 +483,8 @@ export default defineComponent({
       return accent;
     };
 
+    const wordPriority = ref(default_dict_priority);
+
     // 操作（ステートの移動）
     const isWordChanged = computed(() => {
       if (selectedId.value === "") {
@@ -469,7 +497,8 @@ export default defineComponent({
         dictData &&
         (dictData.surface !== surface.value ||
           dictData.yomi !== yomi.value ||
-          dictData.accentType !== computeRegisteredAccent())
+          dictData.accentType !== computeRegisteredAccent() ||
+          dictData.priority !== wordPriority.value)
       );
     });
     const saveWord = async () => {
@@ -607,6 +636,7 @@ export default defineComponent({
       selectedId.value = "";
       surface.value = "";
       setYomi("");
+      wordPriority.value = default_dict_priority;
       editWord();
     };
     const editWord = () => {
@@ -616,6 +646,7 @@ export default defineComponent({
       selectedId.value = id;
       surface.value = userDict.value[id].surface;
       setYomi(userDict.value[id].yomi, true);
+      wordPriority.value = userDict.value[id].priority;
       toWordSelectedState();
     };
     const cancel = () => {
@@ -632,6 +663,7 @@ export default defineComponent({
       selectedId.value = "";
       surface.value = "";
       setYomi("");
+      wordPriority.value = default_dict_priority;
     };
     // 単語が選択されているだけの状態
     const toWordSelectedState = () => {
@@ -676,6 +708,7 @@ export default defineComponent({
       stop,
       isWordChanged,
       isDeletable,
+      wordPriority,
       saveWord,
       deleteWord,
       resetWord,
@@ -823,6 +856,7 @@ export default defineComponent({
   padding: 20px;
 
   display: flex;
+  flex: 1;
   align-items: flex-end;
 }
 </style>

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -511,6 +511,7 @@ export default defineComponent({
             surface: surface.value,
             pronunciation: yomi.value,
             accentType: accent,
+            priority: wordPriority.value,
           });
         } catch {
           $q.dialog({
@@ -531,6 +532,7 @@ export default defineComponent({
               surface: surface.value,
               pronunciation: yomi.value,
               accentType: accent,
+              priority: wordPriority.value,
             })
           );
         } catch {

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -68,7 +68,7 @@ export const dictionaryStore: VoiceVoxStoreOptions<
 
     REWRITE_WORD: async (
       { state, dispatch },
-      { wordUuid, surface, pronunciation, accentType }
+      { wordUuid, surface, pronunciation, accentType, priority }
     ) => {
       const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
       if (engineKey === undefined)
@@ -82,6 +82,7 @@ export const dictionaryStore: VoiceVoxStoreOptions<
             surface,
             pronunciation,
             accentType,
+            priority,
           },
         ],
       }).then(toDispatchResponse("rewriteUserDictWordUserDictWordWordUuidPut"));

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1153,6 +1153,7 @@ type DictionaryStoreTypes = {
       surface: string;
       pronunciation: string;
       accentType: number;
+      priority: number;
     }): Promise<void>;
   };
   REWRITE_WORD: {
@@ -1161,6 +1162,7 @@ type DictionaryStoreTypes = {
       surface: string;
       pronunciation: string;
       accentType: number;
+      priority: number;
     }): Promise<void>;
   };
   DELETE_WORD: {


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通りです、優先度スライダーを追加し、優先度を選べるようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #790 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
![image](https://user-images.githubusercontent.com/34832037/179366818-68ea40f9-1df3-4741-be46-c8fb8c7a62c3.png)

