### PR TITLE
EngineProxyの型の整理を行った

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -16,7 +16,6 @@ import {
   AudioCommandMutations,
   AudioCommandStoreState,
   VoiceVoxStoreOptions,
-  IEngineConnectorFactoryActions,
 } from "./type";
 import { createUILockAction } from "./ui";
 import {
@@ -28,7 +27,6 @@ import {
   WriteFileErrorResult,
 } from "@/type/preload";
 import Encoding from "encoding-japanese";
-import { PromiseType } from "./vuex";
 import {
   buildFileNameFromRawData,
   buildProjectFileName,
@@ -550,11 +548,9 @@ export const audioStore: VoiceVoxStoreOptions<
           }
 
           try {
-            await dispatch("INVOKE_ENGINE_CONNECTOR", {
+            await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
               engineKey,
-              action: "versionVersionGet",
-              payload: [],
-            }).then(toDispatchResponse("versionVersionGet"));
+            }).then((instance) => instance.invoke("versionVersionGet")({}));
           } catch {
             await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -579,13 +575,10 @@ export const audioStore: VoiceVoxStoreOptions<
       if (engineKey === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
-      const speakers = await dispatch("INVOKE_ENGINE_CONNECTOR", {
+      const speakers = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineKey,
-        action: "speakersSpeakersGet",
-        // 連想配列が第一引数になければ失敗する
-        payload: [{}],
       })
-        .then(toDispatchResponse("speakersSpeakersGet"))
+        .then((instance) => instance.invoke("speakersSpeakersGet")({}))
         .catch((error) => {
           window.electron.logError(error, `Failed to get speakers.`);
           throw error;
@@ -618,12 +611,14 @@ export const audioStore: VoiceVoxStoreOptions<
         return styles;
       };
       const getSpeakerInfo = async function (speaker: Speaker) {
-        const speakerInfo = await dispatch("INVOKE_ENGINE_CONNECTOR", {
+        const speakerInfo = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
           engineKey,
-          action: "speakerInfoSpeakerInfoGet",
-          payload: [{ speakerUuid: speaker.speakerUuid }],
         })
-          .then(toDispatchResponse("speakerInfoSpeakerInfoGet"))
+          .then((instance) =>
+            instance.invoke("speakerInfoSpeakerInfoGet")({
+              speakerUuid: speaker.speakerUuid,
+            })
+          )
           .catch((error) => {
             window.electron.logError(error, `Failed to get speakers.`);
             throw error;
@@ -664,22 +659,30 @@ export const audioStore: VoiceVoxStoreOptions<
 
       // FIXME: なぜかbooleanではなくstringが返ってくる。
       // おそらくエンジン側のresponse_modelをBaseModel継承にしないといけない。
-      const isInitialized: string = await dispatch("INVOKE_ENGINE_CONNECTOR", {
-        engineKey,
-        action: "isInitializedSpeakerIsInitializedSpeakerGet",
-        payload: [{ speaker: styleId }],
-      });
+      const isInitialized: string = await dispatch(
+        "INSTANTIATE_ENGINE_CONNECTOR",
+        {
+          engineKey,
+        }
+      ).then(
+        (instance) =>
+          instance.invoke("isInitializedSpeakerIsInitializedSpeakerGet")({
+            speaker: styleId,
+          }) as any as string
+      );
       if (isInitialized !== "true" && isInitialized !== "false")
         throw new Error(`Failed to get isInitialized.`);
 
       if (isInitialized === "false") {
         await dispatch("ASYNC_UI_LOCK", {
           callback: () =>
-            dispatch("INVOKE_ENGINE_CONNECTOR", {
+            dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
               engineKey,
-              action: "initializeSpeakerInitializeSpeakerPost",
-              payload: [{ speaker: styleId }],
-            }),
+            }).then((instance) =>
+              instance.invoke("initializeSpeakerInitializeSpeakerPost")({
+                speaker: styleId,
+              })
+            ),
         });
       }
     },
@@ -821,18 +824,16 @@ export const audioStore: VoiceVoxStoreOptions<
       if (engineKey === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
-      return dispatch("INVOKE_ENGINE_CONNECTOR", {
+      return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineKey,
-        action: "accentPhrasesAccentPhrasesPost",
-        payload: [
-          {
+      })
+        .then((instance) =>
+          instance.invoke("accentPhrasesAccentPhrasesPost")({
             text,
             speaker: styleId,
             isKana,
-          },
-        ],
-      })
-        .then(toDispatchResponse("accentPhrasesAccentPhrasesPost"))
+          })
+        )
         .catch((error) => {
           window.electron.logError(
             error,
@@ -852,12 +853,15 @@ export const audioStore: VoiceVoxStoreOptions<
       if (engineKey === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
-      return dispatch("INVOKE_ENGINE_CONNECTOR", {
+      return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineKey,
-        action: "moraDataMoraDataPost",
-        payload: [{ accentPhrase: accentPhrases, speaker: styleId }],
       })
-        .then(toDispatchResponse("moraDataMoraDataPost"))
+        .then((instance) =>
+          instance.invoke("moraDataMoraDataPost")({
+            accentPhrase: accentPhrases,
+            speaker: styleId,
+          })
+        )
         .catch((error) => {
           window.electron.logError(
             error,
@@ -900,17 +904,15 @@ export const audioStore: VoiceVoxStoreOptions<
       if (engineKey === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
-      return dispatch("INVOKE_ENGINE_CONNECTOR", {
+      return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineKey,
-        action: "audioQueryAudioQueryPost",
-        payload: [
-          {
+      })
+        .then((instance) =>
+          instance.invoke("audioQueryAudioQueryPost")({
             text,
             speaker: styleId,
-          },
-        ],
-      })
-        .then(toDispatchResponse("audioQueryAudioQueryPost"))
+          })
+        )
         .catch((error) => {
           window.electron.logError(
             error,
@@ -1012,16 +1014,14 @@ export const audioStore: VoiceVoxStoreOptions<
         if (engineKey === undefined)
           throw new Error(`No such engine registered: index == 0`);
 
-        return dispatch("INVOKE_ENGINE_CONNECTOR", {
+        return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
           engineKey,
-          action: "connectWavesConnectWavesPost",
-          payload: [
-            {
-              requestBody: encodedBlobs,
-            },
-          ],
         })
-          .then(toDispatchResponse("connectWavesConnectWavesPost"))
+          .then((instance) =>
+            instance.invoke("connectWavesConnectWavesPost")({
+              requestBody: encodedBlobs,
+            })
+          )
           .then(async (blob) => {
             return blob;
           })
@@ -1055,19 +1055,17 @@ export const audioStore: VoiceVoxStoreOptions<
           return null;
         }
 
-        return dispatch("INVOKE_ENGINE_CONNECTOR", {
+        return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
           engineKey,
-          action: "synthesisSynthesisPost",
-          payload: [
-            {
+        })
+          .then((instance) =>
+            instance.invoke("synthesisSynthesisPost")({
               audioQuery,
               speaker,
               enableInterrogativeUpspeak:
                 state.experimentalSetting.enableInterrogativeUpspeak,
-            },
-          ],
-        })
-          .then(toDispatchResponse("synthesisSynthesisPost"))
+            })
+          )
           .then(async (blob) => {
             audioBlobCache[id] = blob;
             return blob;
@@ -2572,14 +2570,3 @@ export const audioCommandStore: VoiceVoxStoreOptions<
     },
   }),
 };
-
-// FIXME: ProxyStoreのactionとVuexの組み合わせでReturnValueの型付けが中途半端になり、Promise<any>になってしまっている
-export const toDispatchResponse =
-  <T extends keyof IEngineConnectorFactoryActions>(_: T) =>
-  (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    response: any
-  ): PromiseType<ReturnType<IEngineConnectorFactoryActions[T]>> => {
-    _; // Unused回避のため
-    return response;
-  };

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -668,7 +668,7 @@ export const audioStore: VoiceVoxStoreOptions<
         (instance) =>
           instance.invoke("isInitializedSpeakerIsInitializedSpeakerGet")({
             speaker: styleId,
-          }) as any as string
+          }) as unknown as string
       );
       if (isInitialized !== "true" && isInitialized !== "false")
         throw new Error(`Failed to get isInitialized.`);

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -6,7 +6,6 @@ import {
   DictionaryStoreState,
   VoiceVoxStoreOptions,
 } from "@/store/type";
-import { toDispatchResponse } from "./audio";
 
 export const dictionaryStoreState: DictionaryStoreState = {};
 
@@ -22,11 +21,9 @@ export const dictionaryStore: VoiceVoxStoreOptions<
       const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
       if (engineKey === undefined)
         throw new Error(`No such engine registered: index == 0`);
-      const engineDict = await dispatch("INVOKE_ENGINE_CONNECTOR", {
+      const engineDict = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineKey,
-        action: "getUserDictWordsUserDictGet",
-        payload: [],
-      }).then(toDispatchResponse("getUserDictWordsUserDictGet"));
+      }).then((instance) => instance.invoke("getUserDictWordsUserDictGet")({}));
 
       // 50音順にソートするために、一旦arrayにする
       const dictArray = Object.keys(engineDict).map((k) => {
@@ -53,17 +50,15 @@ export const dictionaryStore: VoiceVoxStoreOptions<
       const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
       if (engineKey === undefined)
         throw new Error(`No such engine registered: index == 0`);
-      await dispatch("INVOKE_ENGINE_CONNECTOR", {
+      await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineKey,
-        action: "addUserDictWordUserDictWordPost",
-        payload: [
-          {
-            surface,
-            pronunciation,
-            accentType,
-          },
-        ],
-      }).then(toDispatchResponse("addUserDictWordUserDictWordPost"));
+      }).then((instance) =>
+        instance.invoke("addUserDictWordUserDictWordPost")({
+          surface,
+          pronunciation,
+          accentType,
+        })
+      );
     },
 
     REWRITE_WORD: async (
@@ -73,35 +68,29 @@ export const dictionaryStore: VoiceVoxStoreOptions<
       const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
       if (engineKey === undefined)
         throw new Error(`No such engine registered: index == 0`);
-      await dispatch("INVOKE_ENGINE_CONNECTOR", {
+      await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineKey,
-        action: "rewriteUserDictWordUserDictWordWordUuidPut",
-        payload: [
-          {
-            wordUuid,
-            surface,
-            pronunciation,
-            accentType,
-            priority,
-          },
-        ],
-      }).then(toDispatchResponse("rewriteUserDictWordUserDictWordWordUuidPut"));
+      }).then((instance) =>
+        instance.invoke("rewriteUserDictWordUserDictWordWordUuidPut")({
+          wordUuid,
+          surface,
+          pronunciation,
+          accentType,
+          priority,
+        })
+      );
     },
 
     DELETE_WORD: async ({ state, dispatch }, { wordUuid }) => {
       const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
       if (engineKey === undefined)
         throw new Error(`No such engine registered: index == 0`);
-      await dispatch("INVOKE_ENGINE_CONNECTOR", {
+      await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineKey,
-        action: "deleteUserDictWordUserDictWordWordUuidDelete",
-        payload: [
-          {
-            wordUuid,
-          },
-        ],
-      }).then(
-        toDispatchResponse("deleteUserDictWordUserDictWordWordUuidDelete")
+      }).then((instance) =>
+        instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")({
+          wordUuid,
+        })
       );
     },
   },

--- a/src/store/proxy.ts
+++ b/src/store/proxy.ts
@@ -33,7 +33,12 @@ const proxyStoreCreator = (
           );
 
         const instance = _engineFactory.instance(engineInfo.host);
-        return Promise.resolve(instance);
+        return Promise.resolve({
+          invoke: (v) => (arg) =>
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            instance[v](arg) as any,
+        });
       },
     },
   };

--- a/src/store/proxy.ts
+++ b/src/store/proxy.ts
@@ -24,7 +24,7 @@ const proxyStoreCreator = (
     getters: {},
     mutations: {},
     actions: {
-      INVOKE_ENGINE_CONNECTOR({ state }, payload) {
+      INSTANTIATE_ENGINE_CONNECTOR({ state }, payload) {
         const engineKey = payload.engineKey;
         const engineInfo: EngineInfo | undefined = state.engineInfos[engineKey];
         if (engineInfo === undefined)
@@ -33,11 +33,7 @@ const proxyStoreCreator = (
           );
 
         const instance = _engineFactory.instance(engineInfo.host);
-        const action = payload.action;
-        const args = payload.payload;
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        return instance[action](...args);
+        return Promise.resolve(instance);
       },
     },
   };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1184,22 +1184,11 @@ export type IEngineConnectorFactoryActions = ReturnType<
   IEngineConnectorFactory["instance"]
 >;
 
-type IEngineConnectorFactoryActionsMapper<K> =
-  K extends keyof IEngineConnectorFactoryActions
-    ? (payload: {
-        engineKey: string;
-        action: K;
-        payload: Parameters<IEngineConnectorFactoryActions[K]>;
-      }) => ReturnType<IEngineConnectorFactoryActions[K]>
-    : never;
-
 type ProxyStoreTypes = {
-  INVOKE_ENGINE_CONNECTOR: {
-    // FIXME: actionに対してIEngineConnectorFactoryActionsのUnion型を与えているため、actionとpayloadが与えられるとReturnValueの型が得られる
-    // しかしVuexの型を通すとReturnValueの型付けが行われなくなりPromise<any>に落ちてしまうため、明示的な型付けを行う必要がある
-    action: IEngineConnectorFactoryActionsMapper<
-      keyof IEngineConnectorFactoryActions
-    >;
+  INSTANTIATE_ENGINE_CONNECTOR: {
+    action(payload: {
+      engineKey: string;
+    }): Promise<IEngineConnectorFactoryActions>;
   };
 };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1184,11 +1184,19 @@ export type IEngineConnectorFactoryActions = ReturnType<
   IEngineConnectorFactory["instance"]
 >;
 
+type IEngineConnectorFactoryActionsMapper = <
+  K extends keyof IEngineConnectorFactoryActions
+>(
+  action: K
+) => (
+  _: Parameters<IEngineConnectorFactoryActions[K]>[0]
+) => ReturnType<IEngineConnectorFactoryActions[K]>;
+
 type ProxyStoreTypes = {
   INSTANTIATE_ENGINE_CONNECTOR: {
     action(payload: {
       engineKey: string;
-    }): Promise<IEngineConnectorFactoryActions>;
+    }): Promise<{ invoke: IEngineConnectorFactoryActionsMapper }>;
   };
 };
 


### PR DESCRIPTION
## 内容

EngineProxyからインスタンスをラップしたObjectを返すようにして、Vuexを通しても型が一意に決まるようにした。
Objectに生えているinvokeメソッドを通してDefaultApiのメソッドを実行する実装にした。

この様に一層挟み、かつ `(行いたいAction) => (行いたいActionの引数)` という形で実装したため、Mockやバックエンドの実装がWebWorkerなどに変わってOpenAPI準拠のAPIでなくなってもアダプタが書きやすい形になった。
その処理は本来Factoryに実装するべきなので、将来的にバックエンドが増えた時に再検討する。

## 関連 Issue

ref: https://github.com/VOICEVOX/voicevox/issues/864

## スクリーンショット・動画など

## その他
