### PR TITLE
engineKeyをengineIdにすべて変更する

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,6 @@
 DEFAULT_ENGINE_INFOS=`[
     {
-        "key": "074fc39e-678b-4c13-8916-ffca8d505d1d",
+        "id": "074fc39e-678b-4c13-8916-ffca8d505d1d",
         "executionEnabled": true,
         "executionFilePath": "run.exe",
         "host": "http://127.0.0.1:50021"

--- a/src/background.ts
+++ b/src/background.ts
@@ -401,34 +401,34 @@ async function runEngineAll() {
   }
 }
 
-async function runEngine(engineKey: string) {
+async function runEngine(engineId: string) {
   const engineInfo = engineInfos.find(
-    (engineInfo) => engineInfo.key === engineKey
+    (engineInfo) => engineInfo.key === engineId
   );
   if (!engineInfo)
-    throw new Error(`No such engineInfo registered: engineKey == ${engineKey}`);
+    throw new Error(`No such engineInfo registered: engineId == ${engineId}`);
 
   if (!engineInfo.executionEnabled) {
-    log.info(`ENGINE ${engineKey}: Skipped engineInfo execution: disabled`);
+    log.info(`ENGINE ${engineId}: Skipped engineInfo execution: disabled`);
     return;
   }
 
   if (!engineInfo.executionFilePath) {
     log.info(
-      `ENGINE ${engineKey}: Skipped engineInfo execution: empty executionFilePath`
+      `ENGINE ${engineId}: Skipped engineInfo execution: empty executionFilePath`
     );
     return;
   }
 
-  log.info(`ENGINE ${engineKey}: Starting process`);
+  log.info(`ENGINE ${engineId}: Starting process`);
 
-  if (!(engineKey in engineProcessContainers)) {
-    engineProcessContainers[engineKey] = {
+  if (!(engineId in engineProcessContainers)) {
+    engineProcessContainers[engineId] = {
       willQuitEngine: false,
     };
   }
 
-  const engineProcessContainer = engineProcessContainers[engineKey];
+  const engineProcessContainer = engineProcessContainers[engineId];
   engineProcessContainer.willQuitEngine = false;
 
   // 最初のエンジンモード
@@ -451,7 +451,7 @@ async function runEngine(engineKey: string) {
   }
   const useGpu = store.get("useGpu");
 
-  log.info(`ENGINE ${engineKey} mode: ${useGpu ? "GPU" : "CPU"}`);
+  log.info(`ENGINE ${engineId} mode: ${useGpu ? "GPU" : "CPU"}`);
 
   // エンジンプロセスの起動
   const enginePath = path.resolve(
@@ -460,8 +460,8 @@ async function runEngine(engineKey: string) {
   );
   const args = useGpu ? ["--use_gpu"] : [];
 
-  log.info(`ENGINE ${engineKey} path: ${enginePath}`);
-  log.info(`ENGINE ${engineKey} args: ${JSON.stringify(args)}`);
+  log.info(`ENGINE ${engineId} path: ${enginePath}`);
+  log.info(`ENGINE ${engineId} args: ${JSON.stringify(args)}`);
 
   const engineProcess = spawn(enginePath, args, {
     cwd: path.dirname(enginePath),
@@ -469,21 +469,21 @@ async function runEngine(engineKey: string) {
   engineProcessContainer.engineProcess = engineProcess;
 
   engineProcess.stdout?.on("data", (data) => {
-    log.info(`ENGINE ${engineKey} STDOUT: ${data.toString("utf-8")}`);
+    log.info(`ENGINE ${engineId} STDOUT: ${data.toString("utf-8")}`);
   });
 
   engineProcess.stderr?.on("data", (data) => {
-    log.error(`ENGINE ${engineKey} STDERR: ${data.toString("utf-8")}`);
+    log.error(`ENGINE ${engineId} STDERR: ${data.toString("utf-8")}`);
   });
 
   engineProcess.on("close", (code, signal) => {
     log.info(
-      `ENGINE ${engineKey}: Process terminated due to receipt of signal ${signal}`
+      `ENGINE ${engineId}: Process terminated due to receipt of signal ${signal}`
     );
-    log.info(`ENGINE ${engineKey}: Process exited with code ${code}`);
+    log.info(`ENGINE ${engineId}: Process exited with code ${code}`);
 
     if (!engineProcessContainer.willQuitEngine) {
-      ipcMainSend(win, "DETECTED_ENGINE_ERROR", { engineKey });
+      ipcMainSend(win, "DETECTED_ENGINE_ERROR", { engineId });
       dialog.showErrorBox(
         "音声合成エンジンエラー",
         "音声合成エンジンが異常終了しました。エンジンを再起動してください。"
@@ -499,16 +499,16 @@ function killEngineAll({
 }: {
   onFirstKillStart?: VoidFunction;
   onAllKilled?: VoidFunction;
-  onError?: (engineKey: string, message: unknown) => void;
+  onError?: (engineId: string, message: unknown) => void;
 }) {
   let anyKillStart = false;
 
   const numEngineProcess = Object.keys(engineProcessContainers).length;
   let numEngineProcessKilled = 0;
 
-  for (const [engineKey] of Object.entries(engineProcessContainers)) {
+  for (const [engineId] of Object.entries(engineProcessContainers)) {
     killEngine({
-      engineKey,
+      engineId,
       onKillStart: () => {
         if (!anyKillStart) {
           anyKillStart = true;
@@ -526,12 +526,12 @@ function killEngineAll({
         }
       },
       onError: (message) => {
-        onError?.(engineKey, message);
+        onError?.(engineId, message);
 
         // エディタを終了するため、エラーが起きてもエンジンプロセスをキルできたとみなして次のエンジンプロセスをキルする
         numEngineProcessKilled++;
         log.info(
-          `ENGINE ${engineKey}: process kill errored, but assume to have been killed`
+          `ENGINE ${engineId}: process kill errored, but assume to have been killed`
         );
         log.info(
           `ENGINE ${numEngineProcessKilled} / ${numEngineProcess} processes killed`
@@ -546,58 +546,58 @@ function killEngineAll({
 }
 
 function killEngine({
-  engineKey,
+  engineId,
   onKillStart,
   onKilled,
   onError,
 }: {
-  engineKey: string;
+  engineId: string;
   onKillStart?: VoidFunction;
   onKilled?: VoidFunction;
   onError?: (error: unknown) => void;
 }) {
   // この関数では、呼び出し元に結果を通知するためonKilledまたはonErrorを同期または非同期で必ず呼び出さなければならない
 
-  const engineProcessContainer = engineProcessContainers[engineKey];
+  const engineProcessContainer = engineProcessContainers[engineId];
   if (!engineProcessContainer) {
-    onError?.(`No such engineProcessContainer: key == ${engineKey}`);
+    onError?.(`No such engineProcessContainer: key == ${engineId}`);
     return;
   }
 
   const engineProcess = engineProcessContainer.engineProcess;
   if (engineProcess == undefined) {
     // nop if no process started (already killed or not started yet)
-    log.info(`ENGINE ${engineKey}: Process not started`);
+    log.info(`ENGINE ${engineId}: Process not started`);
     onKilled?.();
     return;
   }
 
   // considering the case that ENGINE process killed after checking process status
   engineProcess.once("close", () => {
-    log.info(`ENGINE ${engineKey}: Process closed`);
+    log.info(`ENGINE ${engineId}: Process closed`);
     onKilled?.();
   });
 
   log.info(
-    `ENGINE ${engineKey}: last exit code: ${engineProcess.exitCode}, signal: ${engineProcess.signalCode}`
+    `ENGINE ${engineId}: last exit code: ${engineProcess.exitCode}, signal: ${engineProcess.signalCode}`
   );
 
   const engineNotExited = engineProcess.exitCode === null;
   const engineNotKilled = engineProcess.signalCode === null;
 
   if (engineNotExited && engineNotKilled) {
-    log.info(`ENGINE ${engineKey}: Killing process (PID=${engineProcess.pid})`);
+    log.info(`ENGINE ${engineId}: Killing process (PID=${engineProcess.pid})`);
     onKillStart?.();
 
     engineProcessContainer.willQuitEngine = true;
     try {
       engineProcess.pid != undefined && treeKill(engineProcess.pid);
     } catch (error: unknown) {
-      log.error(`ENGINE ${engineKey}: Error during killing process`);
+      log.error(`ENGINE ${engineId}: Error during killing process`);
       onError?.(error);
     }
   } else {
-    log.info(`ENGINE ${engineKey}: Process already closed`);
+    log.info(`ENGINE ${engineId}: Process already closed`);
     onKilled?.();
   }
 }
@@ -608,14 +608,14 @@ async function restartEngineAll() {
   }
 }
 
-async function restartEngine(engineKey: string) {
+async function restartEngine(engineId: string) {
   await new Promise<void>((resolve, reject) => {
     const engineProcessContainer: EngineProcessContainer | undefined =
-      engineProcessContainers[engineKey];
+      engineProcessContainers[engineId];
     const engineProcess = engineProcessContainer?.engineProcess;
 
     log.info(
-      `ENGINE ${engineKey}: Restarting process (last exit code: ${engineProcess?.exitCode}, signal: ${engineProcess?.signalCode})`
+      `ENGINE ${engineId}: Restarting process (last exit code: ${engineProcess?.exitCode}, signal: ${engineProcess?.signalCode})`
     );
 
     // エンジンのプロセスがすでに終了している、またはkillされている場合
@@ -625,10 +625,10 @@ async function restartEngine(engineKey: string) {
     // engineProcess === undefinedの場合true
     if (engineExited || engineKilled) {
       log.info(
-        `ENGINE ${engineKey}: Process is not started yet or already killed. Starting process...`
+        `ENGINE ${engineId}: Process is not started yet or already killed. Starting process...`
       );
 
-      runEngine(engineKey);
+      runEngine(engineId);
       resolve();
       return;
     }
@@ -639,21 +639,21 @@ async function restartEngine(engineKey: string) {
     // 「killに使用するコマンドが終了するタイミング」と「OSがプロセスをkillするタイミング」が違うので単純にtreeKillのコールバック関数でrunEngine()を実行すると失敗します。
     // closeイベントはexitイベントよりも後に発火します。
     const restartEngineOnProcessClosedCallback = () => {
-      log.info(`ENGINE ${engineKey}: Process killed. Restarting process...`);
+      log.info(`ENGINE ${engineId}: Process killed. Restarting process...`);
 
-      runEngine(engineKey);
+      runEngine(engineId);
       resolve();
     };
     engineProcess.once("close", restartEngineOnProcessClosedCallback);
 
     // treeKillのコールバック関数はコマンドが終了した時に呼ばれます。
     log.info(
-      `ENGINE ${engineKey}: Killing current process (PID=${engineProcess.pid})...`
+      `ENGINE ${engineId}: Killing current process (PID=${engineProcess.pid})...`
     );
     treeKill(engineProcess.pid, (error) => {
       // error変数の値がundefined以外であればkillコマンドが失敗したことを意味します。
       if (error != null) {
-        log.error(`ENGINE ${engineKey}: Failed to kill process`);
+        log.error(`ENGINE ${engineId}: Failed to kill process`);
         log.error(error);
 
         // killに失敗したとき、closeイベントが発生せず、once listenerが消費されない
@@ -1089,8 +1089,8 @@ ipcMainHandle("RESTART_ENGINE_ALL", async () => {
   await restartEngineAll();
 });
 
-ipcMainHandle("RESTART_ENGINE", async (_, { engineKey }) => {
-  await restartEngine(engineKey);
+ipcMainHandle("RESTART_ENGINE", async (_, { engineId }) => {
+  await restartEngine(engineId);
 });
 
 ipcMainHandle("SAVING_SETTING", (_, { newData }) => {
@@ -1281,10 +1281,8 @@ app.on("before-quit", (event) => {
       }
       // else: before-quit event is not cancelled
     },
-    onError: (engineKey, message) => {
-      log.error(
-        `ENGINE ${engineKey}: Error during killing process: ${message}`
-      );
+    onError: (engineId, message) => {
+      log.error(`ENGINE ${engineId}: Error during killing process: ${message}`);
     },
   });
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -396,14 +396,14 @@ async function runEngineAll() {
   log.info(`Starting ${engineInfos.length} engine/s...`);
 
   for (const engineInfo of engineInfos) {
-    log.info(`ENGINE ${engineInfo.key}: Start launching`);
-    await runEngine(engineInfo.key);
+    log.info(`ENGINE ${engineInfo.id}: Start launching`);
+    await runEngine(engineInfo.id);
   }
 }
 
 async function runEngine(engineId: string) {
   const engineInfo = engineInfos.find(
-    (engineInfo) => engineInfo.key === engineId
+    (engineInfo) => engineInfo.id === engineId
   );
   if (!engineInfo)
     throw new Error(`No such engineInfo registered: engineId == ${engineId}`);
@@ -604,7 +604,7 @@ function killEngine({
 
 async function restartEngineAll() {
   for (const engineInfo of engineInfos) {
-    await restartEngine(engineInfo.key);
+    await restartEngine(engineInfo.id);
   }
 }
 

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -202,8 +202,8 @@ const api: Sandbox = {
     return ipcRendererInvoke("RESTART_ENGINE_ALL");
   },
 
-  restartEngine: (engineKey: string) => {
-    return ipcRendererInvoke("RESTART_ENGINE", { engineKey });
+  restartEngine: (engineId: string) => {
+    return ipcRendererInvoke("RESTART_ENGINE", { engineId });
   },
 
   savingSetting: (newData) => {

--- a/src/plugins/ipcMessageReceiverPlugin.ts
+++ b/src/plugins/ipcMessageReceiverPlugin.ts
@@ -24,8 +24,8 @@ export const ipcMessageReceiver: Plugin = {
 
     window.electron.onReceivedIPCMsg(
       "DETECTED_ENGINE_ERROR",
-      (_, { engineKey }) =>
-        options.store.dispatch("DETECTED_ENGINE_ERROR", { engineKey })
+      (_, { engineId }) =>
+        options.store.dispatch("DETECTED_ENGINE_ERROR", { engineId })
     );
 
     window.electron.onReceivedIPCMsg("DETECT_PINNED", () => {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -196,21 +196,20 @@ export const audioStore: VoiceVoxStoreOptions<
       // レンダラープロセスがメインプロセスからエンジンリストを取得完了する前にレンダリングが行われるため、
       // IS_ALL_ENGINE_READYがエンジンリスト未初期化の状態で呼び出される可能性がある
       // この場合の意図しない挙動を抑制するためfalseを返す
-      if (state.engineKeys.length === 0) {
+      if (state.engineIds.length === 0) {
         return false;
       }
 
-      for (const engineKey of state.engineKeys) {
-        const isReady = getters.IS_ENGINE_READY(engineKey);
+      for (const engineId of state.engineIds) {
+        const isReady = getters.IS_ENGINE_READY(engineId);
         if (!isReady) return false;
       }
       return true; // state.engineStatesが空のときはtrue
     },
-    IS_ENGINE_READY: (state) => (engineKey) => {
-      const engineState: EngineState | undefined =
-        state.engineStates[engineKey];
+    IS_ENGINE_READY: (state) => (engineId) => {
+      const engineState: EngineState | undefined = state.engineStates[engineId];
       if (engineState === undefined)
-        throw new Error(`No such engineState set: engineKey == ${engineKey}`);
+        throw new Error(`No such engineState set: engineId == ${engineId}`);
 
       return engineState === "READY";
     },
@@ -232,12 +231,9 @@ export const audioStore: VoiceVoxStoreOptions<
   mutations: {
     SET_ENGINE_STATE(
       state,
-      {
-        engineKey,
-        engineState,
-      }: { engineKey: string; engineState: EngineState }
+      { engineId, engineState }: { engineId: string; engineState: EngineState }
     ) {
-      state.engineStates[engineKey] = engineState;
+      state.engineStates[engineId] = engineState;
     },
     SET_CHARACTER_INFOS(
       state,
@@ -520,28 +516,25 @@ export const audioStore: VoiceVoxStoreOptions<
   actions: {
     START_WAITING_ENGINE_ALL: createUILockAction(
       async ({ state, dispatch }) => {
-        const engineKeys = state.engineKeys;
+        const engineIds = state.engineIds;
 
-        for (const engineKey of engineKeys) {
+        for (const engineId of engineIds) {
           await dispatch("START_WAITING_ENGINE", {
-            engineKey,
+            engineId,
           });
         }
       }
     ),
     START_WAITING_ENGINE: createUILockAction(
-      async ({ state, commit, dispatch }, { engineKey }) => {
-        let engineState: EngineState | undefined =
-          state.engineStates[engineKey];
+      async ({ state, commit, dispatch }, { engineId }) => {
+        let engineState: EngineState | undefined = state.engineStates[engineId];
         if (engineState === undefined)
-          throw new Error(`No such engineState set: engineKey == ${engineKey}`);
+          throw new Error(`No such engineState set: engineId == ${engineId}`);
 
         for (let i = 0; i < 100; i++) {
-          engineState = state.engineStates[engineKey]; // FIXME: explicit undefined
+          engineState = state.engineStates[engineId]; // FIXME: explicit undefined
           if (engineState === undefined)
-            throw new Error(
-              `No such engineState set: engineKey == ${engineKey}`
-            );
+            throw new Error(`No such engineState set: engineId == ${engineId}`);
 
           if (engineState === "FAILED_STARTING") {
             break;
@@ -549,34 +542,34 @@ export const audioStore: VoiceVoxStoreOptions<
 
           try {
             await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-              engineKey,
+              engineId,
             }).then((instance) => instance.invoke("versionVersionGet")({}));
           } catch {
             await new Promise((resolve) => setTimeout(resolve, 1000));
 
-            window.electron.logInfo(`Waiting engine ${engineKey}`);
+            window.electron.logInfo(`Waiting engine ${engineId}`);
             continue;
           }
           engineState = "READY";
-          commit("SET_ENGINE_STATE", { engineKey, engineState });
+          commit("SET_ENGINE_STATE", { engineId, engineState });
           break;
         }
 
         if (engineState !== "READY") {
           commit("SET_ENGINE_STATE", {
-            engineKey,
+            engineId,
             engineState: "FAILED_STARTING",
           });
         }
       }
     ),
     LOAD_CHARACTER: createUILockAction(async ({ state, commit, dispatch }) => {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
       const speakers = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineKey,
+        engineId,
       })
         .then((instance) => instance.invoke("speakersSpeakersGet")({}))
         .catch((error) => {
@@ -612,7 +605,7 @@ export const audioStore: VoiceVoxStoreOptions<
       };
       const getSpeakerInfo = async function (speaker: Speaker) {
         const speakerInfo = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-          engineKey,
+          engineId,
         })
           .then((instance) =>
             instance.invoke("speakerInfoSpeakerInfoGet")({
@@ -653,8 +646,8 @@ export const audioStore: VoiceVoxStoreOptions<
      * 初期化済みだった場合は何もしない。
      */
     async SETUP_ENGINE_SPEAKER({ state, dispatch }, { styleId }) {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応, 暫定的に0番目のエンジンのみを使用する。将来的にGENERATE_AUDIO_ITEMの引数にengineId/engineKeyを追加する予定
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応, 暫定的に0番目のエンジンのみを使用する。将来的にGENERATE_AUDIO_ITEMの引数にengineId/engineIdを追加する予定
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
       // FIXME: なぜかbooleanではなくstringが返ってくる。
@@ -662,7 +655,7 @@ export const audioStore: VoiceVoxStoreOptions<
       const isInitialized: string = await dispatch(
         "INSTANTIATE_ENGINE_CONNECTOR",
         {
-          engineKey,
+          engineId,
         }
       ).then(
         (instance) =>
@@ -677,7 +670,7 @@ export const audioStore: VoiceVoxStoreOptions<
         await dispatch("ASYNC_UI_LOCK", {
           callback: () =>
             dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-              engineKey,
+              engineId,
             }).then((instance) =>
               instance.invoke("initializeSpeakerInitializeSpeakerPost")({
                 speaker: styleId,
@@ -711,8 +704,8 @@ export const audioStore: VoiceVoxStoreOptions<
 
       const text = payload.text ?? "";
 
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応, 暫定的に0番目のエンジンのみを使用する。将来的にGENERATE_AUDIO_ITEMの引数にengineId/engineKeyを追加する予定
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応, 暫定的に0番目のエンジンのみを使用する。将来的にGENERATE_AUDIO_ITEMの引数にengineId/engineIdを追加する予定
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
       const styleId =
@@ -725,7 +718,7 @@ export const audioStore: VoiceVoxStoreOptions<
         ].defaultStyleId;
       const baseAudioItem = payload.baseAudioItem;
 
-      const query = getters.IS_ENGINE_READY(engineKey)
+      const query = getters.IS_ENGINE_READY(engineId)
         ? await dispatch("FETCH_AUDIO_QUERY", {
             text,
             styleId,
@@ -820,12 +813,12 @@ export const audioStore: VoiceVoxStoreOptions<
         isKana?: boolean;
       }
     ) {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
       return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineKey,
+        engineId,
       })
         .then((instance) =>
           instance.invoke("accentPhrasesAccentPhrasesPost")({
@@ -849,12 +842,12 @@ export const audioStore: VoiceVoxStoreOptions<
         styleId,
       }: { accentPhrases: AccentPhrase[]; styleId: number }
     ) {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
       return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineKey,
+        engineId,
       })
         .then((instance) =>
           instance.invoke("moraDataMoraDataPost")({
@@ -900,12 +893,12 @@ export const audioStore: VoiceVoxStoreOptions<
       { dispatch, state },
       { text, styleId }: { text: string; styleId: number }
     ) {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
 
       return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineKey,
+        engineId,
       })
         .then((instance) =>
           instance.invoke("audioQueryAudioQueryPost")({
@@ -1010,12 +1003,12 @@ export const audioStore: VoiceVoxStoreOptions<
         { dispatch, state },
         { encodedBlobs }: { encodedBlobs: string[] }
       ) => {
-        const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-        if (engineKey === undefined)
+        const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+        if (engineId === undefined)
           throw new Error(`No such engine registered: index == 0`);
 
         return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-          engineKey,
+          engineId,
         })
           .then((instance) =>
             instance.invoke("connectWavesConnectWavesPost")({
@@ -1042,9 +1035,9 @@ export const audioStore: VoiceVoxStoreOptions<
     },
     GENERATE_AUDIO_FROM_AUDIO_ITEM: createUILockAction(
       async ({ dispatch, state }, { audioItem }: { audioItem: AudioItem }) => {
-        const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-        if (engineKey === undefined)
-          throw new Error(`No such engineKey registered: index == 0`);
+        const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+        if (engineId === undefined)
+          throw new Error(`No such engineId registered: index == 0`);
 
         const [id, audioQuery] = await generateUniqueIdAndQuery(
           state,
@@ -1056,7 +1049,7 @@ export const audioStore: VoiceVoxStoreOptions<
         }
 
         return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-          engineKey,
+          engineId,
         })
           .then((instance) =>
             instance.invoke("synthesisSynthesisPost")({
@@ -1604,50 +1597,49 @@ export const audioStore: VoiceVoxStoreOptions<
     OPEN_TEXT_EDIT_CONTEXT_MENU() {
       window.electron.openTextEditContextMenu();
     },
-    DETECTED_ENGINE_ERROR({ state, commit }, { engineKey }) {
-      const engineState: EngineState | undefined =
-        state.engineStates[engineKey];
+    DETECTED_ENGINE_ERROR({ state, commit }, { engineId }) {
+      const engineState: EngineState | undefined = state.engineStates[engineId];
       if (engineState === undefined)
-        throw new Error(`No such engineState set: engineKey == ${engineKey}`);
+        throw new Error(`No such engineState set: engineId == ${engineId}`);
 
       switch (engineState) {
         case "STARTING":
           commit("SET_ENGINE_STATE", {
-            engineKey,
+            engineId,
             engineState: "FAILED_STARTING",
           });
           break;
         case "READY":
-          commit("SET_ENGINE_STATE", { engineKey, engineState: "ERROR" });
+          commit("SET_ENGINE_STATE", { engineId, engineState: "ERROR" });
           break;
         default:
-          commit("SET_ENGINE_STATE", { engineKey, engineState: "ERROR" });
+          commit("SET_ENGINE_STATE", { engineId, engineState: "ERROR" });
       }
     },
     async RESTART_ENGINE_ALL({ state, dispatch }) {
       // NOTE: 暫定実装、すべてのエンジンの再起動に成功した場合に、成功とみなす
       let allSuccess = true;
-      const engineKeys = state.engineKeys;
+      const engineIds = state.engineIds;
 
-      for (const engineKey of engineKeys) {
+      for (const engineId of engineIds) {
         const success = await dispatch("RESTART_ENGINE", {
-          engineKey,
+          engineId,
         });
         allSuccess = allSuccess && success;
       }
 
       return allSuccess;
     },
-    async RESTART_ENGINE({ dispatch, commit, state }, { engineKey }) {
-      commit("SET_ENGINE_STATE", { engineKey, engineState: "STARTING" });
+    async RESTART_ENGINE({ dispatch, commit, state }, { engineId }) {
+      commit("SET_ENGINE_STATE", { engineId, engineState: "STARTING" });
       const success = await window.electron
-        .restartEngine(engineKey)
+        .restartEngine(engineId)
         .then(async () => {
-          await dispatch("START_WAITING_ENGINE", { engineKey });
+          await dispatch("START_WAITING_ENGINE", { engineId });
           return state.engineState === "READY";
         })
         .catch(async () => {
-          await dispatch("DETECTED_ENGINE_ERROR", { engineKey });
+          await dispatch("DETECTED_ENGINE_ERROR", { engineId });
           return false;
         });
       return success;

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -18,11 +18,11 @@ export const dictionaryStore: VoiceVoxStoreOptions<
   mutations: {},
   actions: {
     LOAD_USER_DICT: async ({ state, dispatch }) => {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
       const engineDict = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineKey,
+        engineId,
       }).then((instance) => instance.invoke("getUserDictWordsUserDictGet")({}));
 
       // 50音順にソートするために、一旦arrayにする
@@ -47,11 +47,11 @@ export const dictionaryStore: VoiceVoxStoreOptions<
       { state, dispatch },
       { surface, pronunciation, accentType }
     ) => {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
       await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineKey,
+        engineId,
       }).then((instance) =>
         instance.invoke("addUserDictWordUserDictWordPost")({
           surface,
@@ -65,11 +65,11 @@ export const dictionaryStore: VoiceVoxStoreOptions<
       { state, dispatch },
       { wordUuid, surface, pronunciation, accentType, priority }
     ) => {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
       await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineKey,
+        engineId,
       }).then((instance) =>
         instance.invoke("rewriteUserDictWordUserDictWordWordUuidPut")({
           wordUuid,
@@ -82,11 +82,11 @@ export const dictionaryStore: VoiceVoxStoreOptions<
     },
 
     DELETE_WORD: async ({ state, dispatch }, { wordUuid }) => {
-      const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-      if (engineKey === undefined)
+      const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+      if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);
       await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineKey,
+        engineId,
       }).then((instance) =>
         instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")({
           wordUuid,

--- a/src/store/proxy.ts
+++ b/src/store/proxy.ts
@@ -25,11 +25,11 @@ const proxyStoreCreator = (
     mutations: {},
     actions: {
       INSTANTIATE_ENGINE_CONNECTOR({ state }, payload) {
-        const engineKey = payload.engineKey;
-        const engineInfo: EngineInfo | undefined = state.engineInfos[engineKey];
+        const engineId = payload.engineId;
+        const engineInfo: EngineInfo | undefined = state.engineInfos[engineId];
         if (engineInfo === undefined)
           throw new Error(
-            `No such engineInfo registered: engineKey == ${engineKey}`
+            `No such engineInfo registered: engineId == ${engineId}`
           );
 
         const instance = _engineFactory.instance(engineInfo.host);

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -37,7 +37,7 @@ export const settingStoreState: SettingStoreState = {
   },
   hotkeySettings: [],
   toolbarSetting: [],
-  engineKeys: [],
+  engineIds: [],
   engineInfos: {},
   themeSetting: {
     currentTheme: "Default",
@@ -311,12 +311,12 @@ export const settingStore: VoiceVoxStoreOptions<
           }
         }
 
-        const engineKey: string | undefined = state.engineKeys[0]; // TODO: 複数エンジン対応
-        if (engineKey === undefined)
+        const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
+        if (engineId === undefined)
           throw new Error(`No such engine registered: index == 0`);
 
         await dispatch("SET_USE_GPU", { useGpu });
-        const success = await dispatch("RESTART_ENGINE", { engineKey });
+        const success = await dispatch("RESTART_ENGINE", { engineId });
 
         // GPUモードに変更できなかった場合はCPUモードに戻す
         // FIXME: useGpu設定を保存してからエンジン起動を試すのではなく、逆にしたい

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -111,7 +111,7 @@ type AudioStoreTypes = {
   };
 
   IS_ENGINE_READY: {
-    getter(engineKey: string): boolean;
+    getter(engineId: string): boolean;
   };
 
   ACTIVE_AUDIO_ELEM_CURRENT_TIME: {
@@ -123,10 +123,10 @@ type AudioStoreTypes = {
   };
 
   START_WAITING_ENGINE: {
-    action(payload: { engineKey: string }): void;
+    action(payload: { engineId: string }): void;
   };
 
-  // NOTE: 複数のEngineKeyを受け取ってバルク操作する関数にしてもいいかもしれない？
+  // NOTE: 複数のengineIdを受け取ってバルク操作する関数にしてもいいかもしれない？
   // NOTE: 個別にエンジンの状態を確認できるようにする？
   // NOTE: boolean以外でエンジン状態を表現してもいいかもしれない？
   RESTART_ENGINE_ALL: {
@@ -134,15 +134,15 @@ type AudioStoreTypes = {
   };
 
   RESTART_ENGINE: {
-    action(payload: { engineKey: string }): Promise<boolean>;
+    action(payload: { engineId: string }): Promise<boolean>;
   };
 
   DETECTED_ENGINE_ERROR: {
-    action(payload: { engineKey: string }): void;
+    action(payload: { engineId: string }): void;
   };
 
   SET_ENGINE_STATE: {
-    mutation: { engineKey: string; engineState: EngineState };
+    mutation: { engineId: string; engineState: EngineState };
   };
 
   LOAD_CHARACTER: {
@@ -793,7 +793,7 @@ export type SettingStoreState = {
   savingSetting: SavingSetting;
   hotkeySettings: HotkeySetting[];
   toolbarSetting: ToolbarSetting;
-  engineKeys: string[];
+  engineIds: string[];
   engineInfos: Record<string, EngineInfo>;
   themeSetting: ThemeSetting;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
@@ -1195,7 +1195,7 @@ type IEngineConnectorFactoryActionsMapper = <
 type ProxyStoreTypes = {
   INSTANTIATE_ENGINE_CONNECTOR: {
     action(payload: {
-      engineKey: string;
+      engineId: string;
     }): Promise<{ invoke: IEngineConnectorFactoryActionsMapper }>;
   };
 };

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -139,7 +139,7 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
         state.useGpu = useGpu;
       },
       SET_ENGINE_INFOS(state, { engineInfos }: { engineInfos: EngineInfo[] }) {
-        state.engineKeys = engineInfos.map((engineInfo) => engineInfo.key);
+        state.engineIds = engineInfos.map((engineInfo) => engineInfo.key);
         state.engineInfos = Object.fromEntries(
           engineInfos.map((engineInfo) => [engineInfo.key, engineInfo])
         );

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -139,12 +139,12 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
         state.useGpu = useGpu;
       },
       SET_ENGINE_INFOS(state, { engineInfos }: { engineInfos: EngineInfo[] }) {
-        state.engineIds = engineInfos.map((engineInfo) => engineInfo.key);
+        state.engineIds = engineInfos.map((engineInfo) => engineInfo.id);
         state.engineInfos = Object.fromEntries(
-          engineInfos.map((engineInfo) => [engineInfo.key, engineInfo])
+          engineInfos.map((engineInfo) => [engineInfo.id, engineInfo])
         );
         state.engineStates = Object.fromEntries(
-          engineInfos.map((engineInfo) => [engineInfo.key, "STARTING"])
+          engineInfos.map((engineInfo) => [engineInfo.id, "STARTING"])
         );
       },
       SET_INHERIT_AUDIOINFO(

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -207,7 +207,7 @@ export type IpcIHData = {
   };
 
   RESTART_ENGINE: {
-    args: [obj: { engineKey: string }];
+    args: [obj: { engineId: string }];
     return: void;
   };
 
@@ -371,7 +371,7 @@ export type IpcSOData = {
   };
 
   DETECTED_ENGINE_ERROR: {
-    args: [obj: { engineKey: string }];
+    args: [obj: { engineId: string }];
     return: void;
   };
 

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -196,7 +196,7 @@ export type HotkeySetting = {
 };
 
 export type EngineInfo = {
-  key: string;
+  id: string;
   host: string;
   executionEnabled: boolean;
   executionFilePath: string;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -83,7 +83,7 @@ export interface Sandbox {
   logInfo(...params: unknown[]): void;
   engineInfos(): Promise<EngineInfo[]>;
   restartEngineAll(): Promise<void>;
-  restartEngine(engineKey: string): Promise<void>;
+  restartEngine(engineId: string): Promise<void>;
   savingSetting(newData?: SavingSetting): Promise<SavingSetting>;
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   toolbarSetting(newData?: ToolbarSetting): Promise<ToolbarSetting>;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -528,10 +528,10 @@ export default defineComponent({
       let lastEngineState: EngineState | undefined = undefined;
 
       // 登録されているすべてのエンジンについて状態を確認する
-      for (const engineKey of store.state.engineKeys) {
-        const engineState: EngineState | undefined = engineStates[engineKey];
+      for (const engineId of store.state.engineIds) {
+        const engineState: EngineState | undefined = engineStates[engineId];
         if (engineState === undefined)
-          throw new Error(`No such engineState set: engineKey == ${engineKey}`);
+          throw new Error(`No such engineState set: engineId == ${engineId}`);
 
         // FIXME: 1つでも接続テストに成功していないエンジンがあれば、暫定的に起動中とする
         if (engineState === "STARTING") {

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -70,7 +70,7 @@ describe("store/vuex.js test", () => {
         toolbarSetting: [],
         acceptRetrieveTelemetry: "Unconfirmed",
         acceptTerms: "Unconfirmed",
-        engineKeys: ["88022f86-c823-436e-85a3-500c629749c4"],
+        engineIds: ["88022f86-c823-436e-85a3-500c629749c4"],
         engineInfos: {
           "88022f86-c823-436e-85a3-500c629749c4": {
             key: "88022f86-c823-436e-85a3-500c629749c4",
@@ -135,9 +135,9 @@ describe("store/vuex.js test", () => {
     assert.exists(store);
     assert.isObject(store);
     assert.isObject(store.state);
-    assert.hasAllKeys(store.state.engineStates, store.state.engineKeys);
-    store.state.engineKeys.forEach((engineKey) =>
-      assert.equal(store.state.engineStates[engineKey], "STARTING")
+    assert.hasAllKeys(store.state.engineStates, store.state.engineIds);
+    store.state.engineIds.forEach((engineId) =>
+      assert.equal(store.state.engineStates[engineId], "STARTING")
     );
     assert.isArray(store.state.defaultStyleIds);
     assert.isObject(store.state.audioItems);
@@ -184,9 +184,9 @@ describe("store/vuex.js test", () => {
     assert.isEmpty(store.state.themeSetting.availableThemes);
     assert.equal(store.state.acceptRetrieveTelemetry, "Unconfirmed");
     assert.equal(store.state.acceptTerms, "Unconfirmed");
-    assert.isArray(store.state.engineKeys);
+    assert.isArray(store.state.engineIds);
     assert.isObject(store.state.engineInfos);
-    assert.hasAllKeys(store.state.engineInfos, store.state.engineKeys);
+    assert.hasAllKeys(store.state.engineInfos, store.state.engineIds);
     assert.equal(store.state.experimentalSetting.enablePreset, false);
     assert.equal(
       store.state.experimentalSetting.enableInterrogativeUpspeak,

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -73,7 +73,7 @@ describe("store/vuex.js test", () => {
         engineIds: ["88022f86-c823-436e-85a3-500c629749c4"],
         engineInfos: {
           "88022f86-c823-436e-85a3-500c629749c4": {
-            key: "88022f86-c823-436e-85a3-500c629749c4",
+            id: "88022f86-c823-436e-85a3-500c629749c4",
             executionEnabled: false,
             executionFilePath: "",
             host: "http://127.0.0.1",


### PR DESCRIPTION
## 内容

複数エンジン対応のために、engineIdとengineKeyという概念が作られていました。

- https://github.com/VOICEVOX/voicevox/issues/609

engineIdはエンジンが固有で持つID、engineKeyはソフトがエンジンごとに勝手に割り振るIDです。
同じengineIdでも、バージョンが違えば別のkeyを割り当てることができるように設計されています。

現状全部engineKeyになっていますが、[こちらのPR](https://github.com/VOICEVOX/voicevox/pull/743)でengineIdが導入される予定でしたが、まだengineKeyとengineIdの使い分けを議論しきれていない状況です。

そこで一度、VOICEVOXエディタはエンジンの種類ごとに１つだけしかエンジンを把握できない、という設計にしたいと思います。
つまり、engineKeyをなくして、engineIdのみにする戦略です。

engineKeyはあとで導入することもできるはずです。
engineKeyを活かすには更にUIの実装も必要なため、実装をいったん後回しにしたいと思います。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/743
- https://github.com/VOICEVOX/voicevox/issues/609

## その他

この変更により、.envのkeyをidに変えないと起動しなくなります。
あとでissueで案内したいと思います。
