### PR TITLE
複数エンジン対応：エンジン毎の操作欄を追加

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,6 +2,7 @@ DEFAULT_ENGINE_INFOS=`[
     {
         "uuid": "074fc39e-678b-4c13-8916-ffca8d505d1d",
         "name": "VOICEVOX Engine",
+        "icon": "manifest_assets/icon.png",
         "executionEnabled": true,
         "executionFilePath": "run.exe",
         "host": "http://127.0.0.1:50021"

--- a/.env.production
+++ b/.env.production
@@ -2,7 +2,7 @@ DEFAULT_ENGINE_INFOS=`[
     {
         "uuid": "074fc39e-678b-4c13-8916-ffca8d505d1d",
         "name": "VOICEVOX Engine",
-        "icon": "manifest_assets/icon.png",
+        "iconPath": "manifest_assets/icon.png",
         "executionEnabled": true,
         "executionFilePath": "run.exe",
         "host": "http://127.0.0.1:50021",

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,7 @@
 DEFAULT_ENGINE_INFOS=`[
     {
         "uuid": "074fc39e-678b-4c13-8916-ffca8d505d1d",
+        "name": "VOICEVOX Engine",
         "executionEnabled": true,
         "executionFilePath": "run.exe",
         "host": "http://127.0.0.1:50021"

--- a/.env.production
+++ b/.env.production
@@ -5,7 +5,8 @@ DEFAULT_ENGINE_INFOS=`[
         "icon": "manifest_assets/icon.png",
         "executionEnabled": true,
         "executionFilePath": "run.exe",
-        "host": "http://127.0.0.1:50021"
+        "host": "http://127.0.0.1:50021",
+        "path": "."
     }
 ]`
 VUE_APP_GTM_CONTAINER_ID=GTM-DUMMY

--- a/src/background.ts
+++ b/src/background.ts
@@ -719,8 +719,8 @@ function openEngineDirectory(engineId: string) {
   const engineInfo = engineInfos.find(
     (engineInfo) => engineInfo.uuid === engineId
   );
-  if (engineInfo == null) {
-    return;
+  if (!engineInfo) {
+    throw new Error(`No such engineInfo registered: engineId == ${engineId}`);
   }
 
   const engineDirectory = engineInfo.path;

--- a/src/background.ts
+++ b/src/background.ts
@@ -136,6 +136,7 @@ const engineInfos: EngineInfo[] = (() => {
     return {
       ...engineInfo,
       icon: `data:${detectImageTypeFromBase64(b64icon)};base64,${b64icon}`,
+      path: engineInfo.path && path.resolve(appDirPath, engineInfo.path),
     };
   });
 })();
@@ -713,6 +714,23 @@ async function restartEngine(engineId: string) {
   });
 }
 
+// エンジンのフォルダを開く
+function openEngineDirectory(engineId: string) {
+  const engineInfo = engineInfos.find(
+    (engineInfo) => engineInfo.uuid === engineId
+  );
+  if (engineInfo == null) {
+    return;
+  }
+
+  const engineDirectory = engineInfo.path;
+  if (engineDirectory == null) {
+    return;
+  }
+
+  shell.openPath(engineDirectory);
+}
+
 // temp dir
 const tempDir = path.join(app.getPath("temp"), "VOICEVOX");
 if (!fs.existsSync(tempDir)) {
@@ -1111,6 +1129,10 @@ ipcMainHandle("RESTART_ENGINE_ALL", async () => {
 
 ipcMainHandle("RESTART_ENGINE", async (_, { engineId }) => {
   await restartEngine(engineId);
+});
+
+ipcMainHandle("OPEN_ENGINE_DIRECTORY", async (_, { engineId }) => {
+  openEngineDirectory(engineId);
 });
 
 ipcMainHandle("HOTKEY_SETTINGS", (_, { newData }) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -728,7 +728,7 @@ function openEngineDirectory(engineId: string) {
     return;
   }
 
-  shell.openPath(path.resolve(engineDirectory));
+  shell.openPath(path.resolve(engineDirectory)); // Windows環境だとそのまま動かない
 }
 
 // temp dir

--- a/src/background.ts
+++ b/src/background.ts
@@ -728,7 +728,7 @@ function openEngineDirectory(engineId: string) {
     return;
   }
 
-  shell.openPath(engineDirectory);
+  shell.openPath(path.resolve(engineDirectory));
 }
 
 // temp dir

--- a/src/background.ts
+++ b/src/background.ts
@@ -728,7 +728,9 @@ function openEngineDirectory(engineId: string) {
     return;
   }
 
-  shell.openPath(path.resolve(engineDirectory)); // Windows環境だとそのまま動かない
+  // Windows環境だとスラッシュ区切りのパスが動かない。
+  // path.resolveはWindowsだけバックスラッシュ区切りにしてくれるため、path.resolveを挟む。
+  shell.openPath(path.resolve(engineDirectory));
 }
 
 // temp dir

--- a/src/background.ts
+++ b/src/background.ts
@@ -136,7 +136,10 @@ const engineInfos: EngineInfo[] = (() => {
     return {
       ...engineInfo,
       iconData: `data:${detectImageTypeFromBase64(b64icon)};base64,${b64icon}`,
-      path: engineInfo.path && path.resolve(appDirPath, engineInfo.path),
+      path:
+        engineInfo.path === undefined
+          ? undefined
+          : path.resolve(appDirPath, engineInfo.path),
     };
   });
 })();

--- a/src/background.ts
+++ b/src/background.ts
@@ -123,19 +123,19 @@ const engineInfos: EngineInfo[] = (() => {
   }
 
   return engines.map((engineInfo: EngineInfo) => {
-    if (!engineInfo.icon) return engineInfo;
+    if (!engineInfo.iconPath) return engineInfo;
     let b64icon: string;
     try {
-      b64icon = fs.readFileSync(path.resolve(appDirPath, engineInfo.icon), {
+      b64icon = fs.readFileSync(path.resolve(appDirPath, engineInfo.iconPath), {
         encoding: "base64",
       });
     } catch (e) {
-      log.error("Failed to read icon file: " + engineInfo.icon);
+      log.error("Failed to read icon file: " + engineInfo.iconPath);
       return engineInfo;
     }
     return {
       ...engineInfo,
-      icon: `data:${detectImageTypeFromBase64(b64icon)};base64,${b64icon}`,
+      iconData: `data:${detectImageTypeFromBase64(b64icon)};base64,${b64icon}`,
       path: engineInfo.path && path.resolve(appDirPath, engineInfo.path),
     };
   });

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -437,7 +437,7 @@ export default defineComponent({
               ({
                 type: "root",
                 label: engineInfo.name,
-                icon: engineInfo.icon,
+                icon: engineInfo.iconData,
                 subMenu: [
                   engineInfo.path && {
                     type: "button",

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -32,14 +32,7 @@
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  ref,
-  computed,
-  ComputedRef,
-  watch,
-  onMounted,
-} from "vue";
+import { defineComponent, ref, computed, ComputedRef, watch } from "vue";
 import { useStore } from "@/store";
 import MenuButton from "@/components/MenuButton.vue";
 import TitleBarButtons from "@/components/TitleBarButtons.vue";

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -409,6 +409,7 @@ export default defineComponent({
     setHotkeyFunctions(hotkeyMap);
 
     // エンジン毎の項目を追加
+    // TODO: 動的にする
     onMounted(async () => {
       const subMenu = (
         menudata.value.find(

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -32,7 +32,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, ComputedRef, watch } from "vue";
+import {
+  defineComponent,
+  ref,
+  computed,
+  ComputedRef,
+  watch,
+  onMounted,
+} from "vue";
 import { useStore } from "@/store";
 import MenuButton from "@/components/MenuButton.vue";
 import TitleBarButtons from "@/components/TitleBarButtons.vue";
@@ -288,9 +295,10 @@ export default defineComponent({
           closeAllDialog();
         },
         subMenu: [
+          { type: "separator" },
           {
             type: "button",
-            label: "再起動",
+            label: "全てのエンジンを再起動",
             onClick: () => {
               store.dispatch("RESTART_ENGINE_ALL");
             },
@@ -399,6 +407,33 @@ export default defineComponent({
     ]);
 
     setHotkeyFunctions(hotkeyMap);
+
+    onMounted(async () => {
+      const subMenu = (
+        menudata.value.find(
+          (x) => x.type === "root" && x.label === "エンジン"
+        ) as MenuItemRoot
+      ).subMenu;
+      await store.dispatch("GET_ENGINE_INFOS");
+
+      Object.values(store.state.engineInfos).forEach((engineInfo) => {
+        subMenu.unshift({
+          type: "root",
+          label: engineInfo.name,
+          subMenu: [
+            {
+              type: "button",
+              label: "再起動",
+              onClick: () => {
+                store.dispatch("RESTART_ENGINE", {
+                  engineId: engineInfo.uuid,
+                });
+              },
+            },
+          ],
+        } as MenuItemRoot);
+      });
+    });
 
     watch(uiLocked, () => {
       // UIのロックが解除された時に再びメニューが開かれてしまうのを防ぐ

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -408,6 +408,7 @@ export default defineComponent({
 
     setHotkeyFunctions(hotkeyMap);
 
+    // エンジン毎の項目を追加
     onMounted(async () => {
       const subMenu = (
         menudata.value.find(

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -450,8 +450,7 @@ export default defineComponent({
         },
       ];
     }
-    watch(engineInfos, updateEngines); // engineInfosを見て動的に更新できるようにする
-    updateEngines(); // 更新したときに消えるので手動で1回呼び出す。多分もっといい実装ある
+    watch(engineInfos, updateEngines, { immediate: true }); // engineInfosを見て動的に更新できるようにする
 
     watch(uiLocked, () => {
       // UIのロックが解除された時に再びメニューが開かれてしまうのを防ぐ

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -405,50 +405,73 @@ export default defineComponent({
 
     // エンジン毎の項目を追加
     async function updateEngines() {
-      (
-        menudata.value.find(
-          (x) => x.type === "root" && x.label === "エンジン"
-        ) as MenuItemRoot
-      ).subMenu = [
-        ...Object.values(engineInfos.value).map(
-          (engineInfo) =>
-            ({
-              type: "root",
-              label: engineInfo.name,
-              icon: engineInfo.icon,
-              subMenu: [
-                engineInfo.path && {
-                  type: "button",
-                  label: "フォルダを開く",
-                  onClick: () => {
-                    store.dispatch("OPEN_ENGINE_DIRECTORY", {
-                      engineId: engineInfo.uuid,
-                    });
-                  },
-                },
-                {
-                  type: "button",
-                  label: "再起動",
-                  onClick: () => {
-                    store.dispatch("RESTART_ENGINE", {
-                      engineId: engineInfo.uuid,
-                    });
-                  },
-                },
-              ].filter((x) => x),
-            } as MenuItemRoot)
-        ),
-        {
-          type: "separator",
-        },
-        {
-          type: "button",
-          label: "全てのエンジンを再起動",
-          onClick: () => {
-            store.dispatch("RESTART_ENGINE_ALL");
+      const engineMenu = menudata.value.find(
+        (x) => x.type === "root" && x.label === "エンジン"
+      ) as MenuItemRoot;
+      if (Object.values(engineInfos.value).length === 1) {
+        const engineInfo = Object.values(engineInfos.value)[0];
+        engineMenu.subMenu = [
+          engineInfo.path && {
+            type: "button",
+            label: "フォルダを開く",
+            onClick: () => {
+              store.dispatch("OPEN_ENGINE_DIRECTORY", {
+                engineId: engineInfo.uuid,
+              });
+            },
           },
-        },
-      ];
+          {
+            type: "button",
+            label: "再起動",
+            onClick: () => {
+              store.dispatch("RESTART_ENGINE", {
+                engineId: engineInfo.uuid,
+              });
+            },
+          },
+        ].filter((x) => x) as MenuItemData[];
+      } else {
+        engineMenu.subMenu = [
+          ...Object.values(engineInfos.value).map(
+            (engineInfo) =>
+              ({
+                type: "root",
+                label: engineInfo.name,
+                icon: engineInfo.icon,
+                subMenu: [
+                  engineInfo.path && {
+                    type: "button",
+                    label: "フォルダを開く",
+                    onClick: () => {
+                      store.dispatch("OPEN_ENGINE_DIRECTORY", {
+                        engineId: engineInfo.uuid,
+                      });
+                    },
+                  },
+                  {
+                    type: "button",
+                    label: "再起動",
+                    onClick: () => {
+                      store.dispatch("RESTART_ENGINE", {
+                        engineId: engineInfo.uuid,
+                      });
+                    },
+                  },
+                ].filter((x) => x),
+              } as MenuItemRoot)
+          ),
+          {
+            type: "separator",
+          },
+          {
+            type: "button",
+            label: "全てのエンジンを再起動",
+            onClick: () => {
+              store.dispatch("RESTART_ENGINE_ALL");
+            },
+          },
+        ];
+      }
     }
     watch(engineInfos, updateEngines, { immediate: true }); // engineInfosを見て動的に更新できるようにする
 

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -417,6 +417,15 @@ export default defineComponent({
               label: engineInfo.name,
               icon: engineInfo.icon,
               subMenu: [
+                engineInfo.path && {
+                  type: "button",
+                  label: "フォルダを開く",
+                  onClick: () => {
+                    store.dispatch("OPEN_ENGINE_DIRECTORY", {
+                      engineId: engineInfo.uuid,
+                    });
+                  },
+                },
                 {
                   type: "button",
                   label: "再起動",
@@ -426,7 +435,7 @@ export default defineComponent({
                     });
                   },
                 },
-              ],
+              ].filter((x) => x),
             } as MenuItemRoot)
         ),
         {

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -56,10 +56,12 @@ export type MenuItemSeparator = MenuItemBase<"separator">;
 export type MenuItemRoot = MenuItemBase<"root"> & {
   onClick: () => void;
   subMenu: MenuItemData[];
+  icon?: string;
 };
 
 export type MenuItemButton = MenuItemBase<"button"> & {
   onClick: () => void;
+  icon?: string;
 };
 
 export type MenuItemCheckbox = MenuItemBase<"checkbox"> & {
@@ -413,6 +415,7 @@ export default defineComponent({
             ({
               type: "root",
               label: engineInfo.name,
+              icon: engineInfo.icon,
               subMenu: [
                 {
                   type: "button",

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -7,6 +7,10 @@
     dense
     :class="selected && 'active-menu'"
   >
+    <q-item-section side class="q-py-2" v-if="menudata.icon">
+      <img :src="menudata.icon" class="engine-icon" />
+    </q-item-section>
+
     <q-item-section>{{ menudata.label }}</q-item-section>
 
     <q-item-section side>
@@ -43,12 +47,26 @@
       <q-icon v-else />
     </q-item-section>
 
+    <q-item-section avatar v-if="menudata.icon">
+      <q-avatar>
+        <img :src="menudata.icon" />
+      </q-avatar>
+    </q-item-section>
+
     <q-item-section>{{ menudata.label }}</q-item-section>
     <q-item-section side v-if="getMenuBarHotkey(menudata.label)">
       {{ getMenuBarHotkey(menudata.label) }}
     </q-item-section>
   </q-item>
 </template>
+
+<style lang="scss" scoped>
+.engine-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 2px;
+}
+</style>
 
 <script lang="ts">
 import { defineComponent, ref, PropType, computed, watch } from "vue";

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -3,6 +3,7 @@
   <q-item
     class="bg-background"
     v-else-if="menudata.type === 'root'"
+    clickable
     dense
     :class="selected && 'active-menu'"
   >
@@ -17,6 +18,7 @@
       transition-show="none"
       transition-hide="none"
       v-model="selectedComputed"
+      :target="!uiLocked"
     >
       <menu-item
         v-for="(menu, i) of menudata.subMenu"
@@ -87,6 +89,7 @@ export default defineComponent({
       }
     };
     if (props.menudata.type === "root") {
+      const uiLocked = computed(() => store.getters.UI_LOCKED);
       const selectedComputed = computed({
         get: () => props.selected,
         set: (val) => emit("update:selected", val),
@@ -122,6 +125,7 @@ export default defineComponent({
       return {
         selectedComputed,
         subMenuOpenFlags,
+        uiLocked,
         reassignSubMenuOpen,
         getMenuBarHotkey,
       };

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -194,6 +194,10 @@ const api: Sandbox = {
     return ipcRendererInvoke("RESTART_ENGINE", { engineId });
   },
 
+  openEngineDirectory: (engineId: string) => {
+    return ipcRendererInvoke("OPEN_ENGINE_DIRECTORY", { engineId });
+  },
+
   checkFileExists: (file) => {
     return ipcRenderer.invoke("CHECK_FILE_EXISTS", { file });
   },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1644,6 +1644,11 @@ export const audioStore: VoiceVoxStoreOptions<
         });
       return success;
     },
+
+    OPEN_ENGINE_DIRECTORY(_, { engineId }) {
+      return window.electron.openEngineDirectory(engineId);
+    },
+
     CHECK_FILE_EXISTS(_, { file }: { file: string }) {
       return window.electron.checkFileExists(file);
     },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -141,6 +141,10 @@ type AudioStoreTypes = {
     action(payload: { engineId: string }): void;
   };
 
+  OPEN_ENGINE_DIRECTORY: {
+    action(payload: { engineId: string }): void;
+  };
+
   SET_ENGINE_STATE: {
     mutation: { engineId: string; engineState: EngineState };
   };

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -186,6 +186,11 @@ export type IpcIHData = {
     return: void;
   };
 
+  OPEN_ENGINE_DIRECTORY: {
+    args: [obj: { engineId: string }];
+    return: void;
+  };
+
   CHECK_FILE_EXISTS: {
     args: [obj: { file: string }];
     return: boolean;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -79,6 +79,7 @@ export interface Sandbox {
   engineInfos(): Promise<EngineInfo[]>;
   restartEngineAll(): Promise<void>;
   restartEngine(engineId: string): Promise<void>;
+  openEngineDirectory(engineId: string): void;
   savingSetting(newData?: SavingSetting): Promise<SavingSetting>;
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   checkFileExists(file: string): Promise<boolean>;
@@ -172,6 +173,7 @@ export type EngineInfo = {
   host: string;
   name: string;
   icon?: string;
+  path?: string;
   executionEnabled: boolean;
   executionFilePath: string;
 };

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -171,6 +171,7 @@ export type EngineInfo = {
   uuid: string;
   host: string;
   name: string;
+  icon?: string;
   executionEnabled: boolean;
   executionFilePath: string;
 };

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -172,7 +172,8 @@ export type EngineInfo = {
   uuid: string;
   host: string;
   name: string;
-  icon?: string;
+  iconPath?: string;
+  iconData?: string;
   path?: string;
   executionEnabled: boolean;
   executionFilePath: string;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -170,6 +170,7 @@ export type HotkeySetting = {
 export type EngineInfo = {
   uuid: string;
   host: string;
+  name: string;
   executionEnabled: boolean;
   executionFilePath: string;
 };

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -74,6 +74,7 @@ describe("store/vuex.js test", () => {
         engineInfos: {
           "88022f86-c823-436e-85a3-500c629749c4": {
             uuid: "88022f86-c823-436e-85a3-500c629749c4",
+            name: "Engine 1",
             executionEnabled: false,
             executionFilePath: "",
             host: "http://127.0.0.1",


### PR DESCRIPTION
## 内容

エンジン毎の再起動ボタンを追加します。

## 関連 Issue

voicevox/voicevox_project#2
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など


![image](https://user-images.githubusercontent.com/59691627/183287299-55875c82-cc44-4e18-bbdd-86eb9e7f0923.png)

エンジンが一つしかない場合は従来のUIのようになっています。
![image](https://user-images.githubusercontent.com/59691627/183287381-830777be-3a17-43f7-bdb7-cc21448fa61f.png)



## その他


<s>![image](https://user-images.githubusercontent.com/59691627/182767205-58e40c80-d4d5-4127-9aa7-7407d54fdc22.png)
何故かクリックできてしまうのでDraft。</s>→修正。