### PR TITLE
ツールチップが手前に来るようにする

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -800,7 +800,6 @@ export default defineComponent({
 $pitch-label-height: 24px;
 
 .tip-tweakable-slider-by-scroll {
-  z-index: 1;
   position: absolute;
   right: 4px;
   top: 4px;

--- a/src/components/Tip.vue
+++ b/src/components/Tip.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!tipConfirmed">
+  <div v-if="!tipConfirmed" style="z-index: 10">
     <q-banner
       class="bg-display-light text-display"
       dense


### PR DESCRIPTION
## 内容

z-indexがたりなくてsliderのつまみがオーバーレイしていたので修正
