### PR TITLE
Fix: 辞書に単語新規登録時にプライオリティが設定されない不具合を修正

### DIFF
--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -45,7 +45,7 @@ export const dictionaryStore: VoiceVoxStoreOptions<
 
     ADD_WORD: async (
       { state, dispatch },
-      { surface, pronunciation, accentType }
+      { surface, pronunciation, accentType, priority }
     ) => {
       const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応
       if (engineId === undefined)
@@ -57,6 +57,7 @@ export const dictionaryStore: VoiceVoxStoreOptions<
           surface,
           pronunciation,
           accentType,
+          priority,
         })
       );
     },


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
辞書に単語新規登録時にプライオリティが設定されない不具合を修正。

store/dictionary.tsのADD_WORD処理部分で、priorityの取得と、addUserDictWordUserDictWordPostへの引き渡しが漏れていることが原因。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #907

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
