### PR TITLE
ENH: voicevox-updaterをインストール成功後に削除する

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -782,3 +782,20 @@ FunctionEnd
 !define MUI_FINISHPAGE_SHOWREADME_FUNCTION deleteArchive
 
 !macroend
+
+!macro customHeader
+  ; インストール成功後に%LOCALAPPDATA%\voicevox-updater\を削除する
+  Function .onInstSuccess
+    ; https://github.com/electron-userland/electron-builder/blob/f717e0ea67cec7c5c298889efee7df724838491a/packages/app-builder-lib/templates/nsis/include/installer.nsh#L77
+    ${if} $installMode == "all"
+      SetShellVarContext current
+    ${endif}
+    Push $R0
+    ${GetParent} "$LOCALAPPDATA\${APP_PACKAGE_STORE_FILE}" $R0
+    RMDir /r "$R0"
+    Pop $R0
+    ${if} $installMode == "all"
+      SetShellVarContext all
+    ${endif}
+  FunctionEnd
+!macroend


### PR DESCRIPTION
## 内容

%LOCALAPPDATA%\voicevox-updater\package.7zが削除されない問題に対する修正です。

## 関連 Issue

ref #482 

## その他

この修正によってelectron-updaterの差分ダウンロードが機能しなくなります。
ただし #543 では自動ダウンロードを行わないため当分は影響を受けないと思われます。

アンインストール時に削除することも考えましたが

- GPU版とGPU版を切り替えてインストールした場合、最後にインストールした方しか削除されない問題
(CPU版をインストール後にGPU版へアップデートした状態でアンインストールするとvoicevox-cpu-updaterが残る)
- インストールしたユーザーとアンインストールするユーザーが異なる場合削除できない問題
(全てのユーザーに対してインストールした場合に起こる可能性がある)

が解決できませんでした。
