### PR TITLE
複数エンジン対応：キャラ立ち絵にエンジン名を追加

### DIFF
--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -66,7 +66,7 @@ export default defineComponent({
       return store.state.audioKeyInitializingSpeaker === activeAudioKey;
     });
 
-    const isMultipleEngine = store.state.engineIds.length > 1;
+    const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
 
     return {
       characterName,

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -66,7 +66,7 @@ export default defineComponent({
       return store.state.audioKeyInitializingSpeaker === activeAudioKey;
     });
 
-    const isEngineMultiple = store.state.engineIds.length > 1;
+    const isMultipleEngine = store.state.engineIds.length > 1;
 
     return {
       characterName,

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="character-portrait-wrapper">
     <span class="character-name">{{ characterName }}</span>
-    <span class="character-engine-name" v-if="isEngineMultiple">{{
-      characterEngineName
+    <span class="character-engine-name" v-if="isMultipleEngine">{{
+      engineName
     }}</span>
     <img :src="portraitPath" class="character-portrait" />
     <div v-if="isInitializingSpeaker" class="loading">
@@ -49,7 +49,7 @@ export default defineComponent({
         : characterInfo.value?.metas.speakerName;
     });
 
-    const characterEngineName = computed(() => {
+    const engineName = computed(() => {
       const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
       const audioItem = activeAudioKey
         ? store.state.audioItems[activeAudioKey]
@@ -70,10 +70,10 @@ export default defineComponent({
 
     return {
       characterName,
-      characterEngineName,
+      engineName,
       portraitPath,
       isInitializingSpeaker,
-      isEngineMultiple,
+      isMultipleEngine,
     };
   },
 });

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="character-portrait-wrapper">
     <span class="character-name">{{ characterName }}</span>
+    <span class="character-engine-name">{{ characterEngineName }}</span>
     <img :src="portraitPath" class="character-portrait" />
     <div v-if="isInitializingSpeaker" class="loading">
       <q-spinner color="primary" size="5rem" :thickness="4" />
@@ -46,6 +47,16 @@ export default defineComponent({
         : characterInfo.value?.metas.speakerName;
     });
 
+    const characterEngineName = computed(() => {
+      const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
+      const audioItem = activeAudioKey
+        ? store.state.audioItems[activeAudioKey]
+        : undefined;
+      const engineId = audioItem?.engineId ?? store.state.engineIds[0];
+      const engineInfo = store.state.engineInfos[engineId];
+      return engineInfo?.name;
+    });
+
     const portraitPath = computed(() => characterInfo.value?.portraitPath);
 
     const isInitializingSpeaker = computed(() => {
@@ -55,6 +66,7 @@ export default defineComponent({
 
     return {
       characterName,
+      characterEngineName,
       portraitPath,
       isInitializingSpeaker,
     };
@@ -74,6 +86,19 @@ export default defineComponent({
     rgba(colors.$background-rgb, 0.5) 75%,
     transparent 100%
   );
+  overflow-wrap: anywhere;
+}
+
+.character-engine-name {
+  position: absolute;
+  padding: 1px 24px 1px 8px;
+  background-image: linear-gradient(
+    90deg,
+    rgba(colors.$background-rgb, 0.5) 0%,
+    rgba(colors.$background-rgb, 0.5) 75%,
+    transparent 100%
+  );
+  bottom: 0;
   overflow-wrap: anywhere;
 }
 

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="character-portrait-wrapper">
     <span class="character-name">{{ characterName }}</span>
-    <span class="character-engine-name">{{ characterEngineName }}</span>
+    <span class="character-engine-name" v-if="isEngineMultiple">{{
+      characterEngineName
+    }}</span>
     <img :src="portraitPath" class="character-portrait" />
     <div v-if="isInitializingSpeaker" class="loading">
       <q-spinner color="primary" size="5rem" :thickness="4" />
@@ -64,11 +66,14 @@ export default defineComponent({
       return store.state.audioKeyInitializingSpeaker === activeAudioKey;
     });
 
+    const isEngineMultiple = store.state.engineIds.length > 1;
+
     return {
       characterName,
       characterEngineName,
       portraitPath,
       isInitializingSpeaker,
+      isEngineMultiple,
     };
   },
 });


### PR DESCRIPTION
## 内容

キャラ立ち絵の左下にエンジン名を表示するようにします。


## 関連 Issue

- ref: voicevox/voicevox_project#2：キャラ立ち絵（どこかにエンジン名を書く）

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/59691627/189071126-3774d0a7-e997-42ac-ac2c-f2bfecdb46e7.png)
![image](https://user-images.githubusercontent.com/59691627/189071338-8d6f2faf-8cbb-45a9-8f69-4ddda3b7ebfc.png)

エンジンが１つだけの時は表示されません。
![image](https://user-images.githubusercontent.com/59691627/189071723-f1ff2eb9-99d2-4312-b81e-b6261b991ab3.png)

## その他

（なし）