### PR TITLE
誤って残っている`savingSetting`の型を削除する

### DIFF
--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -80,7 +80,6 @@ export interface Sandbox {
   restartEngineAll(): Promise<void>;
   restartEngine(engineId: string): Promise<void>;
   openEngineDirectory(engineId: string): void;
-  savingSetting(newData?: SavingSetting): Promise<SavingSetting>;
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   checkFileExists(file: string): Promise<boolean>;
   changePinWindow(): void;


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
- #872 で、`savingSetting`関数が削除され、同時に`types/preload.ts`に書かれていた型も削除されましたが、 #871 で型だけなぜか戻ってきていました。それが`electron/preload.ts`で型エラーを起こしていたので、修正です。


