### PR TITLE
Update: Vuexを4.0.2に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "vue": "3.0.11",
         "vue-router": "4.0.8",
         "vuedraggable": "4.1.0",
-        "vuex": "4.0.0"
+        "vuex": "4.0.2"
       },
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "2.3.3",
@@ -4627,9 +4627,9 @@
       "dev": true
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.10.tgz",
-      "integrity": "sha512-nktQYRnIFrh4DdXiCBjHnsHOMZXDIVcP9qlm/DMfxmjJMtpMGrSZCOKP8j7kDhObNHyqlicwoGLd+a4hf4x9ww=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.2.1.tgz",
+      "integrity": "sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ=="
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "6.0.0",
@@ -24707,9 +24707,12 @@
       }
     },
     "node_modules/vuex": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.0.tgz",
-      "integrity": "sha512-56VPujlHscP5q/e7Jlpqc40sja4vOhC4uJD1llBCWolVI8ND4+VzisDVkUMl+z5y0MpIImW6HjhNc+ZvuizgOw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
+      "integrity": "sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      },
       "peerDependencies": {
         "vue": "^3.0.2"
       }
@@ -29870,9 +29873,9 @@
       }
     },
     "@vue/devtools-api": {
-      "version": "6.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.10.tgz",
-      "integrity": "sha512-nktQYRnIFrh4DdXiCBjHnsHOMZXDIVcP9qlm/DMfxmjJMtpMGrSZCOKP8j7kDhObNHyqlicwoGLd+a4hf4x9ww=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.2.1.tgz",
+      "integrity": "sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ=="
     },
     "@vue/eslint-config-prettier": {
       "version": "6.0.0",
@@ -45811,10 +45814,12 @@
       }
     },
     "vuex": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.0.tgz",
-      "integrity": "sha512-56VPujlHscP5q/e7Jlpqc40sja4vOhC4uJD1llBCWolVI8ND4+VzisDVkUMl+z5y0MpIImW6HjhNc+ZvuizgOw==",
-      "requires": {}
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
+      "integrity": "sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==",
+      "requires": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vue": "3.0.11",
     "vue-router": "4.0.8",
     "vuedraggable": "4.1.0",
-    "vuex": "4.0.0"
+    "vuex": "4.0.2"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "2.3.3",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,4 @@
 import { InjectionKey } from "vue";
-import { createLogger } from "vuex";
 import { createStore, Store, useStore as baseUseStore } from "./vuex";
 
 import {
@@ -28,8 +27,6 @@ import { presetStoreState, presetStore } from "./preset";
 import { dictionaryStoreState, dictionaryStore } from "./dictionary";
 import { proxyStore, proxyStoreState } from "./proxy";
 import { DefaultStyleId } from "@/type/preload";
-
-const isDevelopment = process.env.NODE_ENV == "development";
 
 export const storeKey: InjectionKey<
   Store<State, AllGetters, AllActions, AllMutations>
@@ -247,7 +244,6 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...indexStore.actions,
     ...proxyStore.actions,
   },
-  plugins: isDevelopment ? [createLogger()] : undefined,
   strict: process.env.NODE_ENV !== "production",
 });
 


### PR DESCRIPTION
## 内容

Vuexを4.0.2に更新します。
これにより、DevtoolsからVuexの内容を見ることが出来るようになります（[参考](https://github.com/vuejs/vuex/issues/1942#issuecomment-847427714)）

## 関連 Issue

（なし）

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/59691627/189513662-c63af29e-8bdc-4d70-8f75-c94758e05967.png)


## その他

（なし）