### PR TITLE
メニューバーが消える不具合に対処

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -721,6 +721,14 @@ export default defineComponent({
   min-height: calc(100vh - #{vars.$menubar-height});
 }
 
+.q-layout-container > :deep(.absolute-full) {
+  right: 0 !important;
+  > .scroll {
+    width: unset !important;
+    overflow: hidden;
+  }
+}
+
 .waiting-engine {
   background-color: rgba(colors.$display-rgb, 0.15);
   position: absolute;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <menu-bar />
 
-  <q-layout reveal elevated>
+  <q-layout reveal elevated container class="layout-container">
     <header-bar />
 
     <q-page-container>
@@ -715,6 +715,10 @@ export default defineComponent({
 
 .q-header {
   height: vars.$header-height;
+}
+
+.layout-container {
+  min-height: calc(100vh - #{vars.$menubar-height});
 }
 
 .waiting-engine {


### PR DESCRIPTION
## 内容
画面下部に存在していた空白を削除することで対処しました

なぜ下部の空白が消えるとメニューバーが消えなくなるかは 
https://github.com/VOICEVOX/voicevox/issues/901#issuecomment-1243810746 ←こちらのコメントを参照してください

## 関連 Issue
close #901 

## スクリーンショット・動画など
どちらもQLayoutのElementを選択している状態で、bodyの `overflow: hidden` を外した状態です
beforeは空白が存在します
afterでは空白が消えているので `overflow: hidden` を外してもスクロールバーが出ません
|before|after|
|----|----|
|![before](https://user-images.githubusercontent.com/241973/190627556-d602dcf2-917c-48a6-b14a-f5d4b3d4e6c8.png)|![after](https://user-images.githubusercontent.com/241973/190627580-1ed9536c-545e-42a8-9886-c21246f976c1.png)|

## 行った動作確認
- ✔️  `<body>` の `overflow: hidden` を外して空白がないことを確認
- ✔️  quasar@2.7.0以上をインストールして #901 と同じ操作を行ってもメニューバーが消えないことを確認
- ✔️  quasar@2.7.0以上をインストールして、適当なスライダーを操作しフォーカスを与えた状態で `document.querySelector("#app > div.q-layout-container").focus()` を実行し、メニューバーが消えないことを確認
   - ぱっと見意味不明ですが #901 の操作をしたときに起きていることと実質同じです
- ✔️ windows 10/macOS monterey 12.6で同様の動作確認済み
