### PR TITLE
複数エンジン対応：エンジンのアイコンをキャラアイコンの近くに表示するように

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -58,6 +58,15 @@
                       getDefaultStyle(characterInfo.metas.speakerUuid).iconPath
                     "
                   />
+                  <q-avatar
+                    class="engine-icon"
+                    rounded
+                    v-if="
+                      isMultipleEngine && characterInfo.metas.styles.length < 2
+                    "
+                  >
+                    <img :src="engineInfos[characterInfo.engineId].iconData" />
+                  </q-avatar>
                 </q-avatar>
                 <div>{{ characterInfo.metas.speakerName }}</div>
               </q-btn>
@@ -114,6 +123,17 @@
                               characterInfo.metas.styles[styleIndex].iconPath
                             "
                           />
+                          <q-avatar
+                            rounded
+                            class="engine-icon"
+                            v-if="isMultipleEngine"
+                          >
+                            <img
+                              :src="
+                                engineInfos[characterInfo.engineId].iconData
+                              "
+                            />
+                          </q-avatar>
                         </q-avatar>
                         <q-item-section v-if="style.styleName"
                           >{{ characterInfo.metas.speakerName }} ({{
@@ -433,6 +453,9 @@ export default defineComponent({
       textfield.value.focus();
     };
 
+    // 複数エンジン
+    const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
+
     return {
       userOrderedCharacterInfos,
       isInitializingSpeaker,
@@ -447,6 +470,8 @@ export default defineComponent({
       reassignSubMenuOpen,
       isActiveAudioCell,
       audioTextBuffer,
+      isMultipleEngine,
+      engineInfos: store.state.engineInfos,
       setAudioTextBuffer,
       pushAudioText,
       changeStyleId,
@@ -561,6 +586,28 @@ export default defineComponent({
   .selected-character-item,
   .opened-character-item {
     background-color: rgba(colors.$primary-rgb, 0.2);
+  }
+  .engine-name {
+    // position: absolute;
+    // left: 4px;
+    // bottom: 0;
+    margin-top: auto;
+    margin-left: auto;
+    padding-left: 8px;
+    text-align: right;
+    opacity: 67%;
+    font-size: 0.67rem;
+  }
+  .engine-icon {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    transform: translate(50%, 50%);
+
+    :deep(img) {
+      width: 27.5% !important;
+      height: 27.5% !important;
+    }
   }
 }
 </style>

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -466,14 +466,13 @@ export default defineComponent({
     // 複数エンジン
     const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
 
-    const engineIcons = computed(
-      () =>
-        Object.fromEntries(
-          store.state.engineIds.map((engineId) => [
-            engineId,
-            store.state.engineInfos[engineId].iconData,
-          ])
-        ) as { [key: string]: string }
+    const engineIcons = computed(() =>
+      Object.fromEntries(
+        store.state.engineIds.map((engineId) => [
+          engineId,
+          store.state.engineInfos[engineId].iconData,
+        ])
+      )
     );
 
     return {

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -67,10 +67,10 @@
                   >
                     <img
                       :src="
-                        engineInfos[
+                        engineIcons[
                           getDefaultStyle(characterInfo.metas.speakerUuid)
                             .engineId
-                        ].iconData
+                        ]
                       "
                     />
                   </q-avatar>
@@ -137,10 +137,10 @@
                           >
                             <img
                               :src="
-                                engineInfos[
+                                engineIcons[
                                   characterInfo.metas.styles[styleIndex]
                                     .engineId
-                                ].iconData
+                                ]
                               "
                             />
                           </q-avatar>
@@ -466,6 +466,16 @@ export default defineComponent({
     // 複数エンジン
     const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
 
+    const engineIcons = computed(
+      () =>
+        Object.fromEntries(
+          store.state.engineIds.map((engineId) => [
+            engineId,
+            store.state.engineInfos[engineId].iconData,
+          ])
+        ) as { [key: string]: string }
+    );
+
     return {
       userOrderedCharacterInfos,
       isInitializingSpeaker,
@@ -481,7 +491,7 @@ export default defineComponent({
       isActiveAudioCell,
       audioTextBuffer,
       isMultipleEngine,
-      engineInfos: store.state.engineInfos,
+      engineIcons,
       setAudioTextBuffer,
       pushAudioText,
       changeStyleId,

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -597,17 +597,6 @@ export default defineComponent({
   .opened-character-item {
     background-color: rgba(colors.$primary-rgb, 0.2);
   }
-  .engine-name {
-    // position: absolute;
-    // left: 4px;
-    // bottom: 0;
-    margin-top: auto;
-    margin-left: auto;
-    padding-left: 8px;
-    text-align: right;
-    opacity: 67%;
-    font-size: 0.67rem;
-  }
   .engine-icon {
     position: absolute;
     bottom: 0;

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -65,7 +65,14 @@
                       isMultipleEngine && characterInfo.metas.styles.length < 2
                     "
                   >
-                    <img :src="engineInfos[characterInfo.engineId].iconData" />
+                    <img
+                      :src="
+                        engineInfos[
+                          getDefaultStyle(characterInfo.metas.speakerUuid)
+                            .engineId
+                        ].iconData
+                      "
+                    />
                   </q-avatar>
                 </q-avatar>
                 <div>{{ characterInfo.metas.speakerName }}</div>
@@ -130,7 +137,10 @@
                           >
                             <img
                               :src="
-                                engineInfos[characterInfo.engineId].iconData
+                                engineInfos[
+                                  characterInfo.metas.styles[styleIndex]
+                                    .engineId
+                                ].iconData
                               "
                             />
                           </q-avatar>

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -666,6 +666,7 @@ export const audioStore: VoiceVoxStoreOptions<
           const styles = getStyles(speaker, speakerInfo);
           const characterInfo: CharacterInfo = {
             portraitPath: base64ToUrl(speakerInfo.portrait, "image/png"),
+            engineId,
             metas: {
               speakerUuid: speaker.speakerUuid,
               speakerName: speaker.name,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -644,6 +644,7 @@ export const audioStore: VoiceVoxStoreOptions<
             styles[i] = {
               styleName: style.name,
               styleId: style.id,
+              engineId,
               iconPath: base64ToUrl(styleInfo.icon, "image/png"),
               voiceSamplePaths: voiceSamples,
             };
@@ -666,7 +667,6 @@ export const audioStore: VoiceVoxStoreOptions<
           const styles = getStyles(speaker, speakerInfo);
           const characterInfo: CharacterInfo = {
             portraitPath: base64ToUrl(speakerInfo.portrait, "image/png"),
-            engineId,
             metas: {
               speakerUuid: speaker.speakerUuid,
               speakerName: speaker.name,

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -117,6 +117,7 @@ export type MetasJson = {
 
 export type CharacterInfo = {
   portraitPath: string;
+  engineId: string;
   metas: {
     speakerUuid: string;
     speakerName: string;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -106,6 +106,7 @@ export type StyleInfo = {
   styleName?: string;
   styleId: number;
   iconPath: string;
+  engineId: string;
   voiceSamplePaths: string[];
 };
 
@@ -117,7 +118,6 @@ export type MetasJson = {
 
 export type CharacterInfo = {
   portraitPath: string;
-  engineId: string;
   metas: {
     speakerUuid: string;
     speakerName: string;


### PR DESCRIPTION
## 内容

エンジンのアイコンをキャラアイコンの近くに表示するようにします。

## 関連 Issue

- ref: voicevox/voicevox_project#2：キャラ選択（キャラ名の右下にエンジン名を目立たなく書く）

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/59691627/190860426-d8e20122-d4c9-442f-9bdc-da9a79e43772.png)

エンジンが1つの時は表示されません。
![image](https://user-images.githubusercontent.com/59691627/190860672-3fdd7ff3-deef-468f-9fe3-00fc34038c46.png)


## その他

![image](https://user-images.githubusercontent.com/59691627/190860552-30b6d7ec-f9ac-4e08-8b0a-78f02b1f212b.png)

エンジン名だと少し微妙だったのでアイコンにしています。