### PR TITLE
Fix: 開発中に出るEISDIRを修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -920,7 +920,9 @@ async function createWindow() {
     } else {
       if (process.argv.length >= 2) {
         const filePath = process.argv[1];
-        ipcMainSend(win, "LOAD_PROJECT_FILE", { filePath, confirm: false });
+        if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+          ipcMainSend(win, "LOAD_PROJECT_FILE", { filePath, confirm: false });
+        }
       }
     }
   });


### PR DESCRIPTION
## 内容

#941 を修正します。
自分の環境ではこのパッチでEISDIRがでなくなりました。

## 関連 Issue

- closes: #941

## スクリーンショット・動画など

（なし）

## その他

Macの分岐コードについてはテストできていませんが、多分大丈夫だと思います。