### PR TITLE
複数エンジン対応：ヘルプにエンジン毎の項目を表示するように

### DIFF
--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -58,7 +58,7 @@
                     />
                   </q-toolbar>
                 </q-header>
-                <component :is="page.component" />
+                <component :is="page.component" :v-if="page.type === 'item'" />
               </div>
             </q-tab-panel>
           </q-tab-panels>
@@ -78,10 +78,16 @@ import UpdateInfo from "@/components/UpdateInfo.vue";
 import OssCommunityInfo from "@/components/OssCommunityInfo.vue";
 import QAndA from "@/components/QAndA.vue";
 import ContactInfo from "@/components/ContactInfo.vue";
-type Page = {
+type PageItem = {
+  type: "item";
   name: string;
   component: Component;
 };
+type PageSeparator = {
+  type: "separator";
+  name: string;
+};
+type PageData = PageItem | PageSeparator;
 
 export default defineComponent({
   name: "HelpDialog",
@@ -99,42 +105,59 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
-    const pagedata: Page[] = [
-      {
-        name: "ソフトウェアの利用規約",
-        component: Policy,
-      },
-      {
-        name: "音声ライブラリの利用規約",
-        component: LibraryPolicy,
-      },
-      {
-        name: "使い方",
-        component: HowToUse,
-      },
-      {
-        name: "開発コミュニティ",
-        component: OssCommunityInfo,
-      },
-      {
-        name: "ライセンス情報",
-        component: OssLicense,
-      },
-      {
-        name: "アップデート情報",
-        component: UpdateInfo,
-      },
-      {
-        name: "よくあるご質問",
-        component: QAndA,
-      },
-      {
-        name: "お問い合わせ",
-        component: ContactInfo,
-      },
-    ];
+    const pagedata = computed(
+      () =>
+        [
+          {
+            type: "separator",
+            name: "VOICEVOX エディタ",
+          },
+          {
+            type: "item",
+            name: "ソフトウェアの利用規約",
+            component: Policy,
+          },
+          {
+            type: "item",
+            name: "音声ライブラリの利用規約",
+            component: LibraryPolicy,
+          },
+          {
+            type: "item",
+            name: "使い方",
+            component: HowToUse,
+          },
+          {
+            type: "item",
+            name: "開発コミュニティ",
+            component: OssCommunityInfo,
+          },
+          {
+            type: "item",
+            name: "ライセンス情報",
+            component: OssLicense,
+          },
+          {
+            type: "item",
+            name: "アップデート情報",
+            component: UpdateInfo,
+          },
+          {
+            type: "item",
+            name: "よくあるご質問",
+            component: QAndA,
+          },
+          {
+            type: "item",
+            name: "お問い合わせ",
+            component: ContactInfo,
+          },
+        ].concat([
+          /* TODO: エンジン毎に項目を追加する */
+        ]) as PageData[]
+    );
 
-    const selectedPage = ref(pagedata[0].name);
+    const selectedPage = ref(pagedata.value[0].name);
 
     return {
       modelValueComputed,

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -269,7 +269,7 @@ export default defineComponent({
               //       https://github.com/VOICEVOX/voicevox_engine/issues/476
               isUpdateAvailable: false,
             },
-          } /* TODO: エンジン毎に項目を追加する */,
+          },
         ])
       )
     );

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -168,8 +168,7 @@ export default defineComponent({
       return isCheckingFinished.value && latestVersion.value !== "";
     });
 
-    // VoicevoxのOSSライセンス取得
-
+    // エディタのOSSライセンス取得
     let licenses = ref<Record<string, string>[]>();
     store.dispatch("GET_OSS_LICENSES").then((obj) => (licenses.value = obj));
 

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -17,17 +17,22 @@
       >
         <div class="column full-height">
           <q-list>
-            <q-item
-              v-for="(page, i) of pagedata"
-              :key="i"
-              clickable
-              v-ripple
-              active-class="selected-item"
-              :active="selectedPage === page.name"
-              @click="selectedPage = page.name"
-            >
-              <q-item-section>{{ page.name }}</q-item-section>
-            </q-item>
+            <template v-for="(page, i) of pagedata" :key="i">
+              <q-item
+                v-if="page.type === 'item'"
+                clickable
+                v-ripple
+                active-class="selected-item"
+                :active="selectedPage === page.name"
+                @click="selectedPage = page.name"
+              >
+                <q-item-section> {{ page.name }} </q-item-section>
+              </q-item>
+              <template v-else-if="page.type === 'separator'">
+                <q-separator />
+                <q-item-label header>{{ page.name }}</q-item-label>
+              </template>
+            </template>
           </q-list>
         </div>
       </q-drawer>
@@ -58,7 +63,7 @@
                     />
                   </q-toolbar>
                 </q-header>
-                <component :is="page.component" :v-if="page.type === 'item'" />
+                <component :is="page.component" />
               </div>
             </q-tab-panel>
           </q-tab-panels>
@@ -105,13 +110,9 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
-    const pagedata = computed(
-      () =>
+    const pagedata = computed(() =>
+      (
         [
-          {
-            type: "separator",
-            name: "VOICEVOX エディタ",
-          },
           {
             type: "item",
             name: "ソフトウェアの利用規約",
@@ -152,12 +153,21 @@ export default defineComponent({
             name: "お問い合わせ",
             component: ContactInfo,
           },
-        ].concat([
-          /* TODO: エンジン毎に項目を追加する */
-        ]) as PageData[]
+        ] as PageData[]
+      ).concat([
+        {
+          type: "separator",
+          name: "ヘッダテスト01",
+        },
+        {
+          type: "item",
+          name: "test",
+          component: ContactInfo,
+        } /* TODO: エンジン毎に項目を追加する */,
+      ])
     );
 
-    const selectedPage = ref(pagedata.value[0].name);
+    const selectedPage = ref(pagedata.value[1].name);
 
     return {
       modelValueComputed,
@@ -184,5 +194,9 @@ export default defineComponent({
 .selected-item {
   background-color: rgba(colors.$primary-rgb, 0.4);
   color: colors.$display;
+}
+
+.q-item__label {
+  padding: 8px 16px;
 }
 </style>

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -266,8 +266,8 @@ export default defineComponent({
             component: UpdateInfo,
             props: {
               updateInfos: manifest.updateInfos,
-              // TODO: エンジン側で最新バージョンのチェックを実装したい。
-              //       /update_availableみたいなエンドポイントがあれば良さそう
+              // TODO: エンジン側で最新バージョンチェックAPIが出来たら実装する。
+              //       https://github.com/VOICEVOX/voicevox_engine/issues/476
               isUpdateAvailable: false,
             },
           } /* TODO: エンジン毎に項目を追加する */,

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -115,7 +115,7 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
-    // Voicevoxのアップデート確認
+    // エディタのアップデート確認
     const store = useStore();
 
     const updateInfos = ref<UpdateInfoObject[]>();

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -17,14 +17,14 @@
       >
         <div class="column full-height">
           <q-list>
-            <template v-for="(page, pageIndex) of pagedata" :key="i">
+            <template v-for="(page, pageIndex) of pagedata" :key="pageIndex">
               <q-item
                 v-if="page.type === 'item'"
                 clickable
                 v-ripple
                 active-class="selected-item"
-                :active="selectedPage === pageIndex"
-                @click="selectedPage = pageIndex"
+                :active="selectedPageIndex === pageIndex"
+                @click="selectedPageIndex = pageIndex"
               >
                 <q-item-section> {{ page.name }} </q-item-section>
               </q-item>
@@ -39,7 +39,7 @@
 
       <q-page-container>
         <q-page>
-          <q-tab-panels v-model="selectedPage">
+          <q-tab-panels v-model="selectedPageIndex">
             <q-tab-panel
               v-for="(page, pageIndex) of pagedata"
               :key="pageIndex"
@@ -275,12 +275,12 @@ export default defineComponent({
       )
     );
 
-    const selectedPage = ref(1);
+    const selectedPageIndex = ref(0);
 
     return {
       modelValueComputed,
       pagedata,
-      selectedPage,
+      selectedPageIndex,
     };
   },
 });

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -17,14 +17,14 @@
       >
         <div class="column full-height">
           <q-list>
-            <template v-for="(page, i) of pagedata" :key="i">
+            <template v-for="(page, pageIndex) of pagedata" :key="i">
               <q-item
                 v-if="page.type === 'item'"
                 clickable
                 v-ripple
                 active-class="selected-item"
-                :active="selectedPage === i"
-                @click="selectedPage = i"
+                :active="selectedPage === pageIndex"
+                @click="selectedPage = pageIndex"
               >
                 <q-item-section> {{ page.name }} </q-item-section>
               </q-item>
@@ -41,9 +41,9 @@
         <q-page>
           <q-tab-panels v-model="selectedPage">
             <q-tab-panel
-              v-for="(page, i) of pagedata"
-              :key="i"
-              :name="i"
+              v-for="(page, pageIndex) of pagedata"
+              :key="pageIndex"
+              :name="pageIndex"
               class="q-pa-none"
             >
               <div class="root">

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -23,8 +23,8 @@
                 clickable
                 v-ripple
                 active-class="selected-item"
-                :active="selectedPage === page.name"
-                @click="selectedPage = page.name"
+                :active="selectedPage === i"
+                @click="selectedPage = i"
               >
                 <q-item-section> {{ page.name }} </q-item-section>
               </q-item>
@@ -43,7 +43,7 @@
             <q-tab-panel
               v-for="(page, i) of pagedata"
               :key="i"
-              :name="page.name"
+              :name="i"
               class="q-pa-none"
             >
               <div class="root">
@@ -216,20 +216,28 @@ export default defineComponent({
             component: ContactInfo,
           },
         ] as PageData[]
-      ).concat([
-        {
-          type: "separator",
-          name: "ヘッダテスト01",
-        },
-        {
-          type: "item",
-          name: "test",
-          component: ContactInfo,
-        } /* TODO: エンジン毎に項目を追加する */,
-      ])
+      ).concat(
+        Object.values(store.state.engineManifests).flatMap((manifest) => [
+          {
+            type: "separator",
+            name: manifest.name,
+          },
+          {
+            type: "item",
+            name: "アップデート情報",
+            component: UpdateInfo,
+            props: {
+              updateInfos: manifest.updateInfos,
+              // TODO: エンジン側で最新バージョンのチェックを実装したい。
+              //       /update_availableみたいなエンドポイントがあれば良さそう
+              isUpdateAvailable: false,
+            },
+          } /* TODO: エンジン毎に項目を追加する */,
+        ])
+      )
     );
 
-    const selectedPage = ref(pagedata.value[1].name);
+    const selectedPage = ref(1);
 
     return {
       modelValueComputed,

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -167,6 +167,11 @@ export default defineComponent({
       return isCheckingFinished.value && latestVersion.value !== "";
     });
 
+    // VoicevoxのOSSライセンス取得
+
+    let licenses = ref<Record<string, string>[]>();
+    store.dispatch("GET_OSS_LICENSES").then((obj) => (licenses.value = obj));
+
     const pagedata = computed(() =>
       (
         [
@@ -194,6 +199,9 @@ export default defineComponent({
             type: "item",
             name: "ライセンス情報",
             component: OssLicense,
+            props: {
+              licenses: licenses.value,
+            },
           },
           {
             type: "item",
@@ -221,6 +229,14 @@ export default defineComponent({
           {
             type: "separator",
             name: manifest.name,
+          },
+          {
+            type: "item",
+            name: "ライセンス情報",
+            component: OssLicense,
+            props: {
+              licenses: manifest.dependencyLicenses,
+            },
           },
           {
             type: "item",

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -10,7 +10,7 @@
           :key="engineIndex"
         >
           <!-- エンジンが一つだけの場合は名前を表示しない -->
-          <template v-if="engineInfos.length > 0">
+          <template v-if="engineInfos.length > 1">
             <q-separator spaced v-if="engineIndex > 0" />
             <q-item-label header>{{ engineInfo.engineName }}</q-item-label>
           </template>

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -21,7 +21,7 @@
             <q-item
               clickable
               @click="
-                selectedCharacterInfo({
+                selectCharacterInfo({
                   engine: engineIndex,
                   character: characterIndex,
                 })
@@ -41,7 +41,7 @@
             color="primary-light"
             icon="keyboard_arrow_left"
             label="戻る"
-            @click="selectedCharacterInfo(undefined)"
+            @click="selectCharacterInfo(undefined)"
           />
         </div>
         <div class="text-subtitle">
@@ -95,7 +95,7 @@ export default defineComponent({
     const detailIndex = ref<detailKey | undefined>(undefined);
 
     const scroller = ref<HTMLElement>();
-    const selectedCharacterInfo = (index: detailKey | undefined) => {
+    const selectCharacterInfo = (index: detailKey | undefined) => {
       if (scroller.value == undefined)
         throw new Error("scroller.value == undefined");
       scroller.value.scrollTop = 0;
@@ -105,7 +105,7 @@ export default defineComponent({
     return {
       engineInfos,
       convertMarkdown,
-      selectedCharacterInfo,
+      selectCharacterInfo,
       detailIndex,
       scroller,
     };

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -5,12 +5,28 @@
   >
     <div class="q-pa-md markdown-body">
       <q-list v-if="detailIndex === undefined">
-        <template v-for="(characterInfo, index) in characterInfos" :key="index">
-          <q-item clickable @click="selectCharacterInfIndex(index)">
-            <q-item-section>{{
-              characterInfo.metas.speakerName
-            }}</q-item-section>
-          </q-item>
+        <template
+          v-for="(engineInfo, engineIndex) in engineInfos"
+          :key="engineIndex"
+        >
+          <!-- エンジンが一つだけの場合は名前を表示しない -->
+          <template v-if="engineInfos.length > 0">
+            <q-separator spaced v-if="engineIndex > 0" />
+            <q-item-label header>{{ engineInfo.engineName }}</q-item-label>
+          </template>
+          <template
+            v-for="(characterInfo, characterIndex) in engineInfo.characterInfos"
+            :key="characterIndex"
+          >
+            <q-item
+              clickable
+              @click="selectCharacterInfoIndex([engineIndex, characterIndex])"
+            >
+              <q-item-section>{{
+                characterInfo.metas.speakerName
+              }}</q-item-section>
+            </q-item>
+          </template>
         </template>
       </q-list>
       <div v-else>
@@ -20,15 +36,23 @@
             color="primary-light"
             icon="keyboard_arrow_left"
             label="戻る"
-            @click="selectCharacterInfIndex(undefined)"
+            @click="selectCharacterInfoIndex(undefined)"
           />
         </div>
         <div class="text-subtitle">
-          {{ characterInfos[detailIndex].metas.speakerName }}
+          {{
+            engineInfos[detailIndex[0]].characterInfos[detailIndex[1]].metas
+              .speakerName
+          }}
         </div>
         <div
           class="markdown"
-          v-html="convertMarkdown(characterInfos[detailIndex].metas.policy)"
+          v-html="
+            convertMarkdown(
+              engineInfos[detailIndex[0]].characterInfos[detailIndex[1]].metas
+                .policy
+            )
+          "
         ></div>
       </div>
     </div>
@@ -45,18 +69,24 @@ export default defineComponent({
     const store = useStore();
     const md = useMarkdownIt();
 
-    const flattenCharacterInfos = computed(
-      () => store.getters.GET_FLATTEN_CHARACTER_INFOS
+    const engineInfos = computed(() =>
+      Object.entries(store.state.characterInfos).map(
+        ([engineId, characterInfos]) => ({
+          engineId,
+          engineName: store.state.engineManifests[engineId].name,
+          characterInfos,
+        })
+      )
     );
 
     const convertMarkdown = (text: string) => {
       return md.render(text);
     };
 
-    const detailIndex = ref<number | undefined>(undefined);
+    const detailIndex = ref<[number, number] | undefined>(undefined);
 
     const scroller = ref<HTMLElement>();
-    const selectCharacterInfIndex = (index: number | undefined) => {
+    const selectCharacterInfoIndex = (index: [number, number] | undefined) => {
       if (scroller.value == undefined)
         throw new Error("scroller.value == undefined");
       scroller.value.scrollTop = 0;
@@ -64,9 +94,9 @@ export default defineComponent({
     };
 
     return {
-      characterInfos: flattenCharacterInfos,
+      engineInfos,
       convertMarkdown,
-      selectCharacterInfIndex,
+      selectCharacterInfoIndex,
       detailIndex,
       scroller,
     };

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -20,7 +20,12 @@
           >
             <q-item
               clickable
-              @click="selectCharacterInfoIndex([engineIndex, characterIndex])"
+              @click="
+                selectedCharacterInfo({
+                  engine: engineIndex,
+                  character: characterIndex,
+                })
+              "
             >
               <q-item-section>{{
                 characterInfo.metas.speakerName
@@ -36,21 +41,23 @@
             color="primary-light"
             icon="keyboard_arrow_left"
             label="戻る"
-            @click="selectCharacterInfoIndex(undefined)"
+            @click="selectedCharacterInfo(undefined)"
           />
         </div>
         <div class="text-subtitle">
           {{
-            engineInfos[detailIndex[0]].characterInfos[detailIndex[1]].metas
-              .speakerName
+            engineInfos[detailIndex.engine].characterInfos[
+              detailIndex.character
+            ].metas.speakerName
           }}
         </div>
         <div
           class="markdown"
           v-html="
             convertMarkdown(
-              engineInfos[detailIndex[0]].characterInfos[detailIndex[1]].metas
-                .policy
+              engineInfos[detailIndex.engine].characterInfos[
+                detailIndex.character
+              ].metas.policy
             )
           "
         ></div>
@@ -63,6 +70,8 @@
 import { useStore } from "@/store";
 import { computed, defineComponent, ref } from "@vue/runtime-core";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
+
+type detailKey = { engine: number; character: number };
 
 export default defineComponent({
   setup() {
@@ -83,10 +92,10 @@ export default defineComponent({
       return md.render(text);
     };
 
-    const detailIndex = ref<[number, number] | undefined>(undefined);
+    const detailIndex = ref<detailKey | undefined>(undefined);
 
     const scroller = ref<HTMLElement>();
-    const selectCharacterInfoIndex = (index: [number, number] | undefined) => {
+    const selectedCharacterInfo = (index: detailKey | undefined) => {
       if (scroller.value == undefined)
         throw new Error("scroller.value == undefined");
       scroller.value.scrollTop = 0;
@@ -96,7 +105,7 @@ export default defineComponent({
     return {
       engineInfos,
       convertMarkdown,
-      selectCharacterInfoIndex,
+      selectedCharacterInfo,
       detailIndex,
       scroller,
     };

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -71,7 +71,7 @@ import { useStore } from "@/store";
 import { computed, defineComponent, ref } from "@vue/runtime-core";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
 
-type detailKey = { engine: number; character: number };
+type DetailKey = { engine: number; character: number };
 
 export default defineComponent({
   setup() {
@@ -92,10 +92,10 @@ export default defineComponent({
       return md.render(text);
     };
 
-    const detailIndex = ref<detailKey | undefined>(undefined);
+    const detailIndex = ref<DetailKey | undefined>(undefined);
 
     const scroller = ref<HTMLElement>();
-    const selectCharacterInfo = (index: detailKey | undefined) => {
+    const selectCharacterInfo = (index: DetailKey | undefined) => {
       if (scroller.value == undefined)
         throw new Error("scroller.value == undefined");
       scroller.value.scrollTop = 0;

--- a/src/components/OssLicense.vue
+++ b/src/components/OssLicense.vue
@@ -35,21 +35,22 @@
 </template>
 
 <script lang="ts">
-import { useStore } from "@/store";
-import { defineComponent, ref } from "vue";
+import { defineComponent, PropType, ref } from "vue";
 
 export default defineComponent({
   name: "OssLicense",
 
+  props: {
+    licenses: {
+      type: Array as PropType<Record<string, string>[]>,
+      required: true,
+    },
+  },
   setup() {
-    const store = useStore();
-
-    let licenses = ref<Record<string, string>[]>();
-    store.dispatch("GET_OSS_LICENSES").then((obj) => (licenses.value = obj));
-
     const detailIndex = ref<number | undefined>(undefined);
 
     const scroller = ref<HTMLElement>();
+
     const selectLicenseIndex = (index: number | undefined) => {
       if (scroller.value == undefined)
         throw new Error("scroller.value == undefined");
@@ -58,7 +59,6 @@ export default defineComponent({
     };
 
     return {
-      licenses,
       selectLicenseIndex,
       detailIndex,
       scroller,

--- a/src/components/Policy.vue
+++ b/src/components/Policy.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page class="relative-absolute-wrapper scroller bg-background">
-    <div class="q-pa-md markdown markdown-body" v-html="policy"></div>
+    <div class="q-pa-md markdown markdown-body" v-html="policyHtml"></div>
   </q-page>
 </template>
 
@@ -10,18 +10,23 @@ import { useStore } from "@/store";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
 
 export default defineComponent({
-  setup() {
-    const store = useStore();
-    const policy = ref("");
+  props: {
+    policy: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const policyHtml = ref("");
 
     const md = useMarkdownIt();
 
     onMounted(async () => {
-      policy.value = md.render(await store.dispatch("GET_POLICY_TEXT"));
+      policyHtml.value = md.render(props.policy);
     });
 
     return {
-      policy,
+      policyHtml,
     };
   },
 });

--- a/src/components/UpdateInfo.vue
+++ b/src/components/UpdateInfo.vue
@@ -6,9 +6,7 @@
     <div class="q-pa-md">
       <template v-if="isUpdateAvailable">
         <h3>最新バージョン {{ latestVersion }} が見つかりました</h3>
-        <a href="https://voicevox.hiroshiba.jp/" target="_blank"
-          >ダウンロードページ</a
-        >
+        <a href="{{ downloadLink }}" target="_blank">ダウンロードページ</a>
         <hr />
       </template>
       <h3>アップデート履歴</h3>
@@ -35,69 +33,28 @@
 
 <script lang="ts">
 import { useStore } from "@/store";
-import { computed, defineComponent, ref } from "@vue/runtime-core";
+import { computed, defineComponent, PropType, ref } from "@vue/runtime-core";
 import { UpdateInfo } from "../type/preload";
 import semver from "semver";
 
 export default defineComponent({
-  setup() {
-    const store = useStore();
-
-    const updateInfos = ref<UpdateInfo[]>();
-    store.dispatch("GET_UPDATE_INFOS").then((obj) => (updateInfos.value = obj));
-
-    let isCheckingFinished = ref<boolean>(false);
-
-    // 最新版があるか調べる
-    const currentVersion = ref("");
-    const latestVersion = ref("");
-    window.electron
-      .getAppInfos()
-      .then((obj) => {
-        currentVersion.value = obj.version;
-      })
-      .then(() => {
-        fetch("https://api.github.com/repos/VOICEVOX/voicevox/releases", {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-          },
-        })
-          .then((response) => {
-            if (!response.ok) throw new Error("Network response was not ok.");
-            return response.json();
-          })
-          .then((json) => {
-            const newerVersion = json.find(
-              (item: { prerelease: boolean; tag_name: string }) => {
-                return (
-                  !item.prerelease &&
-                  semver.valid(currentVersion.value) &&
-                  semver.valid(item.tag_name) &&
-                  semver.lt(currentVersion.value, item.tag_name)
-                );
-              }
-            );
-            if (newerVersion) {
-              latestVersion.value = newerVersion.tag_name;
-            }
-            isCheckingFinished.value = true;
-          })
-          .catch((err) => {
-            throw new Error(err);
-          });
-      });
-
-    const isUpdateAvailable = computed(() => {
-      return isCheckingFinished.value && latestVersion.value !== "";
-    });
-
-    return {
-      isUpdateAvailable,
-      latestVersion,
-      updateInfos,
-    };
+  props: {
+    latestVersion: {
+      type: String,
+      required: false,
+    },
+    downloadLink: {
+      type: String,
+      required: false,
+    },
+    updateInfos: {
+      type: Array as PropType<UpdateInfo[]>,
+      required: false,
+    },
+    isUpdateAvailable: {
+      type: Boolean,
+      required: false,
+    },
   },
 });
 </script>

--- a/src/components/UpdateInfo.vue
+++ b/src/components/UpdateInfo.vue
@@ -10,17 +10,23 @@
         <hr />
       </template>
       <h3>アップデート履歴</h3>
-      <template v-for="(info, i) of updateInfos" :key="i">
+      <template v-for="(info, infoIndex) of updateInfos" :key="infoIndex">
         <h3>バージョン {{ info.version }}</h3>
         <ul>
-          <template v-for="(item, j) of info.descriptions" :key="j">
+          <template
+            v-for="(item, descriptionIndex) of info.descriptions"
+            :key="descriptionIndex"
+          >
             <li>{{ item }}</li>
           </template>
         </ul>
         <h4>貢献者リスト</h4>
         <p>
-          <template v-for="(item, j) of info.contributors" :key="j">
-            <span v-if="j > 0"> / </span>
+          <template
+            v-for="(item, contributorIndex) of info.contributors"
+            :key="contributorIndex"
+          >
+            <span v-if="contributorIndex > 0"> / </span>
             <a :href="`https://github.com/${item}`" target="_blank">{{
               item
             }}</a>

--- a/src/components/UpdateInfo.vue
+++ b/src/components/UpdateInfo.vue
@@ -32,10 +32,8 @@
 </template>
 
 <script lang="ts">
-import { useStore } from "@/store";
-import { computed, defineComponent, PropType, ref } from "@vue/runtime-core";
+import { defineComponent, PropType } from "@vue/runtime-core";
 import { UpdateInfo } from "../type/preload";
-import semver from "semver";
 
 export default defineComponent({
   props: {

--- a/src/components/UpdateInfo.vue
+++ b/src/components/UpdateInfo.vue
@@ -4,7 +4,31 @@
     class="relative-absolute-wrapper scroller markdown-body"
   >
     <div class="q-pa-md">
-      <div v-html="html"></div>
+      <template v-if="isUpdateAvailable">
+        <h3>最新バージョン {{ latestVersion }} が見つかりました</h3>
+        <a href="https://voicevox.hiroshiba.jp/" target="_blank"
+          >ダウンロードページ</a
+        >
+        <hr />
+      </template>
+      <h3>アップデート履歴</h3>
+      <template v-for="(info, i) of updateInfos" :key="i">
+        <h3>バージョン {{ info.version }}</h3>
+        <ul>
+          <template v-for="(item, j) of info.descriptions" :key="j">
+            <li>{{ item }}</li>
+          </template>
+        </ul>
+        <h4>貢献者リスト</h4>
+        <p>
+          <template v-for="(item, j) of info.contributors" :key="j">
+            <span v-if="j > 0"> / </span>
+            <a :href="`https://github.com/${item}`" target="_blank">{{
+              item
+            }}</a>
+          </template>
+        </p>
+      </template>
     </div>
   </q-page>
 </template>
@@ -45,7 +69,7 @@ export default defineComponent({
             return response.json();
           })
           .then((json) => {
-            const obj = json.find(
+            const newerVersion = json.find(
               (item: { prerelease: boolean; tag_name: string }) => {
                 return (
                   !item.prerelease &&
@@ -55,7 +79,9 @@ export default defineComponent({
                 );
               }
             );
-            obj ? (latestVersion.value = obj.tag_name) : undefined;
+            if (newerVersion) {
+              latestVersion.value = newerVersion.tag_name;
+            }
             isCheckingFinished.value = true;
           })
           .catch((err) => {
@@ -67,43 +93,10 @@ export default defineComponent({
       return isCheckingFinished.value && latestVersion.value !== "";
     });
 
-    const html = computed(() => {
-      if (!updateInfos.value) return "";
-
-      let html = "";
-
-      if (isUpdateAvailable.value) {
-        html += `<h3>最新バージョン ${latestVersion.value} が見つかりました</h3>`;
-        html += `<a href="https://voicevox.hiroshiba.jp/" target="_blank">ダウンロードページ</a>`;
-      }
-
-      html += `<hr />`;
-      html += `<h3>アップデート履歴</h3>`;
-
-      for (const info of updateInfos.value) {
-        const version: string = info.version;
-        const descriptions: string[] = info.descriptions;
-        const contributors: string[] = info.contributors;
-
-        html += `<h3>バージョン ${version}</h3>`;
-
-        html += `<ul>`;
-        for (const description of descriptions) {
-          html += `<li>${description}</li>`;
-        }
-        html += `</ul>`;
-
-        if (contributors.length > 0) {
-          html += `<h4>貢献者リスト</h4>`;
-          html += `<p>${contributors.join(" / ")}</p>`;
-        }
-      }
-
-      return html;
-    });
-
     return {
-      html,
+      isUpdateAvailable,
+      latestVersion,
+      updateInfos,
     };
   },
 });


### PR DESCRIPTION
## 内容

ヘルプにエンジン毎の項目を表示するようにします。

## 関連 Issue

- ref: voicevox/voicevox_project#2： ヘルプの移動 

## スクリーンショット・動画など

![image](https://cdn.discordapp.com/attachments/893889888208977960/1021265903670800394/unknown.png)
![image](https://user-images.githubusercontent.com/59691627/190946716-c78c0192-6540-43f8-a23e-1443167ce2f9.png)

![image](https://user-images.githubusercontent.com/59691627/190946701-73149dac-db74-4b00-9c1c-284266d189cf.png)
![image](https://user-images.githubusercontent.com/59691627/190946708-5b641836-1b4d-4878-b2b1-8a60cd87cc22.png)


## その他

（なし）