### PR TITLE
キャンセルボタンの位置を統一

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -214,17 +214,17 @@
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="saveWord"
-                :disable="uiLocked || !isWordChanged"
-                >保存</q-btn
+                @click="isWordChanged ? discardOrNotDialog(cancel) : cancel()"
+                :disable="uiLocked"
+                >キャンセル</q-btn
               >
               <q-btn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="isWordChanged ? discardOrNotDialog(cancel) : cancel()"
-                :disable="uiLocked"
-                >キャンセル</q-btn
+                @click="saveWord"
+                :disable="uiLocked || !isWordChanged"
+                >保存</q-btn
               >
             </div>
           </div>

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -147,6 +147,15 @@
       <q-card-actions align="center">
         <q-btn
           padding="xs md"
+          label="キャンセル"
+          unelevated
+          color="surface"
+          text-color="display"
+          class="q-mt-sm"
+          @click="closeHotkeyDialog"
+        />
+        <q-btn
+          padding="xs md"
           label="ショートカットキーを未設定にする"
           unelevated
           color="surface"
@@ -156,15 +165,6 @@
             deleteHotkey(lastAction);
             closeHotkeyDialog();
           "
-        />
-        <q-btn
-          padding="xs md"
-          label="キャンセル"
-          unelevated
-          color="surface"
-          text-color="display"
-          class="q-mt-sm"
-          @click="closeHotkeyDialog"
         />
         <q-btn
           v-if="duplicatedHotkey == undefined"


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

キャンセルボタンの位置を左に統一しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

ref #903

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
<img width="1205" alt="スクリーンショット 2022-09-19 20 34 06" src="https://user-images.githubusercontent.com/16268532/191010354-5f54b8ec-97b0-4086-ac6a-970942675623.png">

<img width="1216" alt="スクリーンショット 2022-09-19 20 31 32" src="https://user-images.githubusercontent.com/16268532/191010414-91765007-e1d9-49e2-806d-f10dc8128166.png">

## その他

ショートカットキーの画面も一応左に移動しておりますが、こちら不要でしたらお知らせください。
他何かありましたら、微力ながらご協力させていただきます。

