### PR TITLE
Add: ドラッグでボタンの並びを変更できるように

### DIFF
--- a/src/components/HeaderBarCustomDialog.vue
+++ b/src/components/HeaderBarCustomDialog.vue
@@ -52,10 +52,13 @@
                 @end="toolbarButtonDragging = false"
               >
                 <template v-slot:item="{ element: button }">
-                  <div
+                  <q-btn
+                    unelevated
+                    color="toolbar-button"
+                    text-color="toolbar-button-display"
                     :class="
-                      (button === 'EMPTY' ? 'radio-space' : 'radio') +
-                      ' text-no-wrap text-bold text-display q-mr-sm'
+                      (button === 'EMPTY' ? ' radio-space' : ' radio') +
+                      ' text-no-wrap text-bold q-mr-sm'
                     "
                   >
                     {{ getToolbarButtonName(button) }}
@@ -70,7 +73,7 @@
                       }"
                       >{{ usableButtonsDesc[button] }}</q-tooltip
                     >
-                  </div>
+                  </q-btn>
                 </template>
               </draggable>
               <div class="preview-toolbar-drag-hint">
@@ -358,10 +361,9 @@ export default defineComponent({
   border-radius: 3px;
   color: var(--color-toolbar-button-display);
   background-color: var(--color-toolbar-button);
-}
-
-.radio:hover {
-  cursor: grab;
+  &:hover {
+    cursor: grab;
+  }
 }
 
 .radio-space {

--- a/src/components/HeaderBarCustomDialog.vue
+++ b/src/components/HeaderBarCustomDialog.vue
@@ -356,11 +356,6 @@ export default defineComponent({
 }
 
 .radio {
-  padding: 6px 14px;
-  border: solid 2px var(--color-toolbar-button);
-  border-radius: 3px;
-  color: var(--color-toolbar-button-display);
-  background-color: var(--color-toolbar-button);
   &:hover {
     cursor: grab;
   }

--- a/src/components/HeaderBarCustomDialog.vue
+++ b/src/components/HeaderBarCustomDialog.vue
@@ -320,7 +320,7 @@ export default defineComponent({
 }
 
 .preview-toolbar {
-  height: calc(vars.$header-height + 16px);
+  height: calc(#{vars.$header-height} + 8px);
   display: block;
 }
 

--- a/src/components/HeaderBarCustomDialog.vue
+++ b/src/components/HeaderBarCustomDialog.vue
@@ -45,7 +45,12 @@
         <q-page>
           <q-card flat square class="preview-card">
             <q-toolbar class="bg-toolbar preview-toolbar">
-              <draggable v-model="toolbarButtons" :item-key="toolbarButtonKey">
+              <draggable
+                v-model="toolbarButtons"
+                :item-key="toolbarButtonKey"
+                @start="toolbarButtonDragging = true"
+                @end="toolbarButtonDragging = false"
+              >
                 <template v-slot:item="{ element: button }">
                   <div
                     :class="
@@ -60,6 +65,9 @@
                       self="center right"
                       transition-show="jump-left"
                       transition-hide="jump-right"
+                      :style="{
+                        display: toolbarButtonDragging ? 'none' : 'block',
+                      }"
                       >{{ usableButtonsDesc[button] }}</q-tooltip
                     >
                   </div>
@@ -125,6 +133,7 @@ export default defineComponent({
     // computedだと値の編集ができないが、refにすると起動時に読み込まれる設定が反映されないので、watchしている
     const toolbarButtons = ref([...store.state.toolbarSetting]);
     const toolbarButtonKey = (button: ToolbarButtonTagType) => button;
+    const toolbarButtonDragging = ref(false);
     const selectedButton: Ref<ToolbarButtonTagType | undefined> = ref(
       toolbarButtons.value[0]
     );
@@ -167,17 +176,6 @@ export default defineComponent({
       get: () => props.modelValue || isChanged.value,
       set: (val) => emit("update:modelValue", val),
     });
-
-    const leftShiftable = computed(
-      () => selectedButton.value !== toolbarButtons.value[0] && removable.value
-    );
-    const rightShiftable = computed(
-      () =>
-        selectedButton.value !==
-          toolbarButtons.value[toolbarButtons.value.length - 1] &&
-        removable.value
-    );
-    const removable = computed(() => selectedButton.value !== undefined);
 
     const isChanged = computed(() => {
       const nowSetting = store.state.toolbarSetting;
@@ -290,10 +288,8 @@ export default defineComponent({
       headerBarCustomDialogOpenComputed,
       toolbarButtons,
       toolbarButtonKey,
+      toolbarButtonDragging,
       selectedButton,
-      leftShiftable,
-      rightShiftable,
-      removable,
       isChanged,
       isDefault,
       moveLeftButton,


### PR DESCRIPTION
## 内容

ツールバーのカスタム画面にあるボタンをドラッグ&ドロップで入れ替えられるようにします。

## 関連 Issue

（なし）
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

https://user-images.githubusercontent.com/59691627/191862191-f1af6f5f-be62-476e-b236-565c7f2de7d9.mp4



## その他

（なし）
