### PR TITLE
最大化状態で起動しても最大化ボタンのアイコンが変わらないのを修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1115,7 +1115,7 @@ ipcMainHandle("IS_AVAILABLE_GPU_MODE", () => {
   return hasSupportedGpu(process.platform);
 });
 
-ipcMainHandle("IS_MAXIMIZED", () => {
+ipcMainHandle("IS_MAXIMIZED_WINDOW", () => {
   return win.isMaximized();
 });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1115,6 +1115,10 @@ ipcMainHandle("IS_AVAILABLE_GPU_MODE", () => {
   return hasSupportedGpu(process.platform);
 });
 
+ipcMainHandle("IS_MAXIMIZED", () => {
+  return win.isMaximized();
+});
+
 ipcMainHandle("CLOSE_WINDOW", () => {
   willQuit = true;
   win.destroy();

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -158,8 +158,8 @@ const api: Sandbox = {
     return ipcRendererInvoke("IS_AVAILABLE_GPU_MODE");
   },
 
-  isMaximized: () => {
-    return ipcRendererInvoke("IS_MAXIMIZED");
+  isMaximizedWindow: () => {
+    return ipcRendererInvoke("IS_MAXIMIZED_WINDOW");
   },
 
   onReceivedIPCMsg: (channel, callback) => {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -158,8 +158,8 @@ const api: Sandbox = {
     return ipcRendererInvoke("IS_AVAILABLE_GPU_MODE");
   },
 
-  isMaximized: async () => {
-    return await ipcRendererInvoke("IS_MAXIMIZED");
+  isMaximized: () => {
+    return ipcRendererInvoke("IS_MAXIMIZED");
   },
 
   onReceivedIPCMsg: (channel, callback) => {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -158,6 +158,10 @@ const api: Sandbox = {
     return ipcRendererInvoke("IS_AVAILABLE_GPU_MODE");
   },
 
+  isMaximized: async () => {
+    return await ipcRendererInvoke("IS_MAXIMIZED");
+  },
+
   onReceivedIPCMsg: (channel, callback) => {
     return ipcRendererOn(channel, callback);
   },

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -344,6 +344,12 @@ export const uiStore = createPartialStore<UiStoreTypes>({
           "activePointScrollMode"
         ),
       });
+
+      // electron-window-stateがvuex初期化前に働くので
+      // ここで改めてelectron windowの最大化状態をVuex storeに同期
+      if (await window.electron.isMaximized()) {
+        commit("DETECT_MAXIMIZED");
+      }
     },
   },
 

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -347,7 +347,7 @@ export const uiStore = createPartialStore<UiStoreTypes>({
 
       // electron-window-stateがvuex初期化前に働くので
       // ここで改めてelectron windowの最大化状態をVuex storeに同期
-      if (await window.electron.isMaximized()) {
+      if (await window.electron.isMaximizedWindow()) {
         commit("DETECT_MAXIMIZED");
       }
     },

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -146,7 +146,7 @@ export type IpcIHData = {
     return: boolean;
   };
 
-  IS_MAXIMIZED: {
+  IS_MAXIMIZED_WINDOW: {
     args: [];
     return: boolean;
   };

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -146,6 +146,11 @@ export type IpcIHData = {
     return: boolean;
   };
 
+  IS_MAXIMIZED: {
+    args: [];
+    return: boolean;
+  };
+
   CLOSE_WINDOW: {
     args: [];
     return: void;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -67,7 +67,7 @@ export interface Sandbox {
   readFile(obj: { filePath: string }): Promise<ArrayBuffer>;
   openTextEditContextMenu(): Promise<void>;
   isAvailableGPUMode(): Promise<boolean>;
-  isMaximized(): Promise<boolean>;
+  isMaximizedWindow(): Promise<boolean>;
   onReceivedIPCMsg<T extends keyof IpcSOData>(
     channel: T,
     listener: (event: IpcRendererEvent, ...args: IpcSOData[T]["args"]) => void

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -67,6 +67,7 @@ export interface Sandbox {
   readFile(obj: { filePath: string }): Promise<ArrayBuffer>;
   openTextEditContextMenu(): Promise<void>;
   isAvailableGPUMode(): Promise<boolean>;
+  isMaximized(): Promise<boolean>;
   onReceivedIPCMsg<T extends keyof IpcSOData>(
     channel: T,
     listener: (event: IpcRendererEvent, ...args: IpcSOData[T]["args"]) => void


### PR DESCRIPTION
## 内容
ウィンドウの最大化状態がvuexに反映されてなかったのが原因だったので、
今最大化状態か問い合わせるipcメッセージを追加してstore初期化時に呼ぶようにしました。

## 関連 Issue
close #851 

## 動作確認
- 最大化した状態でウィンドウを閉じ、再度起動した際に右上のアイコンが最大化状態になっている
- 元々 `electron:serve` では再現しない問題だったため、
    - `electron:build_pnever` でビルド
    -  `dist_electron/win-unpacked` に `.env` ファイルをコピー
    -  `dist_electron/win-unpacked/electron.exe` を起動
- で再現確認＋動作確認しました
