### PR TITLE
右端のスライダーツールチップが見切れないようにした

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -893,6 +893,10 @@ $pitch-label-height: 24px;
       align-self: stretch;
       grid-template-rows: 1fr 60px 30px;
 
+      &:last-child {
+        padding-right: 20px;
+      }
+
       div {
         padding: 0px;
         &.text-cell {


### PR DESCRIPTION
## 内容
右端にのみ余白を追加してスライダーのツールチップが見切れないようにしました。
cssのlast-childセレクタで実現しています。

## 関連 Issue
close #857 

## 動作確認
- 下ペインに横スクロールバーが出る状態で、右端のスライダーツールチップが見切れないことを確認
- 右端以外に影響が出ないことを確認

## スクリーンショット・動画など
### before
![2](https://user-images.githubusercontent.com/241973/191894559-29269df6-a2e2-4537-8b9f-69ebcd21806d.png)

### after
![1](https://user-images.githubusercontent.com/241973/191894570-8b8b5b5c-505e-4940-b211-133021d3cfb5.png)

### after他のタブ
![a1](https://user-images.githubusercontent.com/241973/191894641-1be370b5-e59d-4375-b3be-2e26397d7b6b.png)
![a2](https://user-images.githubusercontent.com/241973/191894648-88fc6f33-f68f-47ef-8b44-b49587aa29ac.png)
![a3](https://user-images.githubusercontent.com/241973/191894650-efd4c25c-a5fc-480e-ab2e-1dfa219d8218.png)
