### PR TITLE
複数エンジン対応：エンジンのフォルダを開くボタンを追加

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -119,9 +119,10 @@ const defaultEngineInfos: EngineInfo[] = (() => {
   });
 })();
 
+const userEngineDir = path.join(app.getPath("userData"), "engines");
+
 // ユーザーディレクトリにあるエンジンを取得する
 function fetchEngineInfosFromUserDirectory(): EngineInfo[] {
-  const userEngineDir = path.join(app.getPath("userData"), "engines");
   if (!fs.existsSync(userEngineDir)) {
     fs.mkdirSync(userEngineDir);
   }
@@ -1125,6 +1126,12 @@ ipcMainHandle("RESTART_ENGINE", async (_, { engineId }) => {
 
 ipcMainHandle("OPEN_ENGINE_DIRECTORY", async (_, { engineId }) => {
   openEngineDirectory(engineId);
+});
+
+ipcMainHandle("OPEN_USER_ENGINE_DIRECTORY", () => {
+  // Windows環境だとスラッシュ区切りのパスが動かない。
+  // path.resolveはWindowsだけバックスラッシュ区切りにしてくれるため、path.resolveを挟む。
+  shell.openPath(path.resolve(userEngineDir));
 });
 
 ipcMainHandle("HOTKEY_SETTINGS", (_, { newData }) => {

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -413,15 +413,6 @@ export default defineComponent({
       if (Object.values(engineInfos.value).length === 1) {
         const engineInfo = Object.values(engineInfos.value)[0];
         engineMenu.subMenu = [
-          engineInfo.path && {
-            type: "button",
-            label: "フォルダを開く",
-            onClick: () => {
-              store.dispatch("OPEN_ENGINE_DIRECTORY", {
-                engineId: engineInfo.uuid,
-              });
-            },
-          },
           {
             type: "button",
             label: "再起動",
@@ -478,6 +469,13 @@ export default defineComponent({
           },
         ];
       }
+      engineMenu.subMenu.push({
+        type: "button",
+        label: "エンジンのフォルダを開く",
+        onClick: () => {
+          store.dispatch("OPEN_USER_ENGINE_DIRECTORY");
+        },
+      });
     }
     watch([engineInfos, engineManifests], updateEngines, { immediate: true }); // engineInfos、engineManifestsを見て動的に更新できるようにする
 

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -202,6 +202,10 @@ const api: Sandbox = {
     return ipcRendererInvoke("OPEN_ENGINE_DIRECTORY", { engineId });
   },
 
+  openUserEngineDirectory: () => {
+    return ipcRendererInvoke("OPEN_USER_ENGINE_DIRECTORY");
+  },
+
   checkFileExists: (file) => {
     return ipcRenderer.invoke("CHECK_FILE_EXISTS", { file });
   },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -365,6 +365,12 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
+  OPEN_USER_ENGINE_DIRECTORY: {
+    action() {
+      return window.electron.openUserEngineDirectory();
+    },
+  },
+
   SET_ENGINE_STATE: {
     mutation(
       state,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -158,6 +158,10 @@ export type AudioStoreTypes = {
     action(payload: { engineId: string }): void;
   };
 
+  OPEN_USER_ENGINE_DIRECTORY: {
+    action(): void;
+  };
+
   SET_ENGINE_STATE: {
     mutation: { engineId: string; engineState: EngineState };
   };

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -196,6 +196,11 @@ export type IpcIHData = {
     return: void;
   };
 
+  OPEN_USER_ENGINE_DIRECTORY: {
+    args: [];
+    return: void;
+  };
+
   CHECK_FILE_EXISTS: {
     args: [obj: { file: string }];
     return: boolean;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -81,6 +81,7 @@ export interface Sandbox {
   restartEngineAll(): Promise<void>;
   restartEngine(engineId: string): Promise<void>;
   openEngineDirectory(engineId: string): void;
+  openUserEngineDirectory(): void;
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   checkFileExists(file: string): Promise<boolean>;
   changePinWindow(): void;


### PR DESCRIPTION
## 内容

「エンジンのフォルダを開く」ボタンを追加します。

## 関連 Issue

- ref: voicevox/voicevox_project#2：ユーザーディレクトリのenginesディレクトリを開く機能

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/59691627/192476167-19f344ad-82a5-4038-b692-98001037a321.png)
![image](https://user-images.githubusercontent.com/59691627/192478273-8f40c0b5-82a4-4c93-a6ba-3067a828c1b3.png)


## その他

多分もっといい表現があると思います。（「拡張エンジン」とか…？）