### PR TITLE
Fix: Engine Manifestを起動後に読み込むように

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -469,9 +469,11 @@ export default defineComponent({
     const isCompletedInitialStartup = ref(false);
     onMounted(async () => {
       await store.dispatch("GET_ENGINE_INFOS");
-      await store.dispatch("FETCH_AND_SET_ENGINE_MANIFESTS");
 
       await store.dispatch("START_WAITING_ENGINE_ALL");
+
+      await store.dispatch("FETCH_AND_SET_ENGINE_MANIFESTS");
+
       await store.dispatch("LOAD_CHARACTER_ALL");
       await store.dispatch("LOAD_USER_CHARACTER_ORDER");
       await store.dispatch("LOAD_DEFAULT_STYLE_IDS");


### PR DESCRIPTION
## 内容

`FETCH_AND_SET_ENGINE_MANIFESTS`を`START_WAITING_ENGINE_ALL`の後に読み込むようにします。

## 関連 Issue

- close: #940 

## スクリーンショット・動画など

（なし）

## その他

いつもはエンジンを別で動かして常時稼働していたため問題に気がつけませんでした。ごめんなさい。
