### PR TITLE
初回起動時のデフォルトスタイルID選択のとき、「ノーマル」を最初から選ばれている状態にする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1084,11 +1084,6 @@ ipcMainHandle("CHANGE_PIN_WINDOW", () => {
   }
 });
 
-ipcMainHandle("IS_UNSET_DEFAULT_STYLE_ID", (_, speakerUuid) => {
-  const defaultStyleIds = store.get("defaultStyleIds");
-  return !defaultStyleIds.find((style) => style.speakerUuid === speakerUuid);
-});
-
 ipcMainHandle("GET_DEFAULT_HOTKEY_SETTINGS", () => {
   return defaultHotkeySettings;
 });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -206,10 +206,6 @@ const api: Sandbox = {
     return ipcRenderer.invoke("HOTKEY_SETTINGS", { newData });
   },
 
-  isUnsetDefaultStyleId: async (speakerUuid: string) => {
-    return await ipcRendererInvoke("IS_UNSET_DEFAULT_STYLE_ID", speakerUuid);
-  },
-
   getDefaultHotkeySettings: async () => {
     return await ipcRendererInvoke("GET_DEFAULT_HOTKEY_SETTINGS");
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -132,16 +132,12 @@ export const indexStore: VoiceVoxStoreOptions<
       );
       return newSpeakerUuid;
     },
-    async IS_UNSET_DEFAULT_STYLE_ID(_, { speakerUuid }) {
-      return await window.electron.isUnsetDefaultStyleId(speakerUuid);
-    },
     async LOAD_DEFAULT_STYLE_IDS({ commit, state }) {
       let defaultStyleIds = await window.electron.getSetting("defaultStyleIds");
 
       if (!state.characterInfos) throw new Error("characterInfos is undefined");
 
       // デフォルトスタイルが設定されていない場合は0をセットする
-      // FIXME: 保存しているものとstateのものが異なってしまうので良くない。デフォルトスタイルが未設定の場合はAudioCellsを表示しないようにすべき
       const unsetCharacterInfos = state.characterInfos.filter(
         (characterInfo) =>
           !defaultStyleIds.some(

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -712,10 +712,6 @@ type IndexStoreTypes = {
     action(): Promise<string>;
   };
 
-  IS_UNSET_DEFAULT_STYLE_ID: {
-    action(payload: { speakerUuid: string }): Promise<boolean>;
-  };
-
   LOAD_DEFAULT_STYLE_IDS: {
     action(): Promise<void>;
   };

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -201,11 +201,6 @@ export type IpcIHData = {
     return: HotkeySetting[];
   };
 
-  IS_UNSET_DEFAULT_STYLE_ID: {
-    args: [speakerUuid: string];
-    return: boolean;
-  };
-
   GET_DEFAULT_HOTKEY_SETTINGS: {
     args: [];
     return: HotkeySetting[];

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -83,7 +83,6 @@ export interface Sandbox {
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   checkFileExists(file: string): Promise<boolean>;
   changePinWindow(): void;
-  isUnsetDefaultStyleId(speakerUuid: string): Promise<boolean>;
   getDefaultHotkeySettings(): Promise<HotkeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
   theme(newData?: string): Promise<ThemeSetting | void>;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -476,18 +476,6 @@ export default defineComponent({
       const newCharacters = await store.dispatch("GET_NEW_CHARACTERS");
       isCharacterOrderDialogOpenComputed.value = newCharacters.length > 0;
 
-      // スタイルが複数あって未選択なキャラがいる場合はデフォルトスタイル選択ダイアログを表示
-      let isUnsetDefaultStyleIds = false;
-      if (characterInfos.value == undefined) throw new Error();
-      for (const info of characterInfos.value) {
-        isUnsetDefaultStyleIds ||=
-          info.metas.styles.length > 1 &&
-          (await store.dispatch("IS_UNSET_DEFAULT_STYLE_ID", {
-            speakerUuid: info.metas.speakerUuid,
-          }));
-      }
-      isDefaultStyleSelectDialogOpenComputed.value = isUnsetDefaultStyleIds;
-
       // 最初のAudioCellを作成
       const audioItem: AudioItem = await store.dispatch(
         "GENERATE_AUDIO_ITEM",


### PR DESCRIPTION
## 内容

タイトルのとおりです。
0.13.2でスタイル持ちのキャラクターが倍ほどに増えるので、issueにある通り初回のスタイル選択ダイアログを出ないようにします
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #885
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
