### PR TITLE
Fix: スクロールバーを表示しないように

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -609,14 +609,10 @@ export default defineComponent({
   }
   .engine-icon {
     position: absolute;
-    bottom: 0;
-    right: 0;
-    transform: translate(50%, 50%);
-
-    :deep(img) {
-      width: 27.5% !important;
-      height: 27.5% !important;
-    }
+    width: 13px;
+    height: 13px;
+    bottom: -6px;
+    right: -6px;
   }
 }
 </style>


### PR DESCRIPTION
## 内容

キャラクターのスタイル選択にて、q-avatarのサイズが変わっていなかったためスクロールバーが表示されていました。これを修正します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/59691627/193429250-46a117fd-8249-46e4-a1c9-02b073d6fb04.png)

## その他

（なし）