### PR TITLE
複数エンジン対応：複数の辞書に対する操作を追加

### DIFF
--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1144,6 +1144,9 @@ export type DictionaryStoreTypes = {
       engineId: string;
     }): Promise<Record<string, UserDictWord>>;
   };
+  LOAD_ALL_USER_DICT: {
+    action(): Promise<Record<string, UserDictWord>>;
+  };
   ADD_WORD: {
     action(payload: {
       surface: string;
@@ -1163,6 +1166,9 @@ export type DictionaryStoreTypes = {
   };
   DELETE_WORD: {
     action(payload: { wordUuid: string }): Promise<void>;
+  };
+  SYNC_ALL_USER_DICT: {
+    action(): Promise<void>;
   };
 };
 


### PR DESCRIPTION
## 内容

複数の辞書に対する動作を追加します。

## 関連 Issue

- ref: voicevox/voicevox_project#2：辞書の同期 

## スクリーンショット・動画など

（なし）

## その他

（なし）