### PR TITLE
CI: 自動作成されるリリースのタグの場所を正しくする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -874,64 +874,55 @@ jobs:
 
       - name: Upload Linux AppImage splitted archives to Release assets
         if: endsWith(matrix.artifact_name, '-appimage')
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           prerelease: ${{ github.event.inputs.prerelease }}
-          file_glob: true
-          file: artifact/*.7z.*
+          tag_name: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          files: |-
+            artifact/*.7z.*
+          target_commitish: ${{ github.sha }}
 
       # Windows NSIS Web
       - name: Upload Windows nsis-web archives to Release assets
         if: endsWith(matrix.artifact_name, '-nsis-web')
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           prerelease: ${{ github.event.inputs.prerelease }}
-          file_glob: true
-          file: artifact/*.7z.*
-
-      - name: Upload Windows nsis-web installer to Release assets
-        if: endsWith(matrix.artifact_name, '-nsis-web')
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
-          prerelease: ${{ github.event.inputs.prerelease }}
-          file_glob: true
-          file: artifact/*.exe
+          tag_name: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          files: |-
+            artifact/*.7z.*
+            artifact/*.exe
+          target_commitish: ${{ github.sha }}
 
       # macOS dmg
       - name: Upload macOS dmg to Release assets
         if: endsWith(matrix.artifact_name, '-dmg')
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           prerelease: ${{ github.event.inputs.prerelease }}
-          file_glob: true
-          file: artifact/*.dmg
+          tag_name: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          files: |-
+            artifact/*.dmg
+          target_commitish: ${{ github.sha }}
 
       # targz
       - name: Upload targz to Release assets
         if: endsWith(matrix.artifact_name, '-targz')
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           prerelease: ${{ github.event.inputs.prerelease }}
-          file_glob: true
-          file: artifact/*.tar.gz
+          tag_name: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          files: |-
+            artifact/*.tar.gz
+          target_commitish: ${{ github.sha }}
 
       # zip
       - name: Upload zip to Release assets
         if: endsWith(matrix.artifact_name, '-zip')
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.VOICEVOX_EDITOR_VERSION }}
           prerelease: ${{ github.event.inputs.prerelease }}
-          file_glob: true
-          file: artifact/*.zip
+          tag_name: ${{ env.VOICEVOX_EDITOR_VERSION }}
+          files: |-
+            artifact/*.zip
+          target_commitish: ${{ github.sha }}


### PR DESCRIPTION
## 内容

`svenstaro/upload-release-action@v2`で自動作成されたリリースに紐づくtagが、メインブランチの最新コミットを指してしまう問題を修正し、CIが実行されたコミットを指すようにします。
tagのコミットIDを指定できる、`softprops/action-gh-release@v1`を使用するように変更しました。

- 動作確認: <https://github.com/aoirint/voicevox/actions/runs/3270820503>
    - 自動作成されたリリース: <https://github.com/aoirint/voicevox/releases/tag/0.13.0-aoirint.1>

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- ref <https://github.com/VOICEVOX/voicevox/issues/904>
    - コア、エンジン、エディタの修正ができてcloseと思うのでref
- ref <https://github.com/VOICEVOX/voicevox_core/pull/311>
- ref <https://github.com/VOICEVOX/voicevox_engine/pull/489>

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
