### PR TITLE
project-s: 初期化とシンガー・楽譜を設定するaction/mutationを追加

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1,4 +1,4 @@
-import { SingingStoreState, SingingStoreTypes } from "./type";
+import { Score, SingingStoreState, SingingStoreTypes } from "./type";
 import { createPartialStore } from "./vuex";
 
 export const singingStoreState: SingingStoreState = {
@@ -19,6 +19,76 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       commit("SET_SHOW_SINGER", {
         isShowSinger,
       });
+    },
+  },
+
+  SET_SINGER: {
+    mutation(
+      state,
+      { engineId, styleId }: { engineId: string; styleId: number }
+    ) {
+      state.engineId = engineId;
+      state.styleId = styleId;
+    },
+    async action(
+      { state, getters, dispatch, commit },
+      payload: { engineId?: string; styleId?: number }
+    ) {
+      if (state.defaultStyleIds == undefined)
+        throw new Error("state.defaultStyleIds == undefined");
+      if (getters.USER_ORDERED_CHARACTER_INFOS == undefined)
+        throw new Error("state.characterInfos == undefined");
+      const userOrderedCharacterInfos = getters.USER_ORDERED_CHARACTER_INFOS;
+
+      const engineId = payload.engineId ?? state.engineIds[0];
+
+      // FIXME: engineIdも含めて探査する
+      const styleId =
+        payload.styleId ??
+        state.defaultStyleIds[
+          state.defaultStyleIds.findIndex(
+            (x) =>
+              x.speakerUuid === userOrderedCharacterInfos[0].metas.speakerUuid // FIXME: defaultStyleIds内にspeakerUuidがない場合がある
+          )
+        ].defaultStyleId;
+
+      try {
+        // 指定されたstyleIdに対して、エンジン側の初期化を行う
+        const isInitialized = await dispatch("IS_INITIALIZED_ENGINE_SPEAKER", {
+          engineId,
+          styleId,
+        });
+        if (!isInitialized) {
+          await dispatch("INITIALIZE_ENGINE_SPEAKER", {
+            engineId,
+            styleId,
+          });
+        }
+      } finally {
+        commit("SET_SINGER", { engineId, styleId });
+      }
+    },
+  },
+
+  GET_DEFAULT_SCORE: {
+    async action() {
+      const score: Score = {
+        resolution: 480,
+        // テンポの初期値は120で良いでしょうか？
+        tempos: [{ position: 0, tempo: 120 }],
+        timeSignatures: [{ position: 0, beats: 4, beatType: 4 }],
+        notes: [],
+      };
+      return score;
+    },
+  },
+
+  SET_SCORE: {
+    mutation(state, { score }: { score: Score }) {
+      state.score = score;
+    },
+    async action({ commit }, { score }: { score: Score }) {
+      commit("SET_SCORE", { score });
     },
   },
 });

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -708,6 +708,20 @@ export type SingingStoreTypes = {
     mutation: { isShowSinger: boolean };
     action(payload: { isShowSinger: boolean }): void;
   };
+
+  SET_SINGER: {
+    mutation: { engineId: string; styleId: number };
+    action(payload: { engineId?: string; styleId?: number }): void;
+  };
+
+  GET_DEFAULT_SCORE: {
+    action(): Promise<Score>;
+  };
+
+  SET_SCORE: {
+    mutation: { score: Score };
+    action(payload: { score: Score }): void;
+  };
 };
 
 /*

--- a/src/views/SingerHome.vue
+++ b/src/views/SingerHome.vue
@@ -16,11 +16,11 @@ import {
   //computed,
   defineComponent,
   //onBeforeUpdate,
-  //onMounted,
+  onMounted,
   //ref,
   //watch,
 } from "vue";
-// import { useStore } from "@/store";
+import { useStore } from "@/store";
 // import { QResizeObserver, useQuasar } from "quasar";
 // import path from "path";
 
@@ -43,8 +43,26 @@ export default defineComponent({
   },
 
   setup() {
-    //const store = useStore();
+    const store = useStore();
     //const $q = useQuasar();
+
+    // 歌声合成エディターの初期化
+    onMounted(async () => {
+      await store.dispatch("SET_SINGER", {});
+
+      const score = await store.dispatch("GET_DEFAULT_SCORE");
+
+      // 実装時の確認用です TODO: 必要なくなったら削除
+      score.notes = [
+        { position: 0, duration: 480, midi: 60, lyric: "ら" },
+        { position: 480, duration: 480, midi: 62, lyric: "ら" },
+        { position: 960, duration: 480, midi: 64, lyric: "ら" },
+        { position: 1440, duration: 480, midi: 65, lyric: "ら" },
+        { position: 1920, duration: 1920, midi: 67, lyric: "ら" },
+      ];
+
+      await store.dispatch("SET_SCORE", { score });
+    });
     return null;
   },
 });


### PR DESCRIPTION
## 内容

SingingStoreStateの初期化と、以下のaction/mutationを追加します。
- シンガーの設定
- デフォルトScoreの取得
- Scoreの設定

デフォルトシンガーの設定は、ひとまずSET_SINGERで行っています。
ご意見、ご指摘等いただけますと幸いです。

## 関連 Issue
ref VOICEVOX/voicevox_project#15
ref #981
