### PR TITLE
Refactor: engine関連のstoreを分離

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -3,7 +3,6 @@ import path from "path";
 import { v4 as uuidv4 } from "uuid";
 import {
   AudioItem,
-  EngineState,
   SaveResultObject,
   State,
   AudioStoreState,
@@ -182,7 +181,6 @@ const audioBlobCache: Record<string, Blob> = {};
 const audioElements: Record<string, HTMLAudioElement> = {};
 
 export const audioStoreState: AudioStoreState = {
-  engineStates: {},
   characterInfos: {},
   audioItems: {},
   audioKeys: [],
@@ -214,169 +212,11 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
-  IS_ALL_ENGINE_READY: {
-    getter: (state, getters) => {
-      // NOTE: 1つもエンジンが登録されていない場合、準備完了していないことにする
-      // レンダラープロセスがメインプロセスからエンジンリストを取得完了する前にレンダリングが行われるため、
-      // IS_ALL_ENGINE_READYがエンジンリスト未初期化の状態で呼び出される可能性がある
-      // この場合の意図しない挙動を抑制するためfalseを返す
-      if (state.engineIds.length === 0) {
-        return false;
-      }
-
-      for (const engineId of state.engineIds) {
-        const isReady = getters.IS_ENGINE_READY(engineId);
-        if (!isReady) return false;
-      }
-      return true; // state.engineStatesが空のときはtrue
-    },
-  },
-
-  IS_ENGINE_READY: {
-    getter: (state) => (engineId) => {
-      const engineState: EngineState | undefined = state.engineStates[engineId];
-      if (engineState === undefined)
-        throw new Error(`No such engineState set: engineId == ${engineId}`);
-
-      return engineState === "READY";
-    },
-  },
-
   ACTIVE_AUDIO_ELEM_CURRENT_TIME: {
     getter: (state) => {
       return state._activeAudioKey !== undefined
         ? audioElements[state._activeAudioKey]?.currentTime
         : undefined;
-    },
-  },
-
-  START_WAITING_ENGINE_ALL: {
-    action: createUILockAction(async ({ state, dispatch }) => {
-      const engineIds = state.engineIds;
-
-      for (const engineId of engineIds) {
-        await dispatch("START_WAITING_ENGINE", {
-          engineId,
-        });
-      }
-    }),
-  },
-
-  START_WAITING_ENGINE: {
-    action: createUILockAction(
-      async ({ state, commit, dispatch }, { engineId }) => {
-        let engineState: EngineState | undefined = state.engineStates[engineId];
-        if (engineState === undefined)
-          throw new Error(`No such engineState set: engineId == ${engineId}`);
-
-        for (let i = 0; i < 100; i++) {
-          engineState = state.engineStates[engineId]; // FIXME: explicit undefined
-          if (engineState === undefined)
-            throw new Error(`No such engineState set: engineId == ${engineId}`);
-
-          if (engineState === "FAILED_STARTING") {
-            break;
-          }
-
-          try {
-            await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-              engineId,
-            }).then((instance) => instance.invoke("versionVersionGet")({}));
-          } catch {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-
-            window.electron.logInfo(`Waiting engine ${engineId}`);
-            continue;
-          }
-          engineState = "READY";
-          commit("SET_ENGINE_STATE", { engineId, engineState });
-          break;
-        }
-
-        if (engineState !== "READY") {
-          commit("SET_ENGINE_STATE", {
-            engineId,
-            engineState: "FAILED_STARTING",
-          });
-        }
-      }
-    ),
-  },
-
-  RESTART_ENGINE_ALL: {
-    async action({ state, dispatch }) {
-      // NOTE: 暫定実装、すべてのエンジンの再起動に成功した場合に、成功とみなす
-      let allSuccess = true;
-      const engineIds = state.engineIds;
-
-      for (const engineId of engineIds) {
-        const success = await dispatch("RESTART_ENGINE", {
-          engineId,
-        });
-        allSuccess = allSuccess && success;
-      }
-
-      return allSuccess;
-    },
-  },
-
-  RESTART_ENGINE: {
-    async action({ dispatch, commit, state }, { engineId }) {
-      commit("SET_ENGINE_STATE", { engineId, engineState: "STARTING" });
-      const success = await window.electron
-        .restartEngine(engineId)
-        .then(async () => {
-          await dispatch("START_WAITING_ENGINE", { engineId });
-          return state.engineStates[engineId] === "READY";
-        })
-        .catch(async () => {
-          await dispatch("DETECTED_ENGINE_ERROR", { engineId });
-          return false;
-        });
-      return success;
-    },
-  },
-
-  DETECTED_ENGINE_ERROR: {
-    action({ state, commit }, { engineId }) {
-      const engineState: EngineState | undefined = state.engineStates[engineId];
-      if (engineState === undefined)
-        throw new Error(`No such engineState set: engineId == ${engineId}`);
-
-      switch (engineState) {
-        case "STARTING":
-          commit("SET_ENGINE_STATE", {
-            engineId,
-            engineState: "FAILED_STARTING",
-          });
-          break;
-        case "READY":
-          commit("SET_ENGINE_STATE", { engineId, engineState: "ERROR" });
-          break;
-        default:
-          commit("SET_ENGINE_STATE", { engineId, engineState: "ERROR" });
-      }
-    },
-  },
-
-  OPEN_ENGINE_DIRECTORY: {
-    action(_, { engineId }) {
-      return window.electron.openEngineDirectory(engineId);
-    },
-  },
-
-  OPEN_USER_ENGINE_DIRECTORY: {
-    action() {
-      return window.electron.openUserEngineDirectory();
-    },
-  },
-
-  SET_ENGINE_STATE: {
-    mutation(
-      state,
-      { engineId, engineState }: { engineId: string; engineState: EngineState }
-    ) {
-      state.engineStates[engineId] = engineState;
     },
   },
 
@@ -498,49 +338,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       const audioKey = uuidv4();
       audioElements[audioKey] = new Audio();
       return audioKey;
-    },
-  },
-
-  IS_INITIALIZED_ENGINE_SPEAKER: {
-    /**
-     * 指定した話者（スタイルID）がエンジン側で初期化されているか
-     */
-    async action({ dispatch }, { engineId, styleId }) {
-      // FIXME: なぜかbooleanではなくstringが返ってくる。
-      // おそらくエンジン側のresponse_modelをBaseModel継承にしないといけない。
-      const isInitialized: string = await dispatch(
-        "INSTANTIATE_ENGINE_CONNECTOR",
-        {
-          engineId,
-        }
-      ).then(
-        (instance) =>
-          instance.invoke("isInitializedSpeakerIsInitializedSpeakerGet")({
-            speaker: styleId,
-          }) as unknown as string
-      );
-      if (isInitialized !== "true" && isInitialized !== "false")
-        throw new Error(`Failed to get isInitialized.`);
-
-      return isInitialized === "true";
-    },
-  },
-
-  INITIALIZE_ENGINE_SPEAKER: {
-    /**
-     * 指定した話者（スタイルID）に対してエンジン側の初期化を行い、即座に音声合成ができるようにする。
-     */
-    async action({ dispatch }, { engineId, styleId }) {
-      await dispatch("ASYNC_UI_LOCK", {
-        callback: () =>
-          dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-            engineId,
-          }).then((instance) =>
-            instance.invoke("initializeSpeakerInitializeSpeakerPost")({
-              speaker: styleId,
-            })
-          ),
-      });
     },
   },
 

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -1,0 +1,210 @@
+import { EngineState, EngineStoreState, EngineStoreTypes } from "./type";
+import { createUILockAction } from "./ui";
+import { createPartialStore } from "./vuex";
+
+export const engineStoreState: EngineStoreState = {
+  engineStates: {},
+};
+
+export const engineStore = createPartialStore<EngineStoreTypes>({
+  IS_ALL_ENGINE_READY: {
+    getter: (state, getters) => {
+      // NOTE: 1つもエンジンが登録されていない場合、準備完了していないことにする
+      // レンダラープロセスがメインプロセスからエンジンリストを取得完了する前にレンダリングが行われるため、
+      // IS_ALL_ENGINE_READYがエンジンリスト未初期化の状態で呼び出される可能性がある
+      // この場合の意図しない挙動を抑制するためfalseを返す
+      if (state.engineIds.length === 0) {
+        return false;
+      }
+
+      for (const engineId of state.engineIds) {
+        const isReady = getters.IS_ENGINE_READY(engineId);
+        if (!isReady) return false;
+      }
+      return true; // state.engineStatesが空のときはtrue
+    },
+  },
+
+  IS_ENGINE_READY: {
+    getter: (state) => (engineId) => {
+      const engineState: EngineState | undefined = state.engineStates[engineId];
+      if (engineState === undefined)
+        throw new Error(`No such engineState set: engineId == ${engineId}`);
+
+      return engineState === "READY";
+    },
+  },
+
+  START_WAITING_ENGINE_ALL: {
+    action: createUILockAction(async ({ state, dispatch }) => {
+      const engineIds = state.engineIds;
+
+      for (const engineId of engineIds) {
+        await dispatch("START_WAITING_ENGINE", {
+          engineId,
+        });
+      }
+    }),
+  },
+
+  START_WAITING_ENGINE: {
+    action: createUILockAction(
+      async ({ state, commit, dispatch }, { engineId }) => {
+        let engineState: EngineState | undefined = state.engineStates[engineId];
+        if (engineState === undefined)
+          throw new Error(`No such engineState set: engineId == ${engineId}`);
+
+        for (let i = 0; i < 100; i++) {
+          engineState = state.engineStates[engineId]; // FIXME: explicit undefined
+          if (engineState === undefined)
+            throw new Error(`No such engineState set: engineId == ${engineId}`);
+
+          if (engineState === "FAILED_STARTING") {
+            break;
+          }
+
+          try {
+            await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
+              engineId,
+            }).then((instance) => instance.invoke("versionVersionGet")({}));
+          } catch {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            window.electron.logInfo(`Waiting engine ${engineId}`);
+            continue;
+          }
+          engineState = "READY";
+          commit("SET_ENGINE_STATE", { engineId, engineState });
+          break;
+        }
+
+        if (engineState !== "READY") {
+          commit("SET_ENGINE_STATE", {
+            engineId,
+            engineState: "FAILED_STARTING",
+          });
+        }
+      }
+    ),
+  },
+
+  RESTART_ENGINE_ALL: {
+    async action({ state, dispatch }) {
+      // NOTE: 暫定実装、すべてのエンジンの再起動に成功した場合に、成功とみなす
+      let allSuccess = true;
+      const engineIds = state.engineIds;
+
+      for (const engineId of engineIds) {
+        const success = await dispatch("RESTART_ENGINE", {
+          engineId,
+        });
+        allSuccess = allSuccess && success;
+      }
+
+      return allSuccess;
+    },
+  },
+
+  RESTART_ENGINE: {
+    async action({ dispatch, commit, state }, { engineId }) {
+      commit("SET_ENGINE_STATE", { engineId, engineState: "STARTING" });
+      const success = await window.electron
+        .restartEngine(engineId)
+        .then(async () => {
+          await dispatch("START_WAITING_ENGINE", { engineId });
+          return state.engineStates[engineId] === "READY";
+        })
+        .catch(async () => {
+          await dispatch("DETECTED_ENGINE_ERROR", { engineId });
+          return false;
+        });
+      return success;
+    },
+  },
+
+  DETECTED_ENGINE_ERROR: {
+    action({ state, commit }, { engineId }) {
+      const engineState: EngineState | undefined = state.engineStates[engineId];
+      if (engineState === undefined)
+        throw new Error(`No such engineState set: engineId == ${engineId}`);
+
+      switch (engineState) {
+        case "STARTING":
+          commit("SET_ENGINE_STATE", {
+            engineId,
+            engineState: "FAILED_STARTING",
+          });
+          break;
+        case "READY":
+          commit("SET_ENGINE_STATE", { engineId, engineState: "ERROR" });
+          break;
+        default:
+          commit("SET_ENGINE_STATE", { engineId, engineState: "ERROR" });
+      }
+    },
+  },
+
+  OPEN_ENGINE_DIRECTORY: {
+    action(_, { engineId }) {
+      return window.electron.openEngineDirectory(engineId);
+    },
+  },
+
+  OPEN_USER_ENGINE_DIRECTORY: {
+    action() {
+      return window.electron.openUserEngineDirectory();
+    },
+  },
+
+  SET_ENGINE_STATE: {
+    mutation(
+      state,
+      { engineId, engineState }: { engineId: string; engineState: EngineState }
+    ) {
+      state.engineStates[engineId] = engineState;
+    },
+  },
+
+  IS_INITIALIZED_ENGINE_SPEAKER: {
+    /**
+     * 指定した話者（スタイルID）がエンジン側で初期化されているか
+     */
+    async action({ dispatch }, { engineId, styleId }) {
+      // FIXME: なぜかbooleanではなくstringが返ってくる。
+      // おそらくエンジン側のresponse_modelをBaseModel継承にしないといけない。
+      const isInitialized: string = await dispatch(
+        "INSTANTIATE_ENGINE_CONNECTOR",
+        {
+          engineId,
+        }
+      ).then(
+        (instance) =>
+          instance.invoke("isInitializedSpeakerIsInitializedSpeakerGet")({
+            speaker: styleId,
+          }) as unknown as string
+      );
+      if (isInitialized !== "true" && isInitialized !== "false")
+        throw new Error(`Failed to get isInitialized.`);
+
+      return isInitialized === "true";
+    },
+  },
+
+  INITIALIZE_ENGINE_SPEAKER: {
+    /**
+     * 指定した話者（スタイルID）に対してエンジン側の初期化を行い、即座に音声合成ができるようにする。
+     */
+    async action({ dispatch }, { engineId, styleId }) {
+      await dispatch("ASYNC_UI_LOCK", {
+        callback: () =>
+          dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
+            engineId,
+          }).then((instance) =>
+            instance.invoke("initializeSpeakerInitializeSpeakerPost")({
+              speaker: styleId,
+            })
+          ),
+      });
+    },
+  },
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,6 +25,7 @@ import { dictionaryStoreState, dictionaryStore } from "./dictionary";
 import { proxyStore, proxyStoreState } from "./proxy";
 import { createPartialStore } from "./vuex";
 import { DefaultStyleId } from "@/type/preload";
+import { engineStoreState, engineStore } from "./engine";
 
 export const storeKey: InjectionKey<
   Store<State, AllGetters, AllActions, AllMutations>
@@ -292,6 +293,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...uiStoreState,
     ...audioStoreState,
     ...commandStoreState,
+    ...engineStoreState,
     ...projectStoreState,
     ...settingStoreState,
     ...audioCommandStoreState,
@@ -305,6 +307,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...uiStore.getters,
     ...audioStore.getters,
     ...commandStore.getters,
+    ...engineStore.getters,
     ...projectStore.getters,
     ...settingStore.getters,
     ...presetStore.getters,
@@ -318,6 +321,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...uiStore.mutations,
     ...audioStore.mutations,
     ...commandStore.mutations,
+    ...engineStore.mutations,
     ...projectStore.mutations,
     ...settingStore.mutations,
     ...audioCommandStore.mutations,
@@ -330,6 +334,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
   actions: {
     ...uiStore.actions,
     ...audioStore.actions,
+    ...engineStore.actions,
     ...commandStore.actions,
     ...projectStore.actions,
     ...settingStore.actions,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -95,7 +95,6 @@ export type QuasarDialog = QVueGlobals["dialog"];
  */
 
 export type AudioStoreState = {
-  engineStates: Record<string, EngineState>;
   characterInfos: Record<string, CharacterInfo[]>;
   audioKeyInitializingSpeaker?: string;
   audioItems: Record<string, AudioItem>;
@@ -119,51 +118,8 @@ export type AudioStoreTypes = {
     getter(audioKey: string): boolean;
   };
 
-  IS_ALL_ENGINE_READY: {
-    getter: boolean;
-  };
-
-  IS_ENGINE_READY: {
-    getter(engineId: string): boolean;
-  };
-
   ACTIVE_AUDIO_ELEM_CURRENT_TIME: {
     getter: number | undefined;
-  };
-
-  START_WAITING_ENGINE_ALL: {
-    action(): void;
-  };
-
-  START_WAITING_ENGINE: {
-    action(payload: { engineId: string }): void;
-  };
-
-  // NOTE: 複数のengineIdを受け取ってバルク操作する関数にしてもいいかもしれない？
-  // NOTE: 個別にエンジンの状態を確認できるようにする？
-  // NOTE: boolean以外でエンジン状態を表現してもいいかもしれない？
-  RESTART_ENGINE_ALL: {
-    action(): Promise<boolean>;
-  };
-
-  RESTART_ENGINE: {
-    action(payload: { engineId: string }): Promise<boolean>;
-  };
-
-  DETECTED_ENGINE_ERROR: {
-    action(payload: { engineId: string }): void;
-  };
-
-  OPEN_ENGINE_DIRECTORY: {
-    action(payload: { engineId: string }): void;
-  };
-
-  OPEN_USER_ENGINE_DIRECTORY: {
-    action(): void;
-  };
-
-  SET_ENGINE_STATE: {
-    mutation: { engineId: string; engineState: EngineState };
   };
 
   LOAD_CHARACTER_ALL: {
@@ -188,14 +144,6 @@ export type AudioStoreTypes = {
 
   GENERATE_AUDIO_KEY: {
     action(): string;
-  };
-
-  IS_INITIALIZED_ENGINE_SPEAKER: {
-    action(payload: { engineId: string; styleId: number }): Promise<boolean>;
-  };
-
-  INITIALIZE_ENGINE_SPEAKER: {
-    action(payload: { engineId: string; styleId: number }): void;
   };
 
   SETUP_SPEAKER: {
@@ -697,6 +645,67 @@ export type CommandStoreTypes = {
 
   CLEAR_COMMANDS: {
     mutation: undefined;
+  };
+};
+
+/*
+ * Engine Store Types
+ */
+
+export type EngineStoreState = {
+  engineStates: Record<string, EngineState>;
+};
+
+export type EngineStoreTypes = {
+  IS_ALL_ENGINE_READY: {
+    getter: boolean;
+  };
+
+  IS_ENGINE_READY: {
+    getter(engineId: string): boolean;
+  };
+
+  START_WAITING_ENGINE_ALL: {
+    action(): void;
+  };
+
+  START_WAITING_ENGINE: {
+    action(payload: { engineId: string }): void;
+  };
+
+  // NOTE: 複数のengineIdを受け取ってバルク操作する関数にしてもいいかもしれない？
+  // NOTE: 個別にエンジンの状態を確認できるようにする？
+  // NOTE: boolean以外でエンジン状態を表現してもいいかもしれない？
+  RESTART_ENGINE_ALL: {
+    action(): Promise<boolean>;
+  };
+
+  RESTART_ENGINE: {
+    action(payload: { engineId: string }): Promise<boolean>;
+  };
+
+  DETECTED_ENGINE_ERROR: {
+    action(payload: { engineId: string }): void;
+  };
+
+  OPEN_ENGINE_DIRECTORY: {
+    action(payload: { engineId: string }): void;
+  };
+
+  OPEN_USER_ENGINE_DIRECTORY: {
+    action(): void;
+  };
+
+  SET_ENGINE_STATE: {
+    mutation: { engineId: string; engineState: EngineState };
+  };
+
+  IS_INITIALIZED_ENGINE_SPEAKER: {
+    action(payload: { engineId: string; styleId: number }): Promise<boolean>;
+  };
+
+  INITIALIZE_ENGINE_SPEAKER: {
+    action(payload: { engineId: string; styleId: number }): void;
   };
 };
 
@@ -1205,6 +1214,7 @@ export type ProxyStoreTypes = {
 export type State = AudioStoreState &
   AudioCommandStoreState &
   CommandStoreState &
+  EngineStoreState &
   IndexStoreState &
   ProjectStoreState &
   SettingStoreState &
@@ -1216,6 +1226,7 @@ export type State = AudioStoreState &
 type AllStoreTypes = AudioStoreTypes &
   AudioCommandStoreTypes &
   CommandStoreTypes &
+  EngineStoreTypes &
   IndexStoreTypes &
   ProjectStoreTypes &
   SettingStoreTypes &

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -11,6 +11,7 @@ import { presetStore } from "@/store/preset";
 import { assert } from "chai";
 import { proxyStore } from "@/store/proxy";
 import { dictionaryStore } from "@/store/dictionary";
+import { engineStore } from "@/store/engine";
 const isDevelopment = process.env.NODE_ENV == "development";
 // TODO: Swap external files to Mock
 
@@ -121,6 +122,7 @@ describe("store/vuex.js test", () => {
         ...uiStore.getters,
         ...audioStore.getters,
         ...commandStore.getters,
+        ...engineStore.getters,
         ...projectStore.getters,
         ...settingStore.getters,
         ...audioCommandStore.getters,
@@ -133,6 +135,7 @@ describe("store/vuex.js test", () => {
         ...uiStore.mutations,
         ...audioStore.mutations,
         ...commandStore.mutations,
+        ...engineStore.mutations,
         ...projectStore.mutations,
         ...settingStore.mutations,
         ...audioCommandStore.mutations,
@@ -145,6 +148,7 @@ describe("store/vuex.js test", () => {
         ...uiStore.actions,
         ...audioStore.actions,
         ...commandStore.actions,
+        ...engineStore.actions,
         ...projectStore.actions,
         ...settingStore.actions,
         ...audioCommandStore.actions,


### PR DESCRIPTION
## 内容

エンジン関連のstoreをaudio.tsから分離します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）