### PR TITLE
複数エンジン対応：engineManifestで実行時引数を指定できるように

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -4,6 +4,7 @@ DEFAULT_ENGINE_INFOS=`[
         "name": "VOICEVOX Engine",
         "executionEnabled": true,
         "executionFilePath": "run.exe",
+        "executionArgs": [],
         "host": "http://127.0.0.1:50021",
         "path": "."
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "markdown-it": "12.0.4",
         "quasar": "2.4.13",
         "semver": "7.3.5",
+        "shlex": "2.1.2",
         "source-map-support": "0.5.19",
         "systeminformation": "5.8.0",
         "tree-kill": "1.2.2",
@@ -22381,6 +22382,11 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
+    },
+    "node_modules/shlex": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
+      "integrity": "sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.3",
@@ -45060,6 +45066,11 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
+    },
+    "shlex": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
+      "integrity": "sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w=="
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "markdown-it": "12.0.4",
     "quasar": "2.4.13",
     "semver": "7.3.5",
+    "shlex": "2.1.2",
     "source-map-support": "0.5.19",
     "systeminformation": "5.8.0",
     "tree-kill": "1.2.2",

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,6 +4,7 @@ import { spawn, ChildProcess } from "child_process";
 import dotenv from "dotenv";
 import treeKill from "tree-kill";
 import Store from "electron-store";
+import shlex from "shlex";
 
 import {
   app,
@@ -145,13 +146,16 @@ function fetchEngineInfosFromUserDirectory(): EngineInfo[] {
       fs.readFileSync(manifestPath, { encoding: "utf8" })
     );
 
+    const [command, ...args] = shlex.split(manifest.command);
+
     engines.push({
       uuid: manifest.uuid,
       host: `http://127.0.0.1:${manifest.port}`,
       name: manifest.name,
       path: engineDir,
       executionEnabled: true,
-      executionFilePath: path.join(engineDir, manifest.command),
+      executionFilePath: path.join(engineDir, command),
+      executionArgs: args,
     });
   }
   return engines;
@@ -526,7 +530,7 @@ async function runEngine(engineId: string) {
     appDirPath,
     engineInfo.executionFilePath ?? "run.exe"
   );
-  const args = useGpu ? ["--use_gpu"] : [];
+  const args = engineInfo.executionArgs.concat(useGpu ? ["--use_gpu"] : []);
 
   log.info(`ENGINE ${engineId} path: ${enginePath}`);
   log.info(`ENGINE ${engineId} args: ${JSON.stringify(args)}`);

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -177,6 +177,7 @@ export type EngineInfo = {
   path?: string; // エンジンディレクトリのパス
   executionEnabled: boolean;
   executionFilePath: string;
+  executionArgs: string[];
 };
 
 export type Preset = {

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -78,6 +78,7 @@ describe("store/vuex.js test", () => {
             name: "Engine 1",
             executionEnabled: false,
             executionFilePath: "",
+            executionArgs: [],
             host: "http://127.0.0.1",
           },
         },


### PR DESCRIPTION
## 内容

engine_manifest.jsonのcommandsフィールドをnode-shlexで分割し、引数を指定できるようにします。

## 関連 Issue

- ref: voicevox/voicevox_project#2

## スクリーンショット・動画など

（なし）

## その他

（なし）