### PR TITLE
FIX: electron-storeの保存場所をGPU版と統一する

### DIFF
--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -83,11 +83,11 @@ VOICEVOX Twitter アカウント [@voicevox_pj](https://twitter.com/voicevox_pj)
 
 #### Windows 版
 
-`C:\Users\(ユーザー名)\AppData\Roaming\voicevox` もしくは `C:\Users\(ユーザー名)\AppData\Roaming\voicevox-cpu`
+`C:\Users\(ユーザー名)\AppData\Roaming\voicevox`
 
 #### Mac 版
 
-`/Users/(ユーザー名)/Library/Application Support/voicevox-cpu`
+`/Users/(ユーザー名)/Library/Application Support/voicevox`
 
 ### Q. エンジンの起動が失敗したというエラーが表示されます。
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -41,24 +41,28 @@ type SingleInstanceLockData = {
   filePath: string | undefined;
 };
 
+const isDevelopment = process.env.NODE_ENV !== "production";
+
+// Electronの設定ファイルの保存場所を変更
+app.setPath(
+  "userData",
+  path.join(app.getPath("appData"), `voicevox${isDevelopment ? "-dev" : ""}`)
+);
+
 // silly以上のログをコンソールに出力
 log.transports.console.format = "[{h}:{i}:{s}.{ms}] [{level}] {text}";
 log.transports.console.level = "silly";
 
 // warn以上のログをファイルに出力
 const prefix = dayjs().format("YYYYMMDD_HHmmss");
+const logPath = app.getPath("logs");
 log.transports.file.format = "[{h}:{i}:{s}.{ms}] [{level}] {text}";
 log.transports.file.level = "warn";
 log.transports.file.fileName = `${prefix}_error.log`;
-
-const isDevelopment = process.env.NODE_ENV !== "production";
-
-if (isDevelopment) {
-  app.setPath(
-    "userData",
-    path.join(app.getPath("appData"), `${app.getName()}-dev`)
-  );
-}
+log.transports.file.resolvePath = (variables) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return path.join(logPath, variables.fileName!);
+};
 
 let win: BrowserWindow;
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -44,10 +44,14 @@ type SingleInstanceLockData = {
 const isDevelopment = process.env.NODE_ENV !== "production";
 
 // Electronの設定ファイルの保存場所を変更
-app.setPath(
-  "userData",
-  path.join(app.getPath("appData"), `voicevox${isDevelopment ? "-dev" : ""}`)
+const fixedUserDataDir = path.join(
+  app.getPath("appData"),
+  `voicevox${isDevelopment ? "-dev" : ""}`
 );
+if (!fs.existsSync(fixedUserDataDir)) {
+  fs.mkdirSync(fixedUserDataDir);
+}
+app.setPath("userData", fixedUserDataDir);
 
 // silly以上のログをコンソールに出力
 log.transports.console.format = "[{h}:{i}:{s}.{ms}] [{level}] {text}";


### PR DESCRIPTION
## 内容

- #337 の解決です。

## 関連 Issue

close #337 

## その他

最初は`app.setName()`でアプリ名を操作するつもりでしたがそれだけでは保存ディレクトリが変更されなかったので`userData`のディレクトリを`voicevox`と指定しまうことにしました。

開発版のログが製品版のディレクトリに保存されてしまう問題もついでに修正されました。

`electron-log`の既知の問題によりデフォルトのログのディレクトリが必ず作成されてしまいます。