### PR TITLE
Improve: 複数エンジン登録時の起動を高速化

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -431,10 +431,8 @@ export default defineComponent({
                 type: "root",
                 label: engineInfo.name,
                 icon:
-                  store.state.engineManifests[engineInfo.uuid] &&
-                  base64ImageToUri(
-                    store.state.engineManifests[engineInfo.uuid].icon
-                  ),
+                  engineManifests.value[engineInfo.uuid] &&
+                  base64ImageToUri(engineManifests.value[engineInfo.uuid].icon),
                 subMenu: [
                   engineInfo.path && {
                     type: "button",

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -220,15 +220,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
-  LOAD_CHARACTER_ALL: {
-    action: createUILockAction(async ({ state, dispatch }) => {
-      for (const engineId of state.engineIds) {
-        window.electron.logInfo(`Load CharacterInfo from engine ${engineId}`);
-        await dispatch("LOAD_CHARACTER", { engineId });
-      }
-    }),
-  },
-
   LOAD_CHARACTER: {
     action: createUILockAction(async ({ commit, dispatch }, { engineId }) => {
       const speakers = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -37,18 +37,6 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
-  START_WAITING_ENGINE_ALL: {
-    action: createUILockAction(async ({ state, dispatch }) => {
-      const engineIds = state.engineIds;
-
-      for (const engineId of engineIds) {
-        await dispatch("START_WAITING_ENGINE", {
-          engineId,
-        });
-      }
-    }),
-  },
-
   START_WAITING_ENGINE: {
     action: createUILockAction(
       async ({ state, commit, dispatch }, { engineId }) => {
@@ -255,17 +243,6 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
           instance.invoke("engineManifestEngineManifestGet")({})
         ),
       });
-    },
-  },
-
-  FETCH_AND_SET_ENGINE_MANIFEST_ALL: {
-    async action({ state }) {
-      await Promise.all(
-        state.engineIds.map(
-          async (engineId) =>
-            await this.dispatch("FETCH_AND_SET_ENGINE_MANIFEST", { engineId })
-        )
-      );
     },
   },
 });

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -708,6 +708,26 @@ export type EngineStoreTypes = {
   INITIALIZE_ENGINE_SPEAKER: {
     action(payload: { engineId: string; styleId: number }): void;
   };
+
+  GET_ENGINE_INFOS: {
+    action(): void;
+  };
+
+  SET_ENGINE_INFOS: {
+    mutation: { engineInfos: EngineInfo[] };
+  };
+
+  SET_ENGINE_MANIFEST: {
+    mutation: { engineId: string; engineManifest: EngineManifest };
+  };
+
+  FETCH_AND_SET_ENGINE_MANIFEST: {
+    action(payload: { engineId: string }): void;
+  };
+
+  FETCH_AND_SET_ENGINE_MANIFEST_ALL: {
+    action(): void;
+  };
 };
 
 /*
@@ -1050,22 +1070,6 @@ export type UiStoreTypes = {
   SET_USE_GPU: {
     mutation: { useGpu: boolean };
     action(payload: { useGpu: boolean }): void;
-  };
-
-  GET_ENGINE_INFOS: {
-    action(): void;
-  };
-
-  SET_ENGINE_INFOS: {
-    mutation: { engineInfos: EngineInfo[] };
-  };
-
-  SET_ENGINE_MANIFESTS: {
-    mutation: { engineManifests: Record<string, EngineManifest> };
-  };
-
-  FETCH_AND_SET_ENGINE_MANIFESTS: {
-    action(): void;
   };
 
   SET_INHERIT_AUDIOINFO: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -123,10 +123,6 @@ export type AudioStoreTypes = {
     getter: number | undefined;
   };
 
-  LOAD_CHARACTER_ALL: {
-    action(): void;
-  };
-
   LOAD_CHARACTER: {
     action(payload: { engineId: string }): void;
   };
@@ -666,10 +662,6 @@ export type EngineStoreTypes = {
     getter(engineId: string): boolean;
   };
 
-  START_WAITING_ENGINE_ALL: {
-    action(): void;
-  };
-
   START_WAITING_ENGINE: {
     action(payload: { engineId: string }): void;
   };
@@ -723,10 +715,6 @@ export type EngineStoreTypes = {
 
   FETCH_AND_SET_ENGINE_MANIFEST: {
     action(payload: { engineId: string }): void;
-  };
-
-  FETCH_AND_SET_ENGINE_MANIFEST_ALL: {
-    action(): void;
   };
 };
 

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -6,8 +6,7 @@ import {
   UiStoreState,
   UiStoreTypes,
 } from "./type";
-import { ActivePointScrollMode, EngineInfo } from "@/type/preload";
-import { EngineManifest } from "@/openapi";
+import { ActivePointScrollMode } from "@/type/preload";
 import { createPartialStore } from "./vuex";
 
 export function createUILockAction<S, A extends ActionsBase, K extends keyof A>(
@@ -385,55 +384,6 @@ export const uiStore = createPartialStore<UiStoreTypes>({
     async action({ commit }, { useGpu }: { useGpu: boolean }) {
       commit("SET_USE_GPU", {
         useGpu: await window.electron.setSetting("useGpu", useGpu),
-      });
-    },
-  },
-
-  GET_ENGINE_INFOS: {
-    async action({ commit }) {
-      commit("SET_ENGINE_INFOS", {
-        engineInfos: await window.electron.engineInfos(),
-      });
-    },
-  },
-
-  SET_ENGINE_INFOS: {
-    mutation(state, { engineInfos }: { engineInfos: EngineInfo[] }) {
-      state.engineIds = engineInfos.map((engineInfo) => engineInfo.uuid);
-      state.engineInfos = Object.fromEntries(
-        engineInfos.map((engineInfo) => [engineInfo.uuid, engineInfo])
-      );
-      state.engineStates = Object.fromEntries(
-        engineInfos.map((engineInfo) => [engineInfo.uuid, "STARTING"])
-      );
-    },
-  },
-
-  SET_ENGINE_MANIFESTS: {
-    mutation(
-      state,
-      { engineManifests }: { engineManifests: Record<string, EngineManifest> }
-    ) {
-      state.engineManifests = engineManifests;
-    },
-  },
-
-  FETCH_AND_SET_ENGINE_MANIFESTS: {
-    async action({ state, commit }) {
-      commit("SET_ENGINE_MANIFESTS", {
-        engineManifests: Object.fromEntries(
-          await Promise.all(
-            state.engineIds.map(
-              async (engineId) =>
-                await this.dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-                  engineId,
-                }).then(async (instance) => [
-                  engineId,
-                  await instance.invoke("engineManifestEngineManifestGet")({}),
-                ])
-            )
-          )
-        ),
       });
     },
   },

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -472,11 +472,15 @@ export default defineComponent({
     onMounted(async () => {
       await store.dispatch("GET_ENGINE_INFOS");
 
-      await store.dispatch("START_WAITING_ENGINE_ALL");
+      await Promise.all(
+        Object.keys(store.state.engineInfos).map(async (engineId) => {
+          await store.dispatch("START_WAITING_ENGINE", { engineId });
 
-      await store.dispatch("FETCH_AND_SET_ENGINE_MANIFESTS");
+          await store.dispatch("FETCH_AND_SET_ENGINE_MANIFEST", { engineId });
 
-      await store.dispatch("LOAD_CHARACTER_ALL");
+          await store.dispatch("LOAD_CHARACTER", { engineId });
+        })
+      );
       await store.dispatch("LOAD_USER_CHARACTER_ORDER");
       await store.dispatch("LOAD_DEFAULT_STYLE_IDS");
 

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -473,7 +473,7 @@ export default defineComponent({
       await store.dispatch("GET_ENGINE_INFOS");
 
       await Promise.all(
-        Object.keys(store.state.engineInfos).map(async (engineId) => {
+        store.state.engineIds.map(async (engineId) => {
           await store.dispatch("START_WAITING_ENGINE", { engineId });
 
           await store.dispatch("FETCH_AND_SET_ENGINE_MANIFEST", { engineId });


### PR DESCRIPTION
## 内容

複数エンジン登録時の起動を高速化します。
旧実装：
```mermaid
graph LR
    T1[ ]:::empty

    A[起動] --- T1
    T1 --> B1 & B2
    subgraph START_WAITING_ENGINE_ALL
      B1[エンジンAの起動待機]
      B2[エンジンBの起動待機]
    end
    
    T2[ ]:::empty
    T2p[ ]:::empty

    B1 & B2 --- T2p
	T2p --- T2
    T2 --> C1 & C2

    subgraph FETCH_AND_SET_ENGINE_MANIFESTS_ALL
      C1[エンジンAのManifest読み込み]
      C2[エンジンBのManifest読み込み]
    end

    T3[ ]:::empty
    T3p[ ]:::empty

    C1 & C2 --- T3p
	T3p --- T3
    T3 --> D1 & D2

    subgraph LOAD_CHARACTER_ALL
      D1[エンジンAのキャラクター読み込み]
      D2[エンジンBのキャラクター読み込み]
    end

    T4[ ]:::empty
    T4p[ ]:::empty

    D1 & D2 --- T4p
	T4p --- T4
    T4 --> E[UNLOCK_UI]
    classDef empty width:0px,height:0px;
```
新実装：
```mermaid
graph LR
    t1[ ]:::empty

    a[起動] --- t1
    t1 --> b1 & b2
    subgraph  
      b1[エンジンAの起動待機] --> c1
      c1[エンジンAのManifest読み込み] --> d1
      d1[エンジンAのキャラクター読み込み]
    end
    subgraph  
      b2[エンジンBの起動待機] --> c2
      c2[エンジンBのManifest読み込み] --> d2
      d2[エンジンBのキャラクター読み込み]
    end

    t2[ ]:::empty
    d1 & d2 --- t2
    t2 --> e[UNLOCK_UI]
    classDef empty width:0px,height:0px;
```

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）