### PR TITLE
fix: Issue label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.md
+++ b/.github/ISSUE_TEMPLATE/bugreport.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: 不具合の報告
-labels: bug
+labels: バグ
 ---
 
 ## 不具合の内容

--- a/.github/ISSUE_TEMPLATE/featurerequest.md
+++ b/.github/ISSUE_TEMPLATE/featurerequest.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: 機能要望・改善提案
-labels: enhancement
+labels: 機能向上
 ---
 
 ## 内容


### PR DESCRIPTION
## 内容

Issueを立てたときに自動でラベルがつかないのを修正します

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

質問は現在タグがないので触ってません
