### PR TITLE
複数エンジン対応：エンジンバージョンが更新されないのを修正

### DIFF
--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -295,15 +295,20 @@ export default defineComponent({
     const engineVersions = ref<Record<string, string>>({});
 
     watch(
-      [engineInfos],
+      [engineInfos, engineStates],
       async () => {
         for (const id of Object.keys(engineInfos.value)) {
           if (engineVersions.value[id]) return;
           const version = await store
             .dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId: id })
-            .then((instance) => instance.invoke("versionVersionGet")({}));
+            .then((instance) => instance.invoke("versionVersionGet")({}))
+            .catch(() => null);
+          if (!version) continue;
           // "latest"のようにダブルクォーテーションで囲まれているので、JSON.parseで外す。
-          engineVersions.value[id] = JSON.parse(version);
+          engineVersions.value = {
+            ...engineVersions.value,
+            [id]: JSON.parse(version),
+          };
         }
       },
       { immediate: true }


### PR DESCRIPTION
## 内容

エンジン管理ダイアログにて、バージョンの欄が埋まらなかったバグを修正します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）