### PR TITLE
ENH: 話速によって前後の無音時間が変わらないようにする

### DIFF
--- a/src/components/AudioInfo.vue
+++ b/src/components/AudioInfo.vue
@@ -460,7 +460,11 @@ export default defineComponent({
       scrollMinStep: () => 0.01,
     });
     const prePhonemeLengthSlider = previewSliderHelper({
-      modelValue: () => query.value?.prePhonemeLength ?? null,
+      modelValue: () => {
+        const value = query.value;
+        if (value == null) return null;
+        return value.prePhonemeLength / value.speedScale;
+      },
       disable: () => uiLocked.value,
       onChange: setAudioPrePhonemeLength,
       max: () => 1.5,
@@ -470,7 +474,11 @@ export default defineComponent({
       scrollMinStep: () => 0.01,
     });
     const postPhonemeLengthSlider = previewSliderHelper({
-      modelValue: () => query.value?.postPhonemeLength ?? null,
+      modelValue: () => {
+        const value = query.value;
+        if (value == null) return null;
+        return value.postPhonemeLength / value.speedScale;
+      },
       disable: () => uiLocked.value,
       onChange: setAudioPostPhonemeLength,
       max: () => 1.5,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -600,6 +600,10 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     ) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
+      query.prePhonemeLength =
+        (query.prePhonemeLength / query.speedScale) * speedScale;
+      query.postPhonemeLength =
+        (query.postPhonemeLength / query.speedScale) * speedScale;
       query.speedScale = speedScale;
     },
   },
@@ -650,7 +654,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     ) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
-      query.prePhonemeLength = prePhonemeLength;
+      query.prePhonemeLength = prePhonemeLength * query.speedScale;
     },
   },
 
@@ -664,7 +668,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     ) {
       const query = state.audioItems[audioKey].query;
       if (query == undefined) throw new Error("query == undefined");
-      query.postPhonemeLength = postPhonemeLength;
+      query.postPhonemeLength = postPhonemeLength * query.speedScale;
     },
   },
 


### PR DESCRIPTION
## 内容

話速によって前後の無音時間が変わらないようにしました。
UI上の値を話速を乗じた値にしました。
また、`speedScale`を変更すると`prePhonemeLength`の値も同時に変更するようにしました。

## 関連 Issue

- close #308 

## その他

`prePhonemeLength`の値に誤差が発生します。
表面上は問題は起こりませんが将来的に何か問題が起こりそうな予感がします。

旧バージョンのプロジェクトを読み込むと話速と無音時間の組み合わせによってはスライダの最大値を超えてしまいますがとりあえずそのままにしてあります。