### PR TITLE
複数エンジン対応：エラーダイアログを複数エンジン時に変えるように

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -613,10 +613,17 @@ async function runEngine(engineId: string) {
 
     if (!engineProcessContainer.willQuitEngine) {
       ipcMainSend(win, "DETECTED_ENGINE_ERROR", { engineId });
-      dialog.showErrorBox(
-        "音声合成エンジンエラー",
-        "音声合成エンジンが異常終了しました。エンジンを再起動してください。"
-      );
+      if (engineInfos.length === 1) {
+        dialog.showErrorBox(
+          "音声合成エンジンエラー",
+          "音声合成エンジンが異常終了しました。エンジンを再起動してください。"
+        );
+      } else {
+        dialog.showErrorBox(
+          "音声合成エンジンエラー",
+          `${engineInfo.name}の音声合成エンジンが異常終了しました。エンジンを再起動してください。`
+        );
+      }
     }
   });
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -613,17 +613,11 @@ async function runEngine(engineId: string) {
 
     if (!engineProcessContainer.willQuitEngine) {
       ipcMainSend(win, "DETECTED_ENGINE_ERROR", { engineId });
-      if (engineInfos.length === 1) {
-        dialog.showErrorBox(
-          "音声合成エンジンエラー",
-          "音声合成エンジンが異常終了しました。エンジンを再起動してください。"
-        );
-      } else {
-        dialog.showErrorBox(
-          "音声合成エンジンエラー",
-          `${engineInfo.name}の音声合成エンジンが異常終了しました。エンジンを再起動してください。`
-        );
-      }
+      const dialogMessage =
+        engineInfos.length === 1
+          ? "音声合成エンジンが異常終了しました。エンジンを再起動してください。"
+          : `${engineInfo.name}の音声合成エンジンが異常終了しました。エンジンを再起動してください。`;
+      dialog.showErrorBox("音声合成エンジンエラー", dialogMessage);
     }
   });
 }


### PR DESCRIPTION
## 内容

複数エンジン時、エンジンのエラー終了時のダイアログにエンジン名を表示するようにします。

## 関連 Issue

- ref: voicevox/voicevox_project#2

## スクリーンショット・動画など

（なし）

## その他

（なし）