### PR TITLE
CI: 非推奨化されたset-outputをGITHUB_OUTPUTに変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Set output Node version
         id: node-version
         shell: bash
-        run: echo "::set-output name=NODE_VERSION::$(cat .node-version)"
+        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -360,7 +360,7 @@ jobs:
       - name: Set output Node version
         id: node-version
         shell: bash
-        run: echo "::set-output name=NODE_VERSION::$(cat .node-version)"
+        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -662,7 +662,7 @@ jobs:
       - name: Set output Node version
         id: node-version
         shell: bash
-        run: echo "::set-output name=NODE_VERSION::$(cat .node-version)"
+        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: node-version
-        run: echo "::set-output name=NODE_VERSION::$(cat .node-version)"
+        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
+
       - uses: actions/setup-node@v3
         with:
           node-version: "${{ steps.node-version.outputs.NODE_VERSION }}"
+
       - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ env.cache-version }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ env.cache-version }}-node-
+
       - name: Cache Electron
         uses: actions/cache@v3
         with:
@@ -42,6 +45,7 @@ jobs:
           key: ${{ env.cache-version }}-${{ runner.os }}--electron-builder-cache-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ env.cache-version }}-${{ runner.os }}--electron-builder-cache-
+
       - run: npm ci
       - run: npm run typecheck
       - run: npm run lint


### PR DESCRIPTION
## 内容

非推奨警告が出ないように、`set-output`を`GITHUB_OUTPUT`に変更します

- 現在のmainブランチのbuild.ymlによるCI: <https://github.com/VOICEVOX/voicevox/actions/runs/3575688234>
- 現在のmainブランチのtest.ymlによるCI: <https://github.com/VOICEVOX/voicevox/actions/runs/3575688236>
- GITHUB_OUTPUTのドキュメント: <https://docs.github.com/ja/actions/using-jobs/defining-outputs-for-jobs>

<!--
プルリクエストの内容説明を端的に記載してください。
-->
