### PR TITLE
複数エンジン対応：エンジン管理ダイアログでバージョンが出ないときがあるのを修正

### DIFF
--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -316,7 +316,7 @@ export default defineComponent({
     const engineVersions = ref<Record<string, string>>({});
 
     watch(
-      [engineInfos, engineStates],
+      [engineInfos, engineStates, engineManifests],
       async () => {
         for (const id of Object.keys(engineInfos.value)) {
           if (engineVersions.value[id]) return;


### PR DESCRIPTION
## 内容

タイトル通り。engineManifestが取得できたときはエンジンが起動しているのは確定しているので、engineManifestsも監視するようにしました。

## 関連 Issue

- ref:voicevox/voicevox_project#2

## スクリーンショット・動画など

（なし）

## その他

（なし）