### PR TITLE
FIX: AudioInfoのパラメーターが0になると非表示になる問題を修正

### DIFF
--- a/src/components/AudioInfo.vue
+++ b/src/components/AudioInfo.vue
@@ -172,7 +172,7 @@
         }"
         >話速
         {{
-          speedScaleSlider.state.currentValue.value
+          speedScaleSlider.state.currentValue.value != undefined
             ? speedScaleSlider.state.currentValue.value.toFixed(2)
             : undefined
         }}</span
@@ -203,7 +203,7 @@
         }"
         >音高
         {{
-          pitchScaleSlider.state.currentValue.value
+          pitchScaleSlider.state.currentValue.value != undefined
             ? pitchScaleSlider.state.currentValue.value.toFixed(2)
             : undefined
         }}</span
@@ -234,7 +234,7 @@
         }"
         >抑揚
         {{
-          intonationScaleSlider.state.currentValue.value
+          intonationScaleSlider.state.currentValue.value != undefined
             ? intonationScaleSlider.state.currentValue.value.toFixed(2)
             : undefined
         }}</span
@@ -265,7 +265,7 @@
         }"
         >音量
         {{
-          volumeScaleSlider.state.currentValue.value
+          volumeScaleSlider.state.currentValue.value != undefined
             ? volumeScaleSlider.state.currentValue.value.toFixed(2)
             : undefined
         }}</span
@@ -296,7 +296,7 @@
         }"
         >開始無音
         {{
-          prePhonemeLengthSlider.state.currentValue.value
+          prePhonemeLengthSlider.state.currentValue.value != undefined
             ? prePhonemeLengthSlider.state.currentValue.value.toFixed(2)
             : undefined
         }}</span
@@ -327,7 +327,7 @@
         }"
         >終了無音
         {{
-          postPhonemeLengthSlider.state.currentValue.value
+          postPhonemeLengthSlider.state.currentValue.value != undefined
             ? postPhonemeLengthSlider.state.currentValue.value.toFixed(2)
             : undefined
         }}</span


### PR DESCRIPTION
## 内容

AudioInfoの音高・抑揚・音量・無音の値が0のときfalseyなので表示が消えてしまうので修正しました。

## スクリーンショット・動画など

![スクリーンショット 2022-12-05 211131](https://user-images.githubusercontent.com/102559104/205636312-7639ce43-c4db-4dfc-8011-438cc4c1ae4e.png)

