### PR TITLE
FIX: AudioCellのStyleが不明でも表示が壊れないようにする

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -8,7 +8,6 @@
       class="absolute active-arrow"
     />
     <character-button
-      v-if="userOrderedCharacterInfos != undefined"
       :character-infos="userOrderedCharacterInfos"
       :loading="isInitializingSpeaker"
       :show-engine-info="isMultipleEngine"
@@ -72,9 +71,12 @@ export default defineComponent({
 
   setup(props, { emit }) {
     const store = useStore();
-    const userOrderedCharacterInfos = computed(
-      () => store.getters.USER_ORDERED_CHARACTER_INFOS
-    );
+    const userOrderedCharacterInfos = computed(() => {
+      const infos = store.getters.USER_ORDERED_CHARACTER_INFOS;
+      if (infos == undefined)
+        throw new Error("USER_ORDERED_CHARACTER_INFOS == undefined");
+      return infos;
+    });
     const isInitializingSpeaker = computed(
       () => store.state.audioKeyInitializingSpeaker === props.audioKey
     );

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -8,23 +8,13 @@
       class="absolute active-arrow"
     />
     <character-button
+      v-if="userOrderedCharacterInfos != undefined"
       :character-infos="userOrderedCharacterInfos"
       :loading="isInitializingSpeaker"
       :show-engine-info="isMultipleEngine"
       :ui-locked="uiLocked"
       v-model:selected-voice="selectedVoice"
-      ><template #unset-icon
-        ><q-avatar rounded size="2rem" color="warning">?</q-avatar></template
-      ><template #unset-item
-        ><span class="text-warning"
-          >{{
-            userOrderedCharacterInfos.length > 0
-              ? "有効なスタイルが選択されていません"
-              : "選択できるスタイルがありません"
-          }}
-        </span></template
-      ></character-button
-    >
+    />
     <q-input
       ref="textfield"
       filled
@@ -83,7 +73,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const store = useStore();
     const userOrderedCharacterInfos = computed(
-      () => store.getters.USER_ORDERED_CHARACTER_INFOS ?? []
+      () => store.getters.USER_ORDERED_CHARACTER_INFOS
     );
     const isInitializingSpeaker = computed(
       () => store.state.audioKeyInitializingSpeaker === props.audioKey

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -291,6 +291,7 @@ export default defineComponent({
     const supportedFeatures = computed(
       () =>
         (audioItem.value?.engineId &&
+          store.state.engineIds.some((id) => id === audioItem.value.engineId) &&
           store.state.engineManifests[audioItem.value?.engineId]
             .supportedFeatures) as
           | EngineManifest["supportedFeatures"]

--- a/src/components/AudioInfo.vue
+++ b/src/components/AudioInfo.vue
@@ -388,6 +388,7 @@ export default defineComponent({
     const supportedFeatures = computed(
       () =>
         (audioItem.value?.engineId &&
+          store.state.engineIds.some((id) => id === audioItem.value.engineId) &&
           store.state.engineManifests[audioItem.value?.engineId]
             .supportedFeatures) as
           | EngineManifest["supportedFeatures"]

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -29,11 +29,13 @@
           v-if="selectedStyleInfo == undefined"
           class="row no-wrap items-center"
         >
-          <span class="text-warning vertical-middle">{{
-            characterInfos.length === 0
-              ? "選択可能なスタイルがありません"
-              : "有効なスタイルが選択されていません"
-          }}</span>
+          <span class="text-warning vertical-middle">有効なスタイルが選択されていません</span>
+        </q-item>
+        <q-item
+          v-if="characterInfos.length === 0"
+          class="row no-wrap items-center"
+        >
+          <span class="text-warning vertical-middle">選択可能なスタイルがありません</span>
         </q-item>
         <q-item v-if="emptiable" class="q-pa-none">
           <q-btn

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -12,7 +12,9 @@
         class="q-pa-none q-ma-none"
         :src="selectedStyleInfo.iconPath"
       />
-      <slot v-else name="unset-icon"></slot>
+      <q-avatar v-else-if="!emptiable" rounded size="2rem" color="primary"
+        ><span color="text-display-on-primary">?</span></q-avatar
+      >
     </div>
     <div v-if="loading" class="loading">
       <q-spinner color="primary" size="1.6rem" :thickness="7" />
@@ -24,9 +26,16 @@
     >
       <q-list>
         <q-item
-          v-if="selectedStyleInfo == undefined || showUnset"
-          class="q-pa-none"
+          v-if="selectedStyleInfo == undefined"
+          class="row no-wrap items-center"
         >
+          <span class="text-warning vertical-middle">{{
+            characterInfos.length === 0
+              ? "選択可能なスタイルがありません"
+              : "有効なスタイルが選択されていません"
+          }}</span>
+        </q-item>
+        <q-item v-if="emptiable" class="q-pa-none">
           <q-btn
             flat
             no-caps
@@ -35,7 +44,7 @@
             :class="selectedCharacter == undefined && 'selected-character-item'"
             @click="$emit('update:selectedVoice', undefined)"
           >
-            <slot name="unset-item"></slot>
+            <span>選択解除</span>
           </q-btn>
         </q-item>
         <q-item
@@ -186,7 +195,7 @@ export default defineComponent({
     loading: { type: Boolean, default: false },
     selectedVoice: { type: Object as PropType<Voice> },
     showEngineInfo: { type: Boolean, default: false },
-    showUnset: { type: Boolean, default: false },
+    emptiable: { type: Boolean, default: false },
     uiLocked: { type: Boolean, required: true },
   },
 

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -29,13 +29,17 @@
           v-if="selectedStyleInfo == undefined"
           class="row no-wrap items-center"
         >
-          <span class="text-warning vertical-middle">有効なスタイルが選択されていません</span>
+          <span class="text-warning vertical-middle"
+            >有効なスタイルが選択されていません</span
+          >
         </q-item>
         <q-item
           v-if="characterInfos.length === 0"
           class="row no-wrap items-center"
         >
-          <span class="text-warning vertical-middle">選択可能なスタイルがありません</span>
+          <span class="text-warning vertical-middle"
+            >選択可能なスタイルがありません</span
+          >
         </q-item>
         <q-item v-if="emptiable" class="q-pa-none">
           <q-btn

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -30,7 +30,12 @@ export default defineComponent({
       const engineId = audioItem?.engineId;
       const styleId = audioItem?.styleId;
 
-      if (engineId === undefined || styleId === undefined) return undefined;
+      if (
+        engineId === undefined ||
+        styleId === undefined ||
+        !store.state.engineIds.some((id) => id === engineId)
+      )
+        return undefined;
 
       return store.getters.CHARACTER_INFO(engineId, styleId);
     });

--- a/src/store/proxy.ts
+++ b/src/store/proxy.ts
@@ -16,8 +16,8 @@ const proxyStoreCreator = (_engineFactory: IEngineConnectorFactory) => {
         const engineId = payload.engineId;
         const engineInfo: EngineInfo | undefined = state.engineInfos[engineId];
         if (engineInfo === undefined)
-          throw new Error(
-            `No such engineInfo registered: engineId == ${engineId}`
+          return Promise.reject(
+            new Error(`No such engineInfo registered: engineId == ${engineId}`)
           );
 
         const instance = _engineFactory.instance(engineInfo.host);


### PR DESCRIPTION
## 内容

AudioCellに未起動のエンジンのスタイルが適用されているとセルが一切表示されなくなっていました。
複数エンジンに対応するとこの状況は普通に起こり得る現象になります。
最低でもスタイルを再選択できるように修正を行います。

## 関連 Issue

- ref https://github.com/VOICEVOX/voicevox_project/issues/2#issuecomment-1341495231

## スクリーンショット・動画など

プロジェクトファイルを手動で編集してテスト

- 未起動のエンジンや存在しないスタイルを利用したプロジェクトを読み込んだもの
![スクリーンショット 2022-12-09 231110](https://user-images.githubusercontent.com/102559104/206721784-3ec231c9-df3f-4fca-a79d-d3cc76f6c9ef.png)
- 無効なスタイルが適用されているキャラクター選択ボタン
![スクリーンショット 2022-12-09 231136](https://user-images.githubusercontent.com/102559104/206722128-1028f0aa-4f6e-46b6-b200-bef94252ef98.png)


## その他

AudioCellとCharacterButtonだけを直せばいいかと思っていましたが割と影響範囲が多く場当たり的な対応をしている部分もあります。
