### PR TITLE
デフォルトエンジンに変更、ユーザーディレクトリにあるエンジンを省略

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -98,12 +98,8 @@ if (isDevelopment) {
   dotenv.config({ path: envPath });
 }
 
-const userEngineDir = path.join(app.getPath("userData"), "engines");
 const vvppEngineDir = path.join(app.getPath("userData"), "vvpp-engines");
 
-if (!fs.existsSync(userEngineDir)) {
-  fs.mkdirSync(userEngineDir);
-}
 if (!fs.existsSync(vvppEngineDir)) {
   fs.mkdirSync(vvppEngineDir);
 }
@@ -145,10 +141,10 @@ const defaultEngineInfos: EngineInfo[] = (() => {
     throw validate.errors;
   }
 
-  return engines.map((engineInfo, i) => {
+  return engines.map((engineInfo) => {
     return {
       ...engineInfo,
-      type: i === 0 ? "main" : "sub",
+      type: "main",
       path:
         engineInfo.path === undefined
           ? undefined
@@ -160,7 +156,7 @@ const defaultEngineInfos: EngineInfo[] = (() => {
 // 追加エンジンの一覧を取得する
 function fetchAdditionalEngineInfos(): EngineInfo[] {
   const engines: EngineInfo[] = [];
-  const addEngine = (engineDir: string, type: "userDir" | "vvpp" | "path") => {
+  const addEngine = (engineDir: string, type: "vvpp" | "path") => {
     const manifestPath = path.join(engineDir, "engine_manifest.json");
     if (!fs.existsSync(manifestPath)) {
       return "manifestNotFound";
@@ -188,17 +184,6 @@ function fetchAdditionalEngineInfos(): EngineInfo[] {
     });
     return "ok";
   };
-  for (const dirName of fs.readdirSync(userEngineDir)) {
-    const engineDir = path.join(userEngineDir, dirName);
-    if (!fs.statSync(engineDir).isDirectory()) {
-      log.log(`${engineDir} is not directory`);
-      continue;
-    }
-    const result = addEngine(engineDir, "userDir");
-    if (result !== "ok") {
-      log.log(`Failed to load engine: ${result}, ${engineDir}`);
-    }
-  }
   for (const dirName of fs.readdirSync(vvppEngineDir)) {
     const engineDir = path.join(vvppEngineDir, dirName);
     if (!fs.statSync(engineDir).isDirectory()) {
@@ -1327,12 +1312,6 @@ ipcMainHandle("RESTART_ENGINE", async (_, { engineId }) => {
 
 ipcMainHandle("OPEN_ENGINE_DIRECTORY", async (_, { engineId }) => {
   openEngineDirectory(engineId);
-});
-
-ipcMainHandle("OPEN_USER_ENGINE_DIRECTORY", () => {
-  // Windows環境だとスラッシュ区切りのパスが動かない。
-  // path.resolveはWindowsだけバックスラッシュ区切りにしてくれるため、path.resolveを挟む。
-  shell.openPath(path.resolve(userEngineDir));
 });
 
 ipcMainHandle("HOTKEY_SETTINGS", (_, { newData }) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -144,7 +144,7 @@ const defaultEngineInfos: EngineInfo[] = (() => {
   return engines.map((engineInfo) => {
     return {
       ...engineInfo,
-      type: "main",
+      type: "default",
       path:
         engineInfo.path === undefined
           ? undefined

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -372,8 +372,8 @@ export default defineComponent({
 
     const categorizedEngineIds = computed(() => {
       const result = {
-        main: Object.values(engineInfos.value)
-          .filter((info) => info.type === "main")
+        default: Object.values(engineInfos.value)
+          .filter((info) => info.type === "default")
           .map((info) => info.uuid),
         plugin: Object.values(engineInfos.value)
           .filter((info) => info.type === "path" || info.type === "vvpp")
@@ -430,7 +430,7 @@ export default defineComponent({
 
     const getEngineTypeName = (name: string) => {
       const engineTypeMap = {
-        main: "ビルトインエンジン",
+        default: "デフォルトエンジン",
         plugin: "追加エンジン",
       };
       return engineTypeMap[name as keyof typeof engineTypeMap];

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -375,16 +375,8 @@ export default defineComponent({
         main: Object.values(engineInfos.value)
           .filter((info) => info.type === "main")
           .map((info) => info.uuid),
-        sub: Object.values(engineInfos.value)
-          .filter((info) => info.type === "sub")
-          .map((info) => info.uuid),
         plugin: Object.values(engineInfos.value)
-          .filter(
-            (info) =>
-              info.type === "userDir" ||
-              info.type === "path" ||
-              info.type === "vvpp"
-          )
+          .filter((info) => info.type === "path" || info.type === "vvpp")
           .map((info) => info.uuid),
       };
       return Object.fromEntries(
@@ -438,8 +430,7 @@ export default defineComponent({
 
     const getEngineTypeName = (name: string) => {
       const engineTypeMap = {
-        main: "メインエンジン",
-        sub: "サブエンジン",
+        main: "ビルトインエンジン",
         plugin: "追加エンジン",
       };
       return engineTypeMap[name as keyof typeof engineTypeMap];

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -512,26 +512,16 @@ export default defineComponent({
           },
         ];
       }
-      engineMenu.subMenu.push(
-        {
-          type: "button",
-          label: "追加エンジンのフォルダを開く",
-          onClick: () => {
-            store.dispatch("OPEN_USER_ENGINE_DIRECTORY");
-          },
-          disableWhenUiLocked: false,
+      engineMenu.subMenu.push({
+        type: "button",
+        label: "エンジンの管理",
+        onClick: () => {
+          store.dispatch("SET_DIALOG_OPEN", {
+            isEngineManageDialogOpen: true,
+          });
         },
-        {
-          type: "button",
-          label: "エンジンの管理",
-          onClick: () => {
-            store.dispatch("SET_DIALOG_OPEN", {
-              isEngineManageDialogOpen: true,
-            });
-          },
-          disableWhenUiLocked: false,
-        }
-      );
+        disableWhenUiLocked: false,
+      });
     }
     watch([engineInfos, engineManifests], updateEngines, { immediate: true }); // engineInfos、engineManifestsを見て動的に更新できるようにする
 

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -206,10 +206,6 @@ const api: Sandbox = {
     return ipcRendererInvoke("OPEN_ENGINE_DIRECTORY", { engineId });
   },
 
-  openUserEngineDirectory: () => {
-    return ipcRendererInvoke("OPEN_USER_ENGINE_DIRECTORY");
-  },
-
   checkFileExists: (file) => {
     return ipcRenderer.invoke("CHECK_FILE_EXISTS", { file });
   },

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -13,11 +13,11 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     async action({ state, commit }) {
       const engineInfos = await window.electron.engineInfos();
 
-      // セーフモード時はengineIdsをメインエンジンのIDだけにする。
+      // セーフモード時はengineIdsをデフォルトエンジンのIDだけにする。
       let engineIds: string[];
       if (state.isSafeMode) {
         engineIds = engineInfos
-          .filter((engineInfo) => engineInfo.type === "main")
+          .filter((engineInfo) => engineInfo.type === "default")
           .map((info) => info.uuid);
       } else {
         engineIds = engineInfos.map((engineInfo) => engineInfo.uuid);

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -208,12 +208,6 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
-  OPEN_USER_ENGINE_DIRECTORY: {
-    action() {
-      return window.electron.openUserEngineDirectory();
-    },
-  },
-
   SET_ENGINE_STATE: {
     mutation(
       state,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -706,10 +706,6 @@ export type EngineStoreTypes = {
     action(payload: { engineId: string }): void;
   };
 
-  OPEN_USER_ENGINE_DIRECTORY: {
-    action(): void;
-  };
-
   SET_ENGINE_STATE: {
     mutation: { engineId: string; engineState: EngineState };
   };

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -202,11 +202,6 @@ export type IpcIHData = {
     return: void;
   };
 
-  OPEN_USER_ENGINE_DIRECTORY: {
-    args: [];
-    return: void;
-  };
-
   CHECK_FILE_EXISTS: {
     args: [obj: { file: string }];
     return: boolean;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -86,7 +86,6 @@ export interface Sandbox {
   restartEngineAll(): Promise<void>;
   restartEngine(engineId: string): Promise<void>;
   openEngineDirectory(engineId: string): void;
-  openUserEngineDirectory(): void;
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   checkFileExists(file: string): Promise<boolean>;
   changePinWindow(): void;
@@ -195,11 +194,9 @@ export type EngineInfo = {
   executionArgs: string[];
   // エンジンの種類。
   // main: メインエンジン
-  // sub: .envで指定されたその他のエンジン
-  // userDir: ユーザーディレクトリにあるエンジン
   // vvpp: vvppファイルから読み込んだエンジン
   // path: パスを指定して追加したエンジン
-  type: "main" | "sub" | "userDir" | "vvpp" | "path";
+  type: "main" | "vvpp" | "path";
 };
 
 export type Preset = {

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -193,10 +193,10 @@ export type EngineInfo = {
   executionFilePath: string;
   executionArgs: string[];
   // エンジンの種類。
-  // main: メインエンジン
+  // default: デフォルトエンジン
   // vvpp: vvppファイルから読み込んだエンジン
   // path: パスを指定して追加したエンジン
-  type: "main" | "vvpp" | "path";
+  type: "default" | "vvpp" | "path";
 };
 
 export type Preset = {

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -486,9 +486,9 @@ export default defineComponent({
 
       let engineIds: string[];
       if (store.state.isSafeMode) {
-        // メインエンジンだけを含める
+        // デフォルトエンジンだけを含める
         const main = Object.values(store.state.engineInfos).find(
-          (engine) => engine.type === "main"
+          (engine) => engine.type === "default"
         );
         if (!main) {
           throw new Error("No main engine found");

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -83,7 +83,7 @@ describe("store/vuex.js test", () => {
             executionFilePath: "",
             executionArgs: [],
             host: "http://127.0.0.1",
-            type: "main",
+            type: "default",
           },
         },
         engineManifests: {


### PR DESCRIPTION
## 内容

「サブエンジン」と「メインエンジン」と合わせて「デフォルトエンジン」と呼び、
「ユーザーディレクトリにあるエンジン」をなかったことにするプルリクエストです。

参考コメント https://github.com/VOICEVOX/voicevox_project/issues/2#issuecomment-1356267138

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/issues/2

## スクリーンショット・動画など

`.env`の`DEFAULT_ENGINE_INFOS`に２つ登録したときのスクショです。
デフォルトエンジンとして２つ表示されています。
![image](https://user-images.githubusercontent.com/4987327/208245571-df563e1e-e215-4702-9c2e-3de1af9ea9ff.png)

