### PR TITLE
複数エンジン対応：単一エンジン時はセーフモードボタンを出さないように

### DIFF
--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -23,12 +23,17 @@
               }}
             </div>
 
-            <template v-if="isEngineWaitingLong && isMultipleEngine">
+            <template v-if="isEngineWaitingLong">
               <q-separator spaced />
               エンジン起動に時間がかかっています。<br />
-              <q-btn outline @click="restartAppWithSafeMode">
+              <q-btn
+                outline
+                @click="restartAppWithSafeMode"
+                v-if="isMultipleEngine"
+              >
                 セーフモードで起動する</q-btn
               >
+              <q-btn outline @click="openFaq" v-else>FAQを見る</q-btn>
             </template>
           </div>
         </div>
@@ -598,6 +603,10 @@ export default defineComponent({
       store.dispatch("RESTART_APP", { isSafeMode: true });
     };
 
+    const openFaq = () => {
+      window.open("https://voicevox.hiroshiba.jp/qa/", "_blank");
+    };
+
     // ライセンス表示
     const isHelpDialogOpenComputed = computed({
       get: () => store.state.isHelpDialogOpen,
@@ -751,6 +760,7 @@ export default defineComponent({
       isEngineWaitingLong,
       isMultipleEngine,
       restartAppWithSafeMode,
+      openFaq,
       isHelpDialogOpenComputed,
       isSettingDialogOpenComputed,
       isHotkeySettingDialogOpenComputed,

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -579,6 +579,9 @@ export default defineComponent({
     const isEngineWaitingLong = ref<boolean>(false);
     let engineTimer: number | undefined = undefined;
     watch(allEngineState, (newEngineState) => {
+      if (Object.keys(store.state.engineInfos).length === 1) {
+        return;
+      }
       if (engineTimer !== undefined) {
         clearTimeout(engineTimer);
         engineTimer = undefined;
@@ -587,7 +590,7 @@ export default defineComponent({
         isEngineWaitingLong.value = false;
         engineTimer = window.setTimeout(() => {
           isEngineWaitingLong.value = true;
-        }, 10000);
+        }, 60000);
       } else {
         isEngineWaitingLong.value = false;
       }

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -23,7 +23,7 @@
               }}
             </div>
 
-            <template v-if="isEngineWaitingLong">
+            <template v-if="isEngineWaitingLong && isMultipleEngine">
               <q-separator spaced />
               エンジン起動に時間がかかっています。<br />
               <q-btn outline @click="restartAppWithSafeMode">
@@ -228,6 +228,8 @@ export default defineComponent({
     const audioItems = computed(() => store.state.audioItems);
     const audioKeys = computed(() => store.state.audioKeys);
     const uiLocked = computed(() => store.getters.UI_LOCKED);
+
+    const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
 
     // hotkeys handled by Mousetrap
     const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
@@ -579,9 +581,6 @@ export default defineComponent({
     const isEngineWaitingLong = ref<boolean>(false);
     let engineTimer: number | undefined = undefined;
     watch(allEngineState, (newEngineState) => {
-      if (Object.keys(store.state.engineInfos).length === 1) {
-        return;
-      }
       if (engineTimer !== undefined) {
         clearTimeout(engineTimer);
         engineTimer = undefined;
@@ -750,6 +749,7 @@ export default defineComponent({
       isCompletedInitialStartup,
       allEngineState,
       isEngineWaitingLong,
+      isMultipleEngine,
       restartAppWithSafeMode,
       isHelpDialogOpenComputed,
       isSettingDialogOpenComputed,


### PR DESCRIPTION
## 内容

単一エンジン起動時の時はセーフモードのボタンを出さないようにしました。
また、時間を10秒から1分にしています。
今までの平均起動時間みたいにしても良いかもしれない…？

## 関連 Issue

- ref: voicevox/voicevox_project#2

## スクリーンショット・動画など

（なし）

## その他

（なし）