### PR TITLE
outputSamplingRate用の"default"を"engineDefault"に変更

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -224,8 +224,8 @@ const store = new Store<ElectronStoreType>({
         exportText: { type: "boolean", default: false },
         outputStereo: { type: "boolean", default: false },
         outputSamplingRate: {
-          oneOf: [{ type: "number" }, { const: "default" }],
-          default: "default",
+          oneOf: [{ type: "number" }, { const: "engineDefault" }],
+          default: "engineDefault",
         },
         audioOutputDevice: { type: "string", default: "default" },
       },
@@ -238,7 +238,7 @@ const store = new Store<ElectronStoreType>({
         exportLab: false,
         exportText: false,
         outputStereo: false,
-        outputSamplingRate: "default",
+        outputSamplingRate: "engineDefault",
         audioOutputDevice: "default",
         splitTextWhenPaste: "PERIOD_AND_NEW_LINE",
       },
@@ -389,9 +389,8 @@ const store = new Store<ElectronStoreType>({
       }
     },
     ">=0.14": (store) => {
-      // 24000 Hz -> "default"
       if (store.get("savingSetting").outputSamplingRate == 24000) {
-        store.set("savingSetting.outputSamplingRate", "default");
+        store.set("savingSetting.outputSamplingRate", "engineDefault");
       }
     },
   },

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -491,10 +491,19 @@
                   borderless
                   name="samplingRate"
                   :model-value="savingSetting.outputSamplingRate"
-                  :options="['default', 24000, 44100, 48000, 88200, 96000]"
+                  :options="[
+                    'engineDefault',
+                    24000,
+                    44100,
+                    48000,
+                    88200,
+                    96000,
+                  ]"
                   :option-label="
                     (item) =>
-                      item === 'default' ? 'デフォルト' : `${item / 1000} kHz`
+                      item === 'engineDefault'
+                        ? 'デフォルト'
+                        : `${item / 1000} kHz`
                   "
                   @update:model-value="
                     handleSavingSettingChange('outputSamplingRate', $event)
@@ -816,7 +825,7 @@ export default defineComponent({
           data: { ...savingSetting.value, [key]: data },
         });
       };
-      if (key === "outputSamplingRate" && data !== "default") {
+      if (key === "outputSamplingRate" && data !== "engineDefault") {
         $q.dialog({
           title: "出力サンプリングレートを変更します",
           message:

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -494,7 +494,7 @@
                   borderless
                   name="samplingRate"
                   :model-value="savingSetting.outputSamplingRate"
-                  :options="samplingRateOptions as unknown[]"
+                  :options="samplingRateOptions"
                   :option-label="renderSamplingRateLabel"
                   @update:model-value="
                     handleSavingSettingChange('outputSamplingRate', $event)

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -807,11 +807,16 @@ export default defineComponent({
 
     const savingSetting = computed(() => store.state.savingSetting);
 
-    const samplingRateOptions: ReadonlyArray<
-      SavingSetting["outputSamplingRate"]
-    > = ["engineDefault", 24000, 44100, 48000, 88200, 96000] as const;
+    const samplingRateOptions: SavingSetting["outputSamplingRate"][] = [
+      "engineDefault",
+      24000,
+      44100,
+      48000,
+      88200,
+      96000,
+    ];
     const renderSamplingRateLabel = (
-      value: typeof samplingRateOptions[number]
+      value: SavingSetting["outputSamplingRate"]
     ) => {
       if (value === "engineDefault") {
         return "デフォルト";

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -491,20 +491,8 @@
                   borderless
                   name="samplingRate"
                   :model-value="savingSetting.outputSamplingRate"
-                  :options="[
-                    'engineDefault',
-                    24000,
-                    44100,
-                    48000,
-                    88200,
-                    96000,
-                  ]"
-                  :option-label="
-                    (item) =>
-                      item === 'engineDefault'
-                        ? 'デフォルト'
-                        : `${item / 1000} kHz`
-                  "
+                  :options="(samplingRateOptions as unknown[])"
+                  :option-label="renderSamplingRateLabel"
                   @update:model-value="
                     handleSavingSettingChange('outputSamplingRate', $event)
                   "
@@ -816,6 +804,19 @@ export default defineComponent({
 
     const savingSetting = computed(() => store.state.savingSetting);
 
+    const samplingRateOptions: ReadonlyArray<
+      SavingSetting["outputSamplingRate"]
+    > = ["engineDefault", 24000, 44100, 48000, 88200, 96000] as const;
+    const renderSamplingRateLabel = (
+      value: typeof samplingRateOptions[number]
+    ) => {
+      if (value === "engineDefault") {
+        return "デフォルト";
+      } else {
+        return `${value / 1000} kHz`;
+      }
+    };
+
     const handleSavingSettingChange = (
       key: keyof SavingSetting,
       data: string | boolean | number
@@ -881,6 +882,8 @@ export default defineComponent({
       changeExperimentalSetting,
       restartAllEngineProcess,
       savingSetting,
+      samplingRateOptions,
+      renderSamplingRateLabel,
       handleSavingSettingChange,
       openFileExplore,
       currentThemeNameComputed,

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -283,7 +283,10 @@
                     maxWidth: '450px',
                   }"
                   @update:model-value="
-                    handleSavingSettingChange('fixedExportDir', $event)
+                    (event) => {
+                      if (event == null) throw 'event is null';
+                      handleSavingSettingChange('fixedExportDir', event);
+                    }
                   "
                 >
                   <template v-slot:append>
@@ -491,7 +494,7 @@
                   borderless
                   name="samplingRate"
                   :model-value="savingSetting.outputSamplingRate"
-                  :options="(samplingRateOptions as unknown[])"
+                  :options="samplingRateOptions as unknown[]"
                   :option-label="renderSamplingRateLabel"
                   @update:model-value="
                     handleSavingSettingChange('outputSamplingRate', $event)

--- a/src/store/proxy.ts
+++ b/src/store/proxy.ts
@@ -40,7 +40,7 @@ export const convertAudioQueryFromEditorToEngine = (
   return {
     ...editorAudioQuery,
     outputSamplingRate:
-      editorAudioQuery.outputSamplingRate == "default"
+      editorAudioQuery.outputSamplingRate == "engineDefault"
         ? defaultOutputSamplingRate
         : editorAudioQuery.outputSamplingRate,
   };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -27,7 +27,7 @@ export const settingStoreState: SettingStoreState = {
     exportLab: false,
     exportText: false,
     outputStereo: false,
-    outputSamplingRate: "default",
+    outputSamplingRate: "engineDefault",
     audioOutputDevice: "default",
   },
   hotkeySettings: [],

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -43,7 +43,7 @@ import { QVueGlobals } from "quasar";
  * エディタ用のAudioQuery
  */
 export type EditorAudioQuery = Omit<AudioQuery, "outputSamplingRate"> & {
-  outputSamplingRate: number | "default";
+  outputSamplingRate: number | "engineDefault";
 };
 
 // FIXME: SpeakerIdを追加する

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -168,7 +168,7 @@ export type SavingSetting = {
   avoidOverwrite: boolean;
   exportText: boolean;
   outputStereo: boolean;
-  outputSamplingRate: number | "default";
+  outputSamplingRate: number | "engineDefault";
   audioOutputDevice: string;
 };
 


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/1044

を受けて、`outputSamplingRate`用の"default"を"engineDefault"に変更します。

## 関連 Issue

close #1044
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
