### PR TITLE
複数エンジン対応：いくつかのvvpp関連のバグを修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1141,7 +1141,9 @@ app.on("ready", async () => {
     appState.willQuit = true;
     app.quit();
     return;
-  } else if (filePath?.endsWith(".vvpp")) {
+  }
+
+  if (filePath?.endsWith(".vvpp")) {
     await installVvppEngine(filePath);
   }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -85,6 +85,7 @@ if (isDevelopment) {
   appDirPath = path.dirname(app.getPath("exe"));
   const envPath = path.join(appDirPath, ".env");
   dotenv.config({ path: envPath });
+  process.chdir(appDirPath);
 }
 
 protocol.registerSchemesAsPrivileged([
@@ -634,16 +635,22 @@ async function createWindow() {
   win.webContents.once("did-finish-load", () => {
     if (isMac) {
       if (filePathOnMac) {
-        ipcMainSend(win, "LOAD_PROJECT_FILE", {
-          filePath: filePathOnMac,
-          confirm: false,
-        });
+        if (filePathOnMac.endsWith(".vvproj")) {
+          ipcMainSend(win, "LOAD_PROJECT_FILE", {
+            filePath: filePathOnMac,
+            confirm: false,
+          });
+        }
         filePathOnMac = undefined;
       }
     } else {
       if (process.argv.length >= 2) {
         const filePath = process.argv[1];
-        if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+        if (
+          fs.existsSync(filePath) &&
+          fs.statSync(filePath).isFile() &&
+          filePath.endsWith(".vvproj")
+        ) {
           ipcMainSend(win, "LOAD_PROJECT_FILE", { filePath, confirm: false });
         }
       }
@@ -1131,8 +1138,11 @@ app.on("ready", async () => {
   ) {
     log.info("VOICEVOX already running. Cancelling launch.");
     log.info(`File path sent: ${filePath}`);
+    appState.willQuit = true;
     app.quit();
     return;
+  } else if (filePath?.endsWith(".vvpp")) {
+    await installVvppEngine(filePath);
   }
 
   createWindow().then(() => engineManager.runEngineAll(win));


### PR DESCRIPTION
## 内容

[SHAREVOX/sharevox_engine:0.2.0-preview.1](https://github.com/SHAREVOX/sharevox_engine/releases/tag/0.2.0-preview.1)で試して見付かった幾つかのバグを修正します。

- Voicevoxが複数起動していないとき（=`requestSingleInstanceLock`が成功したとき）、vvppファイルをvvprojファイルとして見なしてしまいエラーが出ていたのを修正
- Voicevoxが複数起動していないときに、一回再起動しなくても良い実装があったので変更
- Voicevoxが複数起動しているとき、起動したVoicevoxが終了されないのを修正
- cwdがインストールディレクトリにならず、エンジン起動時にENOENTを吐いていたのを修正（Firefoxのダウンロードタブから直で開くと、cwdがダウンロードフォルダになる？）

また、Linux/Macにて実行権限がついておらず、起動できないバグもあります。これはLinux/Macを持っている方にお願いしたいと思います。

## 関連 Issue

- ref: voicevox/voicevox_project#2

## スクリーンショット・動画など

（なし）

## その他

（なし）