### PR TITLE
vvpp: MacでVVPPファイルを開けるように修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -749,7 +749,7 @@ ipcMainHandle("SHOW_VVPP_OPEN_DIALOG", async (_, { title, defaultPath }) => {
     title,
     defaultPath,
     filters: [{ name: "VOICEVOX Plugin Package", extensions: ["vvpp"] }],
-    properties: [],
+    properties: ["openFile"],
   });
   return result.filePaths[0];
 });


### PR DESCRIPTION
## 内容

Macでvvppを開けないようになっていたので、`openFile`プロパティを付与し、ファイルを開けるようにしました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- VOICEVOX/voicevox_project#2

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
変更前
<img width="1327" alt="image" src="https://user-images.githubusercontent.com/34832037/208872246-1b19652c-0b73-4025-adba-dd7a6a0abbe6.png">
変更後
<img width="1327" alt="image" src="https://user-images.githubusercontent.com/34832037/208872496-a4dd4548-cd94-4d5f-a533-afce7d2db554.png">

