### PR TITLE
Migrate: コンポーネントをキャメルケースに、script setup構文に

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "markdown-it": "12.0.4",
         "move-file": "3.0.0",
         "multistream": "4.1.0",
-        "quasar": "2.4.13",
+        "quasar": "2.11.2",
         "semver": "7.3.5",
         "shlex": "2.1.2",
         "source-map-support": "0.5.19",
@@ -11818,18 +11818,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/electron-devtools-installer/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/electron-devtools-installer/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -11857,31 +11845,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/electron-devtools-installer/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/electron-devtools-installer/node_modules/tslib": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "dev": true
-    },
-    "node_modules/electron-devtools-installer/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "node_modules/electron-log": {
@@ -16899,37 +16866,6 @@
       "integrity": "sha512-vRTPqSU4JK8vVXmjICHSBhwXUvbfh/VJo+j7hvxqe15tLJyomv3FLgFdFgb8kpj0Fe8SsJa/TZUAXv7/sN+N7A==",
       "dev": true
     },
-    "node_modules/markdownlint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/markdownlint/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/markdownlint/node_modules/markdown-it": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-      "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -21277,9 +21213,9 @@
       }
     },
     "node_modules/quasar": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.4.13.tgz",
-      "integrity": "sha512-F2RxZrdqjvGWS2OQM1GArkxzC7Zx9q/guzxHyR2KNa3ZqhFOkv3zii1nGk3fRIzhE2+NL4FcS1+U+e9LBPJwug==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.11.2.tgz",
+      "integrity": "sha512-4u1REwVqJ7KPB7Mo/fxR6P4c5CQ1F7zjW/w4Cnb5OKnWhZDDSRcIWK+kTUZoFZ7/lGlac/0iFQXyrIc0noHhiw==",
       "engines": {
         "node": ">= 10.18.1",
         "npm": ">= 6.13.4",
@@ -37126,15 +37062,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "minimatch": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -37153,25 +37080,10 @@
             "glob": "^7.1.3"
           }
         },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "tslib": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
           "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
@@ -40998,33 +40910,6 @@
       "dev": true,
       "requires": {
         "markdown-it": "12.0.4"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "entities": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-          "dev": true
-        },
-        "markdown-it": {
-          "version": "12.0.4",
-          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-          "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1",
-            "entities": "~2.1.0",
-            "linkify-it": "^3.0.1",
-            "mdurl": "^1.0.1",
-            "uc.micro": "^1.0.5"
-          }
-        }
       }
     },
     "markdownlint-cli": {
@@ -44565,9 +44450,9 @@
       "dev": true
     },
     "quasar": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.4.13.tgz",
-      "integrity": "sha512-F2RxZrdqjvGWS2OQM1GArkxzC7Zx9q/guzxHyR2KNa3ZqhFOkv3zii1nGk3fRIzhE2+NL4FcS1+U+e9LBPJwug=="
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.11.2.tgz",
+      "integrity": "sha512-4u1REwVqJ7KPB7Mo/fxR6P4c5CQ1F7zjW/w4Cnb5OKnWhZDDSRcIWK+kTUZoFZ7/lGlac/0iFQXyrIc0noHhiw=="
     },
     "query-string": {
       "version": "4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "999.999.999",
       "hasInstallScript": true,
       "dependencies": {
-        "@gtm-support/vue-gtm": "1.2.3",
+        "@gtm-support/vue-gtm": "1.3.0",
         "@quasar/extras": "1.10.10",
         "ajv": "8.6.2",
         "core-js": "3.12.1",
@@ -32,8 +32,8 @@
         "tree-kill": "1.2.2",
         "unzipper": "0.10.11",
         "uuid": "9.0.0",
-        "vue": "3.0.11",
-        "vue-router": "4.0.8",
+        "vue": "3.2.45",
+        "vue-router": "4.1.6",
         "vuedraggable": "4.1.0",
         "vuex": "4.0.2"
       },
@@ -60,7 +60,7 @@
         "@vue/cli-plugin-unit-mocha": "4.5.13",
         "@vue/cli-plugin-vuex": "4.5.13",
         "@vue/cli-service": "4.5.13",
-        "@vue/compiler-sfc": "3.0.11",
+        "@vue/compiler-sfc": "3.2.45",
         "@vue/eslint-config-prettier": "7.0.0",
         "@vue/eslint-config-typescript": "11.0.2",
         "@vue/test-utils": "2.0.0-rc.6",
@@ -82,7 +82,7 @@
         "tmp": "0.2.1",
         "typescript": "4.8.4",
         "vue-cli-plugin-electron-builder": "3.0.0-alpha.4",
-        "vue-tsc": "0.40.13",
+        "vue-tsc": "1.0.18",
         "yargs": "17.2.1"
       },
       "engines": {
@@ -411,7 +411,8 @@
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "dev": true
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -1491,6 +1492,7 @@
       "version": "7.14.2",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
       "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
@@ -1761,9 +1763,9 @@
       "integrity": "sha512-GyiZEfKejkAQq2lDS0u2mv6NDVdNWqXi+uQX0zcBOsIpWHfQxWpuCeTTCSv3DZEKv2LMkC0cwv6ukVRJvPmpaA=="
     },
     "node_modules/@gtm-support/vue-gtm": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@gtm-support/vue-gtm/-/vue-gtm-1.2.3.tgz",
-      "integrity": "sha512-ZpOAkaVXG8RSXjCTfW2u70hYAj3xgOg7Fzi+M0OHyYzJf0zYMWfe/0L+Ck0zuA7cZ//aV1rgwZMIaj2DFiK9Jw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gtm-support/vue-gtm/-/vue-gtm-1.3.0.tgz",
+      "integrity": "sha512-QN7BmkE6RQ9bDgfqKdC/7KBALEM1vEjgbJ83c1nO6EJ3AUuc76l44DMH2q9npueQ2Vvl1FaqscQJzYH+rxjZmg==",
       "dependencies": {
         "@gtm-support/core": "1.1.0"
       },
@@ -3775,179 +3777,80 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@volar/code-gen": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.40.13.tgz",
-      "integrity": "sha512-4gShBWuMce868OVvgyA1cU5WxHbjfEme18Tw6uVMfweZCF5fB2KECG0iPrA9D54vHk3FeHarODNwgIaaFfUBlA==",
+    "node_modules/@volar/language-core": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.18.tgz",
+      "integrity": "sha512-PFrqAksKhiuAqNV4fefoMilX+JutVq0Z3iM14xjLvWPv68fs2dLedwU84GiHfSPTMmRiPCJ2HhH2rz4qNY42lA==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "0.40.13"
+        "@volar/source-map": "1.0.18",
+        "@vue/reactivity": "^3.2.45",
+        "muggle-string": "^0.1.0"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.40.13.tgz",
-      "integrity": "sha512-dbdkAB2Nxb0wLjAY5O64o3ywVWlAGONnBIoKAkXSf6qkGZM+nJxcizsoiI66K+RHQG0XqlyvjDizfnTxr+6PWg==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.18.tgz",
+      "integrity": "sha512-D8AcjrT2ukG5XiZhtSQBhcvL1TTlWOebCqS//Z/hGLGQZjpZHWaKD4OyDzKDzM0U9EtOuDh9rttnabCHDPvY2Q==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.2.38"
+        "muggle-string": "^0.1.0"
       }
     },
-    "node_modules/@volar/source-map/node_modules/@vue/reactivity": {
-      "version": "3.2.38",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.38.tgz",
-      "integrity": "sha512-6L4myYcH9HG2M25co7/BSo0skKFHpAN8PhkNPM4xRVkyGl1K5M3Jx4rp5bsYhvYze2K4+l+pioN4e6ZwFLUVtw==",
+    "node_modules/@volar/typescript": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.18.tgz",
+      "integrity": "sha512-xpH1Ij+PKtbIKEEYU2bF0llBRmu+ojjm/UA1WHNpi/dvsFWTIZcPniuqYEpPc32Zq/f8OPk98HbM2Oj5eue+vA==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.2.38"
+        "@volar/language-core": "1.0.18"
       }
-    },
-    "node_modules/@volar/source-map/node_modules/@vue/shared": {
-      "version": "3.2.38",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-      "integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
-      "dev": true
-    },
-    "node_modules/@volar/typescript-faster": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/typescript-faster/-/typescript-faster-0.40.13.tgz",
-      "integrity": "sha512-uy+TlcFkKoNlKEnxA4x5acxdxLyVDIXGSc8cYDNXpPKjBKXrQaetzCzlO3kVBqu1VLMxKNGJMTKn35mo+ILQmw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.3.7"
-      }
-    },
-    "node_modules/@volar/typescript-faster/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@volar/typescript-faster/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@volar/typescript-faster/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/@volar/vue-language-core": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-0.40.13.tgz",
-      "integrity": "sha512-QkCb8msi2KUitTdM6Y4kAb7/ZlEvuLcbBFOC2PLBlFuoZwyxvSP7c/dBGmKGtJlEvMX0LdCyrg5V2aBYxD38/Q==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.18.tgz",
+      "integrity": "sha512-1yJcXYz9SdQUYoKWPbnr1SgMsBGXH29hS8W47p46P8Mm+5mmDdR/GFQw2+Zo5kAIS8vtLstlowI1Okoy7HFzIQ==",
       "dev": true,
       "dependencies": {
-        "@volar/code-gen": "0.40.13",
-        "@volar/source-map": "0.40.13",
-        "@vue/compiler-core": "^3.2.38",
-        "@vue/compiler-dom": "^3.2.38",
-        "@vue/compiler-sfc": "^3.2.38",
-        "@vue/reactivity": "^3.2.38",
-        "@vue/shared": "^3.2.38"
+        "@volar/language-core": "1.0.18",
+        "@volar/source-map": "1.0.18",
+        "@vue/compiler-dom": "^3.2.45",
+        "@vue/compiler-sfc": "^3.2.45",
+        "@vue/reactivity": "^3.2.45",
+        "@vue/shared": "^3.2.45",
+        "minimatch": "^5.1.1",
+        "vue-template-compiler": "^2.7.14"
       }
     },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-core": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.39.tgz",
-      "integrity": "sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==",
+    "node_modules/@volar/vue-language-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.39",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
+        "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-dom": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.39.tgz",
-      "integrity": "sha512-HMFI25Be1C8vLEEv1hgEO1dWwG9QQ8LTTPmCkblVJY/O3OvWx6r1+zsox5mKPMGvqYEZa6l8j+xgOfUspgo7hw==",
+    "node_modules/@volar/vue-language-core/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.2.39",
-        "@vue/shared": "3.2.39"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-sfc": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.39.tgz",
-      "integrity": "sha512-fqAQgFs1/BxTUZkd0Vakn3teKUt//J3c420BgnYgEOoVdTwYpBTSXCMJ88GOBCylmUBbtquGPli9tVs7LzsWIA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.39",
-        "@vue/compiler-dom": "3.2.39",
-        "@vue/compiler-ssr": "3.2.39",
-        "@vue/reactivity-transform": "3.2.39",
-        "@vue/shared": "3.2.39",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-ssr": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.39.tgz",
-      "integrity": "sha512-EoGCJ6lincKOZGW+0Ky4WOKsSmqL7hp1ZYgen8M7u/mlvvEQUaO9tKKOy7K43M9U2aA3tPv0TuYYQFrEbK2eFQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.2.39",
-        "@vue/shared": "3.2.39"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/reactivity": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.39.tgz",
-      "integrity": "sha512-vlaYX2a3qMhIZfrw3Mtfd+BuU+TZmvDrPMa+6lpfzS9k/LnGxkSuf0fhkP0rMGfiOHPtyKoU9OJJJFGm92beVQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/shared": "3.2.39"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/shared": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
-      "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
-      "dev": true
-    },
-    "node_modules/@volar/vue-language-core/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+        "brace-expansion": "^2.0.1"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/@volar/vue-typescript": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-0.40.13.tgz",
-      "integrity": "sha512-o7bNztwjs8JmbQjVkrnbZUOfm7q4B8ZYssETISN1tRaBdun6cfNqgpkvDYd+VUBh1O4CdksvN+5BUNnwAz4oCQ==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.18.tgz",
+      "integrity": "sha512-pfi2/vTLgAPeRNgWzPFFv14YoLc3MnPMVKxl17ZLHStFgROUWQetTN+44FUWVYIl820MesMsyRv4kAIak0XGIQ==",
       "dev": true,
       "dependencies": {
-        "@volar/code-gen": "0.40.13",
-        "@volar/typescript-faster": "0.40.13",
-        "@volar/vue-language-core": "0.40.13"
+        "@volar/typescript": "1.0.18",
+        "@volar/vue-language-core": "1.0.18"
       }
     },
     "node_modules/@vue/babel-helper-vue-jsx-merge-props": {
@@ -5748,14 +5651,13 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.11.tgz",
-      "integrity": "sha512-6sFj6TBac1y2cWCvYCA8YzHJEbsVkX7zdRs/3yK/n1ilvRqcn983XvpBbnN3v4mZ1UiQycTvOiajJmOgN9EVgw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
       "dependencies": {
-        "@babel/parser": "^7.12.0",
-        "@babel/types": "^7.12.0",
-        "@vue/shared": "3.0.11",
-        "estree-walker": "^2.0.1",
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
     },
@@ -5768,70 +5670,46 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.11.tgz",
-      "integrity": "sha512-+3xB50uGeY5Fv9eMKVJs2WSRULfgwaTJsy23OIltKgMrynnIj8hTYY2UL97HCoz78aDw1VDXdrBQ4qepWjnQcw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
       "dependencies": {
-        "@vue/compiler-core": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.11.tgz",
-      "integrity": "sha512-7fNiZuCecRleiyVGUWNa6pn8fB2fnuJU+3AGjbjl7r1P5wBivfl02H4pG+2aJP5gh2u+0wXov1W38tfWOphsXw==",
-      "dev": true,
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
       "dependencies": {
-        "@babel/parser": "^7.13.9",
-        "@babel/types": "^7.13.0",
-        "@vue/compiler-core": "3.0.11",
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/compiler-ssr": "3.0.11",
-        "@vue/shared": "3.0.11",
-        "consolidate": "^0.16.0",
-        "estree-walker": "^2.0.1",
-        "hash-sum": "^2.0.0",
-        "lru-cache": "^5.1.1",
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
-        "merge-source-map": "^1.1.0",
         "postcss": "^8.1.10",
-        "postcss-modules": "^4.0.0",
-        "postcss-selector-parser": "^6.0.4",
         "source-map": "^0.6.1"
-      },
-      "peerDependencies": {
-        "vue": "3.0.11"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/consolidate": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
-      "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "^3.7.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/@vue/compiler-sfc/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.11.tgz",
-      "integrity": "sha512-66yUGI8SGOpNvOcrQybRIhl2M03PJ+OrDPm78i7tvVln86MHTKhM3ERbALK26F7tXl0RkjX4sZpucCpiKs3MnA==",
-      "dev": true,
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
       "dependencies": {
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/@vue/component-compiler-utils": {
@@ -5921,9 +5799,9 @@
       "dev": true
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.2.1.tgz",
-      "integrity": "sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ=="
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.4.5.tgz",
+      "integrity": "sha512-JD5fcdIuFxU4fQyXUu3w2KpAJHzTVdN+p4iOX2lMWSHMOoQdMAcpFLZzm9Z/2nmsoZ1a96QEhZ26e50xLBsgOQ=="
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "7.0.0",
@@ -5998,76 +5876,60 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.11.tgz",
-      "integrity": "sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
       "dependencies": {
-        "@vue/shared": "3.0.11"
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/@vue/reactivity-transform": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.39.tgz",
-      "integrity": "sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==",
-      "dev": true,
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
       "dependencies": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.39",
-        "@vue/shared": "3.2.39",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
-    "node_modules/@vue/reactivity-transform/node_modules/@vue/compiler-core": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.39.tgz",
-      "integrity": "sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.39",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/reactivity-transform/node_modules/@vue/shared": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
-      "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
-      "dev": true
-    },
-    "node_modules/@vue/reactivity-transform/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@vue/runtime-core": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.11.tgz",
-      "integrity": "sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
+      "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
       "dependencies": {
-        "@vue/reactivity": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/reactivity": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz",
-      "integrity": "sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
+      "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
       "dependencies": {
-        "@vue/runtime-core": "3.0.11",
-        "@vue/shared": "3.0.11",
+        "@vue/runtime-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "csstype": "^2.6.8"
       }
     },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
+      "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/shared": "3.2.45"
+      },
+      "peerDependencies": {
+        "vue": "3.2.45"
+      }
+    },
     "node_modules/@vue/shared": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
-      "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
     },
     "node_modules/@vue/test-utils": {
       "version": "2.0.0-rc.6",
@@ -10777,9 +10639,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -10814,6 +10676,12 @@
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true
     },
     "node_modules/debounce-fn": {
       "version": "4.0.0",
@@ -14260,15 +14128,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "node_modules/generic-names": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
-      "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^1.1.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -15251,12 +15110,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/icss-replace-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
-      "dev": true
     },
     "node_modules/icss-utils": {
       "version": "4.1.1",
@@ -16736,12 +16589,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -16861,7 +16708,6 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -18235,6 +18081,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/muggle-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.1.0.tgz",
+      "integrity": "sha512-Tr1knR3d2mKvvWthlk7202rywKbiOm4rVFLsfAaSIhJ6dt9o47W4S+JMtWhd/PW9Wrdew2/S2fSvhz3E2gkfEg==",
+      "dev": true
+    },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -18318,7 +18170,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -19293,8 +19144,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -19479,7 +19329,6 @@
       "version": "8.4.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
       "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20309,25 +20158,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/postcss-modules": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.0.0.tgz",
-      "integrity": "sha512-ghS/ovDzDqARm4Zj6L2ntadjyQMoyJmi0JkLlYtH2QFLrvNlxH5OAVRPWPeKilB0pY7SbuhO173KOWkPAxRJcw==",
-      "dev": true,
-      "dependencies": {
-        "generic-names": "^2.0.1",
-        "icss-replace-symbols": "^1.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "string-hash": "^1.1.1"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
     "node_modules/postcss-modules-extract-imports": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
@@ -20504,77 +20334,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postcss-modules/node_modules/icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules/node_modules/postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules/node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules/node_modules/postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules/node_modules/postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^5.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-normalize-charset": {
@@ -23272,7 +23031,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23318,8 +23076,7 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "node_modules/spawn-command": {
       "version": "0.0.2-1",
@@ -23603,12 +23360,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
-      "dev": true
     },
     "node_modules/string-width": {
       "version": "1.0.2",
@@ -24280,6 +24031,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -25364,13 +25116,15 @@
       "dev": true
     },
     "node_modules/vue": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.11.tgz",
-      "integrity": "sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
+      "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
       "dependencies": {
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/runtime-dom": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-sfc": "3.2.45",
+        "@vue/runtime-dom": "3.2.45",
+        "@vue/server-renderer": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "node_modules/vue-cli-plugin-electron-builder": {
@@ -26463,14 +26217,17 @@
       "dev": true
     },
     "node_modules/vue-router": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.8.tgz",
-      "integrity": "sha512-42mWSQaH7CCBQDspQTHv63f34VEnZC20g9QNK4WJ/zW8SdIUeT6TQ2i/78fjF/pVBUPLBWrGhvB7uDnaz7O/pA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.6.tgz",
+      "integrity": "sha512-DYWYwsG6xNPmLq/FmZn8Ip+qrhFEzA14EI12MsMgVxvHFDYvlr4NXpVF5hrRH1wVcDP8fGi5F4rxuJSl8/r+EQ==",
       "dependencies": {
-        "@vue/devtools-api": "^6.0.0-beta.10"
+        "@vue/devtools-api": "^6.4.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "vue": "^3.0.0"
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vue-style-loader": {
@@ -26489,6 +26246,16 @@
       "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
       "dev": true
     },
+    "node_modules/vue-template-compiler": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "dev": true,
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
     "node_modules/vue-template-es2015-compiler": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
@@ -26496,13 +26263,13 @@
       "dev": true
     },
     "node_modules/vue-tsc": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.40.13.tgz",
-      "integrity": "sha512-xzuN3g5PnKfJcNrLv4+mAjteMd5wLm5fRhW0034OfNJZY4WhB07vhngea/XeGn7wNYt16r7syonzvW/54dcNiA==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.18.tgz",
+      "integrity": "sha512-JFLAz3Xh/iyTnMGdlfG3TuvcaJyFcqyELpLv50jyvOYLAS2+WHzac0IB73FQ37HmGm/4IWMkQZS5r/9FKSejQQ==",
       "dev": true,
       "dependencies": {
-        "@volar/vue-language-core": "0.40.13",
-        "@volar/vue-typescript": "0.40.13"
+        "@volar/vue-language-core": "1.0.18",
+        "@volar/vue-typescript": "1.0.18"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -28354,7 +28121,8 @@
     "@babel/helper-validator-identifier": {
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -29219,6 +28987,7 @@
       "version": "7.14.2",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
       "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
@@ -29427,9 +29196,9 @@
       "integrity": "sha512-GyiZEfKejkAQq2lDS0u2mv6NDVdNWqXi+uQX0zcBOsIpWHfQxWpuCeTTCSv3DZEKv2LMkC0cwv6ukVRJvPmpaA=="
     },
     "@gtm-support/vue-gtm": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@gtm-support/vue-gtm/-/vue-gtm-1.2.3.tgz",
-      "integrity": "sha512-ZpOAkaVXG8RSXjCTfW2u70hYAj3xgOg7Fzi+M0OHyYzJf0zYMWfe/0L+Ck0zuA7cZ//aV1rgwZMIaj2DFiK9Jw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gtm-support/vue-gtm/-/vue-gtm-1.3.0.tgz",
+      "integrity": "sha512-QN7BmkE6RQ9bDgfqKdC/7KBALEM1vEjgbJ83c1nO6EJ3AUuc76l44DMH2q9npueQ2Vvl1FaqscQJzYH+rxjZmg==",
       "requires": {
         "@gtm-support/core": "1.1.0",
         "vue-router": "^4.0.0"
@@ -30974,173 +30743,79 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
-    "@volar/code-gen": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.40.13.tgz",
-      "integrity": "sha512-4gShBWuMce868OVvgyA1cU5WxHbjfEme18Tw6uVMfweZCF5fB2KECG0iPrA9D54vHk3FeHarODNwgIaaFfUBlA==",
+    "@volar/language-core": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.18.tgz",
+      "integrity": "sha512-PFrqAksKhiuAqNV4fefoMilX+JutVq0Z3iM14xjLvWPv68fs2dLedwU84GiHfSPTMmRiPCJ2HhH2rz4qNY42lA==",
       "dev": true,
       "requires": {
-        "@volar/source-map": "0.40.13"
+        "@volar/source-map": "1.0.18",
+        "@vue/reactivity": "^3.2.45",
+        "muggle-string": "^0.1.0"
       }
     },
     "@volar/source-map": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.40.13.tgz",
-      "integrity": "sha512-dbdkAB2Nxb0wLjAY5O64o3ywVWlAGONnBIoKAkXSf6qkGZM+nJxcizsoiI66K+RHQG0XqlyvjDizfnTxr+6PWg==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.18.tgz",
+      "integrity": "sha512-D8AcjrT2ukG5XiZhtSQBhcvL1TTlWOebCqS//Z/hGLGQZjpZHWaKD4OyDzKDzM0U9EtOuDh9rttnabCHDPvY2Q==",
       "dev": true,
       "requires": {
-        "@vue/reactivity": "3.2.38"
-      },
-      "dependencies": {
-        "@vue/reactivity": {
-          "version": "3.2.38",
-          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.38.tgz",
-          "integrity": "sha512-6L4myYcH9HG2M25co7/BSo0skKFHpAN8PhkNPM4xRVkyGl1K5M3Jx4rp5bsYhvYze2K4+l+pioN4e6ZwFLUVtw==",
-          "dev": true,
-          "requires": {
-            "@vue/shared": "3.2.38"
-          }
-        },
-        "@vue/shared": {
-          "version": "3.2.38",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-          "integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
-          "dev": true
-        }
+        "muggle-string": "^0.1.0"
       }
     },
-    "@volar/typescript-faster": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/typescript-faster/-/typescript-faster-0.40.13.tgz",
-      "integrity": "sha512-uy+TlcFkKoNlKEnxA4x5acxdxLyVDIXGSc8cYDNXpPKjBKXrQaetzCzlO3kVBqu1VLMxKNGJMTKn35mo+ILQmw==",
+    "@volar/typescript": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.18.tgz",
+      "integrity": "sha512-xpH1Ij+PKtbIKEEYU2bF0llBRmu+ojjm/UA1WHNpi/dvsFWTIZcPniuqYEpPc32Zq/f8OPk98HbM2Oj5eue+vA==",
       "dev": true,
       "requires": {
-        "semver": "^7.3.7"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
+        "@volar/language-core": "1.0.18"
       }
     },
     "@volar/vue-language-core": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-0.40.13.tgz",
-      "integrity": "sha512-QkCb8msi2KUitTdM6Y4kAb7/ZlEvuLcbBFOC2PLBlFuoZwyxvSP7c/dBGmKGtJlEvMX0LdCyrg5V2aBYxD38/Q==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.18.tgz",
+      "integrity": "sha512-1yJcXYz9SdQUYoKWPbnr1SgMsBGXH29hS8W47p46P8Mm+5mmDdR/GFQw2+Zo5kAIS8vtLstlowI1Okoy7HFzIQ==",
       "dev": true,
       "requires": {
-        "@volar/code-gen": "0.40.13",
-        "@volar/source-map": "0.40.13",
-        "@vue/compiler-core": "^3.2.38",
-        "@vue/compiler-dom": "^3.2.38",
-        "@vue/compiler-sfc": "^3.2.38",
-        "@vue/reactivity": "^3.2.38",
-        "@vue/shared": "^3.2.38"
+        "@volar/language-core": "1.0.18",
+        "@volar/source-map": "1.0.18",
+        "@vue/compiler-dom": "^3.2.45",
+        "@vue/compiler-sfc": "^3.2.45",
+        "@vue/reactivity": "^3.2.45",
+        "@vue/shared": "^3.2.45",
+        "minimatch": "^5.1.1",
+        "vue-template-compiler": "^2.7.14"
       },
       "dependencies": {
-        "@vue/compiler-core": {
-          "version": "3.2.39",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.39.tgz",
-          "integrity": "sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "@babel/parser": "^7.16.4",
-            "@vue/shared": "3.2.39",
-            "estree-walker": "^2.0.2",
-            "source-map": "^0.6.1"
+            "balanced-match": "^1.0.0"
           }
         },
-        "@vue/compiler-dom": {
-          "version": "3.2.39",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.39.tgz",
-          "integrity": "sha512-HMFI25Be1C8vLEEv1hgEO1dWwG9QQ8LTTPmCkblVJY/O3OvWx6r1+zsox5mKPMGvqYEZa6l8j+xgOfUspgo7hw==",
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
           "dev": true,
           "requires": {
-            "@vue/compiler-core": "3.2.39",
-            "@vue/shared": "3.2.39"
+            "brace-expansion": "^2.0.1"
           }
-        },
-        "@vue/compiler-sfc": {
-          "version": "3.2.39",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.39.tgz",
-          "integrity": "sha512-fqAQgFs1/BxTUZkd0Vakn3teKUt//J3c420BgnYgEOoVdTwYpBTSXCMJ88GOBCylmUBbtquGPli9tVs7LzsWIA==",
-          "dev": true,
-          "requires": {
-            "@babel/parser": "^7.16.4",
-            "@vue/compiler-core": "3.2.39",
-            "@vue/compiler-dom": "3.2.39",
-            "@vue/compiler-ssr": "3.2.39",
-            "@vue/reactivity-transform": "3.2.39",
-            "@vue/shared": "3.2.39",
-            "estree-walker": "^2.0.2",
-            "magic-string": "^0.25.7",
-            "postcss": "^8.1.10",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@vue/compiler-ssr": {
-          "version": "3.2.39",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.39.tgz",
-          "integrity": "sha512-EoGCJ6lincKOZGW+0Ky4WOKsSmqL7hp1ZYgen8M7u/mlvvEQUaO9tKKOy7K43M9U2aA3tPv0TuYYQFrEbK2eFQ==",
-          "dev": true,
-          "requires": {
-            "@vue/compiler-dom": "3.2.39",
-            "@vue/shared": "3.2.39"
-          }
-        },
-        "@vue/reactivity": {
-          "version": "3.2.39",
-          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.39.tgz",
-          "integrity": "sha512-vlaYX2a3qMhIZfrw3Mtfd+BuU+TZmvDrPMa+6lpfzS9k/LnGxkSuf0fhkP0rMGfiOHPtyKoU9OJJJFGm92beVQ==",
-          "dev": true,
-          "requires": {
-            "@vue/shared": "3.2.39"
-          }
-        },
-        "@vue/shared": {
-          "version": "3.2.39",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
-          "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
         }
       }
     },
     "@volar/vue-typescript": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-0.40.13.tgz",
-      "integrity": "sha512-o7bNztwjs8JmbQjVkrnbZUOfm7q4B8ZYssETISN1tRaBdun6cfNqgpkvDYd+VUBh1O4CdksvN+5BUNnwAz4oCQ==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.18.tgz",
+      "integrity": "sha512-pfi2/vTLgAPeRNgWzPFFv14YoLc3MnPMVKxl17ZLHStFgROUWQetTN+44FUWVYIl820MesMsyRv4kAIak0XGIQ==",
       "dev": true,
       "requires": {
-        "@volar/code-gen": "0.40.13",
-        "@volar/typescript-faster": "0.40.13",
-        "@volar/vue-language-core": "0.40.13"
+        "@volar/typescript": "1.0.18",
+        "@volar/vue-language-core": "1.0.18"
       }
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
@@ -32511,14 +32186,13 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.11.tgz",
-      "integrity": "sha512-6sFj6TBac1y2cWCvYCA8YzHJEbsVkX7zdRs/3yK/n1ilvRqcn983XvpBbnN3v4mZ1UiQycTvOiajJmOgN9EVgw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
       "requires": {
-        "@babel/parser": "^7.12.0",
-        "@babel/types": "^7.12.0",
-        "@vue/shared": "3.0.11",
-        "estree-walker": "^2.0.1",
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       },
       "dependencies": {
@@ -32530,63 +32204,45 @@
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.11.tgz",
-      "integrity": "sha512-+3xB50uGeY5Fv9eMKVJs2WSRULfgwaTJsy23OIltKgMrynnIj8hTYY2UL97HCoz78aDw1VDXdrBQ4qepWjnQcw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
       "requires": {
-        "@vue/compiler-core": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.11.tgz",
-      "integrity": "sha512-7fNiZuCecRleiyVGUWNa6pn8fB2fnuJU+3AGjbjl7r1P5wBivfl02H4pG+2aJP5gh2u+0wXov1W38tfWOphsXw==",
-      "dev": true,
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
       "requires": {
-        "@babel/parser": "^7.13.9",
-        "@babel/types": "^7.13.0",
-        "@vue/compiler-core": "3.0.11",
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/compiler-ssr": "3.0.11",
-        "@vue/shared": "3.0.11",
-        "consolidate": "^0.16.0",
-        "estree-walker": "^2.0.1",
-        "hash-sum": "^2.0.0",
-        "lru-cache": "^5.1.1",
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
-        "merge-source-map": "^1.1.0",
         "postcss": "^8.1.10",
-        "postcss-modules": "^4.0.0",
-        "postcss-selector-parser": "^6.0.4",
         "source-map": "^0.6.1"
       },
       "dependencies": {
-        "consolidate": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
-          "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.7.2"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.11.tgz",
-      "integrity": "sha512-66yUGI8SGOpNvOcrQybRIhl2M03PJ+OrDPm78i7tvVln86MHTKhM3ERbALK26F7tXl0RkjX4sZpucCpiKs3MnA==",
-      "dev": true,
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
       "requires": {
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/component-compiler-utils": {
@@ -32660,9 +32316,9 @@
       }
     },
     "@vue/devtools-api": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.2.1.tgz",
-      "integrity": "sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ=="
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.4.5.tgz",
+      "integrity": "sha512-JD5fcdIuFxU4fQyXUu3w2KpAJHzTVdN+p4iOX2lMWSHMOoQdMAcpFLZzm9Z/2nmsoZ1a96QEhZ26e50xLBsgOQ=="
     },
     "@vue/eslint-config-prettier": {
       "version": "7.0.0",
@@ -32704,75 +32360,57 @@
       "requires": {}
     },
     "@vue/reactivity": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.11.tgz",
-      "integrity": "sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
       "requires": {
-        "@vue/shared": "3.0.11"
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/reactivity-transform": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.39.tgz",
-      "integrity": "sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==",
-      "dev": true,
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.39",
-        "@vue/shared": "3.2.39",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
-      },
-      "dependencies": {
-        "@vue/compiler-core": {
-          "version": "3.2.39",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.39.tgz",
-          "integrity": "sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==",
-          "dev": true,
-          "requires": {
-            "@babel/parser": "^7.16.4",
-            "@vue/shared": "3.2.39",
-            "estree-walker": "^2.0.2",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@vue/shared": {
-          "version": "3.2.39",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
-          "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "@vue/runtime-core": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.11.tgz",
-      "integrity": "sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
+      "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
       "requires": {
-        "@vue/reactivity": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/reactivity": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz",
-      "integrity": "sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
+      "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
       "requires": {
-        "@vue/runtime-core": "3.0.11",
-        "@vue/shared": "3.0.11",
+        "@vue/runtime-core": "3.2.45",
+        "@vue/shared": "3.2.45",
         "csstype": "^2.6.8"
       }
     },
+    "@vue/server-renderer": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
+      "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
+      "requires": {
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
     "@vue/shared": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
-      "integrity": "sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA=="
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
     },
     "@vue/test-utils": {
       "version": "2.0.0-rc.6",
@@ -36535,9 +36173,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -36569,6 +36207,12 @@
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true
     },
     "debounce-fn": {
       "version": "4.0.0",
@@ -39255,15 +38899,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "generic-names": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
-      "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -40055,12 +39690,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icss-replace-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
-      "dev": true
     },
     "icss-utils": {
       "version": "4.1.1",
@@ -41196,12 +40825,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -41308,7 +40931,6 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -42415,6 +42037,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "muggle-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.1.0.tgz",
+      "integrity": "sha512-Tr1knR3d2mKvvWthlk7202rywKbiOm4rVFLsfAaSIhJ6dt9o47W4S+JMtWhd/PW9Wrdew2/S2fSvhz3E2gkfEg==",
+      "dev": true
+    },
     "multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -42479,8 +42107,7 @@
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -43271,8 +42898,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -43416,7 +43042,6 @@
       "version": "8.4.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
       "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
-      "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -44049,67 +43674,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        }
-      }
-    },
-    "postcss-modules": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.0.0.tgz",
-      "integrity": "sha512-ghS/ovDzDqARm4Zj6L2ntadjyQMoyJmi0JkLlYtH2QFLrvNlxH5OAVRPWPeKilB0pY7SbuhO173KOWkPAxRJcw==",
-      "dev": true,
-      "requires": {
-        "generic-names": "^2.0.1",
-        "icss-replace-symbols": "^1.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "string-hash": "^1.1.1"
-      },
-      "dependencies": {
-        "icss-utils": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-          "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true,
-          "requires": {}
-        },
-        "postcss-modules-extract-imports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-          "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true,
-          "requires": {}
-        },
-        "postcss-modules-local-by-default": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-          "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
-          "dev": true,
-          "requires": {
-            "icss-utils": "^5.0.0",
-            "postcss-selector-parser": "^6.0.2",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-modules-scope": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-          "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
-          "dev": true,
-          "requires": {
-            "postcss-selector-parser": "^6.0.4"
-          }
-        },
-        "postcss-modules-values": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-          "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-          "dev": true,
-          "requires": {
-            "icss-utils": "^5.0.0"
-          }
         }
       }
     },
@@ -46405,8 +45969,7 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -46446,8 +46009,7 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "spawn-command": {
       "version": "0.0.2-1",
@@ -46699,12 +46261,6 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
-      "dev": true
     },
     "string-width": {
       "version": "1.0.2",
@@ -47218,7 +46774,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -48070,13 +47627,15 @@
       "dev": true
     },
     "vue": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.11.tgz",
-      "integrity": "sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
+      "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
       "requires": {
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/runtime-dom": "3.0.11",
-        "@vue/shared": "3.0.11"
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-sfc": "3.2.45",
+        "@vue/runtime-dom": "3.2.45",
+        "@vue/server-renderer": "3.2.45",
+        "@vue/shared": "3.2.45"
       }
     },
     "vue-cli-plugin-electron-builder": {
@@ -48906,11 +48465,11 @@
       }
     },
     "vue-router": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.8.tgz",
-      "integrity": "sha512-42mWSQaH7CCBQDspQTHv63f34VEnZC20g9QNK4WJ/zW8SdIUeT6TQ2i/78fjF/pVBUPLBWrGhvB7uDnaz7O/pA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.6.tgz",
+      "integrity": "sha512-DYWYwsG6xNPmLq/FmZn8Ip+qrhFEzA14EI12MsMgVxvHFDYvlr4NXpVF5hrRH1wVcDP8fGi5F4rxuJSl8/r+EQ==",
       "requires": {
-        "@vue/devtools-api": "^6.0.0-beta.10"
+        "@vue/devtools-api": "^6.4.5"
       }
     },
     "vue-style-loader": {
@@ -48931,6 +48490,16 @@
         }
       }
     },
+    "vue-template-compiler": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
     "vue-template-es2015-compiler": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
@@ -48938,13 +48507,13 @@
       "dev": true
     },
     "vue-tsc": {
-      "version": "0.40.13",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.40.13.tgz",
-      "integrity": "sha512-xzuN3g5PnKfJcNrLv4+mAjteMd5wLm5fRhW0034OfNJZY4WhB07vhngea/XeGn7wNYt16r7syonzvW/54dcNiA==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.18.tgz",
+      "integrity": "sha512-JFLAz3Xh/iyTnMGdlfG3TuvcaJyFcqyELpLv50jyvOYLAS2+WHzac0IB73FQ37HmGm/4IWMkQZS5r/9FKSejQQ==",
       "dev": true,
       "requires": {
-        "@volar/vue-language-core": "0.40.13",
-        "@volar/vue-typescript": "0.40.13"
+        "@volar/vue-language-core": "1.0.18",
+        "@volar/vue-typescript": "1.0.18"
       }
     },
     "vuedraggable": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "markdown-it": "12.0.4",
     "move-file": "3.0.0",
     "multistream": "4.1.0",
-    "quasar": "2.4.13",
+    "quasar": "2.11.2",
     "semver": "7.3.5",
     "shlex": "2.1.2",
     "source-map-support": "0.5.19",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "license:merge": "node build/mergeLicenses.js"
   },
   "dependencies": {
-    "@gtm-support/vue-gtm": "1.2.3",
+    "@gtm-support/vue-gtm": "1.3.0",
     "@quasar/extras": "1.10.10",
     "ajv": "8.6.2",
     "core-js": "3.12.1",
@@ -51,8 +51,8 @@
     "tree-kill": "1.2.2",
     "unzipper": "0.10.11",
     "uuid": "9.0.0",
-    "vue": "3.0.11",
-    "vue-router": "4.0.8",
+    "vue": "3.2.45",
+    "vue-router": "4.1.6",
     "vuedraggable": "4.1.0",
     "vuex": "4.0.2"
   },
@@ -79,7 +79,7 @@
     "@vue/cli-plugin-unit-mocha": "4.5.13",
     "@vue/cli-plugin-vuex": "4.5.13",
     "@vue/cli-service": "4.5.13",
-    "@vue/compiler-sfc": "3.0.11",
+    "@vue/compiler-sfc": "3.2.45",
     "@vue/eslint-config-prettier": "7.0.0",
     "@vue/eslint-config-typescript": "11.0.2",
     "@vue/test-utils": "2.0.0-rc.6",
@@ -101,7 +101,7 @@
     "tmp": "0.2.1",
     "typescript": "4.8.4",
     "vue-cli-plugin-electron-builder": "3.0.0-alpha.4",
-    "vue-tsc": "0.40.13",
+    "vue-tsc": "1.0.18",
     "yargs": "17.2.1"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,9 @@
+<template>
+  <ErrorBoundary>
+    <RouterView />
+  </ErrorBoundary>
+</template>
+
 <script setup lang="ts">
 import { useStore } from "@/store";
 import ErrorBoundary from "@/components/ErrorBoundary.vue";
@@ -26,9 +32,3 @@ watch(
   { immediate: true }
 );
 </script>
-
-<template>
-  <error-boundary>
-    <router-view />
-  </error-boundary>
-</template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,45 +1,34 @@
+<script setup lang="ts">
+import { useStore } from "@/store";
+import ErrorBoundary from "@/components/ErrorBoundary.vue";
+import { watch, computed } from "vue";
+import { useGtm } from "@gtm-support/vue-gtm";
+import { useRoute } from "vue-router";
+const store = useStore();
+store.dispatch("INIT_VUEX");
+
+// URLパラメータに従ってセーフモードにする
+const route = useRoute();
+const query = computed(() => route.query);
+watch(query, (newQuery) => {
+  if (newQuery) {
+    store.dispatch("SET_IS_SAFE_MODE", newQuery["isSafeMode"] === "true");
+  }
+});
+
+// Google Tag Manager
+const gtm = useGtm();
+watch(
+  () => store.state.acceptRetrieveTelemetry,
+  (acceptRetrieveTelemetry) => {
+    gtm?.enable(acceptRetrieveTelemetry === "Accepted");
+  },
+  { immediate: true }
+);
+</script>
+
 <template>
   <error-boundary>
     <router-view />
   </error-boundary>
 </template>
-
-<script lang="ts">
-import { useStore } from "@/store";
-import ErrorBoundary from "@/components/ErrorBoundary.vue";
-import { defineComponent, watch, computed } from "vue";
-import { useGtm } from "@gtm-support/vue-gtm";
-import { useRoute } from "vue-router";
-
-export default defineComponent({
-  name: "App",
-
-  components: {
-    ErrorBoundary,
-  },
-
-  setup() {
-    const store = useStore();
-    store.dispatch("INIT_VUEX");
-
-    // URLパラメータに従ってセーフモードにする
-    const route = useRoute();
-    const query = computed(() => route.query);
-    watch(query, (newQuery) => {
-      if (newQuery) {
-        store.dispatch("SET_IS_SAFE_MODE", newQuery["isSafeMode"] === "true");
-      }
-    });
-
-    // Google Tag Manager
-    const gtm = useGtm();
-    watch(
-      () => store.state.acceptRetrieveTelemetry,
-      (acceptRetrieveTelemetry) => {
-        gtm?.enable(acceptRetrieveTelemetry === "Accepted");
-      },
-      { immediate: true }
-    );
-  },
-});
-</script>

--- a/src/components/AcceptRetrieveTelemetryDialog.vue
+++ b/src/components/AcceptRetrieveTelemetryDialog.vue
@@ -1,3 +1,41 @@
+<script setup lang="ts">
+import { computed, ref, onMounted } from "vue";
+import { useStore } from "@/store";
+import { useMarkdownIt } from "@/plugins/markdownItPlugin";
+
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", value: boolean): void;
+  }>();
+
+const store = useStore();
+
+const modelValueComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+
+const handler = (acceptRetrieveTelemetry: boolean) => {
+  store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
+    acceptRetrieveTelemetry: acceptRetrieveTelemetry ? "Accepted" : "Refused",
+  });
+
+  modelValueComputed.value = false;
+};
+
+const md = useMarkdownIt();
+const privacyPolicy = ref("");
+onMounted(async () => {
+  privacyPolicy.value = md.render(
+    await store.dispatch("GET_PRIVACY_POLICY_TEXT")
+  );
+});
+</script>
+
 <template>
   <q-dialog
     maximized
@@ -62,56 +100,6 @@
     </q-layout>
   </q-dialog>
 </template>
-
-<script lang="ts">
-import { defineComponent, computed, ref, onMounted } from "vue";
-import { useStore } from "@/store";
-import { useMarkdownIt } from "@/plugins/markdownItPlugin";
-
-export default defineComponent({
-  name: "AcceptRetrieveTelemetryDialog",
-
-  props: {
-    modelValue: {
-      type: Boolean,
-      required: true,
-    },
-  },
-
-  setup(props, { emit }) {
-    const store = useStore();
-
-    const modelValueComputed = computed({
-      get: () => props.modelValue,
-      set: (val) => emit("update:modelValue", val),
-    });
-
-    const handler = (acceptRetrieveTelemetry: boolean) => {
-      store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
-        acceptRetrieveTelemetry: acceptRetrieveTelemetry
-          ? "Accepted"
-          : "Refused",
-      });
-
-      modelValueComputed.value = false;
-    };
-
-    const md = useMarkdownIt();
-    const privacyPolicy = ref("");
-    onMounted(async () => {
-      privacyPolicy.value = md.render(
-        await store.dispatch("GET_PRIVACY_POLICY_TEXT")
-      );
-    });
-
-    return {
-      modelValueComputed,
-      handler,
-      privacyPolicy,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 .q-page {

--- a/src/components/AcceptRetrieveTelemetryDialog.vue
+++ b/src/components/AcceptRetrieveTelemetryDialog.vue
@@ -1,41 +1,3 @@
-<script setup lang="ts">
-import { computed, ref, onMounted } from "vue";
-import { useStore } from "@/store";
-import { useMarkdownIt } from "@/plugins/markdownItPlugin";
-
-const props =
-  defineProps<{
-    modelValue: boolean;
-  }>();
-const emit =
-  defineEmits<{
-    (e: "update:modelValue", value: boolean): void;
-  }>();
-
-const store = useStore();
-
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
-
-const handler = (acceptRetrieveTelemetry: boolean) => {
-  store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
-    acceptRetrieveTelemetry: acceptRetrieveTelemetry ? "Accepted" : "Refused",
-  });
-
-  modelValueComputed.value = false;
-};
-
-const md = useMarkdownIt();
-const privacyPolicy = ref("");
-onMounted(async () => {
-  privacyPolicy.value = md.render(
-    await store.dispatch("GET_PRIVACY_POLICY_TEXT")
-  );
-});
-</script>
-
 <template>
   <q-dialog
     maximized
@@ -100,6 +62,44 @@ onMounted(async () => {
     </q-layout>
   </q-dialog>
 </template>
+
+<script setup lang="ts">
+import { computed, ref, onMounted } from "vue";
+import { useStore } from "@/store";
+import { useMarkdownIt } from "@/plugins/markdownItPlugin";
+
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", value: boolean): void;
+  }>();
+
+const store = useStore();
+
+const modelValueComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+
+const handler = (acceptRetrieveTelemetry: boolean) => {
+  store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
+    acceptRetrieveTelemetry: acceptRetrieveTelemetry ? "Accepted" : "Refused",
+  });
+
+  modelValueComputed.value = false;
+};
+
+const md = useMarkdownIt();
+const privacyPolicy = ref("");
+onMounted(async () => {
+  privacyPolicy.value = md.render(
+    await store.dispatch("GET_PRIVACY_POLICY_TEXT")
+  );
+});
+</script>
 
 <style scoped lang="scss">
 .q-page {

--- a/src/components/AcceptTermsDialog.vue
+++ b/src/components/AcceptTermsDialog.vue
@@ -1,39 +1,3 @@
-<script setup lang="ts">
-import { computed, ref, onMounted } from "vue";
-import { useStore } from "@/store";
-import { useMarkdownIt } from "@/plugins/markdownItPlugin";
-
-const props =
-  defineProps<{
-    modelValue: boolean;
-  }>();
-const emit =
-  defineEmits<{
-    (e: "update:modelValue", value: boolean): void;
-  }>();
-const store = useStore();
-
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
-
-const handler = (acceptTerms: boolean) => {
-  store.dispatch("SET_ACCEPT_TERMS", {
-    acceptTerms: acceptTerms ? "Accepted" : "Rejected",
-  });
-  !acceptTerms ? store.dispatch("CHECK_EDITED_AND_NOT_SAVE") : undefined;
-
-  modelValueComputed.value = false;
-};
-
-const md = useMarkdownIt();
-const terms = ref("");
-onMounted(async () => {
-  terms.value = md.render(await store.dispatch("GET_POLICY_TEXT"));
-});
-</script>
-
 <template>
   <QDialog
     maximized
@@ -95,6 +59,42 @@ onMounted(async () => {
     </QLayout>
   </QDialog>
 </template>
+
+<script setup lang="ts">
+import { computed, ref, onMounted } from "vue";
+import { useStore } from "@/store";
+import { useMarkdownIt } from "@/plugins/markdownItPlugin";
+
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", value: boolean): void;
+  }>();
+const store = useStore();
+
+const modelValueComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+
+const handler = (acceptTerms: boolean) => {
+  store.dispatch("SET_ACCEPT_TERMS", {
+    acceptTerms: acceptTerms ? "Accepted" : "Rejected",
+  });
+  !acceptTerms ? store.dispatch("CHECK_EDITED_AND_NOT_SAVE") : undefined;
+
+  modelValueComputed.value = false;
+};
+
+const md = useMarkdownIt();
+const terms = ref("");
+onMounted(async () => {
+  terms.value = md.render(await store.dispatch("GET_POLICY_TEXT"));
+});
+</script>
 
 <style scoped lang="scss">
 .q-page {

--- a/src/components/AcceptTermsDialog.vue
+++ b/src/components/AcceptTermsDialog.vue
@@ -1,24 +1,60 @@
+<script setup lang="ts">
+import { computed, ref, onMounted } from "vue";
+import { useStore } from "@/store";
+import { useMarkdownIt } from "@/plugins/markdownItPlugin";
+
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", value: boolean): void;
+  }>();
+const store = useStore();
+
+const modelValueComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+
+const handler = (acceptTerms: boolean) => {
+  store.dispatch("SET_ACCEPT_TERMS", {
+    acceptTerms: acceptTerms ? "Accepted" : "Rejected",
+  });
+  !acceptTerms ? store.dispatch("CHECK_EDITED_AND_NOT_SAVE") : undefined;
+
+  modelValueComputed.value = false;
+};
+
+const md = useMarkdownIt();
+const terms = ref("");
+onMounted(async () => {
+  terms.value = md.render(await store.dispatch("GET_POLICY_TEXT"));
+});
+</script>
+
 <template>
-  <q-dialog
+  <QDialog
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="accept-terms-dialog transparent-backdrop"
     v-model="modelValueComputed"
   >
-    <q-layout container view="hHh Lpr lff" class="bg-background">
-      <q-header class="q-py-sm">
-        <q-toolbar>
+    <QLayout container view="hHh Lpr lff" class="bg-background">
+      <QHeader class="q-py-sm">
+        <QToolbar>
           <div class="column">
-            <q-toolbar-title class="text-display"
-              >利用規約に関するお知らせ</q-toolbar-title
+            <QToolbarTitle class="text-display"
+              >利用規約に関するお知らせ</QToolbarTitle
             >
           </div>
 
-          <q-space />
+          <QSpace />
 
           <div class="row items-center no-wrap">
-            <q-btn
+            <QBtn
               unelevated
               label="同意せずに終了"
               color="toolbar-button"
@@ -27,7 +63,7 @@
               @click="handler(false)"
             />
 
-            <q-btn
+            <QBtn
               unelevated
               label="同意して使用開始"
               color="toolbar-button"
@@ -36,76 +72,29 @@
               @click="handler(true)"
             />
           </div>
-        </q-toolbar>
-      </q-header>
+        </QToolbar>
+      </QHeader>
 
-      <q-page-container>
-        <q-page>
+      <QPageContainer>
+        <QPage>
           <p class="text-body1 q-mb-lg">
             多くの人が安心して VOICEVOX
             を使えるよう、利用規約への同意をお願いします。
           </p>
-          <q-card flat bordered>
-            <q-card-section>
+          <QCard flat bordered>
+            <QCardSection>
               <div class="text-h5">利用規約</div>
-            </q-card-section>
+            </QCardSection>
 
-            <q-card-section>
+            <QCardSection>
               <div class="q-pa-md markdown markdown-body" v-html="terms" />
-            </q-card-section>
-          </q-card>
-        </q-page>
-      </q-page-container>
-    </q-layout>
-  </q-dialog>
+            </QCardSection>
+          </QCard>
+        </QPage>
+      </QPageContainer>
+    </QLayout>
+  </QDialog>
 </template>
-
-<script lang="ts">
-import { defineComponent, computed, ref, onMounted } from "vue";
-import { useStore } from "@/store";
-import { useMarkdownIt } from "@/plugins/markdownItPlugin";
-
-export default defineComponent({
-  name: "AcceptTermsDialog",
-
-  props: {
-    modelValue: {
-      type: Boolean,
-      required: true,
-    },
-  },
-
-  setup(props, { emit }) {
-    const store = useStore();
-
-    const modelValueComputed = computed({
-      get: () => props.modelValue,
-      set: (val) => emit("update:modelValue", val),
-    });
-
-    const handler = (acceptTerms: boolean) => {
-      store.dispatch("SET_ACCEPT_TERMS", {
-        acceptTerms: acceptTerms ? "Accepted" : "Rejected",
-      });
-      !acceptTerms ? store.dispatch("CHECK_EDITED_AND_NOT_SAVE") : undefined;
-
-      modelValueComputed.value = false;
-    };
-
-    const md = useMarkdownIt();
-    const terms = ref("");
-    onMounted(async () => {
-      terms.value = md.render(await store.dispatch("GET_POLICY_TEXT"));
-    });
-
-    return {
-      modelValueComputed,
-      handler,
-      terms,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 .q-page {

--- a/src/components/AudioAccent.vue
+++ b/src/components/AudioAccent.vue
@@ -1,3 +1,44 @@
+<script setup lang="ts">
+import { previewSliderHelper } from "@/helpers/previewSliderHelper";
+import { AccentPhrase } from "@/openapi";
+import { computed } from "vue";
+
+const props =
+  defineProps<{
+    accentPhrase: AccentPhrase;
+    accentPhraseIndex: number;
+    uiLocked: boolean;
+    shiftKeyFlag: boolean;
+    onChangeAccent: (
+      accentPhraseIndex: number,
+      accent: number
+    ) => Promise<void>;
+  }>();
+
+const changeAccent = (accent: number) =>
+  props.onChangeAccent(props.accentPhraseIndex, accent);
+
+const previewAccentSlider = previewSliderHelper({
+  onChange: changeAccent,
+  modelValue: () => props.accentPhrase.accent,
+  disable: () => props.uiLocked,
+  disableScroll: () => props.shiftKeyFlag,
+  max: () => props.accentPhrase.moras.length,
+  min: () => 1,
+  step: () => 1,
+});
+
+const accentLine = computed(() => {
+  const accent = previewAccentSlider.state.currentValue.value ?? 0;
+  return [...Array(props.accentPhrase.moras.length).keys()].map(
+    (index) =>
+      `${index * 40 + 10} ${
+        index + 1 == accent || (index != 0 && index < accent) ? 5 : 45
+      }`
+  );
+});
+</script>
+
 <template>
   <div
     class="accent-slider-cell"
@@ -8,7 +49,7 @@
     <!-- div for input width -->
     <div>
       <div>
-        <q-slider
+        <QSlider
           v-if="accentPhrase.moras.length > 1"
           snap
           dense
@@ -60,60 +101,6 @@
     </div>
   </template>
 </template>
-
-<script lang="ts">
-import { previewSliderHelper } from "@/helpers/previewSliderHelper";
-import { AccentPhrase } from "@/openapi";
-import { defineComponent, computed, PropType } from "vue";
-
-export default defineComponent({
-  name: "AudioAccent",
-
-  props: {
-    accentPhrase: { type: Object as PropType<AccentPhrase>, required: true },
-    accentPhraseIndex: { type: Number, required: true },
-    uiLocked: { type: Boolean, required: true },
-    shiftKeyFlag: { type: Boolean, default: false },
-    onChangeAccent: {
-      type: Function as PropType<
-        (accentPhraseIndex: number, accent: number) => Promise<void>
-      >,
-      required: true,
-    },
-  },
-
-  setup(props) {
-    const changeAccent = (accent: number) =>
-      props.onChangeAccent(props.accentPhraseIndex, accent);
-
-    const previewAccentSlider = previewSliderHelper({
-      onChange: changeAccent,
-      modelValue: () => props.accentPhrase.accent,
-      disable: () => props.uiLocked,
-      disableScroll: () => props.shiftKeyFlag,
-      max: () => props.accentPhrase.moras.length,
-      min: () => 1,
-      step: () => 1,
-    });
-
-    const accentLine = computed(() => {
-      const accent = previewAccentSlider.state.currentValue.value ?? 0;
-      return [...Array(props.accentPhrase.moras.length).keys()].map(
-        (index) =>
-          `${index * 40 + 10} ${
-            index + 1 == accent || (index != 0 && index < accent) ? 5 : 45
-          }`
-      );
-    });
-
-    return {
-      previewAccentSlider,
-      changeAccent,
-      accentLine,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/AudioAccent.vue
+++ b/src/components/AudioAccent.vue
@@ -1,44 +1,3 @@
-<script setup lang="ts">
-import { previewSliderHelper } from "@/helpers/previewSliderHelper";
-import { AccentPhrase } from "@/openapi";
-import { computed } from "vue";
-
-const props =
-  defineProps<{
-    accentPhrase: AccentPhrase;
-    accentPhraseIndex: number;
-    uiLocked: boolean;
-    shiftKeyFlag: boolean;
-    onChangeAccent: (
-      accentPhraseIndex: number,
-      accent: number
-    ) => Promise<void>;
-  }>();
-
-const changeAccent = (accent: number) =>
-  props.onChangeAccent(props.accentPhraseIndex, accent);
-
-const previewAccentSlider = previewSliderHelper({
-  onChange: changeAccent,
-  modelValue: () => props.accentPhrase.accent,
-  disable: () => props.uiLocked,
-  disableScroll: () => props.shiftKeyFlag,
-  max: () => props.accentPhrase.moras.length,
-  min: () => 1,
-  step: () => 1,
-});
-
-const accentLine = computed(() => {
-  const accent = previewAccentSlider.state.currentValue.value ?? 0;
-  return [...Array(props.accentPhrase.moras.length).keys()].map(
-    (index) =>
-      `${index * 40 + 10} ${
-        index + 1 == accent || (index != 0 && index < accent) ? 5 : 45
-      }`
-  );
-});
-</script>
-
 <template>
   <div
     class="accent-slider-cell"
@@ -101,6 +60,47 @@ const accentLine = computed(() => {
     </div>
   </template>
 </template>
+
+<script setup lang="ts">
+import { previewSliderHelper } from "@/helpers/previewSliderHelper";
+import { AccentPhrase } from "@/openapi";
+import { computed } from "vue";
+
+const props =
+  defineProps<{
+    accentPhrase: AccentPhrase;
+    accentPhraseIndex: number;
+    uiLocked: boolean;
+    shiftKeyFlag: boolean;
+    onChangeAccent: (
+      accentPhraseIndex: number,
+      accent: number
+    ) => Promise<void>;
+  }>();
+
+const changeAccent = (accent: number) =>
+  props.onChangeAccent(props.accentPhraseIndex, accent);
+
+const previewAccentSlider = previewSliderHelper({
+  onChange: changeAccent,
+  modelValue: () => props.accentPhrase.accent,
+  disable: () => props.uiLocked,
+  disableScroll: () => props.shiftKeyFlag,
+  max: () => props.accentPhrase.moras.length,
+  min: () => 1,
+  step: () => 1,
+});
+
+const accentLine = computed(() => {
+  const accent = previewAccentSlider.state.currentValue.value ?? 0;
+  return [...Array(props.accentPhrase.moras.length).keys()].map(
+    (index) =>
+      `${index * 40 + 10} ${
+        index + 1 == accent || (index != 0 && index < accent) ? 5 : 45
+      }`
+  );
+});
+</script>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -1,3 +1,55 @@
+<template>
+  <div class="audio-cell">
+    <QIcon
+      v-if="isActiveAudioCell"
+      name="arrow_right"
+      color="primary-light"
+      size="sm"
+      class="absolute active-arrow"
+    />
+    <CharacterButton
+      :character-infos="userOrderedCharacterInfos"
+      :loading="isInitializingSpeaker"
+      :show-engine-info="isMultipleEngine"
+      :ui-locked="uiLocked"
+      v-model:selected-voice="selectedVoice"
+    />
+    <QInput
+      ref="textfield"
+      filled
+      dense
+      hide-bottom-space
+      class="full-width"
+      color="primary-light"
+      :disable="uiLocked"
+      :error="audioTextBuffer.length >= 80"
+      :model-value="audioTextBuffer"
+      @update:model-value="setAudioTextBuffer"
+      @change="willRemove || pushAudioText()"
+      @paste="pasteOnAudioCell"
+      @focus="setActiveAudioKey()"
+      @keydown.prevent.up.exact="moveUpCell"
+      @keydown.prevent.down.exact="moveDownCell"
+      @mouseup.right="onRightClickTextField"
+    >
+      <template v-slot:error>
+        文章が長いと正常に動作しない可能性があります。
+        句読点の位置で文章を分割してください。
+      </template>
+      <template #after v-if="deleteButtonEnable">
+        <QBtn
+          round
+          flat
+          icon="delete_outline"
+          size="0.8rem"
+          :disable="uiLocked"
+          @click="removeCell"
+        />
+      </template>
+    </QInput>
+  </div>
+</template>
+
 <script setup lang="ts">
 import { computed, watch, ref } from "vue";
 import { useStore } from "@/store";
@@ -204,58 +256,6 @@ const textfield = ref<QInput>();
 // 複数エンジン
 const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
 </script>
-
-<template>
-  <div class="audio-cell">
-    <QIcon
-      v-if="isActiveAudioCell"
-      name="arrow_right"
-      color="primary-light"
-      size="sm"
-      class="absolute active-arrow"
-    />
-    <CharacterButton
-      :character-infos="userOrderedCharacterInfos"
-      :loading="isInitializingSpeaker"
-      :show-engine-info="isMultipleEngine"
-      :ui-locked="uiLocked"
-      v-model:selected-voice="selectedVoice"
-    />
-    <QInput
-      ref="textfield"
-      filled
-      dense
-      hide-bottom-space
-      class="full-width"
-      color="primary-light"
-      :disable="uiLocked"
-      :error="audioTextBuffer.length >= 80"
-      :model-value="audioTextBuffer"
-      @update:model-value="setAudioTextBuffer"
-      @change="willRemove || pushAudioText()"
-      @paste="pasteOnAudioCell"
-      @focus="setActiveAudioKey()"
-      @keydown.prevent.up.exact="moveUpCell"
-      @keydown.prevent.down.exact="moveDownCell"
-      @mouseup.right="onRightClickTextField"
-    >
-      <template v-slot:error>
-        文章が長いと正常に動作しない可能性があります。
-        句読点の位置で文章を分割してください。
-      </template>
-      <template #after v-if="deleteButtonEnable">
-        <QBtn
-          round
-          flat
-          icon="delete_outline"
-          size="0.8rem"
-          :disable="uiLocked"
-          @click="removeCell"
-        />
-      </template>
-    </QInput>
-  </div>
-</template>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -1,20 +1,227 @@
+<script setup lang="ts">
+import { computed, watch, ref } from "vue";
+import { useStore } from "@/store";
+import { Voice } from "@/type/preload";
+import { QBtn, QIcon, QInput } from "quasar";
+import CharacterButton from "./CharacterButton.vue";
+const props =
+  defineProps<{
+    audioKey: string;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "focusCell", value: { audioKey: string }): void;
+  }>();
+
+const store = useStore();
+const userOrderedCharacterInfos = computed(() => {
+  const infos = store.getters.USER_ORDERED_CHARACTER_INFOS;
+  if (infos == undefined)
+    throw new Error("USER_ORDERED_CHARACTER_INFOS == undefined");
+  return infos;
+});
+const isInitializingSpeaker = computed(
+  () => store.state.audioKeyInitializingSpeaker === props.audioKey
+);
+const audioItem = computed(() => store.state.audioItems[props.audioKey]);
+
+const uiLocked = computed(() => store.getters.UI_LOCKED);
+
+const selectedVoice = computed<Voice | undefined>({
+  get() {
+    const engineId = audioItem.value.engineId;
+    const styleId = audioItem.value.styleId;
+
+    if (
+      engineId == undefined ||
+      styleId == undefined ||
+      !store.state.engineIds.some((storeEngineId) => storeEngineId === engineId)
+    )
+      return undefined;
+
+    const speakerInfo =
+      userOrderedCharacterInfos.value != undefined
+        ? store.getters.CHARACTER_INFO(engineId, styleId)
+        : undefined;
+
+    if (speakerInfo == undefined) return undefined;
+    return { engineId, speakerId: speakerInfo.metas.speakerUuid, styleId };
+  },
+  set(voice: Voice | undefined) {
+    if (voice == undefined) return;
+    store.dispatch("COMMAND_CHANGE_STYLE_ID", {
+      audioKey: props.audioKey,
+      engineId: voice.engineId,
+      styleId: voice.styleId,
+    });
+  },
+});
+
+const isActiveAudioCell = computed(
+  () => props.audioKey === store.getters.ACTIVE_AUDIO_KEY
+);
+
+const audioTextBuffer = ref(audioItem.value.text);
+const isChangeFlag = ref(false);
+const setAudioTextBuffer = (text: string) => {
+  audioTextBuffer.value = text;
+  isChangeFlag.value = true;
+};
+
+watch(
+  // `audioItem` becomes undefined just before the component is unmounted.
+  () => audioItem.value?.text,
+  (newText) => {
+    if (!isChangeFlag.value && newText !== undefined) {
+      audioTextBuffer.value = newText;
+    }
+  }
+);
+
+const pushAudioText = async () => {
+  if (isChangeFlag.value) {
+    isChangeFlag.value = false;
+    await store.dispatch("COMMAND_CHANGE_AUDIO_TEXT", {
+      audioKey: props.audioKey,
+      text: audioTextBuffer.value,
+    });
+  }
+};
+
+const setActiveAudioKey = () => {
+  store.dispatch("SET_ACTIVE_AUDIO_KEY", { audioKey: props.audioKey });
+};
+
+const isEnableSplitText = computed(() => store.state.splitTextWhenPaste);
+// コピペしたときに句点と改行で区切る
+const pasteOnAudioCell = async (event: ClipboardEvent) => {
+  if (event.clipboardData && isEnableSplitText.value !== "OFF") {
+    let texts: string[] = [];
+    const clipBoardData = event.clipboardData.getData("text/plain");
+    switch (isEnableSplitText.value) {
+      case "PERIOD_AND_NEW_LINE":
+        texts = clipBoardData.replaceAll("。", "。\n\r").split(/[\n\r]/);
+        break;
+      case "NEW_LINE":
+        texts = clipBoardData.split(/[\n\r]/);
+        break;
+    }
+
+    if (texts.length > 1) {
+      event.preventDefault();
+      blurCell(); // フォーカスを外して編集中のテキスト内容を確定させる
+
+      const prevAudioKey = props.audioKey;
+      if (audioTextBuffer.value == "") {
+        const text = texts.shift();
+        if (text == undefined) return;
+        setAudioTextBuffer(text);
+        await pushAudioText();
+      }
+
+      const engineId = audioItem.value.engineId;
+      if (engineId === undefined)
+        throw new Error("assert engineId !== undefined");
+
+      const styleId = audioItem.value.styleId;
+      if (styleId === undefined)
+        throw new Error("assert styleId !== undefined");
+
+      const audioKeys = await store.dispatch("COMMAND_PUT_TEXTS", {
+        texts,
+        engineId,
+        styleId,
+        prevAudioKey,
+      });
+      if (audioKeys)
+        emit("focusCell", { audioKey: audioKeys[audioKeys.length - 1] });
+    }
+  }
+};
+
+// 上下に移動
+const audioKeys = computed(() => store.state.audioKeys);
+const moveUpCell = (e?: KeyboardEvent) => {
+  if (e && e.isComposing) return;
+  const index = audioKeys.value.indexOf(props.audioKey) - 1;
+  if (index >= 0) {
+    emit("focusCell", { audioKey: audioKeys.value[index] });
+  }
+};
+const moveDownCell = (e?: KeyboardEvent) => {
+  if (e && e.isComposing) return;
+  const index = audioKeys.value.indexOf(props.audioKey) + 1;
+  if (index < audioKeys.value.length) {
+    emit("focusCell", { audioKey: audioKeys.value[index] });
+  }
+};
+
+// 消去
+const willRemove = ref(false);
+const removeCell = async () => {
+  // 1つだけの時は削除せず
+  if (audioKeys.value.length > 1) {
+    // フォーカスを外したりREMOVEしたりすると、
+    // テキストフィールドのchangeイベントが非同期に飛んでundefinedエラーになる
+    // エラー防止のためにまずwillRemoveフラグを建てる
+    willRemove.value = true;
+
+    const index = audioKeys.value.indexOf(props.audioKey);
+    if (index > 0) {
+      emit("focusCell", { audioKey: audioKeys.value[index - 1] });
+    } else {
+      emit("focusCell", { audioKey: audioKeys.value[index + 1] });
+    }
+
+    store.dispatch("COMMAND_REMOVE_AUDIO_ITEM", {
+      audioKey: props.audioKey,
+    });
+  }
+};
+
+// 削除ボタンの有効／無効判定
+const deleteButtonEnable = computed(() => {
+  return 1 < audioKeys.value.length;
+});
+
+// テキスト編集エリアの右クリック
+const onRightClickTextField = () => {
+  store.dispatch("OPEN_TEXT_EDIT_CONTEXT_MENU");
+};
+
+const blurCell = (event?: KeyboardEvent) => {
+  if (event?.isComposing) {
+    return;
+  }
+  if (document.activeElement instanceof HTMLInputElement) {
+    document.activeElement.blur();
+  }
+};
+
+// フォーカス
+const textfield = ref<QInput>();
+
+// 複数エンジン
+const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
+</script>
+
 <template>
   <div class="audio-cell">
-    <q-icon
+    <QIcon
       v-if="isActiveAudioCell"
       name="arrow_right"
       color="primary-light"
       size="sm"
       class="absolute active-arrow"
     />
-    <character-button
+    <CharacterButton
       :character-infos="userOrderedCharacterInfos"
       :loading="isInitializingSpeaker"
       :show-engine-info="isMultipleEngine"
       :ui-locked="uiLocked"
       v-model:selected-voice="selectedVoice"
     />
-    <q-input
+    <QInput
       ref="textfield"
       filled
       dense
@@ -37,7 +244,7 @@
         句読点の位置で文章を分割してください。
       </template>
       <template #after v-if="deleteButtonEnable">
-        <q-btn
+        <QBtn
           round
           flat
           icon="delete_outline"
@@ -46,291 +253,9 @@
           @click="removeCell"
         />
       </template>
-    </q-input>
+    </QInput>
   </div>
 </template>
-
-<script lang="ts">
-import { computed, watch, defineComponent, ref } from "vue";
-import { useStore } from "@/store";
-import { AudioItem } from "@/store/type";
-import { Voice } from "@/type/preload";
-import { QInput } from "quasar";
-import CharacterButton from "./CharacterButton.vue";
-
-export default defineComponent({
-  name: "AudioCell",
-
-  components: { CharacterButton },
-
-  props: {
-    audioKey: { type: String, required: true },
-  },
-
-  emits: ["focusCell"],
-
-  setup(props, { emit }) {
-    const store = useStore();
-    const userOrderedCharacterInfos = computed(() => {
-      const infos = store.getters.USER_ORDERED_CHARACTER_INFOS;
-      if (infos == undefined)
-        throw new Error("USER_ORDERED_CHARACTER_INFOS == undefined");
-      return infos;
-    });
-    const isInitializingSpeaker = computed(
-      () => store.state.audioKeyInitializingSpeaker === props.audioKey
-    );
-    const audioItem = computed(() => store.state.audioItems[props.audioKey]);
-    const nowPlaying = computed(
-      () => store.state.audioStates[props.audioKey].nowPlaying
-    );
-    const nowGenerating = computed(
-      () => store.state.audioStates[props.audioKey].nowGenerating
-    );
-
-    const uiLocked = computed(() => store.getters.UI_LOCKED);
-
-    const selectedVoice = computed<Voice | undefined>({
-      get() {
-        const engineId = audioItem.value.engineId;
-        const styleId = audioItem.value.styleId;
-
-        if (
-          engineId == undefined ||
-          styleId == undefined ||
-          !store.state.engineIds.some(
-            (storeEngineId) => storeEngineId === engineId
-          )
-        )
-          return undefined;
-
-        const speakerInfo =
-          userOrderedCharacterInfos.value != undefined
-            ? store.getters.CHARACTER_INFO(engineId, styleId)
-            : undefined;
-
-        if (speakerInfo == undefined) return undefined;
-        return { engineId, speakerId: speakerInfo.metas.speakerUuid, styleId };
-      },
-      set(voice: Voice | undefined) {
-        if (voice == undefined) return;
-        store.dispatch("COMMAND_CHANGE_STYLE_ID", {
-          audioKey: props.audioKey,
-          engineId: voice.engineId,
-          styleId: voice.styleId,
-        });
-      },
-    });
-
-    const isActiveAudioCell = computed(
-      () => props.audioKey === store.getters.ACTIVE_AUDIO_KEY
-    );
-
-    const audioTextBuffer = ref(audioItem.value.text);
-    const isChangeFlag = ref(false);
-    const setAudioTextBuffer = (text: string) => {
-      audioTextBuffer.value = text;
-      isChangeFlag.value = true;
-    };
-
-    watch(
-      // `audioItem` becomes undefined just before the component is unmounted.
-      () => audioItem.value?.text,
-      (newText) => {
-        if (!isChangeFlag.value && newText !== undefined) {
-          audioTextBuffer.value = newText;
-        }
-      }
-    );
-
-    const pushAudioText = async () => {
-      if (isChangeFlag.value) {
-        isChangeFlag.value = false;
-        await store.dispatch("COMMAND_CHANGE_AUDIO_TEXT", {
-          audioKey: props.audioKey,
-          text: audioTextBuffer.value,
-        });
-      }
-    };
-
-    const setActiveAudioKey = () => {
-      store.dispatch("SET_ACTIVE_AUDIO_KEY", { audioKey: props.audioKey });
-    };
-    const save = () => {
-      store.dispatch("GENERATE_AND_SAVE_AUDIO", { audioKey: props.audioKey });
-    };
-
-    const play = () => {
-      store.dispatch("PLAY_AUDIO", { audioKey: props.audioKey });
-    };
-
-    const stop = () => {
-      store.dispatch("STOP_AUDIO", { audioKey: props.audioKey });
-    };
-
-    const isEnableSplitText = computed(() => store.state.splitTextWhenPaste);
-    // コピペしたときに句点と改行で区切る
-    const pasteOnAudioCell = async (event: ClipboardEvent) => {
-      if (event.clipboardData && isEnableSplitText.value !== "OFF") {
-        let texts: string[] = [];
-        const clipBoardData = event.clipboardData.getData("text/plain");
-        switch (isEnableSplitText.value) {
-          case "PERIOD_AND_NEW_LINE":
-            texts = clipBoardData.replaceAll("。", "。\n\r").split(/[\n\r]/);
-            break;
-          case "NEW_LINE":
-            texts = clipBoardData.split(/[\n\r]/);
-            break;
-        }
-
-        if (texts.length > 1) {
-          event.preventDefault();
-          blurCell(); // フォーカスを外して編集中のテキスト内容を確定させる
-
-          const prevAudioKey = props.audioKey;
-          if (audioTextBuffer.value == "") {
-            const text = texts.shift();
-            if (text == undefined) return;
-            setAudioTextBuffer(text);
-            await pushAudioText();
-          }
-
-          const engineId = audioItem.value.engineId;
-          if (engineId === undefined)
-            throw new Error("assert engineId !== undefined");
-
-          const styleId = audioItem.value.styleId;
-          if (styleId === undefined)
-            throw new Error("assert styleId !== undefined");
-
-          const audioKeys = await store.dispatch("COMMAND_PUT_TEXTS", {
-            texts,
-            engineId,
-            styleId,
-            prevAudioKey,
-          });
-          if (audioKeys)
-            emit("focusCell", { audioKey: audioKeys[audioKeys.length - 1] });
-        }
-      }
-    };
-
-    // 選択されている
-    const isActive = computed(() => store.getters.IS_ACTIVE(props.audioKey));
-
-    // 上下に移動
-    const audioKeys = computed(() => store.state.audioKeys);
-    const moveUpCell = (e?: KeyboardEvent) => {
-      if (e && e.isComposing) return;
-      const index = audioKeys.value.indexOf(props.audioKey) - 1;
-      if (index >= 0) {
-        emit("focusCell", { audioKey: audioKeys.value[index] });
-      }
-    };
-    const moveDownCell = (e?: KeyboardEvent) => {
-      if (e && e.isComposing) return;
-      const index = audioKeys.value.indexOf(props.audioKey) + 1;
-      if (index < audioKeys.value.length) {
-        emit("focusCell", { audioKey: audioKeys.value[index] });
-      }
-    };
-
-    // 消去
-    const willRemove = ref(false);
-    const removeCell = async () => {
-      // 1つだけの時は削除せず
-      if (audioKeys.value.length > 1) {
-        // フォーカスを外したりREMOVEしたりすると、
-        // テキストフィールドのchangeイベントが非同期に飛んでundefinedエラーになる
-        // エラー防止のためにまずwillRemoveフラグを建てる
-        willRemove.value = true;
-
-        const index = audioKeys.value.indexOf(props.audioKey);
-        if (index > 0) {
-          emit("focusCell", { audioKey: audioKeys.value[index - 1] });
-        } else {
-          emit("focusCell", { audioKey: audioKeys.value[index + 1] });
-        }
-
-        store.dispatch("COMMAND_REMOVE_AUDIO_ITEM", {
-          audioKey: props.audioKey,
-        });
-      }
-    };
-
-    // 削除ボタンの有効／無効判定
-    const deleteButtonEnable = computed(() => {
-      return 1 < audioKeys.value.length;
-    });
-
-    // テキスト編集エリアの右クリック
-    const onRightClickTextField = () => {
-      store.dispatch("OPEN_TEXT_EDIT_CONTEXT_MENU");
-    };
-
-    // 下にセルを追加
-    const addCellBellow = async () => {
-      const styleId = store.state.audioItems[props.audioKey].styleId;
-      const audioItem: AudioItem = { text: "", styleId };
-      await store.dispatch("COMMAND_REGISTER_AUDIO_ITEM", {
-        audioItem,
-        prevAudioKey: props.audioKey,
-      });
-      moveDownCell();
-    };
-
-    const blurCell = (event?: KeyboardEvent) => {
-      if (event?.isComposing) {
-        return;
-      }
-      if (document.activeElement instanceof HTMLInputElement) {
-        document.activeElement.blur();
-      }
-    };
-
-    // フォーカス
-    const textfield = ref<QInput>();
-    const focusTextField = () => {
-      if (textfield.value == undefined) return;
-      textfield.value.focus();
-    };
-
-    // 複数エンジン
-    const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
-
-    return {
-      userOrderedCharacterInfos,
-      isInitializingSpeaker,
-      audioItem,
-      deleteButtonEnable,
-      uiLocked,
-      nowPlaying,
-      nowGenerating,
-      selectedVoice,
-      isActiveAudioCell,
-      audioTextBuffer,
-      isMultipleEngine,
-      setAudioTextBuffer,
-      pushAudioText,
-      setActiveAudioKey,
-      save,
-      play,
-      stop,
-      willRemove,
-      removeCell,
-      addCellBellow,
-      isActive,
-      moveUpCell,
-      moveDownCell,
-      pasteOnAudioCell,
-      onRightClickTextField,
-      textfield,
-      focusTextField,
-      blurCell,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -64,6 +64,12 @@ const emit =
   defineEmits<{
     (e: "focusCell", value: { audioKey: string }): void;
   }>();
+defineExpose({
+  audioKey: computed(() => props.audioKey),
+  focusTextField: () => {
+    textfield.value?.focus();
+  },
+});
 
 const store = useStore();
 const userOrderedCharacterInfos = computed(() => {

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -1,37 +1,563 @@
+<script setup lang="ts">
+import {
+  computed,
+  nextTick,
+  onBeforeUpdate,
+  onMounted,
+  onUnmounted,
+  reactive,
+  ref,
+  watch,
+} from "vue";
+import { useStore } from "@/store";
+import { useQuasar } from "quasar";
+import ToolTip from "./ToolTip.vue";
+import AudioAccent from "./AudioAccent.vue";
+import AudioParameter from "./AudioParameter.vue";
+import { HotkeyAction, HotkeyReturnType, MoraDataType } from "@/type/preload";
+import { setHotkeyFunctions } from "@/store/setting";
+import { EngineManifest, Mora } from "@/openapi/models";
+
+const props =
+  defineProps<{
+    activeAudioKey: string;
+  }>();
+
+const store = useStore();
+const $q = useQuasar();
+
+const supportedFeatures = computed(
+  () =>
+    (audioItem.value?.engineId &&
+      store.state.engineIds.some((id) => id === audioItem.value.engineId) &&
+      store.state.engineManifests[audioItem.value?.engineId]
+        .supportedFeatures) as EngineManifest["supportedFeatures"] | undefined
+);
+
+const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
+  [
+    "再生/停止",
+    () => {
+      if (!nowPlaying.value && !nowGenerating.value && !uiLocked.value) {
+        play();
+      } else {
+        stop();
+      }
+    },
+  ],
+  [
+    "ｱｸｾﾝﾄ欄を表示",
+    () => {
+      selectedDetail.value = "accent";
+    },
+  ],
+  [
+    "ｲﾝﾄﾈｰｼｮﾝ欄を表示",
+    () => {
+      if (supportedFeatures.value?.adjustMoraPitch) {
+        selectedDetail.value = "pitch";
+      }
+    },
+  ],
+  [
+    "長さ欄を表示",
+    () => {
+      if (supportedFeatures.value?.adjustPhonemeLength) {
+        selectedDetail.value = "length";
+      }
+    },
+  ],
+  [
+    "全体のイントネーションをリセット",
+    () => {
+      if (!uiLocked.value && store.getters.ACTIVE_AUDIO_KEY) {
+        store.dispatch("COMMAND_RESET_MORA_PITCH_AND_LENGTH", {
+          audioKey: store.getters.ACTIVE_AUDIO_KEY,
+        });
+      }
+    },
+  ],
+  [
+    "選択中のアクセント句のイントネーションをリセット",
+    () => {
+      if (
+        !uiLocked.value &&
+        store.getters.ACTIVE_AUDIO_KEY &&
+        store.state.audioPlayStartPoint !== undefined
+      ) {
+        store.dispatch("COMMAND_RESET_SELECTED_MORA_PITCH_AND_LENGTH", {
+          audioKey: store.getters.ACTIVE_AUDIO_KEY,
+          accentPhraseIndex: store.state.audioPlayStartPoint,
+        });
+      }
+    },
+  ],
+]);
+// このコンポーネントは遅延評価なので手動でバインディングを行う
+setHotkeyFunctions(hotkeyMap, true);
+
+// detail selector
+type DetailTypes = "accent" | "pitch" | "length" | "play" | "stop" | "save";
+const selectedDetail = ref<DetailTypes>("accent");
+
+// accent phrase
+const uiLocked = computed(() => store.getters.UI_LOCKED);
+
+const audioItem = computed(() => store.state.audioItems[props.activeAudioKey]);
+const query = computed(() => audioItem.value?.query);
+const accentPhrases = computed(() => query.value?.accentPhrases);
+
+// エンジンが変わったとき、selectedDetailが対応していないものを選択している場合はaccentに戻す
+// TODO: 連続再生するとアクセントに移動してしまうため、タブの中身を全てdisabledにする、半透明divをかぶせるなど
+//       タブ自体の無効化＆移動以外の方法で無効化する
+watch(
+  supportedFeatures,
+  (newFeatures) => {
+    if (
+      (!newFeatures?.adjustMoraPitch && selectedDetail.value === "pitch") ||
+      (!newFeatures?.adjustPhonemeLength && selectedDetail.value === "length")
+    ) {
+      selectedDetail.value = "accent";
+    }
+  },
+  { immediate: true }
+);
+
+const activePointScrollMode = computed(() => store.state.activePointScrollMode);
+
+// 再生開始アクセント句
+const startPoint = computed({
+  get: () => {
+    return store.state.audioPlayStartPoint;
+  },
+  set: (startPoint) => {
+    store.dispatch("SET_AUDIO_PLAY_START_POINT", { startPoint });
+  },
+});
+// アクティブ(再生されている状態)なアクセント句
+const activePoint = ref<number | undefined>(undefined);
+
+const setPlayAndStartPoint = (accentPhraseIndex: number) => {
+  // UIロック中に再生位置を変えても特に問題は起きないと思われるが、
+  // UIロックというものにそぐわない挙動になるので何もしないようにする
+  if (uiLocked.value) return;
+
+  if (activePoint.value !== accentPhraseIndex) {
+    activePoint.value = accentPhraseIndex;
+    startPoint.value = accentPhraseIndex;
+  } else {
+    // 選択解除で最初から再生できるようにする
+    activePoint.value = undefined;
+    startPoint.value = undefined;
+  }
+};
+
+const lastPitches = ref<number[][]>([]);
+watch(accentPhrases, async (newPhrases) => {
+  activePoint.value = startPoint.value;
+  // 連続再生時に、最初に選択されていた場所に戻るためにscrollToActivePointを呼ぶ必要があるが、
+  // DOMの描画が少し遅いので、nextTickをはさむ
+  await nextTick();
+  scrollToActivePoint();
+  if (newPhrases) {
+    lastPitches.value = newPhrases.map((phrase) =>
+      phrase.moras.map((mora) => mora.pitch)
+    );
+  } else {
+    lastPitches.value = [];
+  }
+});
+
+const changeAccent = (accentPhraseIndex: number, accent: number) =>
+  store.dispatch("COMMAND_CHANGE_ACCENT", {
+    audioKey: props.activeAudioKey,
+    accentPhraseIndex,
+    accent,
+  });
+const toggleAccentPhraseSplit = (
+  accentPhraseIndex: number,
+  isPause: boolean,
+  moraIndex?: number
+) => {
+  store.dispatch("COMMAND_CHANGE_ACCENT_PHRASE_SPLIT", {
+    audioKey: props.activeAudioKey,
+    accentPhraseIndex,
+    ...(!isPause ? { isPause, moraIndex: moraIndex as number } : { isPause }),
+  });
+};
+
+const maxPitch = 6.5;
+const minPitch = 3;
+const maxMoraLength = 0.3;
+const minMoraLength = 0;
+const changeMoraData = (
+  accentPhraseIndex: number,
+  moraIndex: number,
+  data: number,
+  type: MoraDataType
+) => {
+  if (!altKeyFlag.value) {
+    if (type == "pitch") {
+      lastPitches.value[accentPhraseIndex][moraIndex] = data;
+    }
+    store.dispatch("COMMAND_SET_AUDIO_MORA_DATA", {
+      audioKey: props.activeAudioKey,
+      accentPhraseIndex,
+      moraIndex,
+      data,
+      type,
+    });
+  } else {
+    if (accentPhrases.value === undefined) {
+      throw Error("accentPhrases.value === undefined");
+    }
+    store.dispatch("COMMAND_SET_AUDIO_MORA_DATA_ACCENT_PHRASE", {
+      audioKey: props.activeAudioKey,
+      accentPhraseIndex,
+      moraIndex,
+      data,
+      type,
+    });
+  }
+};
+
+// audio play
+const play = async () => {
+  try {
+    await store.dispatch("PLAY_AUDIO", {
+      audioKey: props.activeAudioKey,
+    });
+  } catch (e) {
+    $q.dialog({
+      title: "再生に失敗しました",
+      message: "エンジンの再起動をお試しください。",
+      ok: {
+        label: "閉じる",
+        flat: true,
+        textColor: "display",
+      },
+    });
+  }
+};
+
+const stop = () => {
+  store.dispatch("STOP_AUDIO", { audioKey: props.activeAudioKey });
+};
+
+const nowPlaying = computed(
+  () => store.state.audioStates[props.activeAudioKey]?.nowPlaying
+);
+const nowGenerating = computed(
+  () => store.state.audioStates[props.activeAudioKey]?.nowGenerating
+);
+
+// continuously play
+const nowPlayingContinuously = computed(
+  () => store.state.nowPlayingContinuously
+);
+
+const audioDetail = ref<HTMLElement>();
+let accentPhraseElems: HTMLElement[] = [];
+const addAccentPhraseElem = (elem: HTMLElement) => {
+  if (elem) {
+    accentPhraseElems.push(elem);
+  }
+};
+onBeforeUpdate(() => {
+  accentPhraseElems = [];
+});
+
+const scrollToActivePoint = () => {
+  if (
+    activePoint.value === undefined ||
+    !audioDetail.value ||
+    accentPhraseElems.length === 0
+  )
+    return;
+  const elem = accentPhraseElems[activePoint.value];
+
+  if (activePointScrollMode.value === "CONTINUOUSLY") {
+    const scrollCount = Math.max(
+      elem.offsetLeft -
+        audioDetail.value.offsetLeft +
+        elem.offsetWidth / 2 -
+        audioDetail.value.offsetWidth / 2,
+      0
+    );
+    audioDetail.value.scroll(scrollCount, 0);
+  } else if (activePointScrollMode.value === "PAGE") {
+    const displayedPart =
+      audioDetail.value.scrollLeft + audioDetail.value.offsetWidth;
+    const nextAccentPhraseStart =
+      elem.offsetLeft - audioDetail.value.offsetLeft;
+    const nextAccentPhraseEnd = nextAccentPhraseStart + elem.offsetWidth;
+    // 再生しようとしているアクセント句が表示範囲外にある時に、自動スクロールを行う
+    if (
+      nextAccentPhraseEnd <= audioDetail.value.scrollLeft ||
+      displayedPart <= nextAccentPhraseEnd
+    ) {
+      const scrollCount = elem.offsetLeft - audioDetail.value.offsetLeft;
+      audioDetail.value.scroll(scrollCount, 0);
+    }
+  } else {
+    // activePointScrollMode.value === "OFF"
+    return;
+  }
+};
+
+// NodeJS.Timeout型が直接指定できないので、typeofとReturnTypeで取ってきている
+let focusInterval: ReturnType<typeof setInterval> | undefined;
+watch(nowPlaying, async (newState) => {
+  if (newState) {
+    const accentPhraseOffsets = await store.dispatch("GET_AUDIO_PLAY_OFFSETS", {
+      audioKey: props.activeAudioKey,
+    });
+    // 現在再生されているaudio elementの再生時刻を0.01秒毎に取得(監視)し、
+    // それに合わせてフォーカスするアクセント句を変えていく
+    focusInterval = setInterval(() => {
+      const currentTime = store.getters.ACTIVE_AUDIO_ELEM_CURRENT_TIME;
+      for (let i = 1; i < accentPhraseOffsets.length; i++) {
+        if (
+          currentTime !== undefined &&
+          accentPhraseOffsets[i - 1] <= currentTime &&
+          currentTime < accentPhraseOffsets[i]
+        ) {
+          activePoint.value = i - 1;
+          scrollToActivePoint();
+        }
+      }
+    }, 10);
+  } else if (focusInterval !== undefined) {
+    clearInterval(focusInterval);
+    focusInterval = undefined;
+    // startPointがundefinedの場合、一旦最初のアクセント句までスクロール、その後activePointの選択を解除(undefinedに)する
+    activePoint.value = startPoint.value ?? 0;
+    scrollToActivePoint();
+    if (startPoint.value === undefined) activePoint.value = startPoint.value;
+  }
+});
+
+const pronunciationByPhrase = computed(() => {
+  const textArray: Array<string> = [];
+  accentPhrases.value?.forEach((accentPhrase) => {
+    let textString = "";
+    accentPhrase.moras.forEach((mora) => {
+      textString += mora.text;
+    });
+    if (accentPhrase.pauseMora) {
+      textString += "、";
+    }
+    textArray.push(textString);
+  });
+  return textArray;
+});
+
+const handleChangePronounce = (
+  newPronunciation: string,
+  phraseIndex: number
+) => {
+  let popUntilPause = false;
+  newPronunciation = newPronunciation.replace(",", "、");
+  if (accentPhrases.value == undefined)
+    throw new Error("accentPhrases.value == undefined");
+  if (
+    newPronunciation.slice(-1) == "、" &&
+    accentPhrases.value.length - 1 != phraseIndex
+  ) {
+    newPronunciation += pronunciationByPhrase.value[phraseIndex + 1];
+    popUntilPause = true;
+  }
+  store.dispatch("COMMAND_CHANGE_SINGLE_ACCENT_PHRASE", {
+    audioKey: props.activeAudioKey,
+    newPronunciation,
+    accentPhraseIndex: phraseIndex,
+    popUntilPause,
+  });
+};
+
+type hoveredType = "vowel" | "consonant";
+
+type hoveredInfoType = {
+  accentPhraseIndex: number | undefined;
+  moraIndex?: number | undefined;
+  type?: hoveredType;
+};
+
+const accentHoveredInfo = reactive<hoveredInfoType>({
+  accentPhraseIndex: undefined,
+});
+
+const pitchHoveredInfo = reactive<hoveredInfoType>({
+  accentPhraseIndex: undefined,
+  moraIndex: undefined,
+});
+
+const lengthHoveredInfo = reactive<hoveredInfoType>({
+  accentPhraseIndex: undefined,
+  moraIndex: undefined,
+  type: "vowel",
+});
+
+const handleHoverText = (
+  isOver: boolean,
+  phraseIndex: number,
+  moraIndex: number
+) => {
+  if (selectedDetail.value == "accent") {
+    if (isOver) {
+      accentHoveredInfo.accentPhraseIndex = phraseIndex;
+    } else {
+      accentHoveredInfo.accentPhraseIndex = undefined;
+    }
+  } else if (selectedDetail.value == "pitch") {
+    if (isOver) {
+      pitchHoveredInfo.accentPhraseIndex = phraseIndex;
+      pitchHoveredInfo.moraIndex = moraIndex;
+    } else {
+      pitchHoveredInfo.accentPhraseIndex = undefined;
+      pitchHoveredInfo.moraIndex = undefined;
+    }
+  }
+};
+
+const handleLengthHoverText = (
+  isOver: boolean,
+  phoneme: hoveredType,
+  phraseIndex: number,
+  moraIndex?: number
+) => {
+  lengthHoveredInfo.type = phoneme;
+  // the pause and pitch templates don't emit a mouseOver event
+  if (isOver) {
+    lengthHoveredInfo.accentPhraseIndex = phraseIndex;
+    lengthHoveredInfo.moraIndex = moraIndex;
+  } else {
+    lengthHoveredInfo.accentPhraseIndex = undefined;
+    lengthHoveredInfo.moraIndex = undefined;
+  }
+};
+
+const unvoicableVowels = ["U", "I", "i", "u"];
+
+const isHovered = (
+  vowel: string,
+  accentPhraseIndex: number,
+  moraIndex: number
+) => {
+  let isHover = false;
+  if (!uiLocked.value) {
+    if (selectedDetail.value == "accent") {
+      if (accentPhraseIndex === accentHoveredInfo.accentPhraseIndex) {
+        isHover = true;
+      }
+    } else if (selectedDetail.value == "pitch") {
+      if (
+        accentPhraseIndex === pitchHoveredInfo.accentPhraseIndex &&
+        moraIndex === pitchHoveredInfo.moraIndex &&
+        unvoicableVowels.indexOf(vowel) > -1
+      ) {
+        isHover = true;
+      }
+    }
+  }
+  return isHover;
+};
+
+const getHoveredText = (
+  mora: Mora,
+  accentPhraseIndex: number,
+  moraIndex: number
+) => {
+  if (selectedDetail.value != "length") return mora.text;
+  if (
+    accentPhraseIndex === lengthHoveredInfo.accentPhraseIndex &&
+    moraIndex === lengthHoveredInfo.moraIndex
+  ) {
+    if (lengthHoveredInfo.type == "vowel") {
+      return mora.vowel.toUpperCase();
+    } else {
+      return mora.consonant?.toUpperCase();
+    }
+  } else {
+    return mora.text;
+  }
+};
+
+const shiftKeyFlag = ref(false);
+const altKeyFlag = ref(false);
+
+const keyEventListter = (event: KeyboardEvent) => {
+  shiftKeyFlag.value = event.shiftKey;
+  altKeyFlag.value = event.altKey;
+};
+
+const handleChangeVoicing = (
+  mora: Mora,
+  accentPhraseIndex: number,
+  moraIndex: number
+) => {
+  if (
+    selectedDetail.value == "pitch" &&
+    unvoicableVowels.indexOf(mora.vowel) > -1
+  ) {
+    let data = 0;
+    if (mora.pitch == 0) {
+      if (lastPitches.value[accentPhraseIndex][moraIndex] == 0) {
+        // 元々無声だった場合、適当な値を代入
+        data = 5.5;
+      } else {
+        data = lastPitches.value[accentPhraseIndex][moraIndex];
+      }
+    }
+    changeMoraData(accentPhraseIndex, moraIndex, data, "voicing");
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("keyup", keyEventListter);
+  document.addEventListener("keydown", keyEventListter);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("keyup", keyEventListter);
+  document.removeEventListener("keydown", keyEventListter);
+});
+</script>
+
 <template>
   <div class="full-height root relative-absolute-wrapper">
     <div>
       <div class="side">
         <div class="detail-selector">
-          <q-tabs dense vertical class="text-display" v-model="selectedDetail">
-            <q-tab name="accent" label="ｱｸｾﾝﾄ" />
-            <q-tab
+          <QTabs dense vertical class="text-display" v-model="selectedDetail">
+            <QTab name="accent" label="ｱｸｾﾝﾄ" />
+            <QTab
               name="pitch"
               label="ｲﾝﾄﾈｰｼｮﾝ"
               :disable="
                 !(supportedFeatures && supportedFeatures.adjustMoraPitch)
               "
             />
-            <q-tab
+            <QTab
               name="length"
               label="長さ"
               :disable="
                 !(supportedFeatures && supportedFeatures.adjustPhonemeLength)
               "
             />
-          </q-tabs>
+          </QTabs>
         </div>
         <div class="play-button-wrapper">
           <template v-if="!nowPlayingContinuously">
-            <q-btn
+            <QBtn
               v-if="!nowPlaying && !nowGenerating"
               fab
               color="primary-light"
               text-color="display-on-primary"
               icon="play_arrow"
               @click="play"
-            ></q-btn>
-            <q-btn
+            ></QBtn>
+            <QBtn
               v-else
               fab
               color="primary-light"
@@ -39,13 +565,13 @@
               icon="stop"
               @click="stop"
               :disable="nowGenerating"
-            ></q-btn>
+            ></QBtn>
           </template>
         </div>
       </div>
 
       <div class="overflow-hidden-y accent-phrase-table" ref="audioDetail">
-        <tool-tip
+        <ToolTip
           tip-key="tweakableSliderByScroll"
           v-if="selectedDetail === 'pitch'"
           class="tip-tweakable-slider-by-scroll"
@@ -56,7 +582,7 @@
           </p>
           ホイール: ±0.1<br />
           Ctrl + ホイール: ±0.01
-        </tool-tip>
+        </ToolTip>
         <div
           v-for="(accentPhrase, accentPhraseIndex) in accentPhrases"
           :key="accentPhraseIndex"
@@ -69,7 +595,7 @@
           :ref="addAccentPhraseElem"
         >
           <template v-if="selectedDetail === 'accent'">
-            <audio-accent
+            <AudioAccent
               :accentPhraseIndex="accentPhraseIndex"
               :accentPhrase="accentPhrase"
               :uiLocked="uiLocked"
@@ -85,7 +611,7 @@
               :style="{ 'grid-column': `${moraIndex * 2 + 1} / span 1` }"
             >
               <!-- div for input width -->
-              <audio-parameter
+              <AudioParameter
                 :moraIndex="moraIndex"
                 :accentPhraseIndex="accentPhraseIndex"
                 :value="mora.pitch"
@@ -109,7 +635,7 @@
               :style="{ 'grid-column': `${moraIndex * 2 + 1} / span 1` }"
             >
               <!-- consonant length -->
-              <audio-parameter
+              <AudioParameter
                 v-if="mora.consonant"
                 :moraIndex="moraIndex"
                 :accentPhraseIndex="accentPhraseIndex"
@@ -125,7 +651,7 @@
                 @mouseOver="handleLengthHoverText"
               />
               <!-- vowel length -->
-              <audio-parameter
+              <AudioParameter
                 :moraIndex="moraIndex"
                 :accentPhraseIndex="accentPhraseIndex"
                 :value="mora.vowelLength"
@@ -149,7 +675,7 @@
             }"
           >
             <!-- pause length -->
-            <audio-parameter
+            <AudioParameter
               :moraIndex="accentPhrase.moras.length"
               :accentPhraseIndex="accentPhraseIndex"
               :value="accentPhrase.pauseMora.vowelLength"
@@ -188,7 +714,7 @@
               <span class="text-cell-inner">
                 {{ getHoveredText(mora, accentPhraseIndex, moraIndex) }}
               </span>
-              <q-popup-edit
+              <QPopupEdit
                 v-if="selectedDetail == 'accent' && !uiLocked"
                 :model-value="pronunciationByPhrase[accentPhraseIndex]"
                 auto-save
@@ -197,7 +723,7 @@
                 v-slot="scope"
                 @save="handleChangePronounce($event, accentPhraseIndex)"
               >
-                <q-input
+                <QInput
                   v-model="scope.value"
                   dense
                   :input-style="{
@@ -208,7 +734,7 @@
                   outlined
                   @keyup.enter="scope.set"
                 />
-              </q-popup-edit>
+              </QPopupEdit>
             </div>
             <div
               v-if="
@@ -253,590 +779,6 @@
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import {
-  computed,
-  defineComponent,
-  nextTick,
-  onBeforeUpdate,
-  onMounted,
-  onUnmounted,
-  reactive,
-  ref,
-  watch,
-} from "vue";
-import { useStore } from "@/store";
-import { useQuasar } from "quasar";
-import ToolTip from "./ToolTip.vue";
-import AudioAccent from "./AudioAccent.vue";
-import AudioParameter from "./AudioParameter.vue";
-import { HotkeyAction, HotkeyReturnType, MoraDataType } from "@/type/preload";
-import { setHotkeyFunctions } from "@/store/setting";
-import { EngineManifest, Mora } from "@/openapi/models";
-
-export default defineComponent({
-  components: { AudioAccent, AudioParameter, ToolTip },
-
-  name: "AudioDetail",
-
-  props: {
-    activeAudioKey: { type: String, required: true },
-  },
-
-  setup(props) {
-    const store = useStore();
-    const $q = useQuasar();
-
-    const supportedFeatures = computed(
-      () =>
-        (audioItem.value?.engineId &&
-          store.state.engineIds.some((id) => id === audioItem.value.engineId) &&
-          store.state.engineManifests[audioItem.value?.engineId]
-            .supportedFeatures) as
-          | EngineManifest["supportedFeatures"]
-          | undefined
-    );
-
-    const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
-      [
-        "再生/停止",
-        () => {
-          if (!nowPlaying.value && !nowGenerating.value && !uiLocked.value) {
-            play();
-          } else {
-            stop();
-          }
-        },
-      ],
-      [
-        "ｱｸｾﾝﾄ欄を表示",
-        () => {
-          selectedDetail.value = "accent";
-        },
-      ],
-      [
-        "ｲﾝﾄﾈｰｼｮﾝ欄を表示",
-        () => {
-          if (supportedFeatures.value?.adjustMoraPitch) {
-            selectedDetail.value = "pitch";
-          }
-        },
-      ],
-      [
-        "長さ欄を表示",
-        () => {
-          if (supportedFeatures.value?.adjustPhonemeLength) {
-            selectedDetail.value = "length";
-          }
-        },
-      ],
-      [
-        "全体のイントネーションをリセット",
-        () => {
-          if (!uiLocked.value && store.getters.ACTIVE_AUDIO_KEY) {
-            store.dispatch("COMMAND_RESET_MORA_PITCH_AND_LENGTH", {
-              audioKey: store.getters.ACTIVE_AUDIO_KEY,
-            });
-          }
-        },
-      ],
-      [
-        "選択中のアクセント句のイントネーションをリセット",
-        () => {
-          if (
-            !uiLocked.value &&
-            store.getters.ACTIVE_AUDIO_KEY &&
-            store.state.audioPlayStartPoint !== undefined
-          ) {
-            store.dispatch("COMMAND_RESET_SELECTED_MORA_PITCH_AND_LENGTH", {
-              audioKey: store.getters.ACTIVE_AUDIO_KEY,
-              accentPhraseIndex: store.state.audioPlayStartPoint,
-            });
-          }
-        },
-      ],
-    ]);
-    // このコンポーネントは遅延評価なので手動でバインディングを行う
-    setHotkeyFunctions(hotkeyMap, true);
-
-    // detail selector
-    type DetailTypes = "accent" | "pitch" | "length" | "play" | "stop" | "save";
-    const selectedDetail = ref<DetailTypes>("accent");
-    const selectDetail = (index: number) => {
-      selectedDetail.value = index === 0 ? "accent" : "pitch";
-    };
-
-    // accent phrase
-    const uiLocked = computed(() => store.getters.UI_LOCKED);
-
-    const audioItem = computed(
-      () => store.state.audioItems[props.activeAudioKey]
-    );
-    const query = computed(() => audioItem.value?.query);
-    const accentPhrases = computed(() => query.value?.accentPhrases);
-
-    // エンジンが変わったとき、selectedDetailが対応していないものを選択している場合はaccentに戻す
-    // TODO: 連続再生するとアクセントに移動してしまうため、タブの中身を全てdisabledにする、半透明divをかぶせるなど
-    //       タブ自体の無効化＆移動以外の方法で無効化する
-    watch(
-      supportedFeatures,
-      (newFeatures) => {
-        if (
-          (!newFeatures?.adjustMoraPitch && selectedDetail.value === "pitch") ||
-          (!newFeatures?.adjustPhonemeLength &&
-            selectedDetail.value === "length")
-        ) {
-          selectedDetail.value = "accent";
-        }
-      },
-      { immediate: true }
-    );
-
-    const activePointScrollMode = computed(
-      () => store.state.activePointScrollMode
-    );
-
-    // 再生開始アクセント句
-    const startPoint = computed({
-      get: () => {
-        return store.state.audioPlayStartPoint;
-      },
-      set: (startPoint) => {
-        store.dispatch("SET_AUDIO_PLAY_START_POINT", { startPoint });
-      },
-    });
-    // アクティブ(再生されている状態)なアクセント句
-    const activePoint = ref<number | undefined>(undefined);
-
-    const setPlayAndStartPoint = (accentPhraseIndex: number) => {
-      // UIロック中に再生位置を変えても特に問題は起きないと思われるが、
-      // UIロックというものにそぐわない挙動になるので何もしないようにする
-      if (uiLocked.value) return;
-
-      if (activePoint.value !== accentPhraseIndex) {
-        activePoint.value = accentPhraseIndex;
-        startPoint.value = accentPhraseIndex;
-      } else {
-        // 選択解除で最初から再生できるようにする
-        activePoint.value = undefined;
-        startPoint.value = undefined;
-      }
-    };
-
-    const lastPitches = ref<number[][]>([]);
-    watch(accentPhrases, async (newPhrases) => {
-      activePoint.value = startPoint.value;
-      // 連続再生時に、最初に選択されていた場所に戻るためにscrollToActivePointを呼ぶ必要があるが、
-      // DOMの描画が少し遅いので、nextTickをはさむ
-      await nextTick();
-      scrollToActivePoint();
-      if (newPhrases) {
-        lastPitches.value = newPhrases.map((phrase) =>
-          phrase.moras.map((mora) => mora.pitch)
-        );
-      } else {
-        lastPitches.value = [];
-      }
-    });
-
-    const changeAccent = (accentPhraseIndex: number, accent: number) =>
-      store.dispatch("COMMAND_CHANGE_ACCENT", {
-        audioKey: props.activeAudioKey,
-        accentPhraseIndex,
-        accent,
-      });
-    const toggleAccentPhraseSplit = (
-      accentPhraseIndex: number,
-      isPause: boolean,
-      moraIndex?: number
-    ) => {
-      store.dispatch("COMMAND_CHANGE_ACCENT_PHRASE_SPLIT", {
-        audioKey: props.activeAudioKey,
-        accentPhraseIndex,
-        ...(!isPause
-          ? { isPause, moraIndex: moraIndex as number }
-          : { isPause }),
-      });
-    };
-
-    const maxPitch = 6.5;
-    const minPitch = 3;
-    const maxMoraLength = 0.3;
-    const minMoraLength = 0;
-    const changeMoraData = (
-      accentPhraseIndex: number,
-      moraIndex: number,
-      data: number,
-      type: MoraDataType
-    ) => {
-      if (!altKeyFlag.value) {
-        if (type == "pitch") {
-          lastPitches.value[accentPhraseIndex][moraIndex] = data;
-        }
-        store.dispatch("COMMAND_SET_AUDIO_MORA_DATA", {
-          audioKey: props.activeAudioKey,
-          accentPhraseIndex,
-          moraIndex,
-          data,
-          type,
-        });
-      } else {
-        if (accentPhrases.value === undefined) {
-          throw Error("accentPhrases.value === undefined");
-        }
-        store.dispatch("COMMAND_SET_AUDIO_MORA_DATA_ACCENT_PHRASE", {
-          audioKey: props.activeAudioKey,
-          accentPhraseIndex,
-          moraIndex,
-          data,
-          type,
-        });
-      }
-    };
-
-    // audio play
-    const play = async () => {
-      try {
-        await store.dispatch("PLAY_AUDIO", {
-          audioKey: props.activeAudioKey,
-        });
-      } catch (e) {
-        $q.dialog({
-          title: "再生に失敗しました",
-          message: "エンジンの再起動をお試しください。",
-          ok: {
-            label: "閉じる",
-            flat: true,
-            textColor: "display",
-          },
-        });
-      }
-    };
-
-    const stop = () => {
-      store.dispatch("STOP_AUDIO", { audioKey: props.activeAudioKey });
-    };
-
-    const nowPlaying = computed(
-      () => store.state.audioStates[props.activeAudioKey]?.nowPlaying
-    );
-    const nowGenerating = computed(
-      () => store.state.audioStates[props.activeAudioKey]?.nowGenerating
-    );
-
-    // continuously play
-    const nowPlayingContinuously = computed(
-      () => store.state.nowPlayingContinuously
-    );
-
-    const audioDetail = ref<HTMLElement>();
-    let accentPhraseElems: HTMLElement[] = [];
-    const addAccentPhraseElem = (elem: HTMLElement) => {
-      if (elem) {
-        accentPhraseElems.push(elem);
-      }
-    };
-    onBeforeUpdate(() => {
-      accentPhraseElems = [];
-    });
-
-    const scrollToActivePoint = () => {
-      if (
-        activePoint.value === undefined ||
-        !audioDetail.value ||
-        accentPhraseElems.length === 0
-      )
-        return;
-      const elem = accentPhraseElems[activePoint.value];
-
-      if (activePointScrollMode.value === "CONTINUOUSLY") {
-        const scrollCount = Math.max(
-          elem.offsetLeft -
-            audioDetail.value.offsetLeft +
-            elem.offsetWidth / 2 -
-            audioDetail.value.offsetWidth / 2,
-          0
-        );
-        audioDetail.value.scroll(scrollCount, 0);
-      } else if (activePointScrollMode.value === "PAGE") {
-        const displayedPart =
-          audioDetail.value.scrollLeft + audioDetail.value.offsetWidth;
-        const nextAccentPhraseStart =
-          elem.offsetLeft - audioDetail.value.offsetLeft;
-        const nextAccentPhraseEnd = nextAccentPhraseStart + elem.offsetWidth;
-        // 再生しようとしているアクセント句が表示範囲外にある時に、自動スクロールを行う
-        if (
-          nextAccentPhraseEnd <= audioDetail.value.scrollLeft ||
-          displayedPart <= nextAccentPhraseEnd
-        ) {
-          const scrollCount = elem.offsetLeft - audioDetail.value.offsetLeft;
-          audioDetail.value.scroll(scrollCount, 0);
-        }
-      } else {
-        // activePointScrollMode.value === "OFF"
-        return;
-      }
-    };
-
-    // NodeJS.Timeout型が直接指定できないので、typeofとReturnTypeで取ってきている
-    let focusInterval: ReturnType<typeof setInterval> | undefined;
-    watch(nowPlaying, async (newState) => {
-      if (newState) {
-        const accentPhraseOffsets = await store.dispatch(
-          "GET_AUDIO_PLAY_OFFSETS",
-          {
-            audioKey: props.activeAudioKey,
-          }
-        );
-        // 現在再生されているaudio elementの再生時刻を0.01秒毎に取得(監視)し、
-        // それに合わせてフォーカスするアクセント句を変えていく
-        focusInterval = setInterval(() => {
-          const currentTime = store.getters.ACTIVE_AUDIO_ELEM_CURRENT_TIME;
-          for (let i = 1; i < accentPhraseOffsets.length; i++) {
-            if (
-              currentTime !== undefined &&
-              accentPhraseOffsets[i - 1] <= currentTime &&
-              currentTime < accentPhraseOffsets[i]
-            ) {
-              activePoint.value = i - 1;
-              scrollToActivePoint();
-            }
-          }
-        }, 10);
-      } else if (focusInterval !== undefined) {
-        clearInterval(focusInterval);
-        focusInterval = undefined;
-        // startPointがundefinedの場合、一旦最初のアクセント句までスクロール、その後activePointの選択を解除(undefinedに)する
-        activePoint.value = startPoint.value ?? 0;
-        scrollToActivePoint();
-        if (startPoint.value === undefined)
-          activePoint.value = startPoint.value;
-      }
-    });
-
-    const pronunciationByPhrase = computed(() => {
-      const textArray: Array<string> = [];
-      accentPhrases.value?.forEach((accentPhrase) => {
-        let textString = "";
-        accentPhrase.moras.forEach((mora) => {
-          textString += mora.text;
-        });
-        if (accentPhrase.pauseMora) {
-          textString += "、";
-        }
-        textArray.push(textString);
-      });
-      return textArray;
-    });
-
-    const handleChangePronounce = (
-      newPronunciation: string,
-      phraseIndex: number
-    ) => {
-      let popUntilPause = false;
-      newPronunciation = newPronunciation.replace(",", "、");
-      if (accentPhrases.value == undefined)
-        throw new Error("accentPhrases.value == undefined");
-      if (
-        newPronunciation.slice(-1) == "、" &&
-        accentPhrases.value.length - 1 != phraseIndex
-      ) {
-        newPronunciation += pronunciationByPhrase.value[phraseIndex + 1];
-        popUntilPause = true;
-      }
-      store.dispatch("COMMAND_CHANGE_SINGLE_ACCENT_PHRASE", {
-        audioKey: props.activeAudioKey,
-        newPronunciation,
-        accentPhraseIndex: phraseIndex,
-        popUntilPause,
-      });
-    };
-
-    type hoveredType = "vowel" | "consonant";
-
-    type hoveredInfoType = {
-      accentPhraseIndex: number | undefined;
-      moraIndex?: number | undefined;
-      type?: hoveredType;
-    };
-
-    const accentHoveredInfo = reactive<hoveredInfoType>({
-      accentPhraseIndex: undefined,
-    });
-
-    const pitchHoveredInfo = reactive<hoveredInfoType>({
-      accentPhraseIndex: undefined,
-      moraIndex: undefined,
-    });
-
-    const lengthHoveredInfo = reactive<hoveredInfoType>({
-      accentPhraseIndex: undefined,
-      moraIndex: undefined,
-      type: "vowel",
-    });
-
-    const handleHoverText = (
-      isOver: boolean,
-      phraseIndex: number,
-      moraIndex: number
-    ) => {
-      if (selectedDetail.value == "accent") {
-        if (isOver) {
-          accentHoveredInfo.accentPhraseIndex = phraseIndex;
-        } else {
-          accentHoveredInfo.accentPhraseIndex = undefined;
-        }
-      } else if (selectedDetail.value == "pitch") {
-        if (isOver) {
-          pitchHoveredInfo.accentPhraseIndex = phraseIndex;
-          pitchHoveredInfo.moraIndex = moraIndex;
-        } else {
-          pitchHoveredInfo.accentPhraseIndex = undefined;
-          pitchHoveredInfo.moraIndex = undefined;
-        }
-      }
-    };
-
-    const handleLengthHoverText = (
-      isOver: boolean,
-      phoneme: hoveredType,
-      phraseIndex: number,
-      moraIndex?: number
-    ) => {
-      lengthHoveredInfo.type = phoneme;
-      // the pause and pitch templates don't emit a mouseOver event
-      if (isOver) {
-        lengthHoveredInfo.accentPhraseIndex = phraseIndex;
-        lengthHoveredInfo.moraIndex = moraIndex;
-      } else {
-        lengthHoveredInfo.accentPhraseIndex = undefined;
-        lengthHoveredInfo.moraIndex = undefined;
-      }
-    };
-
-    const unvoicableVowels = ["U", "I", "i", "u"];
-
-    const isHovered = (
-      vowel: string,
-      accentPhraseIndex: number,
-      moraIndex: number
-    ) => {
-      let isHover = false;
-      if (!uiLocked.value) {
-        if (selectedDetail.value == "accent") {
-          if (accentPhraseIndex === accentHoveredInfo.accentPhraseIndex) {
-            isHover = true;
-          }
-        } else if (selectedDetail.value == "pitch") {
-          if (
-            accentPhraseIndex === pitchHoveredInfo.accentPhraseIndex &&
-            moraIndex === pitchHoveredInfo.moraIndex &&
-            unvoicableVowels.indexOf(vowel) > -1
-          ) {
-            isHover = true;
-          }
-        }
-      }
-      return isHover;
-    };
-
-    const getHoveredText = (
-      mora: Mora,
-      accentPhraseIndex: number,
-      moraIndex: number
-    ) => {
-      if (selectedDetail.value != "length") return mora.text;
-      if (
-        accentPhraseIndex === lengthHoveredInfo.accentPhraseIndex &&
-        moraIndex === lengthHoveredInfo.moraIndex
-      ) {
-        if (lengthHoveredInfo.type == "vowel") {
-          return mora.vowel.toUpperCase();
-        } else {
-          return mora.consonant?.toUpperCase();
-        }
-      } else {
-        return mora.text;
-      }
-    };
-
-    const shiftKeyFlag = ref(false);
-    const altKeyFlag = ref(false);
-
-    const keyEventListter = (event: KeyboardEvent) => {
-      shiftKeyFlag.value = event.shiftKey;
-      altKeyFlag.value = event.altKey;
-    };
-
-    const handleChangeVoicing = (
-      mora: Mora,
-      accentPhraseIndex: number,
-      moraIndex: number
-    ) => {
-      if (
-        selectedDetail.value == "pitch" &&
-        unvoicableVowels.indexOf(mora.vowel) > -1
-      ) {
-        let data = 0;
-        if (mora.pitch == 0) {
-          if (lastPitches.value[accentPhraseIndex][moraIndex] == 0) {
-            // 元々無声だった場合、適当な値を代入
-            data = 5.5;
-          } else {
-            data = lastPitches.value[accentPhraseIndex][moraIndex];
-          }
-        }
-        changeMoraData(accentPhraseIndex, moraIndex, data, "voicing");
-      }
-    };
-
-    onMounted(() => {
-      window.addEventListener("keyup", keyEventListter);
-      document.addEventListener("keydown", keyEventListter);
-    });
-
-    onUnmounted(() => {
-      window.removeEventListener("keyup", keyEventListter);
-      document.removeEventListener("keydown", keyEventListter);
-    });
-
-    return {
-      maxPitch,
-      minPitch,
-      maxMoraLength,
-      minMoraLength,
-      selectDetail,
-      selectedDetail,
-      activePoint,
-      setPlayAndStartPoint,
-      uiLocked,
-      supportedFeatures,
-      audioItem,
-      query,
-      accentPhrases,
-      changeAccent,
-      toggleAccentPhraseSplit,
-      changeMoraData,
-      play,
-      stop,
-      nowPlaying,
-      nowGenerating,
-      nowPlayingContinuously,
-      addAccentPhraseElem,
-      pronunciationByPhrase,
-      handleChangePronounce,
-      handleHoverText,
-      handleLengthHoverText,
-      isHovered,
-      getHoveredText,
-      shiftKeyFlag,
-      handleChangeVoicing,
-      audioDetail,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 @use '@/styles/variables' as vars;

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -1,3 +1,45 @@
+<template>
+  <div
+    @mouseenter="handleMouseHover(true)"
+    @mouseleave="handleMouseHover(false)"
+  >
+    <QBadge
+      class="value-label"
+      color="primary-light"
+      text-color="display-on-primary"
+      v-if="
+        !disable && (valueLabel.visible || previewSlider.state.isPanning.value)
+      "
+    >
+      {{
+        previewSlider.state.currentValue.value
+          ? previewSlider.state.currentValue.value.toFixed(precisionComputed)
+          : undefined
+      }}
+    </QBadge>
+    <QSlider
+      vertical
+      reverse
+      snap
+      color="primary-light"
+      trackSize="2.5px"
+      :style="clipPathComputed"
+      :min="previewSlider.qSliderProps.min.value"
+      :max="previewSlider.qSliderProps.max.value"
+      :step="previewSlider.qSliderProps.step.value"
+      :disable="previewSlider.qSliderProps.disable.value"
+      :model-value="previewSlider.qSliderProps.modelValue.value"
+      @update:model-value="previewSlider.qSliderProps['onUpdate:modelValue']"
+      @click.stop="
+        undefined; // クリックでアクセント句が選択されないように
+      "
+      @change="previewSlider.qSliderProps.onChange"
+      @wheel="previewSlider.qSliderProps.onWheel"
+      @pan="previewSlider.qSliderProps.onPan"
+    />
+  </div>
+</template>
+
 <script setup lang="ts">
 import { previewSliderHelper } from "@/helpers/previewSliderHelper";
 import { MoraDataType } from "@/type/preload";
@@ -89,48 +131,6 @@ const precisionComputed = computed(() => {
   }
 });
 </script>
-
-<template>
-  <div
-    @mouseenter="handleMouseHover(true)"
-    @mouseleave="handleMouseHover(false)"
-  >
-    <QBadge
-      class="value-label"
-      color="primary-light"
-      text-color="display-on-primary"
-      v-if="
-        !disable && (valueLabel.visible || previewSlider.state.isPanning.value)
-      "
-    >
-      {{
-        previewSlider.state.currentValue.value
-          ? previewSlider.state.currentValue.value.toFixed(precisionComputed)
-          : undefined
-      }}
-    </QBadge>
-    <QSlider
-      vertical
-      reverse
-      snap
-      color="primary-light"
-      trackSize="2.5px"
-      :style="clipPathComputed"
-      :min="previewSlider.qSliderProps.min.value"
-      :max="previewSlider.qSliderProps.max.value"
-      :step="previewSlider.qSliderProps.step.value"
-      :disable="previewSlider.qSliderProps.disable.value"
-      :model-value="previewSlider.qSliderProps.modelValue.value"
-      @update:model-value="previewSlider.qSliderProps['onUpdate:modelValue']"
-      @click.stop="
-        undefined; // クリックでアクセント句が選択されないように
-      "
-      @change="previewSlider.qSliderProps.onChange"
-      @wheel="previewSlider.qSliderProps.onWheel"
-      @pan="previewSlider.qSliderProps.onPan"
-    />
-  </div>
-</template>
 <style scoped lang="scss">
 $value-label-height: 24px;
 

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -1,98 +1,3 @@
-<script setup lang="ts">
-import { base64ImageToUri } from "@/helpers/imageHelper";
-import { useStore } from "@/store";
-import { CharacterInfo, Voice } from "@/type/preload";
-import { debounce } from "quasar";
-import { computed, ref } from "vue";
-
-const props =
-  defineProps<{
-    characterInfos: CharacterInfo[];
-    loading: boolean;
-    selectedVoice: Voice;
-    showEngineInfo: boolean;
-    emptiable: boolean;
-    uiLocked: boolean;
-  }>();
-const emit =
-  defineEmits<{
-    (e: "update:selectedVoice", value: Voice | undefined): void;
-  }>();
-
-const store = useStore();
-
-const selectedCharacter = computed(() => {
-  const selectedVoice = props.selectedVoice;
-  const character = props.characterInfos.find(
-    (characterInfo) =>
-      characterInfo.metas.speakerUuid === selectedVoice?.speakerId &&
-      characterInfo.metas.styles.some(
-        (style) =>
-          style.engineId === selectedVoice.engineId &&
-          style.styleId === selectedVoice.styleId
-      )
-  );
-  return character;
-});
-
-const selectedStyleInfo = computed(() => {
-  const selectedVoice = props.selectedVoice;
-  const style = selectedCharacter.value?.metas.styles.find(
-    (style) =>
-      style.engineId === selectedVoice?.engineId &&
-      style.styleId === selectedVoice.styleId
-  );
-  return style;
-});
-
-const engineIcons = computed(() =>
-  Object.fromEntries(
-    store.state.engineIds.map((engineId) => [
-      engineId,
-      base64ImageToUri(store.state.engineManifests[engineId].icon),
-    ])
-  )
-);
-
-const getDefaultStyle = (speakerUuid: string) => {
-  // FIXME: 同一キャラが複数エンジンにまたがっているとき、順番が先のエンジンが必ず選択される
-  const characterInfo = props.characterInfos.find(
-    (info) => info.metas.speakerUuid === speakerUuid
-  );
-  const defaultStyleId = store.state.defaultStyleIds.find(
-    (x) => x.speakerUuid === speakerUuid
-  )?.defaultStyleId;
-
-  const defaultStyle = characterInfo?.metas.styles.find(
-    (style) => style.styleId === defaultStyleId
-  );
-
-  if (defaultStyle == undefined) throw new Error("defaultStyle == undefined");
-
-  return defaultStyle;
-};
-
-const onSelectSpeaker = (speakerUuid: string) => {
-  const style = getDefaultStyle(speakerUuid);
-  emit("update:selectedVoice", {
-    engineId: style.engineId,
-    speakerId: speakerUuid,
-    styleId: style.styleId,
-  });
-};
-
-const subMenuOpenFlags = ref(
-  [...Array(props.characterInfos.length)].map(() => false)
-);
-
-const reassignSubMenuOpen = debounce((idx: number) => {
-  if (subMenuOpenFlags.value[idx]) return;
-  const arr = [...Array(props.characterInfos.length)].map(() => false);
-  arr[idx] = true;
-  subMenuOpenFlags.value = arr;
-}, 100);
-</script>
-
 <template>
   <QBtn
     flat
@@ -273,6 +178,101 @@ const reassignSubMenuOpen = debounce((idx: number) => {
     </QMenu>
   </QBtn>
 </template>
+
+<script setup lang="ts">
+import { base64ImageToUri } from "@/helpers/imageHelper";
+import { useStore } from "@/store";
+import { CharacterInfo, Voice } from "@/type/preload";
+import { debounce } from "quasar";
+import { computed, ref } from "vue";
+
+const props =
+  defineProps<{
+    characterInfos: CharacterInfo[];
+    loading: boolean;
+    selectedVoice: Voice;
+    showEngineInfo: boolean;
+    emptiable: boolean;
+    uiLocked: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:selectedVoice", value: Voice | undefined): void;
+  }>();
+
+const store = useStore();
+
+const selectedCharacter = computed(() => {
+  const selectedVoice = props.selectedVoice;
+  const character = props.characterInfos.find(
+    (characterInfo) =>
+      characterInfo.metas.speakerUuid === selectedVoice?.speakerId &&
+      characterInfo.metas.styles.some(
+        (style) =>
+          style.engineId === selectedVoice.engineId &&
+          style.styleId === selectedVoice.styleId
+      )
+  );
+  return character;
+});
+
+const selectedStyleInfo = computed(() => {
+  const selectedVoice = props.selectedVoice;
+  const style = selectedCharacter.value?.metas.styles.find(
+    (style) =>
+      style.engineId === selectedVoice?.engineId &&
+      style.styleId === selectedVoice.styleId
+  );
+  return style;
+});
+
+const engineIcons = computed(() =>
+  Object.fromEntries(
+    store.state.engineIds.map((engineId) => [
+      engineId,
+      base64ImageToUri(store.state.engineManifests[engineId].icon),
+    ])
+  )
+);
+
+const getDefaultStyle = (speakerUuid: string) => {
+  // FIXME: 同一キャラが複数エンジンにまたがっているとき、順番が先のエンジンが必ず選択される
+  const characterInfo = props.characterInfos.find(
+    (info) => info.metas.speakerUuid === speakerUuid
+  );
+  const defaultStyleId = store.state.defaultStyleIds.find(
+    (x) => x.speakerUuid === speakerUuid
+  )?.defaultStyleId;
+
+  const defaultStyle = characterInfo?.metas.styles.find(
+    (style) => style.styleId === defaultStyleId
+  );
+
+  if (defaultStyle == undefined) throw new Error("defaultStyle == undefined");
+
+  return defaultStyle;
+};
+
+const onSelectSpeaker = (speakerUuid: string) => {
+  const style = getDefaultStyle(speakerUuid);
+  emit("update:selectedVoice", {
+    engineId: style.engineId,
+    speakerId: speakerUuid,
+    styleId: style.styleId,
+  });
+};
+
+const subMenuOpenFlags = ref(
+  [...Array(props.characterInfos.length)].map(() => false)
+);
+
+const reassignSubMenuOpen = debounce((idx: number) => {
+  if (subMenuOpenFlags.value[idx]) return;
+  const arr = [...Array(props.characterInfos.length)].map(() => false);
+  arr[idx] = true;
+  subMenuOpenFlags.value = arr;
+}, 100);
+</script>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -1,26 +1,209 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import draggable from "vuedraggable";
+import { useStore } from "@/store";
+import { CharacterInfo, StyleInfo } from "@/type/preload";
+const props =
+  defineProps<{
+    modelValue: boolean;
+    characterInfos: CharacterInfo[];
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", value: boolean): void;
+  }>();
+
+const store = useStore();
+
+const modelValueComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+
+const characterInfosMap = computed(() => {
+  const map: { [key: string]: CharacterInfo } = {};
+  props.characterInfos.forEach((characterInfo) => {
+    map[characterInfo.metas.speakerUuid] = characterInfo;
+  });
+  return map;
+});
+
+// 新しいキャラクター
+const newCharacters = ref<string[]>([]);
+const hasNewCharacter = computed(() => newCharacters.value.length > 0);
+
+// サンプルボイス一覧のキャラクター順番
+const sampleCharacterOrder = ref<string[]>([]);
+
+// 選択中のスタイル
+const selectedStyleIndexes = ref<Record<string, number>>({});
+const selectedStyles = computed(() => {
+  const map: { [key: string]: StyleInfo } = {};
+  props.characterInfos.forEach((characterInfo) => {
+    const selectedStyleIndex: number | undefined =
+      selectedStyleIndexes.value[characterInfo.metas.speakerUuid];
+    map[characterInfo.metas.speakerUuid] =
+      characterInfo.metas.styles[selectedStyleIndex ?? 0];
+  });
+  return map;
+});
+
+// 選択中のキャラクター
+const selectedCharacter = ref(props.characterInfos[0].metas.speakerUuid);
+const selectCharacter = (speakerUuid: string) => {
+  selectedCharacter.value = speakerUuid;
+};
+
+// キャラクター表示順序
+const characterOrder = ref<CharacterInfo[]>([]);
+
+// ダイアログが開かれたときに初期値を求める
+watch(
+  () => props.modelValue,
+  async (newValue, oldValue) => {
+    if (!oldValue && newValue) {
+      // 新しいキャラクター
+      newCharacters.value = await store.dispatch("GET_NEW_CHARACTERS");
+
+      // サンプルの順番、新しいキャラクターは上に
+      sampleCharacterOrder.value = [
+        ...newCharacters.value,
+        ...props.characterInfos
+          .filter(
+            (info) => !newCharacters.value.includes(info.metas.speakerUuid)
+          )
+          .map((info) => info.metas.speakerUuid),
+      ];
+
+      selectedCharacter.value = sampleCharacterOrder.value[0];
+
+      // 保存済みのキャラクターリストを取得
+      // FIXME: 不明なキャラを無視しているので、不明キャラの順番が保存時にリセットされてしまう
+      characterOrder.value = store.state.userCharacterOrder
+        .map((speakerUuid) => characterInfosMap.value[speakerUuid])
+        .filter((info) => info !== undefined) as CharacterInfo[];
+
+      // 含まれていないキャラクターを足す
+      const notIncludesCharacterInfos = props.characterInfos.filter(
+        (characterInfo) =>
+          !characterOrder.value.find(
+            (characterInfoInList) =>
+              characterInfoInList.metas.speakerUuid ===
+              characterInfo.metas.speakerUuid
+          )
+      );
+      characterOrder.value = [
+        ...characterOrder.value,
+        ...notIncludesCharacterInfos,
+      ];
+    }
+  }
+);
+
+// draggable用
+const keyOfCharacterOrderItem = (item: CharacterInfo) => item.metas.speakerUuid;
+
+// キャラクター枠のホバー状態を表示するかどうか
+// 再生ボタンなどにカーソルがある場合はキャラクター枠のホバーUIを表示しないようにするため
+const isHoverableItem = ref(true);
+
+// 音声再生
+const playing = ref<{ speakerUuid: string; styleId: number; index: number }>();
+
+const audio = new Audio();
+audio.volume = 0.5;
+audio.onended = () => stop();
+
+const play = (
+  speakerUuid: string,
+  { styleId, voiceSamplePaths }: StyleInfo,
+  index: number
+) => {
+  if (audio.src !== "") stop();
+
+  audio.src = voiceSamplePaths[index];
+  audio.play();
+  playing.value = { speakerUuid, styleId, index };
+};
+const stop = () => {
+  if (audio.src === "") return;
+
+  audio.pause();
+  audio.removeAttribute("src");
+  playing.value = undefined;
+};
+
+// 再生していたら停止、再生していなかったら再生
+const togglePlayOrStop = (
+  speakerUuid: string,
+  styleInfo: StyleInfo,
+  index: number
+) => {
+  if (
+    playing.value === undefined ||
+    speakerUuid !== playing.value.speakerUuid ||
+    styleInfo.styleId !== playing.value.styleId ||
+    index !== playing.value.index
+  ) {
+    play(speakerUuid, styleInfo, index);
+  } else {
+    stop();
+  }
+};
+
+// スタイル番号をずらす
+const rollStyleIndex = (speakerUuid: string, diff: number) => {
+  // 0 <= index <= length に収める
+  const length = characterInfosMap.value[speakerUuid].metas.styles.length;
+  const selectedStyleIndex: number | undefined =
+    selectedStyleIndexes.value[speakerUuid];
+
+  let styleIndex = (selectedStyleIndex ?? 0) + diff;
+  styleIndex = styleIndex < 0 ? length - 1 : styleIndex % length;
+  selectedStyleIndexes.value[speakerUuid] = styleIndex;
+
+  // 音声を再生する。同じstyleIndexだったら停止する。
+  const selectedStyleInfo =
+    characterInfosMap.value[speakerUuid].metas.styles[styleIndex];
+  togglePlayOrStop(speakerUuid, selectedStyleInfo, 0);
+};
+
+// ドラッグ中かどうか
+const characterOrderDragging = ref(false);
+
+const closeDialog = () => {
+  store.dispatch(
+    "SET_USER_CHARACTER_ORDER",
+    characterOrder.value.map((info) => info.metas.speakerUuid)
+  );
+  stop();
+  modelValueComputed.value = false;
+};
+</script>
+
 <template>
-  <q-dialog
+  <QDialog
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="transparent-backdrop"
     v-model="modelValueComputed"
   >
-    <q-layout container view="hHh Lpr lff" class="bg-background">
-      <q-header class="q-py-sm">
-        <q-toolbar>
+    <QLayout container view="hHh Lpr lff" class="bg-background">
+      <QHeader class="q-py-sm">
+        <QToolbar>
           <div class="column">
-            <q-toolbar-title class="text-display">{{
+            <QToolbarTitle class="text-display">{{
               hasNewCharacter
                 ? "追加キャラクターの紹介"
                 : "設定 / キャラクター並び替え・試聴"
-            }}</q-toolbar-title>
+            }}</QToolbarTitle>
           </div>
 
-          <q-space />
+          <QSpace />
 
           <div class="row items-center no-wrap">
-            <q-btn
+            <QBtn
               unelevated
               label="完了"
               color="toolbar-button"
@@ -29,10 +212,10 @@
               @click="closeDialog"
             />
           </div>
-        </q-toolbar>
-      </q-header>
+        </QToolbar>
+      </QHeader>
 
-      <q-drawer
+      <QDrawer
         bordered
         show-if-above
         :model-value="true"
@@ -45,14 +228,14 @@
             class="character-portrait"
           />
         </div>
-      </q-drawer>
+      </QDrawer>
 
-      <q-page-container>
-        <q-page class="main">
+      <QPageContainer>
+        <QPage class="main">
           <div class="character-items-container">
             <span class="text-h6 q-py-md">サンプルボイス一覧</span>
             <div>
-              <q-item
+              <QItem
                 v-for="speakerUuid of sampleCharacterOrder"
                 :key="speakerUuid"
                 clickable
@@ -88,7 +271,7 @@
                     "
                     class="style-select-container"
                   >
-                    <q-btn
+                    <QBtn
                       flat
                       dense
                       icon="chevron_left"
@@ -104,7 +287,7 @@
                     <span>{{
                       selectedStyles[speakerUuid].styleName || "ノーマル"
                     }}</span>
-                    <q-btn
+                    <QBtn
                       flat
                       dense
                       icon="chevron_right"
@@ -119,7 +302,7 @@
                     />
                   </div>
                   <div class="voice-samples">
-                    <q-btn
+                    <QBtn
                       v-for="voiceSampleIndex of [...Array(3).keys()]"
                       :key="voiceSampleIndex"
                       round
@@ -154,7 +337,7 @@
                     NEW!
                   </div>
                 </div>
-              </q-item>
+              </QItem>
             </div>
           </div>
 
@@ -187,227 +370,11 @@
               </template>
             </draggable>
           </div>
-        </q-page>
-      </q-page-container>
-    </q-layout>
-  </q-dialog>
+        </QPage>
+      </QPageContainer>
+    </QLayout>
+  </QDialog>
 </template>
-
-<script lang="ts">
-import { defineComponent, computed, ref, PropType, watch } from "vue";
-import draggable from "vuedraggable";
-import { useStore } from "@/store";
-import { CharacterInfo, StyleInfo } from "@/type/preload";
-
-export default defineComponent({
-  name: "CharacterOrderDialog",
-  components: {
-    draggable,
-  },
-
-  props: {
-    modelValue: {
-      type: Boolean,
-      required: true,
-    },
-    characterInfos: {
-      type: Object as PropType<CharacterInfo[]>,
-      required: true,
-    },
-  },
-
-  setup(props, { emit }) {
-    const store = useStore();
-
-    const modelValueComputed = computed({
-      get: () => props.modelValue,
-      set: (val) => emit("update:modelValue", val),
-    });
-
-    const characterInfosMap = computed(() => {
-      const map: { [key: string]: CharacterInfo } = {};
-      props.characterInfos.forEach((characterInfo) => {
-        map[characterInfo.metas.speakerUuid] = characterInfo;
-      });
-      return map;
-    });
-
-    // 新しいキャラクター
-    const newCharacters = ref<string[]>([]);
-    const hasNewCharacter = computed(() => newCharacters.value.length > 0);
-
-    // サンプルボイス一覧のキャラクター順番
-    const sampleCharacterOrder = ref<string[]>([]);
-
-    // 選択中のスタイル
-    const selectedStyleIndexes = ref<Record<string, number>>({});
-    const selectedStyles = computed(() => {
-      const map: { [key: string]: StyleInfo } = {};
-      props.characterInfos.forEach((characterInfo) => {
-        const selectedStyleIndex: number | undefined =
-          selectedStyleIndexes.value[characterInfo.metas.speakerUuid];
-        map[characterInfo.metas.speakerUuid] =
-          characterInfo.metas.styles[selectedStyleIndex ?? 0];
-      });
-      return map;
-    });
-
-    // 選択中のキャラクター
-    const selectedCharacter = ref(props.characterInfos[0].metas.speakerUuid);
-    const selectCharacter = (speakerUuid: string) => {
-      selectedCharacter.value = speakerUuid;
-    };
-
-    // キャラクター表示順序
-    const characterOrder = ref<CharacterInfo[]>([]);
-
-    // ダイアログが開かれたときに初期値を求める
-    watch(
-      () => props.modelValue,
-      async (newValue, oldValue) => {
-        if (!oldValue && newValue) {
-          // 新しいキャラクター
-          newCharacters.value = await store.dispatch("GET_NEW_CHARACTERS");
-
-          // サンプルの順番、新しいキャラクターは上に
-          sampleCharacterOrder.value = [
-            ...newCharacters.value,
-            ...props.characterInfos
-              .filter(
-                (info) => !newCharacters.value.includes(info.metas.speakerUuid)
-              )
-              .map((info) => info.metas.speakerUuid),
-          ];
-
-          selectedCharacter.value = sampleCharacterOrder.value[0];
-
-          // 保存済みのキャラクターリストを取得
-          // FIXME: 不明なキャラを無視しているので、不明キャラの順番が保存時にリセットされてしまう
-          characterOrder.value = store.state.userCharacterOrder
-            .map((speakerUuid) => characterInfosMap.value[speakerUuid])
-            .filter((info) => info !== undefined) as CharacterInfo[];
-
-          // 含まれていないキャラクターを足す
-          const notIncludesCharacterInfos = props.characterInfos.filter(
-            (characterInfo) =>
-              !characterOrder.value.find(
-                (characterInfoInList) =>
-                  characterInfoInList.metas.speakerUuid ===
-                  characterInfo.metas.speakerUuid
-              )
-          );
-          characterOrder.value = [
-            ...characterOrder.value,
-            ...notIncludesCharacterInfos,
-          ];
-        }
-      }
-    );
-
-    // draggable用
-    const keyOfCharacterOrderItem = (item: CharacterInfo) =>
-      item.metas.speakerUuid;
-
-    // キャラクター枠のホバー状態を表示するかどうか
-    // 再生ボタンなどにカーソルがある場合はキャラクター枠のホバーUIを表示しないようにするため
-    const isHoverableItem = ref(true);
-
-    // 音声再生
-    const playing =
-      ref<{ speakerUuid: string; styleId: number; index: number }>();
-
-    const audio = new Audio();
-    audio.volume = 0.5;
-    audio.onended = () => stop();
-
-    const play = (
-      speakerUuid: string,
-      { styleId, voiceSamplePaths }: StyleInfo,
-      index: number
-    ) => {
-      if (audio.src !== "") stop();
-
-      audio.src = voiceSamplePaths[index];
-      audio.play();
-      playing.value = { speakerUuid, styleId, index };
-    };
-    const stop = () => {
-      if (audio.src === "") return;
-
-      audio.pause();
-      audio.removeAttribute("src");
-      playing.value = undefined;
-    };
-
-    // 再生していたら停止、再生していなかったら再生
-    const togglePlayOrStop = (
-      speakerUuid: string,
-      styleInfo: StyleInfo,
-      index: number
-    ) => {
-      if (
-        playing.value === undefined ||
-        speakerUuid !== playing.value.speakerUuid ||
-        styleInfo.styleId !== playing.value.styleId ||
-        index !== playing.value.index
-      ) {
-        play(speakerUuid, styleInfo, index);
-      } else {
-        stop();
-      }
-    };
-
-    // スタイル番号をずらす
-    const rollStyleIndex = (speakerUuid: string, diff: number) => {
-      // 0 <= index <= length に収める
-      const length = characterInfosMap.value[speakerUuid].metas.styles.length;
-      const selectedStyleIndex: number | undefined =
-        selectedStyleIndexes.value[speakerUuid];
-
-      let styleIndex = (selectedStyleIndex ?? 0) + diff;
-      styleIndex = styleIndex < 0 ? length - 1 : styleIndex % length;
-      selectedStyleIndexes.value[speakerUuid] = styleIndex;
-
-      // 音声を再生する。同じstyleIndexだったら停止する。
-      const selectedStyleInfo =
-        characterInfosMap.value[speakerUuid].metas.styles[styleIndex];
-      togglePlayOrStop(speakerUuid, selectedStyleInfo, 0);
-    };
-
-    // ドラッグ中かどうか
-    const characterOrderDragging = ref(false);
-
-    const closeDialog = () => {
-      store.dispatch(
-        "SET_USER_CHARACTER_ORDER",
-        characterOrder.value.map((info) => info.metas.speakerUuid)
-      );
-      stop();
-      modelValueComputed.value = false;
-    };
-
-    return {
-      modelValueComputed,
-      characterInfosMap,
-      sampleCharacterOrder,
-      newCharacters,
-      hasNewCharacter,
-      selectedStyleIndexes,
-      selectedStyles,
-      selectedCharacter,
-      selectCharacter,
-      characterOrder,
-      keyOfCharacterOrderItem,
-      isHoverableItem,
-      playing,
-      togglePlayOrStop,
-      rollStyleIndex,
-      characterOrderDragging,
-      closeDialog,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 @use '@/styles/variables' as vars;

--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -1,186 +1,3 @@
-<script setup lang="ts">
-import { computed, ref, watch } from "vue";
-import draggable from "vuedraggable";
-import { useStore } from "@/store";
-import { CharacterInfo, StyleInfo } from "@/type/preload";
-const props =
-  defineProps<{
-    modelValue: boolean;
-    characterInfos: CharacterInfo[];
-  }>();
-const emit =
-  defineEmits<{
-    (e: "update:modelValue", value: boolean): void;
-  }>();
-
-const store = useStore();
-
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
-
-const characterInfosMap = computed(() => {
-  const map: { [key: string]: CharacterInfo } = {};
-  props.characterInfos.forEach((characterInfo) => {
-    map[characterInfo.metas.speakerUuid] = characterInfo;
-  });
-  return map;
-});
-
-// 新しいキャラクター
-const newCharacters = ref<string[]>([]);
-const hasNewCharacter = computed(() => newCharacters.value.length > 0);
-
-// サンプルボイス一覧のキャラクター順番
-const sampleCharacterOrder = ref<string[]>([]);
-
-// 選択中のスタイル
-const selectedStyleIndexes = ref<Record<string, number>>({});
-const selectedStyles = computed(() => {
-  const map: { [key: string]: StyleInfo } = {};
-  props.characterInfos.forEach((characterInfo) => {
-    const selectedStyleIndex: number | undefined =
-      selectedStyleIndexes.value[characterInfo.metas.speakerUuid];
-    map[characterInfo.metas.speakerUuid] =
-      characterInfo.metas.styles[selectedStyleIndex ?? 0];
-  });
-  return map;
-});
-
-// 選択中のキャラクター
-const selectedCharacter = ref(props.characterInfos[0].metas.speakerUuid);
-const selectCharacter = (speakerUuid: string) => {
-  selectedCharacter.value = speakerUuid;
-};
-
-// キャラクター表示順序
-const characterOrder = ref<CharacterInfo[]>([]);
-
-// ダイアログが開かれたときに初期値を求める
-watch(
-  () => props.modelValue,
-  async (newValue, oldValue) => {
-    if (!oldValue && newValue) {
-      // 新しいキャラクター
-      newCharacters.value = await store.dispatch("GET_NEW_CHARACTERS");
-
-      // サンプルの順番、新しいキャラクターは上に
-      sampleCharacterOrder.value = [
-        ...newCharacters.value,
-        ...props.characterInfos
-          .filter(
-            (info) => !newCharacters.value.includes(info.metas.speakerUuid)
-          )
-          .map((info) => info.metas.speakerUuid),
-      ];
-
-      selectedCharacter.value = sampleCharacterOrder.value[0];
-
-      // 保存済みのキャラクターリストを取得
-      // FIXME: 不明なキャラを無視しているので、不明キャラの順番が保存時にリセットされてしまう
-      characterOrder.value = store.state.userCharacterOrder
-        .map((speakerUuid) => characterInfosMap.value[speakerUuid])
-        .filter((info) => info !== undefined) as CharacterInfo[];
-
-      // 含まれていないキャラクターを足す
-      const notIncludesCharacterInfos = props.characterInfos.filter(
-        (characterInfo) =>
-          !characterOrder.value.find(
-            (characterInfoInList) =>
-              characterInfoInList.metas.speakerUuid ===
-              characterInfo.metas.speakerUuid
-          )
-      );
-      characterOrder.value = [
-        ...characterOrder.value,
-        ...notIncludesCharacterInfos,
-      ];
-    }
-  }
-);
-
-// draggable用
-const keyOfCharacterOrderItem = (item: CharacterInfo) => item.metas.speakerUuid;
-
-// キャラクター枠のホバー状態を表示するかどうか
-// 再生ボタンなどにカーソルがある場合はキャラクター枠のホバーUIを表示しないようにするため
-const isHoverableItem = ref(true);
-
-// 音声再生
-const playing = ref<{ speakerUuid: string; styleId: number; index: number }>();
-
-const audio = new Audio();
-audio.volume = 0.5;
-audio.onended = () => stop();
-
-const play = (
-  speakerUuid: string,
-  { styleId, voiceSamplePaths }: StyleInfo,
-  index: number
-) => {
-  if (audio.src !== "") stop();
-
-  audio.src = voiceSamplePaths[index];
-  audio.play();
-  playing.value = { speakerUuid, styleId, index };
-};
-const stop = () => {
-  if (audio.src === "") return;
-
-  audio.pause();
-  audio.removeAttribute("src");
-  playing.value = undefined;
-};
-
-// 再生していたら停止、再生していなかったら再生
-const togglePlayOrStop = (
-  speakerUuid: string,
-  styleInfo: StyleInfo,
-  index: number
-) => {
-  if (
-    playing.value === undefined ||
-    speakerUuid !== playing.value.speakerUuid ||
-    styleInfo.styleId !== playing.value.styleId ||
-    index !== playing.value.index
-  ) {
-    play(speakerUuid, styleInfo, index);
-  } else {
-    stop();
-  }
-};
-
-// スタイル番号をずらす
-const rollStyleIndex = (speakerUuid: string, diff: number) => {
-  // 0 <= index <= length に収める
-  const length = characterInfosMap.value[speakerUuid].metas.styles.length;
-  const selectedStyleIndex: number | undefined =
-    selectedStyleIndexes.value[speakerUuid];
-
-  let styleIndex = (selectedStyleIndex ?? 0) + diff;
-  styleIndex = styleIndex < 0 ? length - 1 : styleIndex % length;
-  selectedStyleIndexes.value[speakerUuid] = styleIndex;
-
-  // 音声を再生する。同じstyleIndexだったら停止する。
-  const selectedStyleInfo =
-    characterInfosMap.value[speakerUuid].metas.styles[styleIndex];
-  togglePlayOrStop(speakerUuid, selectedStyleInfo, 0);
-};
-
-// ドラッグ中かどうか
-const characterOrderDragging = ref(false);
-
-const closeDialog = () => {
-  store.dispatch(
-    "SET_USER_CHARACTER_ORDER",
-    characterOrder.value.map((info) => info.metas.speakerUuid)
-  );
-  stop();
-  modelValueComputed.value = false;
-};
-</script>
-
 <template>
   <QDialog
     maximized
@@ -375,6 +192,189 @@ const closeDialog = () => {
     </QLayout>
   </QDialog>
 </template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import draggable from "vuedraggable";
+import { useStore } from "@/store";
+import { CharacterInfo, StyleInfo } from "@/type/preload";
+const props =
+  defineProps<{
+    modelValue: boolean;
+    characterInfos: CharacterInfo[];
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", value: boolean): void;
+  }>();
+
+const store = useStore();
+
+const modelValueComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+
+const characterInfosMap = computed(() => {
+  const map: { [key: string]: CharacterInfo } = {};
+  props.characterInfos.forEach((characterInfo) => {
+    map[characterInfo.metas.speakerUuid] = characterInfo;
+  });
+  return map;
+});
+
+// 新しいキャラクター
+const newCharacters = ref<string[]>([]);
+const hasNewCharacter = computed(() => newCharacters.value.length > 0);
+
+// サンプルボイス一覧のキャラクター順番
+const sampleCharacterOrder = ref<string[]>([]);
+
+// 選択中のスタイル
+const selectedStyleIndexes = ref<Record<string, number>>({});
+const selectedStyles = computed(() => {
+  const map: { [key: string]: StyleInfo } = {};
+  props.characterInfos.forEach((characterInfo) => {
+    const selectedStyleIndex: number | undefined =
+      selectedStyleIndexes.value[characterInfo.metas.speakerUuid];
+    map[characterInfo.metas.speakerUuid] =
+      characterInfo.metas.styles[selectedStyleIndex ?? 0];
+  });
+  return map;
+});
+
+// 選択中のキャラクター
+const selectedCharacter = ref(props.characterInfos[0].metas.speakerUuid);
+const selectCharacter = (speakerUuid: string) => {
+  selectedCharacter.value = speakerUuid;
+};
+
+// キャラクター表示順序
+const characterOrder = ref<CharacterInfo[]>([]);
+
+// ダイアログが開かれたときに初期値を求める
+watch(
+  () => props.modelValue,
+  async (newValue, oldValue) => {
+    if (!oldValue && newValue) {
+      // 新しいキャラクター
+      newCharacters.value = await store.dispatch("GET_NEW_CHARACTERS");
+
+      // サンプルの順番、新しいキャラクターは上に
+      sampleCharacterOrder.value = [
+        ...newCharacters.value,
+        ...props.characterInfos
+          .filter(
+            (info) => !newCharacters.value.includes(info.metas.speakerUuid)
+          )
+          .map((info) => info.metas.speakerUuid),
+      ];
+
+      selectedCharacter.value = sampleCharacterOrder.value[0];
+
+      // 保存済みのキャラクターリストを取得
+      // FIXME: 不明なキャラを無視しているので、不明キャラの順番が保存時にリセットされてしまう
+      characterOrder.value = store.state.userCharacterOrder
+        .map((speakerUuid) => characterInfosMap.value[speakerUuid])
+        .filter((info) => info !== undefined) as CharacterInfo[];
+
+      // 含まれていないキャラクターを足す
+      const notIncludesCharacterInfos = props.characterInfos.filter(
+        (characterInfo) =>
+          !characterOrder.value.find(
+            (characterInfoInList) =>
+              characterInfoInList.metas.speakerUuid ===
+              characterInfo.metas.speakerUuid
+          )
+      );
+      characterOrder.value = [
+        ...characterOrder.value,
+        ...notIncludesCharacterInfos,
+      ];
+    }
+  }
+);
+
+// draggable用
+const keyOfCharacterOrderItem = (item: CharacterInfo) => item.metas.speakerUuid;
+
+// キャラクター枠のホバー状態を表示するかどうか
+// 再生ボタンなどにカーソルがある場合はキャラクター枠のホバーUIを表示しないようにするため
+const isHoverableItem = ref(true);
+
+// 音声再生
+const playing = ref<{ speakerUuid: string; styleId: number; index: number }>();
+
+const audio = new Audio();
+audio.volume = 0.5;
+audio.onended = () => stop();
+
+const play = (
+  speakerUuid: string,
+  { styleId, voiceSamplePaths }: StyleInfo,
+  index: number
+) => {
+  if (audio.src !== "") stop();
+
+  audio.src = voiceSamplePaths[index];
+  audio.play();
+  playing.value = { speakerUuid, styleId, index };
+};
+const stop = () => {
+  if (audio.src === "") return;
+
+  audio.pause();
+  audio.removeAttribute("src");
+  playing.value = undefined;
+};
+
+// 再生していたら停止、再生していなかったら再生
+const togglePlayOrStop = (
+  speakerUuid: string,
+  styleInfo: StyleInfo,
+  index: number
+) => {
+  if (
+    playing.value === undefined ||
+    speakerUuid !== playing.value.speakerUuid ||
+    styleInfo.styleId !== playing.value.styleId ||
+    index !== playing.value.index
+  ) {
+    play(speakerUuid, styleInfo, index);
+  } else {
+    stop();
+  }
+};
+
+// スタイル番号をずらす
+const rollStyleIndex = (speakerUuid: string, diff: number) => {
+  // 0 <= index <= length に収める
+  const length = characterInfosMap.value[speakerUuid].metas.styles.length;
+  const selectedStyleIndex: number | undefined =
+    selectedStyleIndexes.value[speakerUuid];
+
+  let styleIndex = (selectedStyleIndex ?? 0) + diff;
+  styleIndex = styleIndex < 0 ? length - 1 : styleIndex % length;
+  selectedStyleIndexes.value[speakerUuid] = styleIndex;
+
+  // 音声を再生する。同じstyleIndexだったら停止する。
+  const selectedStyleInfo =
+    characterInfosMap.value[speakerUuid].metas.styles[styleIndex];
+  togglePlayOrStop(speakerUuid, selectedStyleInfo, 0);
+};
+
+// ドラッグ中かどうか
+const characterOrderDragging = ref(false);
+
+const closeDialog = () => {
+  store.dispatch(
+    "SET_USER_CHARACTER_ORDER",
+    characterOrder.value.map((info) => info.metas.speakerUuid)
+  );
+  stop();
+  modelValueComputed.value = false;
+};
+</script>
 
 <style scoped lang="scss">
 @use '@/styles/variables' as vars;

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -1,3 +1,62 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useStore } from "@/store";
+
+const store = useStore();
+
+const characterInfo = computed(() => {
+  const activeAudioKey: string | undefined = store.getters.ACTIVE_AUDIO_KEY;
+  const audioItem = activeAudioKey
+    ? store.state.audioItems[activeAudioKey]
+    : undefined;
+
+  const engineId = audioItem?.engineId;
+  const styleId = audioItem?.styleId;
+
+  if (
+    engineId === undefined ||
+    styleId === undefined ||
+    !store.state.engineIds.some((id) => id === engineId)
+  )
+    return undefined;
+
+  return store.getters.CHARACTER_INFO(engineId, styleId);
+});
+
+const characterName = computed(() => {
+  const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
+  const audioItem = activeAudioKey
+    ? store.state.audioItems[activeAudioKey]
+    : undefined;
+  const styleId = audioItem?.styleId;
+  const style = characterInfo.value?.metas.styles.find(
+    (style) => style.styleId === styleId
+  );
+  return style?.styleName
+    ? `${characterInfo.value?.metas.speakerName} (${style?.styleName})`
+    : characterInfo.value?.metas.speakerName;
+});
+
+const engineName = computed(() => {
+  const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
+  const audioItem = activeAudioKey
+    ? store.state.audioItems[activeAudioKey]
+    : undefined;
+  const engineId = audioItem?.engineId ?? store.state.engineIds[0];
+  const engineInfo = store.state.engineInfos[engineId];
+  return engineInfo?.name;
+});
+
+const portraitPath = computed(() => characterInfo.value?.portraitPath);
+
+const isInitializingSpeaker = computed(() => {
+  const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
+  return store.state.audioKeyInitializingSpeaker === activeAudioKey;
+});
+
+const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
+</script>
+
 <template>
   <div class="character-portrait-wrapper">
     <span class="character-name">{{ characterName }}</span>
@@ -6,83 +65,10 @@
     }}</span>
     <img :src="portraitPath" class="character-portrait" />
     <div v-if="isInitializingSpeaker" class="loading">
-      <q-spinner color="primary" size="5rem" :thickness="4" />
+      <QSpinner color="primary" size="5rem" :thickness="4" />
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, computed } from "vue";
-import { useStore } from "@/store";
-
-export default defineComponent({
-  name: "CharacterPortrait",
-
-  setup() {
-    const store = useStore();
-
-    const characterInfo = computed(() => {
-      const activeAudioKey: string | undefined = store.getters.ACTIVE_AUDIO_KEY;
-      const audioItem = activeAudioKey
-        ? store.state.audioItems[activeAudioKey]
-        : undefined;
-
-      const engineId = audioItem?.engineId;
-      const styleId = audioItem?.styleId;
-
-      if (
-        engineId === undefined ||
-        styleId === undefined ||
-        !store.state.engineIds.some((id) => id === engineId)
-      )
-        return undefined;
-
-      return store.getters.CHARACTER_INFO(engineId, styleId);
-    });
-
-    const characterName = computed(() => {
-      const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
-      const audioItem = activeAudioKey
-        ? store.state.audioItems[activeAudioKey]
-        : undefined;
-      const styleId = audioItem?.styleId;
-      const style = characterInfo.value?.metas.styles.find(
-        (style) => style.styleId === styleId
-      );
-      return style?.styleName
-        ? `${characterInfo.value?.metas.speakerName} (${style?.styleName})`
-        : characterInfo.value?.metas.speakerName;
-    });
-
-    const engineName = computed(() => {
-      const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
-      const audioItem = activeAudioKey
-        ? store.state.audioItems[activeAudioKey]
-        : undefined;
-      const engineId = audioItem?.engineId ?? store.state.engineIds[0];
-      const engineInfo = store.state.engineInfos[engineId];
-      return engineInfo?.name;
-    });
-
-    const portraitPath = computed(() => characterInfo.value?.portraitPath);
-
-    const isInitializingSpeaker = computed(() => {
-      const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
-      return store.state.audioKeyInitializingSpeaker === activeAudioKey;
-    });
-
-    const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
-
-    return {
-      characterName,
-      engineName,
-      portraitPath,
-      isInitializingSpeaker,
-      isMultipleEngine,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -1,3 +1,16 @@
+<template>
+  <div class="character-portrait-wrapper">
+    <span class="character-name">{{ characterName }}</span>
+    <span class="character-engine-name" v-if="isMultipleEngine">{{
+      engineName
+    }}</span>
+    <img :src="portraitPath" class="character-portrait" />
+    <div v-if="isInitializingSpeaker" class="loading">
+      <QSpinner color="primary" size="5rem" :thickness="4" />
+    </div>
+  </div>
+</template>
+
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@/store";
@@ -56,19 +69,6 @@ const isInitializingSpeaker = computed(() => {
 
 const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
 </script>
-
-<template>
-  <div class="character-portrait-wrapper">
-    <span class="character-name">{{ characterName }}</span>
-    <span class="character-engine-name" v-if="isMultipleEngine">{{
-      engineName
-    }}</span>
-    <img :src="portraitPath" class="character-portrait" />
-    <div v-if="isInitializingSpeaker" class="loading">
-      <QSpinner color="primary" size="5rem" :thickness="4" />
-    </div>
-  </div>
-</template>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/ContactInfo.vue
+++ b/src/components/ContactInfo.vue
@@ -1,31 +1,23 @@
-<template>
-  <q-page class="relative-absolute-wrapper scroller bg-background">
-    <div class="q-pa-md markdown markdown-body" v-html="contact"></div>
-  </q-page>
-</template>
-
-<script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
 import { useStore } from "@/store";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
 
-export default defineComponent({
-  setup() {
-    const store = useStore();
-    const contact = ref("");
+const store = useStore();
+const contact = ref("");
 
-    const md = useMarkdownIt();
+const md = useMarkdownIt();
 
-    onMounted(async () => {
-      contact.value = md.render(await store.dispatch("GET_CONTACT_TEXT"));
-    });
-
-    return {
-      contact,
-    };
-  },
+onMounted(async () => {
+  contact.value = md.render(await store.dispatch("GET_CONTACT_TEXT"));
 });
 </script>
+
+<template>
+  <QPage class="relative-absolute-wrapper scroller bg-background">
+    <div class="q-pa-md markdown markdown-body" v-html="contact"></div>
+  </QPage>
+</template>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/ContactInfo.vue
+++ b/src/components/ContactInfo.vue
@@ -1,3 +1,9 @@
+<template>
+  <QPage class="relative-absolute-wrapper scroller bg-background">
+    <div class="q-pa-md markdown markdown-body" v-html="contact"></div>
+  </QPage>
+</template>
+
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 import { useStore } from "@/store";
@@ -12,12 +18,6 @@ onMounted(async () => {
   contact.value = md.render(await store.dispatch("GET_CONTACT_TEXT"));
 });
 </script>
-
-<template>
-  <QPage class="relative-absolute-wrapper scroller bg-background">
-    <div class="q-pa-md markdown markdown-body" v-html="contact"></div>
-  </QPage>
-</template>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -1,21 +1,337 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useStore } from "@/store";
+import { useQuasar } from "quasar";
+import { base64ImageToUri } from "@/helpers/imageHelper";
+import type { EngineDirValidationResult } from "@/type/preload";
+import type { SupportedFeatures } from "@/openapi/models/SupportedFeatures";
+
+type EngineLoaderType = "dir" | "vvpp";
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", value: boolean): void;
+  }>();
+
+const store = useStore();
+const $q = useQuasar();
+
+const engineManageDialogOpenedComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+const uiLockedState = ref<null | "addingEngine" | "deletingEngine">(null); // ダイアログ内でstore.getters.UI_LOCKEDは常にtrueなので独自に管理
+const uiLocked = computed(() => uiLockedState.value !== null);
+const isAddingEngine = ref(false);
+const engineLoaderType = ref<EngineLoaderType>("dir");
+
+const lockUi = function <T>(
+  lockType: "addingEngine" | "deletingEngine",
+  action: Promise<T>
+): Promise<T> {
+  uiLockedState.value = lockType;
+  return action.finally(() => {
+    uiLockedState.value = null;
+  });
+};
+
+const categorizedEngineIds = computed(() => {
+  const result = {
+    default: Object.values(engineInfos.value)
+      .filter((info) => info.type === "default")
+      .map((info) => info.uuid),
+    plugin: Object.values(engineInfos.value)
+      .filter((info) => info.type === "path" || info.type === "vvpp")
+      .map((info) => info.uuid),
+  };
+  return Object.fromEntries(
+    Object.entries(result).filter(([, ids]) => ids.length > 0)
+  );
+});
+const engineInfos = computed(() => store.state.engineInfos);
+const engineStates = computed(() => store.state.engineStates);
+const engineManifests = computed(() => store.state.engineManifests);
+const engineIcons = computed(() =>
+  Object.fromEntries(
+    Object.entries(store.state.engineManifests).map(([id, manifest]) => [
+      id,
+      base64ImageToUri(manifest.icon),
+    ])
+  )
+);
+const engineVersions = ref<Record<string, string>>({});
+
+watch(
+  [engineInfos, engineStates, engineManifests],
+  async () => {
+    for (const id of Object.keys(engineInfos.value)) {
+      if (engineStates.value[id] !== "READY") continue;
+      if (engineVersions.value[id]) continue;
+      const version = await store
+        .dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId: id })
+        .then((instance) => instance.invoke("versionVersionGet")({}))
+        .catch(() => null);
+      if (!version) continue;
+      // "latest"のようにダブルクォーテーションで囲まれているので、JSON.parseで外す。
+      engineVersions.value = {
+        ...engineVersions.value,
+        [id]: JSON.parse(version),
+      };
+    }
+  },
+  { immediate: true }
+);
+
+const selectedId = ref("");
+const engineDir = computed(() => {
+  return engineInfos.value[selectedId.value]?.path || "（組み込み）";
+});
+
+const getEngineTypeName = (name: string) => {
+  const engineTypeMap = {
+    default: "デフォルトエンジン",
+    plugin: "追加エンジン",
+  };
+  return engineTypeMap[name as keyof typeof engineTypeMap];
+};
+
+const getFeatureName = (name: keyof SupportedFeatures) => {
+  const featureNameMap: { [key in keyof SupportedFeatures]: string } = {
+    adjustMoraPitch: "モーラごとの音高の調整",
+    adjustPhonemeLength: "音素ごとの長さの調整",
+    adjustSpeedScale: "全体の話速の調整",
+    adjustPitchScale: "全体の音高の調整",
+    adjustIntonationScale: "全体の抑揚の調整",
+    adjustVolumeScale: "全体の音量の調整",
+    interrogativeUpspeak: "疑問文の自動調整",
+    synthesisMorphing: "2人の話者でモーフィングした音声を合成",
+  };
+  return featureNameMap[name];
+};
+
+const getEngineDirValidationMessage = (result: EngineDirValidationResult) => {
+  const messageMap: {
+    [key in EngineDirValidationResult]: string | undefined;
+  } = {
+    directoryNotFound: "フォルダが見つかりませんでした。",
+    notADirectory: "フォルダではありません。",
+    manifestNotFound: "engine_manifest.jsonが見つかりませんでした。",
+    invalidManifest: "engine_manifest.jsonの内容が不正です。",
+    alreadyExists: "同じIDのエンジンが既に登録されています。",
+    ok: undefined,
+  };
+  return messageMap[result];
+};
+
+const addEngine = () => {
+  $q.dialog({
+    title: "エンジン追加の確認",
+    message:
+      "この操作はコンピュータに損害を与える可能性があります。エンジンの配布元が信頼できない場合は追加しないでください。",
+    cancel: {
+      label: "キャンセル",
+      color: "display",
+      flat: true,
+    },
+    ok: {
+      label: "追加",
+      flat: true,
+      textColor: "warning",
+    },
+  }).onOk(async () => {
+    if (engineLoaderType.value === "dir") {
+      await lockUi(
+        "addingEngine",
+        store.dispatch("ADD_ENGINE_DIR", {
+          engineDir: newEngineDir.value,
+        })
+      );
+
+      requireRestart(
+        "エンジンを追加しました。反映には再起動が必要です。今すぐ再起動しますか？"
+      );
+    } else {
+      const success = await lockUi(
+        "addingEngine",
+        store.dispatch("INSTALL_VVPP_ENGINE", vvppFilePath.value)
+      );
+      if (success) {
+        requireRestart(
+          "エンジンを追加しました。反映には再起動が必要です。今すぐ再起動しますか？"
+        );
+      }
+    }
+  });
+};
+const deleteEngine = () => {
+  $q.dialog({
+    title: "確認",
+    message: "選択中のエンジンを削除します。よろしいですか？",
+    cancel: {
+      label: "キャンセル",
+      color: "display",
+      flat: true,
+    },
+    ok: {
+      label: "削除",
+      flat: true,
+      textColor: "warning",
+    },
+  }).onOk(async () => {
+    switch (engineInfos.value[selectedId.value].type) {
+      case "path": {
+        const engineDir = store.state.engineInfos[selectedId.value].path;
+        if (!engineDir)
+          throw new Error("assert engineInfos[selectedId.value].path");
+        await lockUi(
+          "deletingEngine",
+          store.dispatch("REMOVE_ENGINE_DIR", {
+            engineDir,
+          })
+        );
+        requireRestart(
+          "エンジンを削除しました。反映には再起動が必要です。今すぐ再起動しますか？"
+        );
+        break;
+      }
+      case "vvpp": {
+        const success = await lockUi(
+          "deletingEngine",
+          store.dispatch("UNINSTALL_VVPP_ENGINE", selectedId.value)
+        );
+        if (success) {
+          requireRestart(
+            "エンジンの削除には再起動が必要です。今すぐ再起動しますか？"
+          );
+        }
+        break;
+      }
+      default:
+        throw new Error("assert engineInfos[selectedId.value].type");
+    }
+  });
+};
+
+const selectEngine = (id: string) => {
+  selectedId.value = id;
+};
+
+const openSelectedEngineDirectory = () => {
+  store.dispatch("OPEN_ENGINE_DIRECTORY", { engineId: selectedId.value });
+};
+
+const restartSelectedEngine = () => {
+  store.dispatch("RESTART_ENGINE", { engineId: selectedId.value });
+};
+
+const requireRestart = (message: string) => {
+  $q.dialog({
+    title: "再起動が必要です",
+    message: message,
+    noBackdropDismiss: true,
+    cancel: {
+      label: "後で",
+      color: "display",
+      flat: true,
+    },
+    ok: {
+      label: "再起動",
+      flat: true,
+      textColor: "warning",
+    },
+  })
+    .onOk(() => {
+      store.dispatch("RESTART_APP", {});
+    })
+    .onCancel(() => {
+      toInitialState();
+    });
+};
+
+const newEngineDir = ref("");
+const newEngineDirValidationState = ref<EngineDirValidationResult | null>(null);
+const selectEngineDir = async () => {
+  const path = await window.electron.showOpenDirectoryDialog({
+    title: "エンジンのフォルダを選択",
+  });
+  if (path) {
+    newEngineDir.value = path;
+    if (path === "") {
+      newEngineDirValidationState.value = null;
+      return;
+    }
+    newEngineDirValidationState.value = await store.dispatch(
+      "VALIDATE_ENGINE_DIR",
+      {
+        engineDir: path,
+      }
+    );
+  }
+};
+
+const vvppFilePath = ref("");
+const selectVvppFile = async () => {
+  const path = await window.electron.showVvppOpenDialog({
+    title: "vvppファイルを選択",
+    defaultPath: vvppFilePath.value,
+  });
+  if (path) {
+    vvppFilePath.value = path;
+  }
+};
+
+const canAddEngine = computed(() => {
+  if (uiLocked.value) return false;
+  if (engineLoaderType.value === "dir") {
+    return (
+      newEngineDir.value !== "" && newEngineDirValidationState.value === "ok"
+    );
+  } else if (engineLoaderType.value === "vvpp") {
+    return vvppFilePath.value !== "";
+  } else {
+    return false;
+  }
+});
+
+// ステートの移動
+// 初期状態
+const toInitialState = () => {
+  selectedId.value = "";
+  isAddingEngine.value = false;
+};
+// エンジン追加状態
+const toAddEngineState = () => {
+  isAddingEngine.value = true;
+  selectedId.value = "";
+  newEngineDirValidationState.value = null;
+  newEngineDir.value = "";
+  vvppFilePath.value = "";
+};
+// ダイアログが閉じている状態
+const toDialogClosedState = () => {
+  engineManageDialogOpenedComputed.value = false;
+  isAddingEngine.value = false;
+};
+</script>
 <template>
-  <q-dialog
+  <QDialog
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="setting-dialog transparent-backdrop"
     v-model="engineManageDialogOpenedComputed"
   >
-    <q-layout container view="hHh Lpr fFf" class="bg-background">
-      <q-page-container>
-        <q-header class="q-pa-sm">
-          <q-toolbar>
-            <q-toolbar-title class="text-display"
-              >エンジンの管理</q-toolbar-title
-            >
-            <q-space />
+    <QLayout container view="hHh Lpr fFf" class="bg-background">
+      <QPageContainer>
+        <QHeader class="q-pa-sm">
+          <QToolbar>
+            <QToolbarTitle class="text-display">エンジンの管理</QToolbarTitle>
+            <QSpace />
             <!-- close button -->
-            <q-btn
+            <QBtn
               round
               flat
               icon="close"
@@ -23,12 +339,12 @@
               @click="toDialogClosedState"
               :disabled="isAddingEngine || uiLocked"
             />
-          </q-toolbar>
-        </q-header>
-        <q-page class="row">
+          </QToolbar>
+        </QHeader>
+        <QPage class="row">
           <div class="ui-lock-popup" v-if="uiLockedState">
             <div class="q-pa-md">
-              <q-spinner color="primary" size="2.5rem" />
+              <QSpinner color="primary" size="2.5rem" />
               <div class="q-mt-xs">
                 <template v-if="uiLockedState === 'addingEngine'"
                   >追加中・・・</template
@@ -44,28 +360,26 @@
             <div class="engine-list-header text-no-wrap">
               <div class="row engine-list-title text-h5">エンジン一覧</div>
               <div class="row no-wrap">
-                <q-btn
+                <QBtn
                   outline
                   text-color="display"
                   class="text-no-wrap text-bold col-sm q-ma-sm"
                   @click="toAddEngineState"
                   :disable="uiLocked"
-                  >追加</q-btn
+                  >追加</QBtn
                 >
               </div>
             </div>
-            <q-list class="engine-list">
+            <QList class="engine-list">
               <template
                 v-for="([type, engineIds], i) in Object.entries(
                   categorizedEngineIds
                 )"
                 :key="`engine-list-${i}`"
               >
-                <q-separator v-if="i > 0" spaced />
-                <q-item-label header>
-                  {{ getEngineTypeName(type) }}</q-item-label
-                >
-                <q-item
+                <QSeparator v-if="i > 0" spaced />
+                <QItemLabel header> {{ getEngineTypeName(type) }}</QItemLabel>
+                <QItem
                   v-for="id in engineIds"
                   :key="id"
                   tag="label"
@@ -75,27 +389,27 @@
                   :active="selectedId === id"
                   active-class="active-engine"
                 >
-                  <q-item-section avatar>
-                    <q-avatar rounded color="primary">
+                  <QItemSection avatar>
+                    <QAvatar rounded color="primary">
                       <img
                         :src="engineIcons[id]"
                         :alt="engineInfos[id].name"
                         v-if="engineIcons[id]"
                       />
                       <span v-else class="text-display-on-primary"> ? </span>
-                    </q-avatar>
-                  </q-item-section>
-                  <q-item-section>
-                    <q-item-label class="text-display">{{
+                    </QAvatar>
+                  </QItemSection>
+                  <QItemSection>
+                    <QItemLabel class="text-display">{{
                       engineInfos[id].name
-                    }}</q-item-label>
-                    <q-item-label caption class="engine-path">{{
+                    }}</QItemLabel>
+                    <QItemLabel caption class="engine-path">{{
                       engineInfos[id].uuid
-                    }}</q-item-label>
-                  </q-item-section>
-                </q-item>
+                    }}</QItemLabel>
+                  </QItemSection>
+                </QItem>
               </template>
-            </q-list>
+            </QList>
           </div>
 
           <!-- 右側のpane -->
@@ -107,7 +421,7 @@
               <div class="text-h5 q-ma-sm">エンジンの追加</div>
 
               <div class="q-ma-sm">
-                <q-btn-toggle
+                <QBtnToggle
                   :options="[
                     { value: 'dir', label: 'フォルダ' },
                     { value: 'vvpp', label: 'VVPPファイル' },
@@ -125,7 +439,7 @@
             <div class="no-wrap q-pl-md" v-if="engineLoaderType === 'dir'">
               <div class="text-h6 q-ma-sm">フォルダの場所</div>
               <div class="q-ma-sm">
-                <q-input
+                <QInput
                   ref="newEngineDirInput"
                   v-model="newEngineDir"
                   dense
@@ -136,7 +450,7 @@
                   "
                 >
                   <template v-slot:append>
-                    <q-btn
+                    <QBtn
                       square
                       dense
                       flat
@@ -144,17 +458,17 @@
                       icon="folder_open"
                       @click="selectEngineDir"
                     >
-                      <q-tooltip :delay="500" anchor="bottom left">
+                      <QTooltip :delay="500" anchor="bottom left">
                         フォルダ選択
-                      </q-tooltip>
-                    </q-btn>
+                      </QTooltip>
+                    </QBtn>
                   </template>
                   <template v-slot:error>
                     {{
                       getEngineDirValidationMessage(newEngineDirValidationState)
                     }}
                   </template>
-                </q-input>
+                </QInput>
               </div>
               <div class="q-ma-sm">
                 既にインストールされているエンジンのフォルダを指定します。FIXME:
@@ -164,14 +478,14 @@
             <div class="no-wrap q-pl-md" v-if="engineLoaderType === 'vvpp'">
               <div class="text-h6 q-ma-sm">VVPPファイルの場所</div>
               <div class="q-ma-sm">
-                <q-input
+                <QInput
                   ref="vvppFilePathInput"
                   v-model="vvppFilePath"
                   dense
                   readonly
                 >
                   <template v-slot:append>
-                    <q-btn
+                    <QBtn
                       square
                       dense
                       flat
@@ -179,17 +493,17 @@
                       icon="folder_open"
                       @click="selectVvppFile"
                     >
-                      <q-tooltip :delay="500" anchor="bottom left">
+                      <QTooltip :delay="500" anchor="bottom left">
                         ファイル選択
-                      </q-tooltip>
-                    </q-btn>
+                      </QTooltip>
+                    </QBtn>
                   </template>
                   <template v-slot:error>
                     {{
                       getEngineDirValidationMessage(newEngineDirValidationState)
                     }}
                   </template>
-                </q-input>
+                </QInput>
               </div>
               <div class="q-ma-sm">
                 VVPPファイルとして配布されているエンジンを追加します。FIXME:
@@ -197,22 +511,22 @@
               </div>
             </div>
             <div class="row q-px-md right-pane-buttons">
-              <q-space />
+              <QSpace />
 
-              <q-btn
+              <QBtn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
                 @click="toInitialState"
-                >キャンセル</q-btn
+                >キャンセル</QBtn
               >
-              <q-btn
+              <QBtn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
                 @click="addEngine"
                 :disabled="!canAddEngine"
-                >追加</q-btn
+                >追加</QBtn
               >
             </div>
           </div>
@@ -228,9 +542,9 @@
                 class="engine-icon"
               />
               <div class="q-mt-sm inline-block" v-else>
-                <q-avatar rounded color="primary" size="2rem">
+                <QAvatar rounded color="primary" size="2rem">
                   <span class="text-display-on-primary"> ? </span>
-                </q-avatar>
+                </QAvatar>
               </div>
               <div class="text-h5 q-ma-sm">
                 {{ engineInfos[selectedId].name }}
@@ -281,7 +595,7 @@
                   'q-ma-sm' + (engineInfos[selectedId].path ? '' : ' disabled')
                 "
               >
-                <q-input
+                <QInput
                   ref="pathInput"
                   v-model="engineDir"
                   disabled
@@ -291,9 +605,9 @@
               </div>
             </div>
             <div class="row q-px-md right-pane-buttons">
-              <q-space />
+              <QSpace />
 
-              <q-btn
+              <QBtn
                 outline
                 text-color="warning"
                 class="text-no-wrap text-bold q-mr-sm"
@@ -302,398 +616,31 @@
                   uiLocked ||
                   !['path', 'vvpp'].includes(engineInfos[selectedId].type)
                 "
-                >削除</q-btn
+                >削除</QBtn
               >
-              <q-btn
+              <QBtn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
                 @click="openSelectedEngineDirectory"
                 :disable="uiLocked || !engineInfos[selectedId].path"
-                >フォルダを開く</q-btn
+                >フォルダを開く</QBtn
               >
-              <q-btn
+              <QBtn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
                 @click="restartSelectedEngine"
                 :disable="uiLocked || engineStates[selectedId] !== 'READY'"
-                >再起動</q-btn
+                >再起動</QBtn
               >
             </div>
           </div>
-        </q-page>
-      </q-page-container>
-    </q-layout>
-  </q-dialog>
+        </QPage>
+      </QPageContainer>
+    </QLayout>
+  </QDialog>
 </template>
-
-<script lang="ts">
-import { computed, defineComponent, ref, watch } from "vue";
-import { useStore } from "@/store";
-import { useQuasar } from "quasar";
-import { base64ImageToUri } from "@/helpers/imageHelper";
-import type { EngineDirValidationResult } from "@/type/preload";
-import type { SupportedFeatures } from "@/openapi/models/SupportedFeatures";
-
-type EngineLoaderType = "dir" | "vvpp";
-
-export default defineComponent({
-  name: "EngineManageDialog",
-  props: {
-    modelValue: {
-      type: Boolean,
-      required: true,
-    },
-  },
-
-  setup(props, { emit }) {
-    const store = useStore();
-    const $q = useQuasar();
-
-    const engineManageDialogOpenedComputed = computed({
-      get: () => props.modelValue,
-      set: (val) => emit("update:modelValue", val),
-    });
-    const uiLockedState = ref<null | "addingEngine" | "deletingEngine">(null); // ダイアログ内でstore.getters.UI_LOCKEDは常にtrueなので独自に管理
-    const uiLocked = computed(() => uiLockedState.value !== null);
-    const isAddingEngine = ref(false);
-    const engineLoaderType = ref<EngineLoaderType>("dir");
-
-    const lockUi = function <T>(
-      lockType: "addingEngine" | "deletingEngine",
-      action: Promise<T>
-    ): Promise<T> {
-      uiLockedState.value = lockType;
-      return action.finally(() => {
-        uiLockedState.value = null;
-      });
-    };
-
-    const categorizedEngineIds = computed(() => {
-      const result = {
-        default: Object.values(engineInfos.value)
-          .filter((info) => info.type === "default")
-          .map((info) => info.uuid),
-        plugin: Object.values(engineInfos.value)
-          .filter((info) => info.type === "path" || info.type === "vvpp")
-          .map((info) => info.uuid),
-      };
-      return Object.fromEntries(
-        Object.entries(result).filter(([, ids]) => ids.length > 0)
-      );
-    });
-    const engineInfos = computed(() => store.state.engineInfos);
-    const engineStates = computed(() => store.state.engineStates);
-    const engineManifests = computed(() => store.state.engineManifests);
-    const engineIcons = computed(() =>
-      Object.fromEntries(
-        Object.entries(store.state.engineManifests).map(([id, manifest]) => [
-          id,
-          base64ImageToUri(manifest.icon),
-        ])
-      )
-    );
-    const engineVersions = ref<Record<string, string>>({});
-
-    watch(
-      [engineInfos, engineStates, engineManifests],
-      async () => {
-        for (const id of Object.keys(engineInfos.value)) {
-          if (engineStates.value[id] !== "READY") continue;
-          if (engineVersions.value[id]) continue;
-          const version = await store
-            .dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId: id })
-            .then((instance) => instance.invoke("versionVersionGet")({}))
-            .catch(() => null);
-          if (!version) continue;
-          // "latest"のようにダブルクォーテーションで囲まれているので、JSON.parseで外す。
-          engineVersions.value = {
-            ...engineVersions.value,
-            [id]: JSON.parse(version),
-          };
-        }
-      },
-      { immediate: true }
-    );
-
-    const selectedId = ref("");
-    const isDeletable = computed(() => {
-      return (
-        engineInfos.value[selectedId.value] &&
-        engineInfos.value[selectedId.value].type === "path"
-      );
-    });
-    const engineDir = computed(() => {
-      return engineInfos.value[selectedId.value]?.path || "（組み込み）";
-    });
-
-    const getEngineTypeName = (name: string) => {
-      const engineTypeMap = {
-        default: "デフォルトエンジン",
-        plugin: "追加エンジン",
-      };
-      return engineTypeMap[name as keyof typeof engineTypeMap];
-    };
-
-    const getFeatureName = (name: keyof SupportedFeatures) => {
-      const featureNameMap: { [key in keyof SupportedFeatures]: string } = {
-        adjustMoraPitch: "モーラごとの音高の調整",
-        adjustPhonemeLength: "音素ごとの長さの調整",
-        adjustSpeedScale: "全体の話速の調整",
-        adjustPitchScale: "全体の音高の調整",
-        adjustIntonationScale: "全体の抑揚の調整",
-        adjustVolumeScale: "全体の音量の調整",
-        interrogativeUpspeak: "疑問文の自動調整",
-        synthesisMorphing: "2人の話者でモーフィングした音声を合成",
-      };
-      return featureNameMap[name];
-    };
-
-    const getEngineDirValidationMessage = (
-      result: EngineDirValidationResult
-    ) => {
-      const messageMap: {
-        [key in EngineDirValidationResult]: string | undefined;
-      } = {
-        directoryNotFound: "フォルダが見つかりませんでした。",
-        notADirectory: "フォルダではありません。",
-        manifestNotFound: "engine_manifest.jsonが見つかりませんでした。",
-        invalidManifest: "engine_manifest.jsonの内容が不正です。",
-        alreadyExists: "同じIDのエンジンが既に登録されています。",
-        ok: undefined,
-      };
-      return messageMap[result];
-    };
-
-    const addEngine = () => {
-      $q.dialog({
-        title: "エンジン追加の確認",
-        message:
-          "この操作はコンピュータに損害を与える可能性があります。エンジンの配布元が信頼できない場合は追加しないでください。",
-        cancel: {
-          label: "キャンセル",
-          color: "display",
-          flat: true,
-        },
-        ok: {
-          label: "追加",
-          flat: true,
-          textColor: "warning",
-        },
-      }).onOk(async () => {
-        if (engineLoaderType.value === "dir") {
-          await lockUi(
-            "addingEngine",
-            store.dispatch("ADD_ENGINE_DIR", {
-              engineDir: newEngineDir.value,
-            })
-          );
-
-          requireRestart(
-            "エンジンを追加しました。反映には再起動が必要です。今すぐ再起動しますか？"
-          );
-        } else {
-          const success = await lockUi(
-            "addingEngine",
-            store.dispatch("INSTALL_VVPP_ENGINE", vvppFilePath.value)
-          );
-          if (success) {
-            requireRestart(
-              "エンジンを追加しました。反映には再起動が必要です。今すぐ再起動しますか？"
-            );
-          }
-        }
-      });
-    };
-    const deleteEngine = () => {
-      $q.dialog({
-        title: "確認",
-        message: "選択中のエンジンを削除します。よろしいですか？",
-        cancel: {
-          label: "キャンセル",
-          color: "display",
-          flat: true,
-        },
-        ok: {
-          label: "削除",
-          flat: true,
-          textColor: "warning",
-        },
-      }).onOk(async () => {
-        switch (engineInfos.value[selectedId.value].type) {
-          case "path": {
-            const engineDir = store.state.engineInfos[selectedId.value].path;
-            if (!engineDir)
-              throw new Error("assert engineInfos[selectedId.value].path");
-            await lockUi(
-              "deletingEngine",
-              store.dispatch("REMOVE_ENGINE_DIR", {
-                engineDir,
-              })
-            );
-            requireRestart(
-              "エンジンを削除しました。反映には再起動が必要です。今すぐ再起動しますか？"
-            );
-            break;
-          }
-          case "vvpp": {
-            const success = await lockUi(
-              "deletingEngine",
-              store.dispatch("UNINSTALL_VVPP_ENGINE", selectedId.value)
-            );
-            if (success) {
-              requireRestart(
-                "エンジンの削除には再起動が必要です。今すぐ再起動しますか？"
-              );
-            }
-            break;
-          }
-          default:
-            throw new Error("assert engineInfos[selectedId.value].type");
-        }
-      });
-    };
-
-    const selectEngine = (id: string) => {
-      selectedId.value = id;
-    };
-
-    const openSelectedEngineDirectory = () => {
-      store.dispatch("OPEN_ENGINE_DIRECTORY", { engineId: selectedId.value });
-    };
-
-    const restartSelectedEngine = () => {
-      store.dispatch("RESTART_ENGINE", { engineId: selectedId.value });
-    };
-
-    const requireRestart = (message: string) => {
-      $q.dialog({
-        title: "再起動が必要です",
-        message: message,
-        noBackdropDismiss: true,
-        cancel: {
-          label: "後で",
-          color: "display",
-          flat: true,
-        },
-        ok: {
-          label: "再起動",
-          flat: true,
-          textColor: "warning",
-        },
-      })
-        .onOk(() => {
-          store.dispatch("RESTART_APP", {});
-        })
-        .onCancel(() => {
-          toInitialState();
-        });
-    };
-
-    const newEngineDir = ref("");
-    const newEngineDirValidationState =
-      ref<EngineDirValidationResult | null>(null);
-    const selectEngineDir = async () => {
-      const path = await window.electron.showOpenDirectoryDialog({
-        title: "エンジンのフォルダを選択",
-      });
-      if (path) {
-        newEngineDir.value = path;
-        if (path === "") {
-          newEngineDirValidationState.value = null;
-          return;
-        }
-        newEngineDirValidationState.value = await store.dispatch(
-          "VALIDATE_ENGINE_DIR",
-          {
-            engineDir: path,
-          }
-        );
-      }
-    };
-
-    const vvppFilePath = ref("");
-    const selectVvppFile = async () => {
-      const path = await window.electron.showVvppOpenDialog({
-        title: "vvppファイルを選択",
-        defaultPath: vvppFilePath.value,
-      });
-      if (path) {
-        vvppFilePath.value = path;
-      }
-    };
-
-    const canAddEngine = computed(() => {
-      if (uiLocked.value) return false;
-      if (engineLoaderType.value === "dir") {
-        return (
-          newEngineDir.value !== "" &&
-          newEngineDirValidationState.value === "ok"
-        );
-      } else if (engineLoaderType.value === "vvpp") {
-        return vvppFilePath.value !== "";
-      } else {
-        return false;
-      }
-    });
-
-    // ステートの移動
-    // 初期状態
-    const toInitialState = () => {
-      selectedId.value = "";
-      isAddingEngine.value = false;
-    };
-    // エンジン追加状態
-    const toAddEngineState = () => {
-      isAddingEngine.value = true;
-      selectedId.value = "";
-      newEngineDirValidationState.value = null;
-      newEngineDir.value = "";
-      vvppFilePath.value = "";
-    };
-    // ダイアログが閉じている状態
-    const toDialogClosedState = () => {
-      engineManageDialogOpenedComputed.value = false;
-      isAddingEngine.value = false;
-    };
-
-    return {
-      engineManageDialogOpenedComputed,
-      categorizedEngineIds,
-      engineInfos,
-      engineStates,
-      engineManifests,
-      engineIcons,
-      engineVersions,
-      engineLoaderType,
-      selectEngine,
-      addEngine,
-      deleteEngine,
-      isDeletable,
-      getFeatureName,
-      getEngineTypeName,
-      getEngineDirValidationMessage,
-      uiLockedState,
-      uiLocked,
-      isAddingEngine,
-      selectedId,
-      toInitialState,
-      toAddEngineState,
-      toDialogClosedState,
-      openSelectedEngineDirectory,
-      restartSelectedEngine,
-      engineDir,
-      newEngineDir,
-      selectEngineDir,
-      newEngineDirValidationState,
-      vvppFilePath,
-      selectVvppFile,
-      canAddEngine,
-    };
-  },
-});
-</script>
 
 <style lang="scss" scoped>
 @use '@/styles/colors' as colors;

--- a/src/components/ErrorBoundary.vue
+++ b/src/components/ErrorBoundary.vue
@@ -2,36 +2,28 @@
   <slot />
 </template>
 
-<script lang="ts">
-import { defineComponent, onErrorCaptured, onMounted } from "vue";
+<script setup lang="ts">
+import { onErrorCaptured, onMounted } from "vue";
 import { useStore } from "@/store";
 
-export default defineComponent({
-  name: "ErrorBoundary",
-  setup() {
-    const store = useStore();
-    const logError = (error: Error): void => {
-      store.dispatch("LOG_ERROR", error.stack);
-    };
+const store = useStore();
+const logError = (error: Error): void => {
+  store.dispatch("LOG_ERROR", error.stack);
+};
 
-    onMounted(() => {
-      const handlePromiseRejectionEvent = (event: PromiseRejectionEvent) => {
-        logError(event.reason);
-      };
-      window.addEventListener("error", (event: ErrorEvent) => {
-        logError(event.error);
-      });
-      window.addEventListener(
-        "unhandledrejection",
-        handlePromiseRejectionEvent
-      );
-      window.addEventListener("rejectionhandled", handlePromiseRejectionEvent);
-    });
+onMounted(() => {
+  const handlePromiseRejectionEvent = (event: PromiseRejectionEvent) => {
+    logError(event.reason);
+  };
+  window.addEventListener("error", (event: ErrorEvent) => {
+    logError(event.error);
+  });
+  window.addEventListener("unhandledrejection", handlePromiseRejectionEvent);
+  window.addEventListener("rejectionhandled", handlePromiseRejectionEvent);
+});
 
-    onErrorCaptured((error) => {
-      if (error instanceof Error) logError(error);
-      return false;
-    });
-  },
+onErrorCaptured((error) => {
+  if (error instanceof Error) logError(error);
+  return false;
 });
 </script>

--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -1,20 +1,151 @@
+<script setup lang="ts">
+import { computed, ref, nextTick } from "vue";
+import { QInput } from "quasar";
+import { useStore } from "@/store";
+import {
+  buildFileNameFromRawData,
+  DEFAULT_FILE_NAME_TEMPLATE,
+  replaceTagIdToTagString,
+  sanitizeFileName,
+} from "@/store/utility";
+
+const props =
+  defineProps<{
+    openDialog: boolean;
+  }>();
+
+const emit =
+  defineEmits<{
+    (e: "update:openDialog", value: boolean): void;
+  }>();
+
+const updateOpenDialog = (isOpen: boolean) => emit("update:openDialog", isOpen);
+
+const store = useStore();
+const patternInput = ref<QInput>();
+const maxLength = 128;
+const tagStrings = Object.values(replaceTagIdToTagString);
+
+const savingSetting = computed(() => store.state.savingSetting);
+
+const currentFileNamePattern = ref(savingSetting.value.fileNamePattern);
+const sanitizedFileNamePattern = computed(() =>
+  sanitizeFileName(currentFileNamePattern.value)
+);
+
+const hasInvalidChar = computed(
+  () => currentFileNamePattern.value !== sanitizedFileNamePattern.value
+);
+const hasNotIndexTagString = computed(
+  () => !currentFileNamePattern.value.includes(replaceTagIdToTagString["index"])
+);
+const invalidChar = computed(() => {
+  if (!hasInvalidChar.value) return "";
+
+  const a = currentFileNamePattern.value;
+  const b = sanitizedFileNamePattern.value;
+
+  let diffAt = "";
+  for (let i = 0; i < a.length; i++) {
+    if (b[i] !== a[i]) {
+      diffAt = a[i];
+      break;
+    }
+  }
+
+  return diffAt;
+});
+const errorMessage = computed(() => {
+  if (currentFileNamePattern.value.length === 0) {
+    return "何か入力してください";
+  }
+
+  const result: string[] = [];
+  if (invalidChar.value !== "") {
+    result.push(`使用できない文字が含まれています：「${invalidChar.value}」`);
+  }
+  if (previewFileName.value.includes("$")) {
+    result.push(`不正なタグが存在するか、$が単体で含まれています`);
+  }
+  if (hasNotIndexTagString.value) {
+    result.push(`$${replaceTagIdToTagString["index"]}$は必須です`);
+  }
+  return result.join(", ");
+});
+const hasError = computed(() => errorMessage.value !== "");
+
+const previewFileName = computed(() =>
+  buildFileNameFromRawData(currentFileNamePattern.value + ".wav")
+);
+
+const removeExtension = (str: string) => {
+  return str.replace(/\.wav$/, "");
+};
+
+const initializeInput = () => {
+  const pattern = savingSetting.value.fileNamePattern;
+  currentFileNamePattern.value = removeExtension(pattern);
+
+  if (currentFileNamePattern.value.length === 0) {
+    currentFileNamePattern.value = removeExtension(DEFAULT_FILE_NAME_TEMPLATE);
+  }
+};
+const resetToDefault = () => {
+  currentFileNamePattern.value = removeExtension(DEFAULT_FILE_NAME_TEMPLATE);
+  patternInput.value?.focus();
+};
+
+const insertTagToCurrentPosition = (tag: string) => {
+  const elem = patternInput.value?.getNativeElement() as HTMLInputElement;
+  if (elem) {
+    const text = elem.value;
+
+    if (text.length + tag.length > maxLength) {
+      return;
+    }
+
+    const from = elem.selectionStart ?? 0;
+    const to = elem.selectionEnd ?? 0;
+    const newText = text.substring(0, from) + tag + text.substring(to);
+    currentFileNamePattern.value = newText;
+
+    // キャレットの位置を挿入した後の位置にずらす
+    nextTick(() => {
+      elem.selectionStart = from + tag.length;
+      elem.selectionEnd = from + tag.length;
+      elem.focus();
+    });
+  }
+};
+
+const submit = async () => {
+  await store.dispatch("SET_SAVING_SETTING", {
+    data: {
+      ...savingSetting.value,
+      fileNamePattern: currentFileNamePattern.value + ".wav",
+    },
+  });
+  updateOpenDialog(false);
+};
+</script>
+
 <template>
-  <q-dialog
-    :model-value="openDialog"
+  <QDialog
+    :model-value="props.openDialog"
     @update:model-value="updateOpenDialog"
     @before-show="initializeInput"
   >
-    <q-card class="q-pa-md dialog-card">
-      <q-card-section>
+    <QCard class="q-pa-md dialog-card">
+      <QCardSection>
         <div class="text-h5">書き出しファイル名パターン</div>
         <div class="text-body2 text-grey-8">
           「$キャラ$」のようなタグを使って書き出すファイル名をカスタマイズできます
         </div>
-      </q-card-section>
-      <q-card-actions class="setting-card q-px-md q-py-sm">
+      </QCardSection>
+      <QCardActions class="setting-card q-px-md q-py-sm">
         <div class="row full-width justify-between">
           <div class="col">
-            <q-input
+            <QInput
               dense
               outlined
               bg-color="background"
@@ -27,7 +158,7 @@
               ref="patternInput"
             >
               <template v-slot:after>
-                <q-btn
+                <QBtn
                   label="デフォルトにリセット"
                   outline
                   text-color="display"
@@ -35,14 +166,14 @@
                   @click="resetToDefault"
                 />
               </template>
-            </q-input>
+            </QInput>
           </div>
         </div>
         <div class="text-body2 text-ellipsis">
           出力例）{{ previewFileName }}
         </div>
         <div class="row full-width q-my-md">
-          <q-btn
+          <QBtn
             v-for="tagString in tagStrings"
             :key="tagString"
             :label="`$${tagString}$`"
@@ -53,14 +184,14 @@
           />
         </div>
         <div class="row full-width justify-end">
-          <q-btn
+          <QBtn
             label="キャンセル"
             outline
             text-color="display"
             class="text-no-wrap text-bold q-mr-sm col-2"
             @click="updateOpenDialog(false)"
           />
-          <q-btn
+          <QBtn
             label="確定"
             unelevated
             color="primary"
@@ -70,167 +201,10 @@
             @click="submit"
           />
         </div>
-      </q-card-actions>
-    </q-card>
-  </q-dialog>
+      </QCardActions>
+    </QCard>
+  </QDialog>
 </template>
-
-<script lang="ts">
-import { defineComponent, computed, ref, nextTick } from "vue";
-import { QInput } from "quasar";
-import { useStore } from "@/store";
-import {
-  buildFileNameFromRawData,
-  DEFAULT_FILE_NAME_TEMPLATE,
-  replaceTagIdToTagString,
-  sanitizeFileName,
-} from "@/store/utility";
-
-export default defineComponent({
-  name: "FileNamePatternDialog",
-
-  props: {
-    openDialog: Boolean,
-  },
-
-  emits: ["update:openDialog"],
-
-  setup(props, context) {
-    const updateOpenDialog = (isOpen: boolean) =>
-      context.emit("update:openDialog", isOpen);
-
-    const store = useStore();
-    const patternInput = ref<QInput>();
-    const maxLength = 128;
-    const tagStrings = Object.values(replaceTagIdToTagString);
-
-    const savingSetting = computed(() => store.state.savingSetting);
-
-    const currentFileNamePattern = ref(savingSetting.value.fileNamePattern);
-    const sanitizedFileNamePattern = computed(() =>
-      sanitizeFileName(currentFileNamePattern.value)
-    );
-
-    const hasInvalidChar = computed(
-      () => currentFileNamePattern.value !== sanitizedFileNamePattern.value
-    );
-    const hasNotIndexTagString = computed(
-      () =>
-        !currentFileNamePattern.value.includes(replaceTagIdToTagString["index"])
-    );
-    const invalidChar = computed(() => {
-      if (!hasInvalidChar.value) return "";
-
-      const a = currentFileNamePattern.value;
-      const b = sanitizedFileNamePattern.value;
-
-      let diffAt = "";
-      for (let i = 0; i < a.length; i++) {
-        if (b[i] !== a[i]) {
-          diffAt = a[i];
-          break;
-        }
-      }
-
-      return diffAt;
-    });
-    const errorMessage = computed(() => {
-      if (currentFileNamePattern.value.length === 0) {
-        return "何か入力してください";
-      }
-
-      const result: string[] = [];
-      if (invalidChar.value !== "") {
-        result.push(
-          `使用できない文字が含まれています：「${invalidChar.value}」`
-        );
-      }
-      if (previewFileName.value.includes("$")) {
-        result.push(`不正なタグが存在するか、$が単体で含まれています`);
-      }
-      if (hasNotIndexTagString.value) {
-        result.push(`$${replaceTagIdToTagString["index"]}$は必須です`);
-      }
-      return result.join(", ");
-    });
-    const hasError = computed(() => errorMessage.value !== "");
-
-    const previewFileName = computed(() =>
-      buildFileNameFromRawData(currentFileNamePattern.value + ".wav")
-    );
-
-    const removeExtension = (str: string) => {
-      return str.replace(/\.wav$/, "");
-    };
-
-    const initializeInput = () => {
-      const pattern = savingSetting.value.fileNamePattern;
-      currentFileNamePattern.value = removeExtension(pattern);
-
-      if (currentFileNamePattern.value.length === 0) {
-        currentFileNamePattern.value = removeExtension(
-          DEFAULT_FILE_NAME_TEMPLATE
-        );
-      }
-    };
-    const resetToDefault = () => {
-      currentFileNamePattern.value = removeExtension(
-        DEFAULT_FILE_NAME_TEMPLATE
-      );
-      patternInput.value?.focus();
-    };
-
-    const insertTagToCurrentPosition = (tag: string) => {
-      const elem = patternInput.value?.getNativeElement() as HTMLInputElement;
-      if (elem) {
-        const text = elem.value;
-
-        if (text.length + tag.length > maxLength) {
-          return;
-        }
-
-        const from = elem.selectionStart ?? 0;
-        const to = elem.selectionEnd ?? 0;
-        const newText = text.substring(0, from) + tag + text.substring(to);
-        currentFileNamePattern.value = newText;
-
-        // キャレットの位置を挿入した後の位置にずらす
-        nextTick(() => {
-          elem.selectionStart = from + tag.length;
-          elem.selectionEnd = from + tag.length;
-          elem.focus();
-        });
-      }
-    };
-
-    const submit = async () => {
-      await store.dispatch("SET_SAVING_SETTING", {
-        data: {
-          ...savingSetting.value,
-          fileNamePattern: currentFileNamePattern.value + ".wav",
-        },
-      });
-      updateOpenDialog(false);
-    };
-
-    return {
-      patternInput,
-      tagStrings,
-      maxLength,
-      updateOpenDialog,
-      resetToDefault,
-      insertTagToCurrentPosition,
-      submit,
-      initializeInput,
-      savingSetting,
-      currentFileNamePattern,
-      errorMessage,
-      hasError,
-      previewFileName,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -1,3 +1,80 @@
+<template>
+  <QDialog
+    :model-value="props.openDialog"
+    @update:model-value="updateOpenDialog"
+    @before-show="initializeInput"
+  >
+    <QCard class="q-pa-md dialog-card">
+      <QCardSection>
+        <div class="text-h5">書き出しファイル名パターン</div>
+        <div class="text-body2 text-grey-8">
+          「$キャラ$」のようなタグを使って書き出すファイル名をカスタマイズできます
+        </div>
+      </QCardSection>
+      <QCardActions class="setting-card q-px-md q-py-sm">
+        <div class="row full-width justify-between">
+          <div class="col">
+            <QInput
+              dense
+              outlined
+              bg-color="background"
+              label="ファイル名パターン"
+              suffix=".wav"
+              :maxlength="maxLength"
+              :error="hasError"
+              :error-message="errorMessage"
+              v-model="currentFileNamePattern"
+              ref="patternInput"
+            >
+              <template v-slot:after>
+                <QBtn
+                  label="デフォルトにリセット"
+                  outline
+                  text-color="display"
+                  class="text-no-wrap q-mr-sm"
+                  @click="resetToDefault"
+                />
+              </template>
+            </QInput>
+          </div>
+        </div>
+        <div class="text-body2 text-ellipsis">
+          出力例）{{ previewFileName }}
+        </div>
+        <div class="row full-width q-my-md">
+          <QBtn
+            v-for="tagString in tagStrings"
+            :key="tagString"
+            :label="`$${tagString}$`"
+            outline
+            text-color="display"
+            class="text-no-wrap q-mr-sm"
+            @click="insertTagToCurrentPosition(`$${tagString}$`)"
+          />
+        </div>
+        <div class="row full-width justify-end">
+          <QBtn
+            label="キャンセル"
+            outline
+            text-color="display"
+            class="text-no-wrap text-bold q-mr-sm col-2"
+            @click="updateOpenDialog(false)"
+          />
+          <QBtn
+            label="確定"
+            unelevated
+            color="primary"
+            text-color="display-on-primary"
+            class="text-no-wrap text-bold q-mr-sm col-2"
+            :disable="hasError"
+            @click="submit"
+          />
+        </div>
+      </QCardActions>
+    </QCard>
+  </QDialog>
+</template>
+
 <script setup lang="ts">
 import { computed, ref, nextTick } from "vue";
 import { QInput } from "quasar";
@@ -128,83 +205,6 @@ const submit = async () => {
   updateOpenDialog(false);
 };
 </script>
-
-<template>
-  <QDialog
-    :model-value="props.openDialog"
-    @update:model-value="updateOpenDialog"
-    @before-show="initializeInput"
-  >
-    <QCard class="q-pa-md dialog-card">
-      <QCardSection>
-        <div class="text-h5">書き出しファイル名パターン</div>
-        <div class="text-body2 text-grey-8">
-          「$キャラ$」のようなタグを使って書き出すファイル名をカスタマイズできます
-        </div>
-      </QCardSection>
-      <QCardActions class="setting-card q-px-md q-py-sm">
-        <div class="row full-width justify-between">
-          <div class="col">
-            <QInput
-              dense
-              outlined
-              bg-color="background"
-              label="ファイル名パターン"
-              suffix=".wav"
-              :maxlength="maxLength"
-              :error="hasError"
-              :error-message="errorMessage"
-              v-model="currentFileNamePattern"
-              ref="patternInput"
-            >
-              <template v-slot:after>
-                <QBtn
-                  label="デフォルトにリセット"
-                  outline
-                  text-color="display"
-                  class="text-no-wrap q-mr-sm"
-                  @click="resetToDefault"
-                />
-              </template>
-            </QInput>
-          </div>
-        </div>
-        <div class="text-body2 text-ellipsis">
-          出力例）{{ previewFileName }}
-        </div>
-        <div class="row full-width q-my-md">
-          <QBtn
-            v-for="tagString in tagStrings"
-            :key="tagString"
-            :label="`$${tagString}$`"
-            outline
-            text-color="display"
-            class="text-no-wrap q-mr-sm"
-            @click="insertTagToCurrentPosition(`$${tagString}$`)"
-          />
-        </div>
-        <div class="row full-width justify-end">
-          <QBtn
-            label="キャンセル"
-            outline
-            text-color="display"
-            class="text-no-wrap text-bold q-mr-sm col-2"
-            @click="updateOpenDialog(false)"
-          />
-          <QBtn
-            label="確定"
-            unelevated
-            color="primary"
-            text-color="display-on-primary"
-            class="text-no-wrap text-bold q-mr-sm col-2"
-            :disable="hasError"
-            @click="submit"
-          />
-        </div>
-      </QCardActions>
-    </QCard>
-  </QDialog>
-</template>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -1,25 +1,5 @@
-<template>
-  <q-header class="q-py-sm">
-    <q-toolbar>
-      <template v-for="button in headerButtons" :key="button.text">
-        <q-space v-if="button.text === null" />
-        <q-btn
-          v-else
-          unelevated
-          color="toolbar-button"
-          text-color="toolbar-button-display"
-          class="text-no-wrap text-bold q-mr-sm"
-          :disable="button.disable.value"
-          @click="button.click"
-          >{{ button.text }}</q-btn
-        >
-      </template>
-    </q-toolbar>
-  </q-header>
-</template>
-
-<script lang="ts">
-import { defineComponent, computed, ComputedRef } from "vue";
+<script setup lang="ts">
+import { computed, ComputedRef } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
 import { setHotkeyFunctions } from "@/store/setting";
@@ -45,176 +25,188 @@ type SpacerContent = {
   text: null;
 };
 
-export default defineComponent({
-  setup() {
-    const store = useStore();
-    const $q = useQuasar();
+const store = useStore();
+const $q = useQuasar();
 
-    const uiLocked = computed(() => store.getters.UI_LOCKED);
-    const canUndo = computed(() => store.getters.CAN_UNDO);
-    const canRedo = computed(() => store.getters.CAN_REDO);
-    const activeAudioKey = computed(() => store.getters.ACTIVE_AUDIO_KEY);
-    const nowPlayingContinuously = computed(
-      () => store.state.nowPlayingContinuously
-    );
+const uiLocked = computed(() => store.getters.UI_LOCKED);
+const canUndo = computed(() => store.getters.CAN_UNDO);
+const canRedo = computed(() => store.getters.CAN_REDO);
+const activeAudioKey = computed(() => store.getters.ACTIVE_AUDIO_KEY);
+const nowPlayingContinuously = computed(
+  () => store.state.nowPlayingContinuously
+);
 
-    const undoRedoHotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
-      // undo
-      [
-        "元に戻す",
-        () => {
-          if (!uiLocked.value && canUndo.value) {
-            undo();
-          }
-          return false;
-        },
-      ],
-      // redo
-      [
-        "やり直す",
-        () => {
-          if (!uiLocked.value && canRedo.value) {
-            redo();
-          }
-          return false;
-        },
-      ],
-    ]);
-    setHotkeyFunctions(undoRedoHotkeyMap);
-
-    const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
-      // play/stop continuously
-      [
-        "連続再生/停止",
-        () => {
-          if (!uiLocked.value) {
-            if (nowPlayingContinuously.value) {
-              stopContinuously();
-            } else {
-              playContinuously();
-            }
-          }
-        },
-      ],
-    ]);
-
-    setHotkeyFunctions(hotkeyMap);
-
-    const undo = () => {
-      store.dispatch("UNDO");
-    };
-    const redo = () => {
-      store.dispatch("REDO");
-    };
-    const playContinuously = async () => {
-      try {
-        await store.dispatch("PLAY_CONTINUOUSLY_AUDIO");
-      } catch {
-        $q.dialog({
-          title: "再生に失敗しました",
-          message: "エンジンの再起動をお試しください。",
-          ok: {
-            label: "閉じる",
-            flat: true,
-            textColor: "display",
-          },
-        });
+const undoRedoHotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
+  // undo
+  [
+    "元に戻す",
+    () => {
+      if (!uiLocked.value && canUndo.value) {
+        undo();
       }
-    };
-    const stopContinuously = () => {
-      store.dispatch("STOP_CONTINUOUSLY_AUDIO");
-    };
-    const generateAndSaveOneAudio = async () => {
-      await generateAndSaveOneAudioWithDialog({
-        audioKey: activeAudioKey.value as string,
-        quasarDialog: $q.dialog,
-        dispatch: store.dispatch,
-        encoding: store.state.savingSetting.fileEncoding,
-      });
-    };
-    const generateAndSaveAllAudio = async () => {
-      await generateAndSaveAllAudioWithDialog({
-        quasarDialog: $q.dialog,
-        dispatch: store.dispatch,
-        encoding: store.state.savingSetting.fileEncoding,
-      });
-    };
-    const generateAndConnectAndSaveAudio = async () => {
-      await generateAndConnectAndSaveAudioWithDialog({
-        quasarDialog: $q.dialog,
-        dispatch: store.dispatch,
-        encoding: store.state.savingSetting.fileEncoding,
-      });
-    };
-    const saveProject = async () => {
-      await store.dispatch("SAVE_PROJECT_FILE", { overwrite: true });
-    };
-    const importTextFile = () => {
-      store.dispatch("COMMAND_IMPORT_FROM_FILE", {});
-    };
+      return false;
+    },
+  ],
+  // redo
+  [
+    "やり直す",
+    () => {
+      if (!uiLocked.value && canRedo.value) {
+        redo();
+      }
+      return false;
+    },
+  ],
+]);
+setHotkeyFunctions(undoRedoHotkeyMap);
 
-    const usableButtons: Record<
-      ToolbarButtonTagType,
-      Omit<ButtonContent, "text"> | null
-    > = {
-      PLAY_CONTINUOUSLY: {
-        click: playContinuously,
-        disable: uiLocked,
-      },
-      STOP: {
-        click: stopContinuously,
-        disable: computed(() => !nowPlayingContinuously.value),
-      },
-      EXPORT_AUDIO_ONE: {
-        click: generateAndSaveOneAudio,
-        disable: computed(() => !activeAudioKey.value || uiLocked.value),
-      },
-      EXPORT_AUDIO_ALL: {
-        click: generateAndSaveAllAudio,
-        disable: uiLocked,
-      },
-      EXPORT_AUDIO_CONNECT_ALL: {
-        click: generateAndConnectAndSaveAudio,
-        disable: uiLocked,
-      },
-      SAVE_PROJECT: {
-        click: saveProject,
-        disable: uiLocked,
-      },
-      UNDO: {
-        click: undo,
-        disable: computed(() => !canUndo.value || uiLocked.value),
-      },
-      REDO: {
-        click: redo,
-        disable: computed(() => !canRedo.value || uiLocked.value),
-      },
-      IMPORT_TEXT: {
-        click: importTextFile,
-        disable: uiLocked,
-      },
-      EMPTY: null,
-    };
-
-    const headerButtons = computed(() =>
-      store.state.toolbarSetting.map<ButtonContent | SpacerContent>((tag) => {
-        const buttonContent = usableButtons[tag];
-        if (buttonContent) {
-          return {
-            ...buttonContent,
-            text: getToolbarButtonName(tag),
-          };
+const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
+  // play/stop continuously
+  [
+    "連続再生/停止",
+    () => {
+      if (!uiLocked.value) {
+        if (nowPlayingContinuously.value) {
+          stopContinuously();
         } else {
-          return {
-            text: null,
-          };
+          playContinuously();
         }
-      })
-    );
+      }
+    },
+  ],
+]);
 
-    return {
-      headerButtons,
-    };
+setHotkeyFunctions(hotkeyMap);
+
+const undo = () => {
+  store.dispatch("UNDO");
+};
+const redo = () => {
+  store.dispatch("REDO");
+};
+const playContinuously = async () => {
+  try {
+    await store.dispatch("PLAY_CONTINUOUSLY_AUDIO");
+  } catch {
+    $q.dialog({
+      title: "再生に失敗しました",
+      message: "エンジンの再起動をお試しください。",
+      ok: {
+        label: "閉じる",
+        flat: true,
+        textColor: "display",
+      },
+    });
+  }
+};
+const stopContinuously = () => {
+  store.dispatch("STOP_CONTINUOUSLY_AUDIO");
+};
+const generateAndSaveOneAudio = async () => {
+  await generateAndSaveOneAudioWithDialog({
+    audioKey: activeAudioKey.value as string,
+    quasarDialog: $q.dialog,
+    dispatch: store.dispatch,
+    encoding: store.state.savingSetting.fileEncoding,
+  });
+};
+const generateAndSaveAllAudio = async () => {
+  await generateAndSaveAllAudioWithDialog({
+    quasarDialog: $q.dialog,
+    dispatch: store.dispatch,
+    encoding: store.state.savingSetting.fileEncoding,
+  });
+};
+const generateAndConnectAndSaveAudio = async () => {
+  await generateAndConnectAndSaveAudioWithDialog({
+    quasarDialog: $q.dialog,
+    dispatch: store.dispatch,
+    encoding: store.state.savingSetting.fileEncoding,
+  });
+};
+const saveProject = async () => {
+  await store.dispatch("SAVE_PROJECT_FILE", { overwrite: true });
+};
+const importTextFile = () => {
+  store.dispatch("COMMAND_IMPORT_FROM_FILE", {});
+};
+
+const usableButtons: Record<
+  ToolbarButtonTagType,
+  Omit<ButtonContent, "text"> | null
+> = {
+  PLAY_CONTINUOUSLY: {
+    click: playContinuously,
+    disable: uiLocked,
   },
-});
+  STOP: {
+    click: stopContinuously,
+    disable: computed(() => !nowPlayingContinuously.value),
+  },
+  EXPORT_AUDIO_ONE: {
+    click: generateAndSaveOneAudio,
+    disable: computed(() => !activeAudioKey.value || uiLocked.value),
+  },
+  EXPORT_AUDIO_ALL: {
+    click: generateAndSaveAllAudio,
+    disable: uiLocked,
+  },
+  EXPORT_AUDIO_CONNECT_ALL: {
+    click: generateAndConnectAndSaveAudio,
+    disable: uiLocked,
+  },
+  SAVE_PROJECT: {
+    click: saveProject,
+    disable: uiLocked,
+  },
+  UNDO: {
+    click: undo,
+    disable: computed(() => !canUndo.value || uiLocked.value),
+  },
+  REDO: {
+    click: redo,
+    disable: computed(() => !canRedo.value || uiLocked.value),
+  },
+  IMPORT_TEXT: {
+    click: importTextFile,
+    disable: uiLocked,
+  },
+  EMPTY: null,
+};
+
+const headerButtons = computed(() =>
+  store.state.toolbarSetting.map<ButtonContent | SpacerContent>((tag) => {
+    const buttonContent = usableButtons[tag];
+    if (buttonContent) {
+      return {
+        ...buttonContent,
+        text: getToolbarButtonName(tag),
+      };
+    } else {
+      return {
+        text: null,
+      };
+    }
+  })
+);
 </script>
+
+<template>
+  <QHeader class="q-py-sm">
+    <QToolbar>
+      <template v-for="button in headerButtons" :key="button.text">
+        <QSpace v-if="button.text === null" />
+        <QBtn
+          v-else
+          unelevated
+          color="toolbar-button"
+          text-color="toolbar-button-display"
+          class="text-no-wrap text-bold q-mr-sm"
+          :disable="button.disable.value"
+          @click="button.click"
+          >{{ button.text }}</QBtn
+        >
+      </template>
+    </QToolbar>
+  </QHeader>
+</template>

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -1,3 +1,23 @@
+<template>
+  <QHeader class="q-py-sm">
+    <QToolbar>
+      <template v-for="button in headerButtons" :key="button.text">
+        <QSpace v-if="button.text === null" />
+        <QBtn
+          v-else
+          unelevated
+          color="toolbar-button"
+          text-color="toolbar-button-display"
+          class="text-no-wrap text-bold q-mr-sm"
+          :disable="button.disable.value"
+          @click="button.click"
+          >{{ button.text }}</QBtn
+        >
+      </template>
+    </QToolbar>
+  </QHeader>
+</template>
+
 <script setup lang="ts">
 import { computed, ComputedRef } from "vue";
 import { useStore } from "@/store";
@@ -190,23 +210,3 @@ const headerButtons = computed(() =>
   })
 );
 </script>
-
-<template>
-  <QHeader class="q-py-sm">
-    <QToolbar>
-      <template v-for="button in headerButtons" :key="button.text">
-        <QSpace v-if="button.text === null" />
-        <QBtn
-          v-else
-          unelevated
-          color="toolbar-button"
-          text-color="toolbar-button-display"
-          class="text-no-wrap text-bold q-mr-sm"
-          :disable="button.disable.value"
-          @click="button.click"
-          >{{ button.text }}</QBtn
-        >
-      </template>
-    </QToolbar>
-  </QHeader>
-</template>

--- a/src/components/HeaderBarCustomDialog.vue
+++ b/src/components/HeaderBarCustomDialog.vue
@@ -1,50 +1,202 @@
+<script setup lang="ts">
+import { computed, ref, watch, Ref } from "vue";
+import { useStore } from "@/store";
+import { ToolbarButtonTagType, ToolbarSetting } from "@/type/preload";
+import { useQuasar } from "quasar";
+import { getToolbarButtonName } from "@/store/utility";
+import draggable from "vuedraggable";
+
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", value: boolean): void;
+  }>();
+
+const store = useStore();
+const $q = useQuasar();
+
+// computedだと値の編集ができないが、refにすると起動時に読み込まれる設定が反映されないので、watchしている
+const toolbarButtons = ref([...store.state.toolbarSetting]);
+const toolbarButtonKey = (button: ToolbarButtonTagType) => button;
+const toolbarButtonDragging = ref(false);
+const selectedButton: Ref<ToolbarButtonTagType | undefined> = ref(
+  toolbarButtons.value[0]
+);
+watch(
+  () => store.state.toolbarSetting,
+  (newData) => {
+    // このwatchはToolbar Setting更新時にも機能するが、
+    // 以下の処理はVOICEVOX起動時のみ機能してほしいので、toolbarButtonsのlengthが0の時だけ機能させる
+    if (!toolbarButtons.value.length) {
+      toolbarButtons.value = [...newData];
+      selectedButton.value = newData[0];
+    }
+  }
+);
+
+const defaultSetting: ToolbarSetting = [];
+window.electron.getDefaultToolbarSetting().then((setting) => {
+  defaultSetting.push(...setting);
+});
+
+const usableButtonsDesc: Record<ToolbarButtonTagType, string> = {
+  PLAY_CONTINUOUSLY:
+    "選択されているテキスト以降のすべてのテキストを読み上げます。",
+  STOP: "テキストが読み上げられているときに、それを止めます。",
+  EXPORT_AUDIO_ONE:
+    "選択されているテキストの読み上げを音声ファイルに書き出します。",
+  EXPORT_AUDIO_ALL:
+    "入力されているすべてのテキストの読み上げを音声ファイルに書き出します。",
+  EXPORT_AUDIO_CONNECT_ALL:
+    "入力されているすべてのテキストの読み上げを一つの音声ファイルに繋げて書き出します。",
+  SAVE_PROJECT: "プロジェクトを上書き保存します。",
+  UNDO: "操作を一つ戻します。",
+  REDO: "元に戻した操作をやり直します。",
+  IMPORT_TEXT: "テキストファイル(.txt)を読み込みます。",
+  EMPTY:
+    "これはボタンではありません。レイアウトの調整に使います。また、実際には表示されません。",
+};
+
+const headerBarCustomDialogOpenComputed = computed({
+  get: () => props.modelValue || isChanged.value,
+  set: (val) => emit("update:modelValue", val),
+});
+
+const isChanged = computed(() => {
+  const nowSetting = store.state.toolbarSetting;
+  return (
+    toolbarButtons.value.length != nowSetting.length ||
+    toolbarButtons.value.some((e, i) => e != nowSetting[i])
+  );
+});
+const isDefault = computed(() => {
+  return (
+    toolbarButtons.value.length == defaultSetting.length &&
+    toolbarButtons.value.every((e, i) => e == defaultSetting[i])
+  );
+});
+
+// ボタンが追加されたときはそれをフォーカスし、
+// 削除されたときは一番最初のボタンをフォーカスするようにする
+watch(
+  () => toolbarButtons.value,
+  (newData, oldData) => {
+    if (oldData.length < newData.length) {
+      selectedButton.value = newData[newData.length - 1];
+    } else if (
+      selectedButton.value !== undefined &&
+      oldData.includes(selectedButton.value) &&
+      !newData.includes(selectedButton.value)
+    ) {
+      selectedButton.value = newData[0];
+    }
+  }
+);
+
+const applyDefaultSetting = () => {
+  $q.dialog({
+    title: "ツールバーをデフォルトに戻します",
+    message: "ツールバーをデフォルトに戻します。<br/>よろしいですか？",
+    html: true,
+    ok: {
+      label: "はい",
+      flat: true,
+      textColor: "display",
+    },
+    cancel: {
+      label: "いいえ",
+      flat: true,
+      textColor: "display",
+    },
+  }).onOk(() => {
+    toolbarButtons.value = [...defaultSetting];
+    selectedButton.value = toolbarButtons.value[0];
+  });
+};
+const saveCustomToolbar = () => {
+  store.dispatch("SET_TOOLBAR_SETTING", {
+    data: [...toolbarButtons.value],
+  });
+};
+
+const finishOrNotDialog = () => {
+  if (isChanged.value) {
+    $q.dialog({
+      title: "カスタマイズを終了しますか？",
+      message: "このまま終了すると、カスタマイズは破棄されてリセットされます。",
+      persistent: true,
+      focus: "cancel",
+      ok: {
+        label: "終了",
+        flat: true,
+        textColor: "display",
+      },
+      cancel: {
+        label: "キャンセル",
+        flat: true,
+        textColor: "display",
+      },
+    }).onOk(() => {
+      toolbarButtons.value = [...store.state.toolbarSetting];
+      selectedButton.value = toolbarButtons.value[0];
+      headerBarCustomDialogOpenComputed.value = false;
+    });
+  } else {
+    selectedButton.value = toolbarButtons.value[0];
+    headerBarCustomDialogOpenComputed.value = false;
+  }
+};
+</script>
 <template>
-  <q-dialog
+  <QDialog
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="header-bar-custom-dialog transparent-backdrop"
     v-model="headerBarCustomDialogOpenComputed"
   >
-    <q-layout container view="hHh Lpr fFf" class="bg-background">
-      <q-page-container class="root">
-        <q-header class="q-py-sm">
-          <q-toolbar>
-            <q-toolbar-title class="text-display"
-              >ツールバーのカスタマイズ</q-toolbar-title
+    <QLayout container view="hHh Lpr fFf" class="bg-background">
+      <QPageContainer class="root">
+        <QHeader class="q-py-sm">
+          <QToolbar>
+            <QToolbarTitle class="text-display"
+              >ツールバーのカスタマイズ</QToolbarTitle
             >
-            <q-space />
-            <q-btn
+            <QSpace />
+            <QBtn
               unelevated
               color="toolbar-button"
               text-color="toolbar-button-display"
               class="text-no-wrap text-bold q-mr-sm"
               @click="applyDefaultSetting"
               :disable="isDefault"
-              >デフォルトに戻す</q-btn
+              >デフォルトに戻す</QBtn
             >
-            <q-btn
+            <QBtn
               unelevated
               color="toolbar-button"
               text-color="toolbar-button-display"
               class="text-no-wrap text-bold q-mr-sm"
               @click="saveCustomToolbar"
               :disable="!isChanged"
-              >保存</q-btn
+              >保存</QBtn
             >
             <!-- close button -->
-            <q-btn
+            <QBtn
               round
               flat
               icon="close"
               color="display"
               @click="finishOrNotDialog"
             />
-          </q-toolbar>
-        </q-header>
-        <q-page>
-          <q-card flat square class="preview-card">
-            <q-toolbar class="bg-toolbar preview-toolbar">
+          </QToolbar>
+        </QHeader>
+        <QPage>
+          <QCard flat square class="preview-card">
+            <QToolbar class="bg-toolbar preview-toolbar">
               <draggable
                 v-model="toolbarButtons"
                 :item-key="toolbarButtonKey"
@@ -52,7 +204,7 @@
                 @end="toolbarButtonDragging = false"
               >
                 <template v-slot:item="{ element: button }">
-                  <q-btn
+                  <QBtn
                     unelevated
                     color="toolbar-button"
                     text-color="toolbar-button-display"
@@ -62,7 +214,7 @@
                     "
                   >
                     {{ getToolbarButtonName(button) }}
-                    <q-tooltip
+                    <QTooltip
                       :delay="800"
                       anchor="center left"
                       self="center right"
@@ -71,242 +223,43 @@
                       :style="{
                         display: toolbarButtonDragging ? 'none' : 'block',
                       }"
-                      >{{ usableButtonsDesc[button] }}</q-tooltip
+                      >{{ usableButtonsDesc[button] }}</QTooltip
                     >
-                  </q-btn>
+                  </QBtn>
                 </template>
               </draggable>
               <div class="preview-toolbar-drag-hint">
                 ドラッグでボタンの並びを変更できます。
               </div>
-            </q-toolbar>
+            </QToolbar>
 
-            <q-card-actions>
+            <QCardActions>
               <div class="text-h5">表示するボタンの選択</div>
-            </q-card-actions>
-            <q-card-actions class="no-padding">
-              <q-list class="usable-button-list bg-surface">
-                <q-item
+            </QCardActions>
+            <QCardActions class="no-padding">
+              <QList class="usable-button-list bg-surface">
+                <QItem
                   v-for="(desc, key) in usableButtonsDesc"
                   :key="key"
                   tag="label"
                   v-ripple
                 >
-                  <q-item-section>
-                    <q-item-label>{{ getToolbarButtonName(key) }}</q-item-label>
-                    <q-item-label caption>{{ desc }}</q-item-label>
-                  </q-item-section>
-                  <q-item-section avatar>
-                    <q-toggle v-model="toolbarButtons" :val="key" />
-                  </q-item-section>
-                </q-item>
-              </q-list>
-            </q-card-actions>
-          </q-card>
-        </q-page>
-      </q-page-container>
-    </q-layout>
-  </q-dialog>
+                  <QItemSection>
+                    <QItemLabel>{{ getToolbarButtonName(key) }}</QItemLabel>
+                    <QItemLabel caption>{{ desc }}</QItemLabel>
+                  </QItemSection>
+                  <QItemSection avatar>
+                    <QToggle v-model="toolbarButtons" :val="key" />
+                  </QItemSection>
+                </QItem>
+              </QList>
+            </QCardActions>
+          </QCard>
+        </QPage>
+      </QPageContainer>
+    </QLayout>
+  </QDialog>
 </template>
-
-<script lang="ts">
-import { computed, defineComponent, ref, watch, Ref } from "vue";
-import { useStore } from "@/store";
-import { ToolbarButtonTagType, ToolbarSetting } from "@/type/preload";
-import { useQuasar } from "quasar";
-import { getToolbarButtonName } from "@/store/utility";
-import draggable from "vuedraggable";
-
-export default defineComponent({
-  name: "HeaderBarCustomDialog",
-  components: {
-    draggable,
-  },
-  props: {
-    modelValue: {
-      type: Boolean,
-      required: true,
-    },
-  },
-
-  setup(props, { emit }) {
-    const store = useStore();
-    const $q = useQuasar();
-
-    // computedだと値の編集ができないが、refにすると起動時に読み込まれる設定が反映されないので、watchしている
-    const toolbarButtons = ref([...store.state.toolbarSetting]);
-    const toolbarButtonKey = (button: ToolbarButtonTagType) => button;
-    const toolbarButtonDragging = ref(false);
-    const selectedButton: Ref<ToolbarButtonTagType | undefined> = ref(
-      toolbarButtons.value[0]
-    );
-    watch(
-      () => store.state.toolbarSetting,
-      (newData) => {
-        // このwatchはToolbar Setting更新時にも機能するが、
-        // 以下の処理はVOICEVOX起動時のみ機能してほしいので、toolbarButtonsのlengthが0の時だけ機能させる
-        if (!toolbarButtons.value.length) {
-          toolbarButtons.value = [...newData];
-          selectedButton.value = newData[0];
-        }
-      }
-    );
-
-    const defaultSetting: ToolbarSetting = [];
-    window.electron.getDefaultToolbarSetting().then((setting) => {
-      defaultSetting.push(...setting);
-    });
-
-    const usableButtonsDesc: Record<ToolbarButtonTagType, string> = {
-      PLAY_CONTINUOUSLY:
-        "選択されているテキスト以降のすべてのテキストを読み上げます。",
-      STOP: "テキストが読み上げられているときに、それを止めます。",
-      EXPORT_AUDIO_ONE:
-        "選択されているテキストの読み上げを音声ファイルに書き出します。",
-      EXPORT_AUDIO_ALL:
-        "入力されているすべてのテキストの読み上げを音声ファイルに書き出します。",
-      EXPORT_AUDIO_CONNECT_ALL:
-        "入力されているすべてのテキストの読み上げを一つの音声ファイルに繋げて書き出します。",
-      SAVE_PROJECT: "プロジェクトを上書き保存します。",
-      UNDO: "操作を一つ戻します。",
-      REDO: "元に戻した操作をやり直します。",
-      IMPORT_TEXT: "テキストファイル(.txt)を読み込みます。",
-      EMPTY:
-        "これはボタンではありません。レイアウトの調整に使います。また、実際には表示されません。",
-    };
-
-    const headerBarCustomDialogOpenComputed = computed({
-      get: () => props.modelValue || isChanged.value,
-      set: (val) => emit("update:modelValue", val),
-    });
-
-    const isChanged = computed(() => {
-      const nowSetting = store.state.toolbarSetting;
-      return (
-        toolbarButtons.value.length != nowSetting.length ||
-        toolbarButtons.value.some((e, i) => e != nowSetting[i])
-      );
-    });
-    const isDefault = computed(() => {
-      return (
-        toolbarButtons.value.length == defaultSetting.length &&
-        toolbarButtons.value.every((e, i) => e == defaultSetting[i])
-      );
-    });
-
-    const moveLeftButton = () => {
-      if (selectedButton.value === undefined) return;
-      const index = toolbarButtons.value.indexOf(selectedButton.value);
-      toolbarButtons.value[index] = toolbarButtons.value[index - 1];
-      toolbarButtons.value[index - 1] = selectedButton.value;
-    };
-    const moveRightButton = () => {
-      if (selectedButton.value === undefined) return;
-      const index = toolbarButtons.value.indexOf(selectedButton.value);
-      toolbarButtons.value[index] = toolbarButtons.value[index + 1];
-      toolbarButtons.value[index + 1] = selectedButton.value;
-    };
-    const removeButton = () => {
-      if (selectedButton.value === undefined) return;
-      const index = toolbarButtons.value.indexOf(selectedButton.value);
-      toolbarButtons.value = [
-        ...toolbarButtons.value.slice(0, index),
-        ...toolbarButtons.value.slice(index + 1),
-      ];
-    };
-
-    // ボタンが追加されたときはそれをフォーカスし、
-    // 削除されたときは一番最初のボタンをフォーカスするようにする
-    watch(
-      () => toolbarButtons.value,
-      (newData, oldData) => {
-        if (oldData.length < newData.length) {
-          selectedButton.value = newData[newData.length - 1];
-        } else if (
-          selectedButton.value !== undefined &&
-          oldData.includes(selectedButton.value) &&
-          !newData.includes(selectedButton.value)
-        ) {
-          selectedButton.value = newData[0];
-        }
-      }
-    );
-
-    const applyDefaultSetting = () => {
-      $q.dialog({
-        title: "ツールバーをデフォルトに戻します",
-        message: "ツールバーをデフォルトに戻します。<br/>よろしいですか？",
-        html: true,
-        ok: {
-          label: "はい",
-          flat: true,
-          textColor: "display",
-        },
-        cancel: {
-          label: "いいえ",
-          flat: true,
-          textColor: "display",
-        },
-      }).onOk(() => {
-        toolbarButtons.value = [...defaultSetting];
-        selectedButton.value = toolbarButtons.value[0];
-      });
-    };
-    const saveCustomToolbar = () => {
-      store.dispatch("SET_TOOLBAR_SETTING", {
-        data: [...toolbarButtons.value],
-      });
-    };
-
-    const finishOrNotDialog = () => {
-      if (isChanged.value) {
-        $q.dialog({
-          title: "カスタマイズを終了しますか？",
-          message:
-            "このまま終了すると、カスタマイズは破棄されてリセットされます。",
-          persistent: true,
-          focus: "cancel",
-          ok: {
-            label: "終了",
-            flat: true,
-            textColor: "display",
-          },
-          cancel: {
-            label: "キャンセル",
-            flat: true,
-            textColor: "display",
-          },
-        }).onOk(() => {
-          toolbarButtons.value = [...store.state.toolbarSetting];
-          selectedButton.value = toolbarButtons.value[0];
-          headerBarCustomDialogOpenComputed.value = false;
-        });
-      } else {
-        selectedButton.value = toolbarButtons.value[0];
-        headerBarCustomDialogOpenComputed.value = false;
-      }
-    };
-
-    return {
-      headerBarCustomDialogOpenComputed,
-      toolbarButtons,
-      toolbarButtonKey,
-      toolbarButtonDragging,
-      selectedButton,
-      isChanged,
-      isDefault,
-      moveLeftButton,
-      moveRightButton,
-      removeButton,
-      saveCustomToolbar,
-      usableButtonsDesc,
-      getToolbarButtonName,
-      applyDefaultSetting,
-      finishOrNotDialog,
-    };
-  },
-});
-</script>
 
 <style lang="scss" scoped>
 @use '@/styles/variables' as vars;

--- a/src/components/HeaderBarCustomDialog.vue
+++ b/src/components/HeaderBarCustomDialog.vue
@@ -1,3 +1,114 @@
+<template>
+  <QDialog
+    maximized
+    transition-show="jump-up"
+    transition-hide="jump-down"
+    class="header-bar-custom-dialog transparent-backdrop"
+    v-model="headerBarCustomDialogOpenComputed"
+  >
+    <QLayout container view="hHh Lpr fFf" class="bg-background">
+      <QPageContainer class="root">
+        <QHeader class="q-py-sm">
+          <QToolbar>
+            <QToolbarTitle class="text-display"
+              >ツールバーのカスタマイズ</QToolbarTitle
+            >
+            <QSpace />
+            <QBtn
+              unelevated
+              color="toolbar-button"
+              text-color="toolbar-button-display"
+              class="text-no-wrap text-bold q-mr-sm"
+              @click="applyDefaultSetting"
+              :disable="isDefault"
+              >デフォルトに戻す</QBtn
+            >
+            <QBtn
+              unelevated
+              color="toolbar-button"
+              text-color="toolbar-button-display"
+              class="text-no-wrap text-bold q-mr-sm"
+              @click="saveCustomToolbar"
+              :disable="!isChanged"
+              >保存</QBtn
+            >
+            <!-- close button -->
+            <QBtn
+              round
+              flat
+              icon="close"
+              color="display"
+              @click="finishOrNotDialog"
+            />
+          </QToolbar>
+        </QHeader>
+        <QPage>
+          <QCard flat square class="preview-card">
+            <QToolbar class="bg-toolbar preview-toolbar">
+              <draggable
+                v-model="toolbarButtons"
+                :item-key="toolbarButtonKey"
+                @start="toolbarButtonDragging = true"
+                @end="toolbarButtonDragging = false"
+              >
+                <template v-slot:item="{ element: button }">
+                  <QBtn
+                    unelevated
+                    color="toolbar-button"
+                    text-color="toolbar-button-display"
+                    :class="
+                      (button === 'EMPTY' ? ' radio-space' : ' radio') +
+                      ' text-no-wrap text-bold q-mr-sm'
+                    "
+                  >
+                    {{ getToolbarButtonName(button) }}
+                    <QTooltip
+                      :delay="800"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                      :style="{
+                        display: toolbarButtonDragging ? 'none' : 'block',
+                      }"
+                      >{{ usableButtonsDesc[button] }}</QTooltip
+                    >
+                  </QBtn>
+                </template>
+              </draggable>
+              <div class="preview-toolbar-drag-hint">
+                ドラッグでボタンの並びを変更できます。
+              </div>
+            </QToolbar>
+
+            <QCardActions>
+              <div class="text-h5">表示するボタンの選択</div>
+            </QCardActions>
+            <QCardActions class="no-padding">
+              <QList class="usable-button-list bg-surface">
+                <QItem
+                  v-for="(desc, key) in usableButtonsDesc"
+                  :key="key"
+                  tag="label"
+                  v-ripple
+                >
+                  <QItemSection>
+                    <QItemLabel>{{ getToolbarButtonName(key) }}</QItemLabel>
+                    <QItemLabel caption>{{ desc }}</QItemLabel>
+                  </QItemSection>
+                  <QItemSection avatar>
+                    <QToggle v-model="toolbarButtons" :val="key" />
+                  </QItemSection>
+                </QItem>
+              </QList>
+            </QCardActions>
+          </QCard>
+        </QPage>
+      </QPageContainer>
+    </QLayout>
+  </QDialog>
+</template>
+
 <script setup lang="ts">
 import { computed, ref, watch, Ref } from "vue";
 import { useStore } from "@/store";
@@ -150,117 +261,6 @@ const finishOrNotDialog = () => {
   }
 };
 </script>
-<template>
-  <QDialog
-    maximized
-    transition-show="jump-up"
-    transition-hide="jump-down"
-    class="header-bar-custom-dialog transparent-backdrop"
-    v-model="headerBarCustomDialogOpenComputed"
-  >
-    <QLayout container view="hHh Lpr fFf" class="bg-background">
-      <QPageContainer class="root">
-        <QHeader class="q-py-sm">
-          <QToolbar>
-            <QToolbarTitle class="text-display"
-              >ツールバーのカスタマイズ</QToolbarTitle
-            >
-            <QSpace />
-            <QBtn
-              unelevated
-              color="toolbar-button"
-              text-color="toolbar-button-display"
-              class="text-no-wrap text-bold q-mr-sm"
-              @click="applyDefaultSetting"
-              :disable="isDefault"
-              >デフォルトに戻す</QBtn
-            >
-            <QBtn
-              unelevated
-              color="toolbar-button"
-              text-color="toolbar-button-display"
-              class="text-no-wrap text-bold q-mr-sm"
-              @click="saveCustomToolbar"
-              :disable="!isChanged"
-              >保存</QBtn
-            >
-            <!-- close button -->
-            <QBtn
-              round
-              flat
-              icon="close"
-              color="display"
-              @click="finishOrNotDialog"
-            />
-          </QToolbar>
-        </QHeader>
-        <QPage>
-          <QCard flat square class="preview-card">
-            <QToolbar class="bg-toolbar preview-toolbar">
-              <draggable
-                v-model="toolbarButtons"
-                :item-key="toolbarButtonKey"
-                @start="toolbarButtonDragging = true"
-                @end="toolbarButtonDragging = false"
-              >
-                <template v-slot:item="{ element: button }">
-                  <QBtn
-                    unelevated
-                    color="toolbar-button"
-                    text-color="toolbar-button-display"
-                    :class="
-                      (button === 'EMPTY' ? ' radio-space' : ' radio') +
-                      ' text-no-wrap text-bold q-mr-sm'
-                    "
-                  >
-                    {{ getToolbarButtonName(button) }}
-                    <QTooltip
-                      :delay="800"
-                      anchor="center left"
-                      self="center right"
-                      transition-show="jump-left"
-                      transition-hide="jump-right"
-                      :style="{
-                        display: toolbarButtonDragging ? 'none' : 'block',
-                      }"
-                      >{{ usableButtonsDesc[button] }}</QTooltip
-                    >
-                  </QBtn>
-                </template>
-              </draggable>
-              <div class="preview-toolbar-drag-hint">
-                ドラッグでボタンの並びを変更できます。
-              </div>
-            </QToolbar>
-
-            <QCardActions>
-              <div class="text-h5">表示するボタンの選択</div>
-            </QCardActions>
-            <QCardActions class="no-padding">
-              <QList class="usable-button-list bg-surface">
-                <QItem
-                  v-for="(desc, key) in usableButtonsDesc"
-                  :key="key"
-                  tag="label"
-                  v-ripple
-                >
-                  <QItemSection>
-                    <QItemLabel>{{ getToolbarButtonName(key) }}</QItemLabel>
-                    <QItemLabel caption>{{ desc }}</QItemLabel>
-                  </QItemSection>
-                  <QItemSection avatar>
-                    <QToggle v-model="toolbarButtons" :val="key" />
-                  </QItemSection>
-                </QItem>
-              </QList>
-            </QCardActions>
-          </QCard>
-        </QPage>
-      </QPageContainer>
-    </QLayout>
-  </QDialog>
-</template>
-
 <style lang="scss" scoped>
 @use '@/styles/variables' as vars;
 @use '@/styles/colors' as colors;

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -1,80 +1,5 @@
-<template>
-  <q-dialog
-    maximized
-    transition-show="jump-up"
-    transition-hide="jump-down"
-    class="help-dialog transparent-backdrop"
-    v-model="modelValueComputed"
-  >
-    <q-layout container view="hHh Lpr lff">
-      <q-drawer
-        bordered
-        show-if-above
-        class="bg-background"
-        :model-value="true"
-        :width="250"
-        :breakpoint="0"
-      >
-        <div class="column full-height">
-          <q-list>
-            <template v-for="(page, pageIndex) of pagedata" :key="pageIndex">
-              <q-item
-                v-if="page.type === 'item'"
-                clickable
-                v-ripple
-                active-class="selected-item"
-                :active="selectedPageIndex === pageIndex"
-                @click="selectedPageIndex = pageIndex"
-              >
-                <q-item-section> {{ page.name }} </q-item-section>
-              </q-item>
-              <template v-else-if="page.type === 'separator'">
-                <q-separator />
-                <q-item-label header>{{ page.name }}</q-item-label>
-              </template>
-            </template>
-          </q-list>
-        </div>
-      </q-drawer>
-
-      <q-page-container>
-        <q-page>
-          <q-tab-panels v-model="selectedPageIndex">
-            <q-tab-panel
-              v-for="(page, pageIndex) of pagedata"
-              :key="pageIndex"
-              :name="pageIndex"
-              class="q-pa-none"
-            >
-              <div class="root">
-                <q-header class="q-pa-sm">
-                  <q-toolbar>
-                    <q-toolbar-title class="text-display">
-                      ヘルプ / {{ page.parent ? page.parent + " / " : ""
-                      }}{{ page.name }}
-                    </q-toolbar-title>
-                    <!-- close button -->
-                    <q-btn
-                      round
-                      flat
-                      icon="close"
-                      color="display"
-                      @click="modelValueComputed = false"
-                    />
-                  </q-toolbar>
-                </q-header>
-                <component :is="page.component" v-bind="page.props" />
-              </div>
-            </q-tab-panel>
-          </q-tab-panels>
-        </q-page>
-      </q-page-container>
-    </q-layout>
-  </q-dialog>
-</template>
-
-<script lang="ts">
-import { defineComponent, computed, ref, Component } from "vue";
+<script setup lang="ts">
+import { computed, ref, Component } from "vue";
 import HelpPolicy from "@/components/HelpPolicy.vue";
 import LibraryPolicy from "@/components/LibraryPolicy.vue";
 import HowToUse from "@/components/HowToUse.vue";
@@ -98,192 +23,256 @@ type PageSeparator = {
   name: string;
 };
 type PageData = PageItem | PageSeparator;
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    "update:modelValue": (value: boolean) => void;
+  }>();
 
-export default defineComponent({
-  name: "HelpDialog",
-
-  props: {
-    modelValue: {
-      type: Boolean,
-      required: true,
-    },
-  },
-
-  setup(props, { emit }) {
-    const modelValueComputed = computed({
-      get: () => props.modelValue,
-      set: (val) => emit("update:modelValue", val),
-    });
-
-    // エディタのアップデート確認
-    const store = useStore();
-
-    const updateInfos = ref<UpdateInfoObject[]>();
-    store.dispatch("GET_UPDATE_INFOS").then((obj) => (updateInfos.value = obj));
-
-    const isCheckingFinished = ref<boolean>(false);
-
-    // 最新版があるか調べる
-    const currentVersion = ref("");
-    const latestVersion = ref("");
-    window.electron
-      .getAppInfos()
-      .then((obj) => {
-        currentVersion.value = obj.version;
-      })
-      .then(() => {
-        fetch("https://api.github.com/repos/VOICEVOX/voicevox/releases", {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-          },
-        })
-          .then((response) => {
-            if (!response.ok) throw new Error("Network response was not ok.");
-            return response.json();
-          })
-          .then((json) => {
-            const newerVersion = json.find(
-              (item: { prerelease: boolean; tag_name: string }) => {
-                return (
-                  !item.prerelease &&
-                  semver.valid(currentVersion.value) &&
-                  semver.valid(item.tag_name) &&
-                  semver.lt(currentVersion.value, item.tag_name)
-                );
-              }
-            );
-            if (newerVersion) {
-              latestVersion.value = newerVersion.tag_name;
-            }
-            isCheckingFinished.value = true;
-          })
-          .catch((err) => {
-            throw new Error(err);
-          });
-      });
-
-    const isUpdateAvailable = computed(() => {
-      return isCheckingFinished.value && latestVersion.value !== "";
-    });
-
-    // エディタのOSSライセンス取得
-    const licenses = ref<Record<string, string>[]>();
-    store.dispatch("GET_OSS_LICENSES").then((obj) => (licenses.value = obj));
-
-    const policy = ref<string>();
-    store.dispatch("GET_POLICY_TEXT").then((obj) => (policy.value = obj));
-
-    const pagedata = computed(() =>
-      (
-        [
-          {
-            type: "item",
-            name: "ソフトウェアの利用規約",
-            component: HelpPolicy,
-            props: {
-              policy: policy.value,
-            },
-          },
-          {
-            type: "item",
-            name: "音声ライブラリの利用規約",
-            component: LibraryPolicy,
-          },
-          {
-            type: "item",
-            name: "使い方",
-            component: HowToUse,
-          },
-          {
-            type: "item",
-            name: "開発コミュニティ",
-            component: OssCommunityInfo,
-          },
-          {
-            type: "item",
-            name: "ライセンス情報",
-            component: OssLicense,
-            props: {
-              licenses: licenses.value,
-            },
-          },
-          {
-            type: "item",
-            name: "アップデート情報",
-            component: UpdateInfo,
-            props: {
-              updateInfos: updateInfos.value,
-              isUpdateAvailable: isUpdateAvailable.value,
-              latestVersion: latestVersion.value,
-            },
-          },
-          {
-            type: "item",
-            name: "よくあるご質問",
-            component: QAndA,
-          },
-          {
-            type: "item",
-            name: "お問い合わせ",
-            component: ContactInfo,
-          },
-        ] as PageData[]
-      ).concat(
-        // エンジンが一つだけの場合は従来の表示のみ
-        (store.state.engineIds.length > 1
-          ? Object.values(store.state.engineManifests)
-          : []
-        ).flatMap((manifest) => [
-          {
-            type: "separator",
-            name: manifest.name,
-          },
-          {
-            type: "item",
-            name: "利用規約",
-            parent: manifest.name,
-            component: HelpPolicy,
-            props: {
-              policy: manifest.termsOfService,
-            },
-          },
-          {
-            type: "item",
-            name: "ライセンス情報",
-            parent: manifest.name,
-            component: OssLicense,
-            props: {
-              licenses: manifest.dependencyLicenses,
-            },
-          },
-          {
-            type: "item",
-            name: "アップデート情報",
-            parent: manifest.name,
-            component: UpdateInfo,
-            props: {
-              updateInfos: manifest.updateInfos,
-              // TODO: エンジン側で最新バージョンチェックAPIが出来たら実装する。
-              //       https://github.com/VOICEVOX/voicevox_engine/issues/476
-              isUpdateAvailable: false,
-            },
-          },
-        ])
-      )
-    );
-
-    const selectedPageIndex = ref(0);
-
-    return {
-      modelValueComputed,
-      pagedata,
-      selectedPageIndex,
-    };
-  },
+const modelValueComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
 });
+
+// エディタのアップデート確認
+const store = useStore();
+
+const updateInfos = ref<UpdateInfoObject[]>();
+store.dispatch("GET_UPDATE_INFOS").then((obj) => (updateInfos.value = obj));
+
+const isCheckingFinished = ref<boolean>(false);
+
+// 最新版があるか調べる
+const currentVersion = ref("");
+const latestVersion = ref("");
+window.electron
+  .getAppInfos()
+  .then((obj) => {
+    currentVersion.value = obj.version;
+  })
+  .then(() => {
+    fetch("https://api.github.com/repos/VOICEVOX/voicevox/releases", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error("Network response was not ok.");
+        return response.json();
+      })
+      .then((json) => {
+        const newerVersion = json.find(
+          (item: { prerelease: boolean; tag_name: string }) => {
+            return (
+              !item.prerelease &&
+              semver.valid(currentVersion.value) &&
+              semver.valid(item.tag_name) &&
+              semver.lt(currentVersion.value, item.tag_name)
+            );
+          }
+        );
+        if (newerVersion) {
+          latestVersion.value = newerVersion.tag_name;
+        }
+        isCheckingFinished.value = true;
+      })
+      .catch((err) => {
+        throw new Error(err);
+      });
+  });
+
+const isUpdateAvailable = computed(() => {
+  return isCheckingFinished.value && latestVersion.value !== "";
+});
+
+// エディタのOSSライセンス取得
+const licenses = ref<Record<string, string>[]>();
+store.dispatch("GET_OSS_LICENSES").then((obj) => (licenses.value = obj));
+
+const policy = ref<string>();
+store.dispatch("GET_POLICY_TEXT").then((obj) => (policy.value = obj));
+
+const pagedata = computed(() =>
+  (
+    [
+      {
+        type: "item",
+        name: "ソフトウェアの利用規約",
+        component: HelpPolicy,
+        props: {
+          policy: policy.value,
+        },
+      },
+      {
+        type: "item",
+        name: "音声ライブラリの利用規約",
+        component: LibraryPolicy,
+      },
+      {
+        type: "item",
+        name: "使い方",
+        component: HowToUse,
+      },
+      {
+        type: "item",
+        name: "開発コミュニティ",
+        component: OssCommunityInfo,
+      },
+      {
+        type: "item",
+        name: "ライセンス情報",
+        component: OssLicense,
+        props: {
+          licenses: licenses.value,
+        },
+      },
+      {
+        type: "item",
+        name: "アップデート情報",
+        component: UpdateInfo,
+        props: {
+          updateInfos: updateInfos.value,
+          isUpdateAvailable: isUpdateAvailable.value,
+          latestVersion: latestVersion.value,
+        },
+      },
+      {
+        type: "item",
+        name: "よくあるご質問",
+        component: QAndA,
+      },
+      {
+        type: "item",
+        name: "お問い合わせ",
+        component: ContactInfo,
+      },
+    ] as PageData[]
+  ).concat(
+    // エンジンが一つだけの場合は従来の表示のみ
+    (store.state.engineIds.length > 1
+      ? Object.values(store.state.engineManifests)
+      : []
+    ).flatMap((manifest) => [
+      {
+        type: "separator",
+        name: manifest.name,
+      },
+      {
+        type: "item",
+        name: "利用規約",
+        parent: manifest.name,
+        component: HelpPolicy,
+        props: {
+          policy: manifest.termsOfService,
+        },
+      },
+      {
+        type: "item",
+        name: "ライセンス情報",
+        parent: manifest.name,
+        component: OssLicense,
+        props: {
+          licenses: manifest.dependencyLicenses,
+        },
+      },
+      {
+        type: "item",
+        name: "アップデート情報",
+        parent: manifest.name,
+        component: UpdateInfo,
+        props: {
+          updateInfos: manifest.updateInfos,
+          // TODO: エンジン側で最新バージョンチェックAPIが出来たら実装する。
+          //       https://github.com/VOICEVOX/voicevox_engine/issues/476
+          isUpdateAvailable: false,
+        },
+      },
+    ])
+  )
+);
+
+const selectedPageIndex = ref(0);
 </script>
+
+<template>
+  <QDialog
+    maximized
+    transition-show="jump-up"
+    transition-hide="jump-down"
+    class="help-dialog transparent-backdrop"
+    v-model="modelValueComputed"
+  >
+    <QLayout container view="hHh Lpr lff">
+      <QDrawer
+        bordered
+        show-if-above
+        class="bg-background"
+        :model-value="true"
+        :width="250"
+        :breakpoint="0"
+      >
+        <div class="column full-height">
+          <QList>
+            <template v-for="(page, pageIndex) of pagedata" :key="pageIndex">
+              <QItem
+                v-if="page.type === 'item'"
+                clickable
+                v-ripple
+                active-class="selected-item"
+                :active="selectedPageIndex === pageIndex"
+                @click="selectedPageIndex = pageIndex"
+              >
+                <QItemSection> {{ page.name }} </QItemSection>
+              </QItem>
+              <template v-else-if="page.type === 'separator'">
+                <QSeparator />
+                <QItemLabel header>{{ page.name }}</QItemLabel>
+              </template>
+            </template>
+          </QList>
+        </div>
+      </QDrawer>
+
+      <QPageContainer>
+        <QPage>
+          <QTabPanels v-model="selectedPageIndex">
+            <QTabPanel
+              v-for="(page, pageIndex) of pagedata"
+              :key="pageIndex"
+              :name="pageIndex"
+              class="q-pa-none"
+            >
+              <div class="root">
+                <QHeader class="q-pa-sm">
+                  <QToolbar>
+                    <QToolbarTitle class="text-display">
+                      ヘルプ / {{ page.parent ? page.parent + " / " : ""
+                      }}{{ page.name }}
+                    </QToolbarTitle>
+                    <!-- close button -->
+                    <QBtn
+                      round
+                      flat
+                      icon="close"
+                      color="display"
+                      @click="modelValueComputed = false"
+                    />
+                  </QToolbar>
+                </QHeader>
+                <component :is="page.component" v-bind="page.props" />
+              </div>
+            </QTabPanel>
+          </QTabPanels>
+        </QPage>
+      </QPageContainer>
+    </QLayout>
+  </QDialog>
+</template>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -1,3 +1,78 @@
+<template>
+  <QDialog
+    maximized
+    transition-show="jump-up"
+    transition-hide="jump-down"
+    class="help-dialog transparent-backdrop"
+    v-model="modelValueComputed"
+  >
+    <QLayout container view="hHh Lpr lff">
+      <QDrawer
+        bordered
+        show-if-above
+        class="bg-background"
+        :model-value="true"
+        :width="250"
+        :breakpoint="0"
+      >
+        <div class="column full-height">
+          <QList>
+            <template v-for="(page, pageIndex) of pagedata" :key="pageIndex">
+              <QItem
+                v-if="page.type === 'item'"
+                clickable
+                v-ripple
+                active-class="selected-item"
+                :active="selectedPageIndex === pageIndex"
+                @click="selectedPageIndex = pageIndex"
+              >
+                <QItemSection> {{ page.name }} </QItemSection>
+              </QItem>
+              <template v-else-if="page.type === 'separator'">
+                <QSeparator />
+                <QItemLabel header>{{ page.name }}</QItemLabel>
+              </template>
+            </template>
+          </QList>
+        </div>
+      </QDrawer>
+
+      <QPageContainer>
+        <QPage>
+          <QTabPanels v-model="selectedPageIndex">
+            <QTabPanel
+              v-for="(page, pageIndex) of pagedata"
+              :key="pageIndex"
+              :name="pageIndex"
+              class="q-pa-none"
+            >
+              <div class="root">
+                <QHeader class="q-pa-sm">
+                  <QToolbar>
+                    <QToolbarTitle class="text-display">
+                      ヘルプ / {{ page.parent ? page.parent + " / " : ""
+                      }}{{ page.name }}
+                    </QToolbarTitle>
+                    <!-- close button -->
+                    <QBtn
+                      round
+                      flat
+                      icon="close"
+                      color="display"
+                      @click="modelValueComputed = false"
+                    />
+                  </QToolbar>
+                </QHeader>
+                <component :is="page.component" v-bind="page.props" />
+              </div>
+            </QTabPanel>
+          </QTabPanels>
+        </QPage>
+      </QPageContainer>
+    </QLayout>
+  </QDialog>
+</template>
+
 <script setup lang="ts">
 import { computed, ref, Component } from "vue";
 import HelpPolicy from "@/components/HelpPolicy.vue";
@@ -198,81 +273,6 @@ const pagedata = computed(() =>
 
 const selectedPageIndex = ref(0);
 </script>
-
-<template>
-  <QDialog
-    maximized
-    transition-show="jump-up"
-    transition-hide="jump-down"
-    class="help-dialog transparent-backdrop"
-    v-model="modelValueComputed"
-  >
-    <QLayout container view="hHh Lpr lff">
-      <QDrawer
-        bordered
-        show-if-above
-        class="bg-background"
-        :model-value="true"
-        :width="250"
-        :breakpoint="0"
-      >
-        <div class="column full-height">
-          <QList>
-            <template v-for="(page, pageIndex) of pagedata" :key="pageIndex">
-              <QItem
-                v-if="page.type === 'item'"
-                clickable
-                v-ripple
-                active-class="selected-item"
-                :active="selectedPageIndex === pageIndex"
-                @click="selectedPageIndex = pageIndex"
-              >
-                <QItemSection> {{ page.name }} </QItemSection>
-              </QItem>
-              <template v-else-if="page.type === 'separator'">
-                <QSeparator />
-                <QItemLabel header>{{ page.name }}</QItemLabel>
-              </template>
-            </template>
-          </QList>
-        </div>
-      </QDrawer>
-
-      <QPageContainer>
-        <QPage>
-          <QTabPanels v-model="selectedPageIndex">
-            <QTabPanel
-              v-for="(page, pageIndex) of pagedata"
-              :key="pageIndex"
-              :name="pageIndex"
-              class="q-pa-none"
-            >
-              <div class="root">
-                <QHeader class="q-pa-sm">
-                  <QToolbar>
-                    <QToolbarTitle class="text-display">
-                      ヘルプ / {{ page.parent ? page.parent + " / " : ""
-                      }}{{ page.name }}
-                    </QToolbarTitle>
-                    <!-- close button -->
-                    <QBtn
-                      round
-                      flat
-                      icon="close"
-                      color="display"
-                      @click="modelValueComputed = false"
-                    />
-                  </QToolbar>
-                </QHeader>
-                <component :is="page.component" v-bind="page.props" />
-              </div>
-            </QTabPanel>
-          </QTabPanels>
-        </QPage>
-      </QPageContainer>
-    </QLayout>
-  </QDialog>
-</template>
 
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;

--- a/src/components/HelpPolicy.vue
+++ b/src/components/HelpPolicy.vue
@@ -1,35 +1,24 @@
-<template>
-  <q-page class="relative-absolute-wrapper scroller bg-background">
-    <div class="q-pa-md markdown markdown-body" v-html="policyHtml"></div>
-  </q-page>
-</template>
-
-<script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
+const props =
+  defineProps<{
+    policy: string;
+  }>();
+const policyHtml = ref("");
 
-export default defineComponent({
-  props: {
-    policy: {
-      type: String,
-      required: true,
-    },
-  },
-  setup(props) {
-    const policyHtml = ref("");
+const md = useMarkdownIt();
 
-    const md = useMarkdownIt();
-
-    onMounted(async () => {
-      policyHtml.value = md.render(props.policy);
-    });
-
-    return {
-      policyHtml,
-    };
-  },
+onMounted(async () => {
+  policyHtml.value = md.render(props.policy);
 });
 </script>
+
+<template>
+  <QPage class="relative-absolute-wrapper scroller bg-background">
+    <div class="q-pa-md markdown markdown-body" v-html="policyHtml"></div>
+  </QPage>
+</template>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/HelpPolicy.vue
+++ b/src/components/HelpPolicy.vue
@@ -1,3 +1,9 @@
+<template>
+  <QPage class="relative-absolute-wrapper scroller bg-background">
+    <div class="q-pa-md markdown markdown-body" v-html="policyHtml"></div>
+  </QPage>
+</template>
+
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
@@ -13,12 +19,6 @@ onMounted(async () => {
   policyHtml.value = md.render(props.policy);
 });
 </script>
-
-<template>
-  <QPage class="relative-absolute-wrapper scroller bg-background">
-    <div class="q-pa-md markdown markdown-body" v-html="policyHtml"></div>
-  </QPage>
-</template>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -1,160 +1,3 @@
-<script setup lang="ts">
-import { computed, ref } from "vue";
-import { useStore } from "@/store";
-import { parseCombo } from "@/store/setting";
-import { HotkeyAction, HotkeySetting } from "@/type/preload";
-import { useQuasar } from "quasar";
-
-const props =
-  defineProps<{
-    modelValue: boolean;
-  }>();
-const emit =
-  defineEmits<{
-    (e: "update:modelValue", val: boolean): void;
-  }>();
-
-const store = useStore();
-const $q = useQuasar();
-
-const hotkeySettingDialogOpenComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
-
-const isHotkeyDialogOpened = ref(false);
-
-const hotkeyPagination = ref({ rowsPerPage: 0 });
-const hotkeyFilter = ref("");
-
-const hotkeySettings = computed(() => store.state.hotkeySettings);
-
-const hotkeyColumns = ref([
-  {
-    name: "action",
-    align: "left",
-    label: "操作",
-    field: "action",
-  },
-  {
-    name: "combination",
-    align: "left",
-    label: "ショートカットキー",
-    field: "combination",
-  },
-]);
-
-const lastAction = ref("");
-const lastRecord = ref("");
-
-const recordCombination = (event: KeyboardEvent) => {
-  if (!isHotkeyDialogOpened.value) {
-    return;
-  } else {
-    const recordedCombo = parseCombo(event);
-    lastRecord.value = recordedCombo;
-    event.preventDefault();
-  }
-};
-
-const changeHotkeySettings = (action: string, combo: string) => {
-  return store.dispatch("SET_HOTKEY_SETTINGS", {
-    data: {
-      action: action as HotkeyAction,
-      combination: combo,
-    },
-  });
-};
-
-const duplicatedHotkey = computed(() => {
-  if (lastRecord.value == "") return undefined;
-  return hotkeySettings.value.find(
-    (item) =>
-      item.combination == lastRecord.value && item.action != lastAction.value
-  );
-});
-
-const deleteHotkey = (action: HotkeyAction) => {
-  changeHotkeySettings(action, "");
-};
-
-const getHotkeyText = (action: string, combo: string) => {
-  if (checkHotkeyReadonly(action)) combo = "(読み取り専用) " + combo;
-  if (combo == "") return "未設定";
-  else return combo;
-};
-
-// for later developers, in case anyone wants to add a readonly hotkey
-const readonlyHotkeyKeys: string[] = [];
-
-const checkHotkeyReadonly = (action: string) => {
-  let flag = false;
-  readonlyHotkeyKeys.forEach((key) => {
-    if (key == action) {
-      flag = true;
-    }
-  });
-  return flag;
-};
-
-const openHotkeyDialog = (action: string) => {
-  lastAction.value = action;
-  lastRecord.value = "";
-  isHotkeyDialogOpened.value = true;
-  document.addEventListener("keydown", recordCombination);
-};
-
-const closeHotkeyDialog = () => {
-  lastAction.value = "";
-  lastRecord.value = "";
-  isHotkeyDialogOpened.value = false;
-  document.removeEventListener("keydown", recordCombination);
-};
-
-const solveDuplicated = () => {
-  if (duplicatedHotkey.value == undefined)
-    throw new Error("duplicatedHotkey.value == undefined");
-  deleteHotkey(duplicatedHotkey.value.action);
-  return changeHotkeySettings(lastAction.value, lastRecord.value);
-};
-
-const confirmBtnEnabled = computed(() => {
-  return (
-    lastRecord.value == "" ||
-    ["Ctrl", "Shift", "Alt", "Meta"].indexOf(
-      lastRecord.value.split(" ")[lastRecord.value.split(" ").length - 1]
-    ) > -1
-  );
-});
-
-const resetHotkey = (action: string) => {
-  $q.dialog({
-    title: "ショートカットキーを初期値に戻します",
-    message: `${action}のショートカットキーを初期値に戻します。<br/>本当に戻しますか？`,
-    html: true,
-    ok: {
-      label: "初期値に戻す",
-      flat: true,
-      textColor: "secondary",
-    },
-    cancel: {
-      label: "初期値に戻さない",
-      flat: true,
-      textColor: "secondary",
-    },
-  }).onOk(() => {
-    window.electron
-      .getDefaultHotkeySettings()
-      .then((defaultSettings: HotkeySetting[]) => {
-        const setting = defaultSettings.find((value) => value.action == action);
-        if (setting) {
-          changeHotkeySettings(action, setting.combination);
-        }
-      });
-  });
-};
-</script>
-
 <template>
   <QDialog
     maximized
@@ -353,6 +196,163 @@ const resetHotkey = (action: string) => {
     </QCard>
   </QDialog>
 </template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useStore } from "@/store";
+import { parseCombo } from "@/store/setting";
+import { HotkeyAction, HotkeySetting } from "@/type/preload";
+import { useQuasar } from "quasar";
+
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", val: boolean): void;
+  }>();
+
+const store = useStore();
+const $q = useQuasar();
+
+const hotkeySettingDialogOpenComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+
+const isHotkeyDialogOpened = ref(false);
+
+const hotkeyPagination = ref({ rowsPerPage: 0 });
+const hotkeyFilter = ref("");
+
+const hotkeySettings = computed(() => store.state.hotkeySettings);
+
+const hotkeyColumns = ref([
+  {
+    name: "action",
+    align: "left",
+    label: "操作",
+    field: "action",
+  },
+  {
+    name: "combination",
+    align: "left",
+    label: "ショートカットキー",
+    field: "combination",
+  },
+]);
+
+const lastAction = ref("");
+const lastRecord = ref("");
+
+const recordCombination = (event: KeyboardEvent) => {
+  if (!isHotkeyDialogOpened.value) {
+    return;
+  } else {
+    const recordedCombo = parseCombo(event);
+    lastRecord.value = recordedCombo;
+    event.preventDefault();
+  }
+};
+
+const changeHotkeySettings = (action: string, combo: string) => {
+  return store.dispatch("SET_HOTKEY_SETTINGS", {
+    data: {
+      action: action as HotkeyAction,
+      combination: combo,
+    },
+  });
+};
+
+const duplicatedHotkey = computed(() => {
+  if (lastRecord.value == "") return undefined;
+  return hotkeySettings.value.find(
+    (item) =>
+      item.combination == lastRecord.value && item.action != lastAction.value
+  );
+});
+
+const deleteHotkey = (action: HotkeyAction) => {
+  changeHotkeySettings(action, "");
+};
+
+const getHotkeyText = (action: string, combo: string) => {
+  if (checkHotkeyReadonly(action)) combo = "(読み取り専用) " + combo;
+  if (combo == "") return "未設定";
+  else return combo;
+};
+
+// for later developers, in case anyone wants to add a readonly hotkey
+const readonlyHotkeyKeys: string[] = [];
+
+const checkHotkeyReadonly = (action: string) => {
+  let flag = false;
+  readonlyHotkeyKeys.forEach((key) => {
+    if (key == action) {
+      flag = true;
+    }
+  });
+  return flag;
+};
+
+const openHotkeyDialog = (action: string) => {
+  lastAction.value = action;
+  lastRecord.value = "";
+  isHotkeyDialogOpened.value = true;
+  document.addEventListener("keydown", recordCombination);
+};
+
+const closeHotkeyDialog = () => {
+  lastAction.value = "";
+  lastRecord.value = "";
+  isHotkeyDialogOpened.value = false;
+  document.removeEventListener("keydown", recordCombination);
+};
+
+const solveDuplicated = () => {
+  if (duplicatedHotkey.value == undefined)
+    throw new Error("duplicatedHotkey.value == undefined");
+  deleteHotkey(duplicatedHotkey.value.action);
+  return changeHotkeySettings(lastAction.value, lastRecord.value);
+};
+
+const confirmBtnEnabled = computed(() => {
+  return (
+    lastRecord.value == "" ||
+    ["Ctrl", "Shift", "Alt", "Meta"].indexOf(
+      lastRecord.value.split(" ")[lastRecord.value.split(" ").length - 1]
+    ) > -1
+  );
+});
+
+const resetHotkey = (action: string) => {
+  $q.dialog({
+    title: "ショートカットキーを初期値に戻します",
+    message: `${action}のショートカットキーを初期値に戻します。<br/>本当に戻しますか？`,
+    html: true,
+    ok: {
+      label: "初期値に戻す",
+      flat: true,
+      textColor: "secondary",
+    },
+    cancel: {
+      label: "初期値に戻さない",
+      flat: true,
+      textColor: "secondary",
+    },
+  }).onOk(() => {
+    window.electron
+      .getDefaultHotkeySettings()
+      .then((defaultSettings: HotkeySetting[]) => {
+        const setting = defaultSettings.find((value) => value.action == action);
+        if (setting) {
+          changeHotkeySettings(action, setting.combination);
+        }
+      });
+  });
+};
+</script>
 
 <style scoped lang="scss">
 @use '@/styles/variables' as vars;

--- a/src/components/HowToUse.vue
+++ b/src/components/HowToUse.vue
@@ -1,27 +1,21 @@
-<template>
-  <q-page class="relative-absolute-wrapper scroller markdown-body">
-    <div class="q-pa-md markdown" v-html="howToUse"></div>
-  </q-page>
-</template>
-
-<script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
 import { useStore } from "@/store";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
-export default defineComponent({
-  setup() {
-    const store = useStore();
-    const howToUse = ref("");
-    const md = useMarkdownIt();
-    onMounted(async () => {
-      howToUse.value = md.render(await store.dispatch("GET_HOW_TO_USE_TEXT"));
-    });
-    return {
-      howToUse,
-    };
-  },
+
+const store = useStore();
+const howToUse = ref("");
+const md = useMarkdownIt();
+onMounted(async () => {
+  howToUse.value = md.render(await store.dispatch("GET_HOW_TO_USE_TEXT"));
 });
 </script>
+
+<template>
+  <QPage class="relative-absolute-wrapper scroller markdown-body">
+    <div class="q-pa-md markdown" v-html="howToUse"></div>
+  </QPage>
+</template>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/HowToUse.vue
+++ b/src/components/HowToUse.vue
@@ -1,3 +1,9 @@
+<template>
+  <QPage class="relative-absolute-wrapper scroller markdown-body">
+    <div class="q-pa-md markdown" v-html="howToUse"></div>
+  </QPage>
+</template>
+
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 import { useStore } from "@/store";
@@ -10,12 +16,6 @@ onMounted(async () => {
   howToUse.value = md.render(await store.dispatch("GET_HOW_TO_USE_TEXT"));
 });
 </script>
-
-<template>
-  <QPage class="relative-absolute-wrapper scroller markdown-body">
-    <div class="q-pa-md markdown" v-html="howToUse"></div>
-  </QPage>
-</template>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -1,46 +1,3 @@
-<script setup lang="ts">
-import { useStore } from "@/store";
-import { computed, ref } from "vue";
-import { useMarkdownIt } from "@/plugins/markdownItPlugin";
-
-type DetailKey = { engine: string; character: string };
-
-const store = useStore();
-const md = useMarkdownIt();
-
-const engineInfos = computed(
-  () =>
-    new Map(
-      Object.entries(store.state.characterInfos).map(
-        ([engineId, characterInfos]) => [
-          engineId,
-          {
-            engineId,
-            engineName: store.state.engineManifests[engineId].name,
-            characterInfos: new Map(
-              characterInfos.map((ci) => [ci.metas.speakerUuid, ci])
-            ),
-          },
-        ]
-      )
-    )
-);
-
-const convertMarkdown = (text: string) => {
-  return md.render(text);
-};
-
-const selectedInfo = ref<DetailKey | undefined>(undefined);
-
-const scroller = ref<HTMLElement>();
-const selectCharacterInfo = (index: DetailKey | undefined) => {
-  if (scroller.value == undefined)
-    throw new Error("scroller.value == undefined");
-  scroller.value.scrollTop = 0;
-  selectedInfo.value = index;
-};
-</script>
-
 <template>
   <QPage
     ref="scroller"
@@ -109,6 +66,48 @@ const selectCharacterInfo = (index: DetailKey | undefined) => {
   </QPage>
 </template>
 
+<script setup lang="ts">
+import { useStore } from "@/store";
+import { computed, ref } from "vue";
+import { useMarkdownIt } from "@/plugins/markdownItPlugin";
+
+type DetailKey = { engine: string; character: string };
+
+const store = useStore();
+const md = useMarkdownIt();
+
+const engineInfos = computed(
+  () =>
+    new Map(
+      Object.entries(store.state.characterInfos).map(
+        ([engineId, characterInfos]) => [
+          engineId,
+          {
+            engineId,
+            engineName: store.state.engineManifests[engineId].name,
+            characterInfos: new Map(
+              characterInfos.map((ci) => [ci.metas.speakerUuid, ci])
+            ),
+          },
+        ]
+      )
+    )
+);
+
+const convertMarkdown = (text: string) => {
+  return md.render(text);
+};
+
+const selectedInfo = ref<DetailKey | undefined>(undefined);
+
+const scroller = ref<HTMLElement>();
+const selectCharacterInfo = (index: DetailKey | undefined) => {
+  if (scroller.value == undefined)
+    throw new Error("scroller.value == undefined");
+  scroller.value.scrollTop = 0;
+  selectedInfo.value = index;
+};
+</script>
 <style scoped lang="scss">
 .root {
   .scroller {

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -1,3 +1,30 @@
+<template>
+  <q-bar class="bg-background q-pa-none relative-position">
+    <div
+      v-if="$q.platform.is.mac && !isFullscreen"
+      class="mac-traffic-light-space"
+    ></div>
+    <img v-else src="icon.png" class="window-logo" alt="application logo" />
+    <menu-button
+      v-for="(root, index) of menudata"
+      :key="index"
+      :menudata="root"
+      v-model:selected="subMenuOpenFlags[index]"
+      :disable="menubarLocked"
+      @mouseover="reassignSubMenuOpen(index)"
+      @mouseleave="
+        root.type === 'button' ? (subMenuOpenFlags[index] = false) : undefined
+      "
+    />
+    <q-space />
+    <div class="window-title" :class="{ 'text-warning': isSafeMode }">
+      {{ titleText }}
+    </div>
+    <q-space />
+    <title-bar-buttons />
+  </q-bar>
+</template>
+
 <script lang="ts">
 import { ComputedRef } from "vue";
 type MenuItemBase<T extends string> = {
@@ -497,32 +524,6 @@ watch(uiLocked, () => {
 });
 </script>
 
-<template>
-  <q-bar class="bg-background q-pa-none relative-position">
-    <div
-      v-if="$q.platform.is.mac && !isFullscreen"
-      class="mac-traffic-light-space"
-    ></div>
-    <img v-else src="icon.png" class="window-logo" alt="application logo" />
-    <menu-button
-      v-for="(root, index) of menudata"
-      :key="index"
-      :menudata="root"
-      v-model:selected="subMenuOpenFlags[index]"
-      :disable="menubarLocked"
-      @mouseover="reassignSubMenuOpen(index)"
-      @mouseleave="
-        root.type === 'button' ? (subMenuOpenFlags[index] = false) : undefined
-      "
-    />
-    <q-space />
-    <div class="window-title" :class="{ 'text-warning': isSafeMode }">
-      {{ titleText }}
-    </div>
-    <q-space />
-    <title-bar-buttons />
-  </q-bar>
-</template>
 <style lang="scss">
 @use '@/styles/colors' as colors;
 

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -1,46 +1,5 @@
-<template>
-  <q-bar class="bg-background q-pa-none relative-position">
-    <div
-      v-if="$q.platform.is.mac && !isFullscreen"
-      class="mac-traffic-light-space"
-    ></div>
-    <img v-else src="icon.png" class="window-logo" alt="application logo" />
-    <menu-button
-      v-for="(root, index) of menudata"
-      :key="index"
-      :menudata="root"
-      v-model:selected="subMenuOpenFlags[index]"
-      :disable="menubarLocked"
-      @mouseover="reassignSubMenuOpen(index)"
-      @mouseleave="
-        root.type === 'button' ? (subMenuOpenFlags[index] = false) : undefined
-      "
-    />
-    <q-space />
-    <div class="window-title" :class="{ 'text-warning': isSafeMode }">
-      {{ titleText }}
-    </div>
-    <q-space />
-    <title-bar-buttons />
-  </q-bar>
-</template>
-
 <script lang="ts">
-import { defineComponent, ref, computed, ComputedRef, watch } from "vue";
-import { useStore } from "@/store";
-import MenuButton from "@/components/MenuButton.vue";
-import TitleBarButtons from "@/components/TitleBarButtons.vue";
-import { useQuasar } from "quasar";
-import { HotkeyAction, HotkeyReturnType } from "@/type/preload";
-import { setHotkeyFunctions } from "@/store/setting";
-import {
-  generateAndConnectAndSaveAudioWithDialog,
-  generateAndSaveAllAudioWithDialog,
-  generateAndSaveOneAudioWithDialog,
-  connectAndExportTextWithDialog,
-} from "@/components/Dialog";
-import { base64ImageToUri } from "@/helpers/imageHelper";
-
+import { ComputedRef } from "vue";
 type MenuItemBase<T extends string> = {
   type: T;
   label?: string;
@@ -74,484 +33,496 @@ export type MenuItemData =
   | MenuItemCheckbox;
 
 export type MenuItemType = MenuItemData["type"];
+</script>
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import { useStore } from "@/store";
+import MenuButton from "@/components/MenuButton.vue";
+import TitleBarButtons from "@/components/TitleBarButtons.vue";
+import { useQuasar } from "quasar";
+import { HotkeyAction, HotkeyReturnType } from "@/type/preload";
+import { setHotkeyFunctions } from "@/store/setting";
+import {
+  generateAndConnectAndSaveAudioWithDialog,
+  generateAndSaveAllAudioWithDialog,
+  generateAndSaveOneAudioWithDialog,
+  connectAndExportTextWithDialog,
+} from "@/components/Dialog";
+import { base64ImageToUri } from "@/helpers/imageHelper";
 
-export default defineComponent({
-  name: "MenuBar",
+const store = useStore();
+const $q = useQuasar();
+const currentVersion = ref("");
+window.electron.getAppInfos().then((obj) => {
+  currentVersion.value = obj.version;
+});
+const isSafeMode = computed(() => store.state.isSafeMode);
+const uiLocked = computed(() => store.getters.UI_LOCKED);
+const menubarLocked = computed(() => store.getters.MENUBAR_LOCKED);
+const projectName = computed(() => store.getters.PROJECT_NAME);
+const useGpu = computed(() => store.state.useGpu);
+const isEdited = computed(() => store.getters.IS_EDITED);
+const isFullscreen = computed(() => store.getters.IS_FULLSCREEN);
+const engineInfos = computed(() => store.state.engineInfos);
+const engineManifests = computed(() => store.state.engineManifests);
 
-  components: {
-    MenuButton,
-    TitleBarButtons,
+const titleText = computed(
+  () =>
+    (isEdited.value ? "*" : "") +
+    (projectName.value !== undefined ? projectName.value + " - " : "") +
+    "VOICEVOX" +
+    (currentVersion.value ? " - Ver. " + currentVersion.value + " - " : "") +
+    (useGpu.value ? "GPU" : "CPU") +
+    (isSafeMode.value ? " - セーフモード" : "")
+);
+
+// FIXME: App.vue内に移動する
+watch(titleText, (newTitle) => {
+  window.document.title = newTitle;
+});
+
+const createNewProject = async () => {
+  if (!uiLocked.value) {
+    await store.dispatch("CREATE_NEW_PROJECT", {});
+  }
+};
+
+const generateAndSaveAllAudio = async () => {
+  if (!uiLocked.value) {
+    await generateAndSaveAllAudioWithDialog({
+      encoding: store.state.savingSetting.fileEncoding,
+      quasarDialog: $q.dialog,
+      dispatch: store.dispatch,
+    });
+  }
+};
+
+const generateAndConnectAndSaveAllAudio = async () => {
+  if (!uiLocked.value) {
+    await generateAndConnectAndSaveAudioWithDialog({
+      quasarDialog: $q.dialog,
+      dispatch: store.dispatch,
+      encoding: store.state.savingSetting.fileEncoding,
+    });
+  }
+};
+
+const generateAndSaveOneAudio = async () => {
+  if (uiLocked.value) return;
+
+  const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
+  if (activeAudioKey == undefined) {
+    $q.dialog({
+      title: "テキスト欄が選択されていません",
+      message: "音声を書き出したいテキスト欄を選択してください。",
+      ok: {
+        label: "閉じる",
+        flat: true,
+        textColor: "secondary",
+      },
+    });
+    return;
+  }
+
+  await generateAndSaveOneAudioWithDialog({
+    audioKey: activeAudioKey,
+    encoding: store.state.savingSetting.fileEncoding,
+    quasarDialog: $q.dialog,
+    dispatch: store.dispatch,
+  });
+};
+
+const connectAndExportText = async () => {
+  if (!uiLocked.value) {
+    await connectAndExportTextWithDialog({
+      quasarDialog: $q.dialog,
+      dispatch: store.dispatch,
+      encoding: store.state.savingSetting.fileEncoding,
+    });
+  }
+};
+
+const importTextFile = () => {
+  if (!uiLocked.value) {
+    store.dispatch("COMMAND_IMPORT_FROM_FILE", {});
+  }
+};
+
+const saveProject = () => {
+  if (!uiLocked.value) {
+    store.dispatch("SAVE_PROJECT_FILE", { overwrite: true });
+  }
+};
+
+const saveProjectAs = () => {
+  if (!uiLocked.value) {
+    store.dispatch("SAVE_PROJECT_FILE", {});
+  }
+};
+
+const importProject = () => {
+  if (!uiLocked.value) {
+    store.dispatch("LOAD_PROJECT_FILE", {});
+  }
+};
+const closeAllDialog = () => {
+  store.dispatch("SET_DIALOG_OPEN", {
+    isSettingDialogOpen: false,
+  });
+  store.dispatch("SET_DIALOG_OPEN", {
+    isHelpDialogOpen: false,
+  });
+  store.dispatch("SET_DIALOG_OPEN", {
+    isHotkeySettingDialogOpen: false,
+  });
+  store.dispatch("SET_DIALOG_OPEN", {
+    isToolbarSettingDialogOpen: false,
+  });
+  store.dispatch("SET_DIALOG_OPEN", {
+    isCharacterOrderDialogOpen: false,
+  });
+  store.dispatch("SET_DIALOG_OPEN", {
+    isDefaultStyleSelectDialogOpen: false,
+  });
+};
+
+const openHelpDialog = () => {
+  store.dispatch("SET_DIALOG_OPEN", {
+    isHelpDialogOpen: true,
+  });
+};
+
+const menudata = ref<MenuItemData[]>([
+  {
+    type: "root",
+    label: "ファイル",
+    onClick: () => {
+      closeAllDialog();
+    },
+    disableWhenUiLocked: false,
+    subMenu: [
+      {
+        type: "button",
+        label: "音声書き出し",
+        onClick: () => {
+          generateAndSaveAllAudio();
+        },
+        disableWhenUiLocked: true,
+      },
+      {
+        type: "button",
+        label: "一つだけ書き出し",
+        onClick: () => {
+          generateAndSaveOneAudio();
+        },
+        disableWhenUiLocked: true,
+      },
+      {
+        type: "button",
+        label: "音声を繋げて書き出し",
+        onClick: () => {
+          generateAndConnectAndSaveAllAudio();
+        },
+        disableWhenUiLocked: true,
+      },
+      { type: "separator" },
+      {
+        type: "button",
+        label: "テキストを繋げて書き出し",
+        onClick: () => {
+          connectAndExportText();
+        },
+        disableWhenUiLocked: true,
+      },
+      {
+        type: "button",
+        label: "テキスト読み込み",
+        onClick: () => {
+          importTextFile();
+        },
+        disableWhenUiLocked: true,
+      },
+      { type: "separator" },
+      {
+        type: "button",
+        label: "新規プロジェクト",
+        onClick: createNewProject,
+        disableWhenUiLocked: true,
+      },
+      {
+        type: "button",
+        label: "プロジェクトを上書き保存",
+        onClick: () => {
+          saveProject();
+        },
+        disableWhenUiLocked: true,
+      },
+      {
+        type: "button",
+        label: "プロジェクトを名前を付けて保存",
+        onClick: () => {
+          saveProjectAs();
+        },
+        disableWhenUiLocked: true,
+      },
+      {
+        type: "button",
+        label: "プロジェクト読み込み",
+        onClick: () => {
+          importProject();
+        },
+        disableWhenUiLocked: true,
+      },
+    ],
   },
-
-  setup() {
-    const store = useStore();
-    const $q = useQuasar();
-    const currentVersion = ref("");
-    window.electron.getAppInfos().then((obj) => {
-      currentVersion.value = obj.version;
-    });
-    const isSafeMode = computed(() => store.state.isSafeMode);
-    const uiLocked = computed(() => store.getters.UI_LOCKED);
-    const menubarLocked = computed(() => store.getters.MENUBAR_LOCKED);
-    const projectName = computed(() => store.getters.PROJECT_NAME);
-    const useGpu = computed(() => store.state.useGpu);
-    const isEdited = computed(() => store.getters.IS_EDITED);
-    const isFullscreen = computed(() => store.getters.IS_FULLSCREEN);
-    const engineInfos = computed(() => store.state.engineInfos);
-    const engineManifests = computed(() => store.state.engineManifests);
-
-    const titleText = computed(
-      () =>
-        (isEdited.value ? "*" : "") +
-        (projectName.value !== undefined ? projectName.value + " - " : "") +
-        "VOICEVOX" +
-        (currentVersion.value
-          ? " - Ver. " + currentVersion.value + " - "
-          : "") +
-        (useGpu.value ? "GPU" : "CPU") +
-        (isSafeMode.value ? " - セーフモード" : "")
-    );
-
-    // FIXME: App.vue内に移動する
-    watch(titleText, (newTitle) => {
-      window.document.title = newTitle;
-    });
-
-    const createNewProject = async () => {
-      if (!uiLocked.value) {
-        await store.dispatch("CREATE_NEW_PROJECT", {});
-      }
-    };
-
-    const generateAndSaveAllAudio = async () => {
-      if (!uiLocked.value) {
-        await generateAndSaveAllAudioWithDialog({
-          encoding: store.state.savingSetting.fileEncoding,
-          quasarDialog: $q.dialog,
-          dispatch: store.dispatch,
-        });
-      }
-    };
-
-    const generateAndConnectAndSaveAllAudio = async () => {
-      if (!uiLocked.value) {
-        await generateAndConnectAndSaveAudioWithDialog({
-          quasarDialog: $q.dialog,
-          dispatch: store.dispatch,
-          encoding: store.state.savingSetting.fileEncoding,
-        });
-      }
-    };
-
-    const generateAndSaveOneAudio = async () => {
-      if (uiLocked.value) return;
-
-      const activeAudioKey = store.getters.ACTIVE_AUDIO_KEY;
-      if (activeAudioKey == undefined) {
-        $q.dialog({
-          title: "テキスト欄が選択されていません",
-          message: "音声を書き出したいテキスト欄を選択してください。",
-          ok: {
-            label: "閉じる",
-            flat: true,
-            textColor: "secondary",
-          },
-        });
-        return;
-      }
-
-      await generateAndSaveOneAudioWithDialog({
-        audioKey: activeAudioKey,
-        encoding: store.state.savingSetting.fileEncoding,
-        quasarDialog: $q.dialog,
-        dispatch: store.dispatch,
-      });
-    };
-
-    const connectAndExportText = async () => {
-      if (!uiLocked.value) {
-        await connectAndExportTextWithDialog({
-          quasarDialog: $q.dialog,
-          dispatch: store.dispatch,
-          encoding: store.state.savingSetting.fileEncoding,
-        });
-      }
-    };
-
-    const importTextFile = () => {
-      if (!uiLocked.value) {
-        store.dispatch("COMMAND_IMPORT_FROM_FILE", {});
-      }
-    };
-
-    const saveProject = () => {
-      if (!uiLocked.value) {
-        store.dispatch("SAVE_PROJECT_FILE", { overwrite: true });
-      }
-    };
-
-    const saveProjectAs = () => {
-      if (!uiLocked.value) {
-        store.dispatch("SAVE_PROJECT_FILE", {});
-      }
-    };
-
-    const importProject = () => {
-      if (!uiLocked.value) {
-        store.dispatch("LOAD_PROJECT_FILE", {});
-      }
-    };
-    const closeAllDialog = () => {
-      store.dispatch("SET_DIALOG_OPEN", {
-        isSettingDialogOpen: false,
-      });
-      store.dispatch("SET_DIALOG_OPEN", {
-        isHelpDialogOpen: false,
-      });
-      store.dispatch("SET_DIALOG_OPEN", {
-        isHotkeySettingDialogOpen: false,
-      });
-      store.dispatch("SET_DIALOG_OPEN", {
-        isToolbarSettingDialogOpen: false,
-      });
-      store.dispatch("SET_DIALOG_OPEN", {
-        isCharacterOrderDialogOpen: false,
-      });
-      store.dispatch("SET_DIALOG_OPEN", {
-        isDefaultStyleSelectDialogOpen: false,
-      });
-    };
-
-    const openHelpDialog = () => {
-      store.dispatch("SET_DIALOG_OPEN", {
-        isHelpDialogOpen: true,
-      });
-    };
-
-    const menudata = ref<MenuItemData[]>([
-      {
-        type: "root",
-        label: "ファイル",
-        onClick: () => {
-          closeAllDialog();
-        },
-        disableWhenUiLocked: false,
-        subMenu: [
-          {
-            type: "button",
-            label: "音声書き出し",
-            onClick: () => {
-              generateAndSaveAllAudio();
-            },
-            disableWhenUiLocked: true,
-          },
-          {
-            type: "button",
-            label: "一つだけ書き出し",
-            onClick: () => {
-              generateAndSaveOneAudio();
-            },
-            disableWhenUiLocked: true,
-          },
-          {
-            type: "button",
-            label: "音声を繋げて書き出し",
-            onClick: () => {
-              generateAndConnectAndSaveAllAudio();
-            },
-            disableWhenUiLocked: true,
-          },
-          { type: "separator" },
-          {
-            type: "button",
-            label: "テキストを繋げて書き出し",
-            onClick: () => {
-              connectAndExportText();
-            },
-            disableWhenUiLocked: true,
-          },
-          {
-            type: "button",
-            label: "テキスト読み込み",
-            onClick: () => {
-              importTextFile();
-            },
-            disableWhenUiLocked: true,
-          },
-          { type: "separator" },
-          {
-            type: "button",
-            label: "新規プロジェクト",
-            onClick: createNewProject,
-            disableWhenUiLocked: true,
-          },
-          {
-            type: "button",
-            label: "プロジェクトを上書き保存",
-            onClick: () => {
-              saveProject();
-            },
-            disableWhenUiLocked: true,
-          },
-          {
-            type: "button",
-            label: "プロジェクトを名前を付けて保存",
-            onClick: () => {
-              saveProjectAs();
-            },
-            disableWhenUiLocked: true,
-          },
-          {
-            type: "button",
-            label: "プロジェクト読み込み",
-            onClick: () => {
-              importProject();
-            },
-            disableWhenUiLocked: true,
-          },
-        ],
-      },
-      {
-        type: "root",
-        label: "エンジン",
-        onClick: () => {
-          closeAllDialog();
-        },
-        disableWhenUiLocked: false,
-        subMenu: [],
-      },
-      {
-        type: "root",
-        label: "設定",
-        onClick: () => {
-          closeAllDialog();
-        },
-        disableWhenUiLocked: false,
-        subMenu: [
-          {
-            type: "button",
-            label: "キー割り当て",
-            onClick() {
-              store.dispatch("SET_DIALOG_OPEN", {
-                isHotkeySettingDialogOpen: true,
-              });
-            },
-            disableWhenUiLocked: false,
-          },
-          {
-            type: "button",
-            label: "ツールバーのカスタマイズ",
-            onClick() {
-              store.dispatch("SET_DIALOG_OPEN", {
-                isToolbarSettingDialogOpen: true,
-              });
-            },
-            disableWhenUiLocked: false,
-          },
-          {
-            type: "button",
-            label: "キャラクター並び替え・試聴",
-            onClick() {
-              store.dispatch("SET_DIALOG_OPEN", {
-                isCharacterOrderDialogOpen: true,
-              });
-            },
-            disableWhenUiLocked: true,
-          },
-          {
-            type: "button",
-            label: "デフォルトスタイル",
-            onClick() {
-              store.dispatch("SET_DIALOG_OPEN", {
-                isDefaultStyleSelectDialogOpen: true,
-              });
-            },
-            disableWhenUiLocked: true,
-          },
-          {
-            type: "button",
-            label: "読み方＆アクセント辞書",
-            onClick() {
-              store.dispatch("SET_DIALOG_OPEN", {
-                isDictionaryManageDialogOpen: true,
-              });
-            },
-            disableWhenUiLocked: true,
-          },
-          { type: "separator" },
-          {
-            type: "button",
-            label: "オプション",
-            onClick() {
-              store.dispatch("SET_DIALOG_OPEN", {
-                isSettingDialogOpen: true,
-              });
-            },
-            disableWhenUiLocked: false,
-          },
-        ],
-      },
+  {
+    type: "root",
+    label: "エンジン",
+    onClick: () => {
+      closeAllDialog();
+    },
+    disableWhenUiLocked: false,
+    subMenu: [],
+  },
+  {
+    type: "root",
+    label: "設定",
+    onClick: () => {
+      closeAllDialog();
+    },
+    disableWhenUiLocked: false,
+    subMenu: [
       {
         type: "button",
-        label: "ヘルプ",
-        onClick: () => {
-          if (store.state.isHelpDialogOpen) closeAllDialog();
-          else {
-            closeAllDialog();
-            openHelpDialog();
-          }
-        },
-        disableWhenUiLocked: false,
-      },
-    ]);
-
-    if (store.state.isSafeMode) {
-      (
-        menudata.value.find((data) => data.label === "設定") as MenuItemRoot
-      ).subMenu.push({
-        type: "button",
-        label: "セーフモードを解除",
+        label: "キー割り当て",
         onClick() {
-          store.dispatch("RESTART_APP", {
-            isSafeMode: false,
-          });
-        },
-        disableWhenUiLocked: false,
-      });
-    }
-
-    const subMenuOpenFlags = ref(
-      [...Array(menudata.value.length)].map(() => false)
-    );
-
-    const reassignSubMenuOpen = (idx: number) => {
-      if (subMenuOpenFlags.value[idx]) return;
-      if (subMenuOpenFlags.value.find((x) => x)) {
-        const arr = [...Array(menudata.value.length)].map(() => false);
-        arr[idx] = true;
-        subMenuOpenFlags.value = arr;
-      }
-    };
-
-    const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
-      ["新規プロジェクト", createNewProject],
-      ["音声書き出し", generateAndSaveAllAudio],
-      ["一つだけ書き出し", generateAndSaveOneAudio],
-      ["音声を繋げて書き出し", generateAndConnectAndSaveAllAudio],
-      ["テキスト読み込む", importTextFile],
-      ["プロジェクトを上書き保存", saveProject],
-      ["プロジェクトを名前を付けて保存", saveProjectAs],
-      ["プロジェクト読み込み", importProject],
-    ]);
-
-    setHotkeyFunctions(hotkeyMap);
-
-    // エンジン毎の項目を追加
-    async function updateEngines() {
-      const engineMenu = menudata.value.find(
-        (x) => x.type === "root" && x.label === "エンジン"
-      ) as MenuItemRoot;
-      if (Object.values(engineInfos.value).length === 1) {
-        const engineInfo = Object.values(engineInfos.value)[0];
-        engineMenu.subMenu = [
-          {
-            type: "button",
-            label: "再起動",
-            onClick: () => {
-              store.dispatch("RESTART_ENGINE", {
-                engineId: engineInfo.uuid,
-              });
-            },
-            disableWhenUiLocked: false,
-          },
-        ].filter((x) => x) as MenuItemData[];
-      } else {
-        engineMenu.subMenu = [
-          ...Object.values(engineInfos.value).map(
-            (engineInfo) =>
-              ({
-                type: "root",
-                label: engineInfo.name,
-                icon:
-                  engineManifests.value[engineInfo.uuid] &&
-                  base64ImageToUri(engineManifests.value[engineInfo.uuid].icon),
-                subMenu: [
-                  engineInfo.path && {
-                    type: "button",
-                    label: "フォルダを開く",
-                    onClick: () => {
-                      store.dispatch("OPEN_ENGINE_DIRECTORY", {
-                        engineId: engineInfo.uuid,
-                      });
-                    },
-                    disableWhenUiLocked: false,
-                  },
-                  {
-                    type: "button",
-                    label: "再起動",
-                    onClick: () => {
-                      store.dispatch("RESTART_ENGINE", {
-                        engineId: engineInfo.uuid,
-                      });
-                    },
-                    disableWhenUiLocked: false,
-                  },
-                ].filter((x) => x),
-              } as MenuItemRoot)
-          ),
-          {
-            type: "separator",
-          },
-          {
-            type: "button",
-            label: "全てのエンジンを再起動",
-            onClick: () => {
-              store.dispatch("RESTART_ENGINE_ALL");
-            },
-            disableWhenUiLocked: false,
-          },
-        ];
-      }
-      engineMenu.subMenu.push({
-        type: "button",
-        label: "エンジンの管理",
-        onClick: () => {
           store.dispatch("SET_DIALOG_OPEN", {
-            isEngineManageDialogOpen: true,
+            isHotkeySettingDialogOpen: true,
           });
         },
         disableWhenUiLocked: false,
-      });
-    }
-    watch([engineInfos, engineManifests], updateEngines, { immediate: true }); // engineInfos、engineManifestsを見て動的に更新できるようにする
-
-    watch(uiLocked, () => {
-      // UIのロックが解除された時に再びメニューが開かれてしまうのを防ぐ
-      if (uiLocked.value) {
-        subMenuOpenFlags.value = [...Array(menudata.value.length)].map(
-          () => false
-        );
-      }
-    });
-
-    return {
-      currentVersion,
-      uiLocked,
-      menubarLocked,
-      projectName,
-      titleText,
-      isEdited,
-      isSafeMode,
-      isFullscreen,
-      subMenuOpenFlags,
-      reassignSubMenuOpen,
-      menudata,
-      useGpu,
-    };
+      },
+      {
+        type: "button",
+        label: "ツールバーのカスタマイズ",
+        onClick() {
+          store.dispatch("SET_DIALOG_OPEN", {
+            isToolbarSettingDialogOpen: true,
+          });
+        },
+        disableWhenUiLocked: false,
+      },
+      {
+        type: "button",
+        label: "キャラクター並び替え・試聴",
+        onClick() {
+          store.dispatch("SET_DIALOG_OPEN", {
+            isCharacterOrderDialogOpen: true,
+          });
+        },
+        disableWhenUiLocked: true,
+      },
+      {
+        type: "button",
+        label: "デフォルトスタイル",
+        onClick() {
+          store.dispatch("SET_DIALOG_OPEN", {
+            isDefaultStyleSelectDialogOpen: true,
+          });
+        },
+        disableWhenUiLocked: true,
+      },
+      {
+        type: "button",
+        label: "読み方＆アクセント辞書",
+        onClick() {
+          store.dispatch("SET_DIALOG_OPEN", {
+            isDictionaryManageDialogOpen: true,
+          });
+        },
+        disableWhenUiLocked: true,
+      },
+      { type: "separator" },
+      {
+        type: "button",
+        label: "オプション",
+        onClick() {
+          store.dispatch("SET_DIALOG_OPEN", {
+            isSettingDialogOpen: true,
+          });
+        },
+        disableWhenUiLocked: false,
+      },
+    ],
   },
+  {
+    type: "button",
+    label: "ヘルプ",
+    onClick: () => {
+      if (store.state.isHelpDialogOpen) closeAllDialog();
+      else {
+        closeAllDialog();
+        openHelpDialog();
+      }
+    },
+    disableWhenUiLocked: false,
+  },
+]);
+
+if (store.state.isSafeMode) {
+  (
+    menudata.value.find((data) => data.label === "設定") as MenuItemRoot
+  ).subMenu.push({
+    type: "button",
+    label: "セーフモードを解除",
+    onClick() {
+      store.dispatch("RESTART_APP", {
+        isSafeMode: false,
+      });
+    },
+    disableWhenUiLocked: false,
+  });
+}
+
+const subMenuOpenFlags = ref(
+  [...Array(menudata.value.length)].map(() => false)
+);
+
+const reassignSubMenuOpen = (idx: number) => {
+  if (subMenuOpenFlags.value[idx]) return;
+  if (subMenuOpenFlags.value.find((x) => x)) {
+    const arr = [...Array(menudata.value.length)].map(() => false);
+    arr[idx] = true;
+    subMenuOpenFlags.value = arr;
+  }
+};
+
+const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
+  ["新規プロジェクト", createNewProject],
+  ["音声書き出し", generateAndSaveAllAudio],
+  ["一つだけ書き出し", generateAndSaveOneAudio],
+  ["音声を繋げて書き出し", generateAndConnectAndSaveAllAudio],
+  ["テキスト読み込む", importTextFile],
+  ["プロジェクトを上書き保存", saveProject],
+  ["プロジェクトを名前を付けて保存", saveProjectAs],
+  ["プロジェクト読み込み", importProject],
+]);
+
+setHotkeyFunctions(hotkeyMap);
+
+// エンジン毎の項目を追加
+async function updateEngines() {
+  const engineMenu = menudata.value.find(
+    (x) => x.type === "root" && x.label === "エンジン"
+  ) as MenuItemRoot;
+  if (Object.values(engineInfos.value).length === 1) {
+    const engineInfo = Object.values(engineInfos.value)[0];
+    engineMenu.subMenu = [
+      {
+        type: "button",
+        label: "再起動",
+        onClick: () => {
+          store.dispatch("RESTART_ENGINE", {
+            engineId: engineInfo.uuid,
+          });
+        },
+        disableWhenUiLocked: false,
+      },
+    ].filter((x) => x) as MenuItemData[];
+  } else {
+    engineMenu.subMenu = [
+      ...Object.values(engineInfos.value).map(
+        (engineInfo) =>
+          ({
+            type: "root",
+            label: engineInfo.name,
+            icon:
+              engineManifests.value[engineInfo.uuid] &&
+              base64ImageToUri(engineManifests.value[engineInfo.uuid].icon),
+            subMenu: [
+              engineInfo.path && {
+                type: "button",
+                label: "フォルダを開く",
+                onClick: () => {
+                  store.dispatch("OPEN_ENGINE_DIRECTORY", {
+                    engineId: engineInfo.uuid,
+                  });
+                },
+                disableWhenUiLocked: false,
+              },
+              {
+                type: "button",
+                label: "再起動",
+                onClick: () => {
+                  store.dispatch("RESTART_ENGINE", {
+                    engineId: engineInfo.uuid,
+                  });
+                },
+                disableWhenUiLocked: false,
+              },
+            ].filter((x) => x),
+          } as MenuItemRoot)
+      ),
+      {
+        type: "separator",
+      },
+      {
+        type: "button",
+        label: "全てのエンジンを再起動",
+        onClick: () => {
+          store.dispatch("RESTART_ENGINE_ALL");
+        },
+        disableWhenUiLocked: false,
+      },
+    ];
+  }
+  engineMenu.subMenu.push({
+    type: "button",
+    label: "エンジンの管理",
+    onClick: () => {
+      store.dispatch("SET_DIALOG_OPEN", {
+        isEngineManageDialogOpen: true,
+      });
+    },
+    disableWhenUiLocked: false,
+  });
+}
+watch([engineInfos, engineManifests], updateEngines, { immediate: true }); // engineInfos、engineManifestsを見て動的に更新できるようにする
+
+watch(uiLocked, () => {
+  // UIのロックが解除された時に再びメニューが開かれてしまうのを防ぐ
+  if (uiLocked.value) {
+    subMenuOpenFlags.value = [...Array(menudata.value.length)].map(() => false);
+  }
 });
 </script>
 
+<template>
+  <q-bar class="bg-background q-pa-none relative-position">
+    <div
+      v-if="$q.platform.is.mac && !isFullscreen"
+      class="mac-traffic-light-space"
+    ></div>
+    <img v-else src="icon.png" class="window-logo" alt="application logo" />
+    <menu-button
+      v-for="(root, index) of menudata"
+      :key="index"
+      :menudata="root"
+      v-model:selected="subMenuOpenFlags[index]"
+      :disable="menubarLocked"
+      @mouseover="reassignSubMenuOpen(index)"
+      @mouseleave="
+        root.type === 'button' ? (subMenuOpenFlags[index] = false) : undefined
+      "
+    />
+    <q-space />
+    <div class="window-title" :class="{ 'text-warning': isSafeMode }">
+      {{ titleText }}
+    </div>
+    <q-space />
+    <title-bar-buttons />
+  </q-bar>
+</template>
 <style lang="scss">
 @use '@/styles/colors' as colors;
 

--- a/src/components/MenuButton.vue
+++ b/src/components/MenuButton.vue
@@ -1,3 +1,46 @@
+<template>
+  <QBtn
+    flat
+    text-color="display"
+    class="
+      full-height
+      cursor-pointer
+      no-border-radius
+      text-no-wrap
+      q-py-none q-px-sm
+    "
+    :class="selected ? 'active-menu' : 'bg-transparent'"
+    :disable="disable"
+    @click="
+      (menudata.type === 'button' || menudata.type === 'root') &&
+        menudata.onClick()
+    "
+  >
+    {{ menudata.label }}
+    <QMenu
+      v-if="menudata.type === 'root'"
+      transition-show="none"
+      transition-hide="none"
+      :fit="true"
+      v-model="selectedComputed"
+    >
+      <QList dense>
+        <MenuItem
+          v-for="(menu, index) of menudata.subMenu"
+          :key="index"
+          :menudata="menu"
+          :disable="
+            menu.type !== 'separator' && uiLocked && menu.disableWhenUiLocked
+          "
+          v-model:selected="subMenuOpenFlags[index]"
+          @mouseenter="reassignSubMenuOpen(index)"
+          @mouseleave="reassignSubMenuOpen.cancel()"
+        />
+      </QList>
+    </QMenu>
+  </QBtn>
+</template>
+
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { debounce } from "quasar";
@@ -52,49 +95,6 @@ watch(
   }
 );
 </script>
-
-<template>
-  <QBtn
-    flat
-    text-color="display"
-    class="
-      full-height
-      cursor-pointer
-      no-border-radius
-      text-no-wrap
-      q-py-none q-px-sm
-    "
-    :class="selected ? 'active-menu' : 'bg-transparent'"
-    :disable="disable"
-    @click="
-      (menudata.type === 'button' || menudata.type === 'root') &&
-        menudata.onClick()
-    "
-  >
-    {{ menudata.label }}
-    <QMenu
-      v-if="menudata.type === 'root'"
-      transition-show="none"
-      transition-hide="none"
-      :fit="true"
-      v-model="selectedComputed"
-    >
-      <QList dense>
-        <MenuItem
-          v-for="(menu, index) of menudata.subMenu"
-          :key="index"
-          :menudata="menu"
-          :disable="
-            menu.type !== 'separator' && uiLocked && menu.disableWhenUiLocked
-          "
-          v-model:selected="subMenuOpenFlags[index]"
-          @mouseenter="reassignSubMenuOpen(index)"
-          @mouseleave="reassignSubMenuOpen.cancel()"
-        />
-      </QList>
-    </QMenu>
-  </QBtn>
-</template>
 
 <style scoped lang="scss">
 @use '@/styles/variables' as vars;

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -68,7 +68,7 @@ import { HotkeyAction } from "@/type/preload";
 
 const props =
   defineProps<{
-    selected: boolean;
+    selected?: boolean;
     menudata: MenuItemData;
   }>();
 const emit =

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -68,41 +68,41 @@ watch(
 </script>
 
 <template>
-  <q-separator class="bg-surface" v-if="menudata.type === 'separator'" />
-  <q-item
+  <QSeparator class="bg-surface" v-if="menudata.type === 'separator'" />
+  <QItem
     class="bg-background"
     v-else-if="menudata.type === 'root'"
     clickable
     dense
     :class="selected && 'active-menu'"
   >
-    <q-item-section side class="q-py-2" v-if="menudata.icon">
+    <QItemSection side class="q-py-2" v-if="menudata.icon">
       <img :src="menudata.icon" class="engine-icon" />
-    </q-item-section>
+    </QItemSection>
 
-    <q-item-section>{{ menudata.label }}</q-item-section>
+    <QItemSection>{{ menudata.label }}</QItemSection>
 
-    <q-item-section side>
-      <q-icon name="keyboard_arrow_right" />
-    </q-item-section>
+    <QItemSection side>
+      <QIcon name="keyboard_arrow_right" />
+    </QItemSection>
 
-    <q-menu
+    <QMenu
       anchor="top end"
       transition-show="none"
       transition-hide="none"
       v-model="selectedComputed"
       :target="!uiLocked"
     >
-      <menu-item
+      <MenuItem
         v-for="(menu, i) of menudata.subMenu"
         :key="i"
         :menudata="menu"
         v-model:selected="subMenuOpenFlags[i]"
         @mouseover="reassignSubMenuOpen(i)"
       />
-    </q-menu>
-  </q-item>
-  <q-item
+    </QMenu>
+  </QItem>
+  <QItem
     v-else
     dense
     clickable
@@ -111,22 +111,22 @@ watch(
     class="bg-background"
     @click="menudata.onClick"
   >
-    <q-item-section v-if="menudata.type === 'checkbox'" side class="q-pr-sm">
-      <q-icon v-if="menudata.checked" name="check" />
-      <q-icon v-else />
-    </q-item-section>
+    <QItemSection v-if="menudata.type === 'checkbox'" side class="q-pr-sm">
+      <QIcon v-if="menudata.checked" name="check" />
+      <QIcon v-else />
+    </QItemSection>
 
-    <q-item-section avatar v-if="menudata.icon">
-      <q-avatar>
+    <QItemSection avatar v-if="menudata.icon">
+      <QAvatar>
         <img :src="menudata.icon" />
-      </q-avatar>
-    </q-item-section>
+      </QAvatar>
+    </QItemSection>
 
-    <q-item-section>{{ menudata.label }}</q-item-section>
-    <q-item-section side v-if="getMenuBarHotkey(menudata.label)">
+    <QItemSection>{{ menudata.label }}</QItemSection>
+    <QItemSection side v-if="getMenuBarHotkey(menudata.label)">
       {{ getMenuBarHotkey(menudata.label) }}
-    </q-item-section>
-  </q-item>
+    </QItemSection>
+  </QItem>
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -1,3 +1,65 @@
+<template>
+  <QSeparator class="bg-surface" v-if="menudata.type === 'separator'" />
+  <QItem
+    class="bg-background"
+    v-else-if="menudata.type === 'root'"
+    clickable
+    dense
+    :class="selected && 'active-menu'"
+  >
+    <QItemSection side class="q-py-2" v-if="menudata.icon">
+      <img :src="menudata.icon" class="engine-icon" />
+    </QItemSection>
+
+    <QItemSection>{{ menudata.label }}</QItemSection>
+
+    <QItemSection side>
+      <QIcon name="keyboard_arrow_right" />
+    </QItemSection>
+
+    <QMenu
+      anchor="top end"
+      transition-show="none"
+      transition-hide="none"
+      v-model="selectedComputed"
+      :target="!uiLocked"
+    >
+      <MenuItem
+        v-for="(menu, i) of menudata.subMenu"
+        :key="i"
+        :menudata="menu"
+        v-model:selected="subMenuOpenFlags[i]"
+        @mouseover="reassignSubMenuOpen(i)"
+      />
+    </QMenu>
+  </QItem>
+  <QItem
+    v-else
+    dense
+    clickable
+    v-ripple
+    v-close-popup
+    class="bg-background"
+    @click="menudata.onClick"
+  >
+    <QItemSection v-if="menudata.type === 'checkbox'" side class="q-pr-sm">
+      <QIcon v-if="menudata.checked" name="check" />
+      <QIcon v-else />
+    </QItemSection>
+
+    <QItemSection avatar v-if="menudata.icon">
+      <QAvatar>
+        <img :src="menudata.icon" />
+      </QAvatar>
+    </QItemSection>
+
+    <QItemSection>{{ menudata.label }}</QItemSection>
+    <QItemSection side v-if="getMenuBarHotkey(menudata.label)">
+      {{ getMenuBarHotkey(menudata.label) }}
+    </QItemSection>
+  </QItem>
+</template>
+
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import type { MenuItemData } from "@/components/MenuBar.vue";
@@ -66,68 +128,6 @@ watch(
   }
 );
 </script>
-
-<template>
-  <QSeparator class="bg-surface" v-if="menudata.type === 'separator'" />
-  <QItem
-    class="bg-background"
-    v-else-if="menudata.type === 'root'"
-    clickable
-    dense
-    :class="selected && 'active-menu'"
-  >
-    <QItemSection side class="q-py-2" v-if="menudata.icon">
-      <img :src="menudata.icon" class="engine-icon" />
-    </QItemSection>
-
-    <QItemSection>{{ menudata.label }}</QItemSection>
-
-    <QItemSection side>
-      <QIcon name="keyboard_arrow_right" />
-    </QItemSection>
-
-    <QMenu
-      anchor="top end"
-      transition-show="none"
-      transition-hide="none"
-      v-model="selectedComputed"
-      :target="!uiLocked"
-    >
-      <MenuItem
-        v-for="(menu, i) of menudata.subMenu"
-        :key="i"
-        :menudata="menu"
-        v-model:selected="subMenuOpenFlags[i]"
-        @mouseover="reassignSubMenuOpen(i)"
-      />
-    </QMenu>
-  </QItem>
-  <QItem
-    v-else
-    dense
-    clickable
-    v-ripple
-    v-close-popup
-    class="bg-background"
-    @click="menudata.onClick"
-  >
-    <QItemSection v-if="menudata.type === 'checkbox'" side class="q-pr-sm">
-      <QIcon v-if="menudata.checked" name="check" />
-      <QIcon v-else />
-    </QItemSection>
-
-    <QItemSection avatar v-if="menudata.icon">
-      <QAvatar>
-        <img :src="menudata.icon" />
-      </QAvatar>
-    </QItemSection>
-
-    <QItemSection>{{ menudata.label }}</QItemSection>
-    <QItemSection side v-if="getMenuBarHotkey(menudata.label)">
-      {{ getMenuBarHotkey(menudata.label) }}
-    </QItemSection>
-  </QItem>
-</template>
 
 <style lang="scss" scoped>
 .engine-icon {

--- a/src/components/MinMaxCloseButtons.vue
+++ b/src/components/MinMaxCloseButtons.vue
@@ -85,33 +85,20 @@
   </q-badge>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import { useStore } from "@/store";
 import { mdiWindowRestore } from "@quasar/extras/mdi-v5";
 
-export default defineComponent({
-  name: "MinMaxCloseButtons",
-  setup() {
-    const store = useStore();
+const store = useStore();
 
-    const closeWindow = async () => {
-      store.dispatch("CHECK_EDITED_AND_NOT_SAVE");
-    };
-    const minimizeWindow = () => window.electron.minimizeWindow();
-    const maximizeWindow = () => window.electron.maximizeWindow();
+const closeWindow = async () => {
+  store.dispatch("CHECK_EDITED_AND_NOT_SAVE");
+};
+const minimizeWindow = () => window.electron.minimizeWindow();
+const maximizeWindow = () => window.electron.maximizeWindow();
 
-    const isMaximized = computed(() => store.state.isMaximized);
-
-    return {
-      closeWindow,
-      minimizeWindow,
-      maximizeWindow,
-      mdiWindowRestore,
-      isMaximized,
-    };
-  },
-});
+const isMaximized = computed(() => store.state.isMaximized);
 </script>
 
 <style scoped lang="scss">

--- a/src/components/OssCommunityInfo.vue
+++ b/src/components/OssCommunityInfo.vue
@@ -4,24 +4,18 @@
   </q-page>
 </template>
 
-<script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
 import { useStore } from "@/store";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
-export default defineComponent({
-  setup() {
-    const store = useStore();
-    const ossCommunityInfos = ref("");
-    const md = useMarkdownIt();
-    onMounted(async () => {
-      ossCommunityInfos.value = md.render(
-        await store.dispatch("GET_OSS_COMMUNITY_INFOS")
-      );
-    });
-    return {
-      ossCommunityInfos,
-    };
-  },
+
+const store = useStore();
+const ossCommunityInfos = ref("");
+const md = useMarkdownIt();
+onMounted(async () => {
+  ossCommunityInfos.value = md.render(
+    await store.dispatch("GET_OSS_COMMUNITY_INFOS")
+  );
 });
 </script>
 

--- a/src/components/OssLicense.vue
+++ b/src/components/OssLicense.vue
@@ -1,25 +1,43 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+defineProps<{
+  licenses: Record<string, string>[];
+}>();
+const detailIndex = ref<number | undefined>(undefined);
+
+const scroller = ref<HTMLElement>();
+
+const selectLicenseIndex = (index: number | undefined) => {
+  if (scroller.value == undefined)
+    throw new Error("scroller.value == undefined");
+  scroller.value.scrollTop = 0;
+  detailIndex.value = index;
+};
+</script>
+
 <template>
-  <q-page
+  <QPage
     ref="scroller"
     class="relative-absolute-wrapper scroller bg-background"
   >
     <div class="q-pa-md markdown-body">
-      <q-list v-if="detailIndex === undefined">
-        <q-item
+      <QList v-if="detailIndex === undefined">
+        <QItem
           v-for="(license, index) in licenses"
           :key="index"
           clickable
           dense
           @click="selectLicenseIndex(index)"
         >
-          <q-item-section>{{
+          <QItemSection>{{
             license.name + (license.version ? " | " + license.version : "")
-          }}</q-item-section>
-        </q-item>
-      </q-list>
+          }}</QItemSection>
+        </QItem>
+      </QList>
       <div v-else>
         <div class="q-mb-md">
-          <q-btn
+          <QBtn
             outline
             color="primary-light"
             icon="keyboard_arrow_left"
@@ -31,41 +49,8 @@
         <pre>{{ licenses[detailIndex].text }}</pre>
       </div>
     </div>
-  </q-page>
+  </QPage>
 </template>
-
-<script lang="ts">
-import { defineComponent, PropType, ref } from "vue";
-
-export default defineComponent({
-  name: "OssLicense",
-
-  props: {
-    licenses: {
-      type: Array as PropType<Record<string, string>[]>,
-      required: true,
-    },
-  },
-  setup() {
-    const detailIndex = ref<number | undefined>(undefined);
-
-    const scroller = ref<HTMLElement>();
-
-    const selectLicenseIndex = (index: number | undefined) => {
-      if (scroller.value == undefined)
-        throw new Error("scroller.value == undefined");
-      scroller.value.scrollTop = 0;
-      detailIndex.value = index;
-    };
-
-    return {
-      selectLicenseIndex,
-      detailIndex,
-      scroller,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/OssLicense.vue
+++ b/src/components/OssLicense.vue
@@ -1,21 +1,3 @@
-<script setup lang="ts">
-import { ref } from "vue";
-
-defineProps<{
-  licenses: Record<string, string>[];
-}>();
-const detailIndex = ref<number | undefined>(undefined);
-
-const scroller = ref<HTMLElement>();
-
-const selectLicenseIndex = (index: number | undefined) => {
-  if (scroller.value == undefined)
-    throw new Error("scroller.value == undefined");
-  scroller.value.scrollTop = 0;
-  detailIndex.value = index;
-};
-</script>
-
 <template>
   <QPage
     ref="scroller"
@@ -51,6 +33,24 @@ const selectLicenseIndex = (index: number | undefined) => {
     </div>
   </QPage>
 </template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+defineProps<{
+  licenses: Record<string, string>[];
+}>();
+const detailIndex = ref<number | undefined>(undefined);
+
+const scroller = ref<HTMLElement>();
+
+const selectLicenseIndex = (index: number | undefined) => {
+  if (scroller.value == undefined)
+    throw new Error("scroller.value == undefined");
+  scroller.value.scrollTop = 0;
+  detailIndex.value = index;
+};
+</script>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/PresetManageDialog.vue
+++ b/src/components/PresetManageDialog.vue
@@ -1,130 +1,113 @@
-<template>
-  <q-dialog :model-value="openDialog" @update:model-value="updateOpenDialog">
-    <q-card class="setting-card q-pa-md dialog-card">
-      <q-card-section>
-        <div class="text-h5">プリセット管理</div>
-      </q-card-section>
-      <q-card-actions class="q-px-md q-py-sm">
-        <div class="full-width row wrap justify-between">
-          <q-list bordered separator class="col-sm-grow">
-            <draggable
-              :modelValue="previewPresetList"
-              @update:modelValue="reorderPreset"
-              item-key="key"
-            >
-              <template v-slot:item="{ element: item }">
-                <q-item>
-                  <q-item-section>{{ item.name }}</q-item-section>
-                  <q-space />
-                  <q-item-section avatar>
-                    <q-btn
-                      icon="delete"
-                      flat
-                      color="display"
-                      @click="deletePreset(item.key)"
-                    ></q-btn>
-                  </q-item-section>
-                </q-item>
-              </template>
-            </draggable>
-            <q-item v-if="presetList.length === 0">
-              <q-item-section class="display">
-                プリセットがありません
-              </q-item-section>
-            </q-item>
-          </q-list>
-        </div>
-      </q-card-actions>
-    </q-card>
-  </q-dialog>
-</template>
-
-<script lang="ts">
-import { defineComponent, computed, ref } from "vue";
+<script setup lang="ts">
+import { computed, ref } from "vue";
 import { useQuasar } from "quasar";
 import { useStore } from "@/store";
 import draggable from "vuedraggable";
 
 import { Preset } from "@/type/preload";
 
-export default defineComponent({
-  name: "PresetManageDialog",
-  components: {
-    draggable,
-  },
+defineProps<{
+  openDialog: boolean;
+}>();
+const emit =
+  defineEmits<{
+    (e: "update:openDialog", val: boolean): void;
+  }>();
+const updateOpenDialog = (isOpen: boolean) => emit("update:openDialog", isOpen);
 
-  props: {
-    openDialog: Boolean,
-  },
+const store = useStore();
+const $q = useQuasar();
 
-  emits: ["update:openDialog"],
+const presetItems = computed(() => store.state.presetItems);
+const presetKeys = computed(() => store.state.presetKeys);
 
-  setup(props, context) {
-    const updateOpenDialog = (isOpen: boolean) =>
-      context.emit("update:openDialog", isOpen);
+const presetList = computed(() =>
+  presetKeys.value
+    .filter((key) => presetItems.value[key] != undefined)
+    .map((key) => ({
+      key,
+      ...presetItems.value[key],
+    }))
+);
 
-    const store = useStore();
-    const $q = useQuasar();
+const isPreview = ref(false);
+const previewPresetKeys = ref(store.state.presetKeys);
 
-    const presetItems = computed(() => store.state.presetItems);
-    const presetKeys = computed(() => store.state.presetKeys);
-
-    const presetList = computed(() =>
-      presetKeys.value
+const previewPresetList = computed(() =>
+  isPreview.value
+    ? previewPresetKeys.value
         .filter((key) => presetItems.value[key] != undefined)
         .map((key) => ({
           key,
           ...presetItems.value[key],
         }))
-    );
+    : presetList.value
+);
 
-    const isPreview = ref(false);
-    const previewPresetKeys = ref(store.state.presetKeys);
+const reorderPreset = (featurePresetList: (Preset & { key: string })[]) => {
+  const newPresetKeys = featurePresetList.map((item) => item.key);
+  previewPresetKeys.value = newPresetKeys;
+  isPreview.value = true;
+  store
+    .dispatch("SAVE_PRESET_ORDER", {
+      presetKeys: newPresetKeys,
+    })
+    .finally(() => (isPreview.value = false));
+};
 
-    const previewPresetList = computed(() =>
-      isPreview.value
-        ? previewPresetKeys.value
-            .filter((key) => presetItems.value[key] != undefined)
-            .map((key) => ({
-              key,
-              ...presetItems.value[key],
-            }))
-        : presetList.value
-    );
-
-    const reorderPreset = (featurePresetList: (Preset & { key: string })[]) => {
-      const newPresetKeys = featurePresetList.map((item) => item.key);
-      previewPresetKeys.value = newPresetKeys;
-      isPreview.value = true;
-      store
-        .dispatch("SAVE_PRESET_ORDER", {
-          presetKeys: newPresetKeys,
-        })
-        .finally(() => (isPreview.value = false));
-    };
-
-    const deletePreset = (key: string) => {
-      $q.dialog({
-        title: "プリセット削除の確認",
-        message: `プリセット "${presetItems.value[key].name}" を削除してもよろしいですか？`,
-        cancel: true,
-      }).onOk(async () => {
-        await store.dispatch("DELETE_PRESET", {
-          presetKey: key,
-        });
-      });
-    };
-
-    return {
-      updateOpenDialog,
-      presetList,
-      previewPresetList,
-      deletePreset,
-      reorderPreset,
-    };
-  },
-});
+const deletePreset = (key: string) => {
+  $q.dialog({
+    title: "プリセット削除の確認",
+    message: `プリセット "${presetItems.value[key].name}" を削除してもよろしいですか？`,
+    cancel: true,
+  }).onOk(async () => {
+    await store.dispatch("DELETE_PRESET", {
+      presetKey: key,
+    });
+  });
+};
 </script>
+
+<template>
+  <QDialog :model-value="openDialog" @update:model-value="updateOpenDialog">
+    <QCard class="setting-card q-pa-md dialog-card">
+      <QCardSection>
+        <div class="text-h5">プリセット管理</div>
+      </QCardSection>
+      <QCardActions class="q-px-md q-py-sm">
+        <div class="full-width row wrap justify-between">
+          <QList bordered separator class="col-sm-grow">
+            <draggable
+              :modelValue="previewPresetList"
+              @update:modelValue="reorderPreset"
+              item-key="key"
+            >
+              <template v-slot:item="{ element: item }">
+                <QItem>
+                  <QItemSection>{{ item.name }}</QItemSection>
+                  <QSpace />
+                  <QItemSection avatar>
+                    <QBtn
+                      icon="delete"
+                      flat
+                      color="display"
+                      @click="deletePreset(item.key)"
+                    ></QBtn>
+                  </QItemSection>
+                </QItem>
+              </template>
+            </draggable>
+            <QItem v-if="presetList.length === 0">
+              <QItemSection class="display">
+                プリセットがありません
+              </QItemSection>
+            </QItem>
+          </QList>
+        </div>
+      </QCardActions>
+    </QCard>
+  </QDialog>
+</template>
 
 <style>
 .dialog-card {

--- a/src/components/PresetManageDialog.vue
+++ b/src/components/PresetManageDialog.vue
@@ -1,3 +1,44 @@
+<template>
+  <QDialog :model-value="openDialog" @update:model-value="updateOpenDialog">
+    <QCard class="setting-card q-pa-md dialog-card">
+      <QCardSection>
+        <div class="text-h5">プリセット管理</div>
+      </QCardSection>
+      <QCardActions class="q-px-md q-py-sm">
+        <div class="full-width row wrap justify-between">
+          <QList bordered separator class="col-sm-grow">
+            <draggable
+              :modelValue="previewPresetList"
+              @update:modelValue="reorderPreset"
+              item-key="key"
+            >
+              <template v-slot:item="{ element: item }">
+                <QItem>
+                  <QItemSection>{{ item.name }}</QItemSection>
+                  <QSpace />
+                  <QItemSection avatar>
+                    <QBtn
+                      icon="delete"
+                      flat
+                      color="display"
+                      @click="deletePreset(item.key)"
+                    ></QBtn>
+                  </QItemSection>
+                </QItem>
+              </template>
+            </draggable>
+            <QItem v-if="presetList.length === 0">
+              <QItemSection class="display">
+                プリセットがありません
+              </QItemSection>
+            </QItem>
+          </QList>
+        </div>
+      </QCardActions>
+    </QCard>
+  </QDialog>
+</template>
+
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { useQuasar } from "quasar";
@@ -67,47 +108,6 @@ const deletePreset = (key: string) => {
   });
 };
 </script>
-
-<template>
-  <QDialog :model-value="openDialog" @update:model-value="updateOpenDialog">
-    <QCard class="setting-card q-pa-md dialog-card">
-      <QCardSection>
-        <div class="text-h5">プリセット管理</div>
-      </QCardSection>
-      <QCardActions class="q-px-md q-py-sm">
-        <div class="full-width row wrap justify-between">
-          <QList bordered separator class="col-sm-grow">
-            <draggable
-              :modelValue="previewPresetList"
-              @update:modelValue="reorderPreset"
-              item-key="key"
-            >
-              <template v-slot:item="{ element: item }">
-                <QItem>
-                  <QItemSection>{{ item.name }}</QItemSection>
-                  <QSpace />
-                  <QItemSection avatar>
-                    <QBtn
-                      icon="delete"
-                      flat
-                      color="display"
-                      @click="deletePreset(item.key)"
-                    ></QBtn>
-                  </QItemSection>
-                </QItem>
-              </template>
-            </draggable>
-            <QItem v-if="presetList.length === 0">
-              <QItemSection class="display">
-                プリセットがありません
-              </QItemSection>
-            </QItem>
-          </QList>
-        </div>
-      </QCardActions>
-    </QCard>
-  </QDialog>
-</template>
 
 <style>
 .dialog-card {

--- a/src/components/ProgressDialog.vue
+++ b/src/components/ProgressDialog.vue
@@ -1,7 +1,49 @@
+<script setup lang="ts">
+import { useStore } from "@/store";
+import { computed, onUnmounted, ref, watch } from "vue";
+
+const store = useStore();
+
+const progress = computed(() => store.getters.PROGRESS);
+const isShowProgress = ref<boolean>(false);
+const isDeterminate = ref<boolean>(false);
+
+let timeoutId: ReturnType<typeof setTimeout>;
+
+const deferredProgressStart = () => {
+  // 3秒待ってから表示する
+  timeoutId = setTimeout(() => {
+    isShowProgress.value = true;
+  }, 3000);
+};
+
+watch(progress, (newValue, oldValue) => {
+  if (newValue === -1) {
+    // → 非表示
+    clearTimeout(timeoutId);
+    isShowProgress.value = false;
+  } else if (oldValue === -1 && newValue <= 1) {
+    // 非表示 → 処理中
+    deferredProgressStart();
+    isDeterminate.value = false;
+  } else if (oldValue !== -1 && 0 < newValue) {
+    // 処理中 → 処理中(0%より大きな値)
+    // 0 < value <= 1の間のみ進捗を%で表示する
+    isDeterminate.value = true;
+  }
+});
+
+onUnmounted(() => clearTimeout(timeoutId));
+
+const formattedProgress = computed(() =>
+  (store.getters.PROGRESS * 100).toFixed()
+);
+</script>
+
 <template>
   <div v-if="isShowProgress" class="progress">
     <div>
-      <q-circular-progress
+      <QCircularProgress
         v-if="isDeterminate"
         show-value
         :value="progress"
@@ -14,8 +56,8 @@
         :thickness="0.3"
       >
         {{ formattedProgress }}%
-      </q-circular-progress>
-      <q-circular-progress
+      </QCircularProgress>
+      <QCircularProgress
         v-if="!isDeterminate"
         indeterminate
         color="primary"
@@ -27,61 +69,6 @@
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import { useStore } from "@/store";
-import { computed, defineComponent, onUnmounted, ref, watch } from "vue";
-
-export default defineComponent({
-  name: "ProgressDialog",
-
-  setup() {
-    const store = useStore();
-
-    const progress = computed(() => store.getters.PROGRESS);
-    const isShowProgress = ref<boolean>(false);
-    const isDeterminate = ref<boolean>(false);
-
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    const deferredProgressStart = () => {
-      // 3秒待ってから表示する
-      timeoutId = setTimeout(() => {
-        isShowProgress.value = true;
-      }, 3000);
-    };
-
-    watch(progress, (newValue, oldValue) => {
-      if (newValue === -1) {
-        // → 非表示
-        clearTimeout(timeoutId);
-        isShowProgress.value = false;
-      } else if (oldValue === -1 && newValue <= 1) {
-        // 非表示 → 処理中
-        deferredProgressStart();
-        isDeterminate.value = false;
-      } else if (oldValue !== -1 && 0 < newValue) {
-        // 処理中 → 処理中(0%より大きな値)
-        // 0 < value <= 1の間のみ進捗を%で表示する
-        isDeterminate.value = true;
-      }
-    });
-
-    onUnmounted(() => clearTimeout(timeoutId));
-
-    const formattedProgress = computed(() =>
-      (store.getters.PROGRESS * 100).toFixed()
-    );
-
-    return {
-      isShowProgress,
-      isDeterminate,
-      progress,
-      formattedProgress,
-    };
-  },
-});
-</script>
 
 <style lang="scss" scoped>
 @use '@/styles/colors' as colors;

--- a/src/components/ProgressDialog.vue
+++ b/src/components/ProgressDialog.vue
@@ -1,3 +1,33 @@
+<template>
+  <div v-if="isShowProgress" class="progress">
+    <div>
+      <QCircularProgress
+        v-if="isDeterminate"
+        show-value
+        :value="progress"
+        :min="0"
+        :max="1"
+        rounded
+        font-size="12px"
+        color="primary"
+        size="xl"
+        :thickness="0.3"
+      >
+        {{ formattedProgress }}%
+      </QCircularProgress>
+      <QCircularProgress
+        v-if="!isDeterminate"
+        indeterminate
+        color="primary"
+        rounded
+        :thickness="0.3"
+        size="xl"
+      />
+      <div class="q-mt-md">生成中です...</div>
+    </div>
+  </div>
+</template>
+
 <script setup lang="ts">
 import { useStore } from "@/store";
 import { computed, onUnmounted, ref, watch } from "vue";
@@ -39,36 +69,6 @@ const formattedProgress = computed(() =>
   (store.getters.PROGRESS * 100).toFixed()
 );
 </script>
-
-<template>
-  <div v-if="isShowProgress" class="progress">
-    <div>
-      <QCircularProgress
-        v-if="isDeterminate"
-        show-value
-        :value="progress"
-        :min="0"
-        :max="1"
-        rounded
-        font-size="12px"
-        color="primary"
-        size="xl"
-        :thickness="0.3"
-      >
-        {{ formattedProgress }}%
-      </QCircularProgress>
-      <QCircularProgress
-        v-if="!isDeterminate"
-        indeterminate
-        color="primary"
-        rounded
-        :thickness="0.3"
-        size="xl"
-      />
-      <div class="q-mt-md">生成中です...</div>
-    </div>
-  </div>
-</template>
 
 <style lang="scss" scoped>
 @use '@/styles/colors' as colors;

--- a/src/components/QAndA.vue
+++ b/src/components/QAndA.vue
@@ -1,31 +1,23 @@
-<template>
-  <q-page class="relative-absolute-wrapper scroller bg-background">
-    <div class="q-pa-md markdown markdown-body" v-html="qAndA"></div>
-  </q-page>
-</template>
-
-<script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
 import { useStore } from "@/store";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
 
-export default defineComponent({
-  setup() {
-    const store = useStore();
-    const qAndA = ref("");
+const store = useStore();
+const qAndA = ref("");
 
-    const md = useMarkdownIt();
+const md = useMarkdownIt();
 
-    onMounted(async () => {
-      qAndA.value = md.render(await store.dispatch("GET_Q_AND_A_TEXT"));
-    });
-
-    return {
-      qAndA,
-    };
-  },
+onMounted(async () => {
+  qAndA.value = md.render(await store.dispatch("GET_Q_AND_A_TEXT"));
 });
 </script>
+
+<template>
+  <QPage class="relative-absolute-wrapper scroller bg-background">
+    <div class="q-pa-md markdown markdown-body" v-html="qAndA"></div>
+  </QPage>
+</template>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/QAndA.vue
+++ b/src/components/QAndA.vue
@@ -1,3 +1,9 @@
+<template>
+  <QPage class="relative-absolute-wrapper scroller bg-background">
+    <div class="q-pa-md markdown markdown-body" v-html="qAndA"></div>
+  </QPage>
+</template>
+
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 import { useStore } from "@/store";
@@ -12,12 +18,6 @@ onMounted(async () => {
   qAndA.value = md.render(await store.dispatch("GET_Q_AND_A_TEXT"));
 });
 </script>
-
-<template>
-  <QPage class="relative-absolute-wrapper scroller bg-background">
-    <div class="q-pa-md markdown markdown-body" v-html="qAndA"></div>
-  </QPage>
-</template>
 
 <style scoped lang="scss">
 .root {

--- a/src/components/SaveAllResultDialog.vue
+++ b/src/components/SaveAllResultDialog.vue
@@ -1,79 +1,71 @@
 <template>
-  <q-dialog persistent ref="dialogRef">
+  <QDialog persistent ref="dialogRef">
     <!-- 仮デザイン -->
-    <q-layout container class="q-dialog-plugin bg-background">
-      <q-header>
-        <q-toolbar>
-          <q-toolbar-title class="text-display"
-            >音声書き出し結果</q-toolbar-title
-          >
-        </q-toolbar>
-        <q-space />
-      </q-header>
-      <q-page-container>
-        <q-page>
-          <q-list separator v-if="writeErrorArray.length > 0">
+    <QLayout container class="q-dialog-plugin bg-background">
+      <QHeader>
+        <QToolbar>
+          <QToolbarTitle class="text-display">音声書き出し結果</QToolbarTitle>
+        </QToolbar>
+        <QSpace />
+      </QHeader>
+      <QPageContainer>
+        <QPage>
+          <QList separator v-if="writeErrorArray.length > 0">
             <div class="error">失敗（書き込みエラー）:</div>
-            <q-item v-for="(value, index) in writeErrorArray" :key="index">
-              <q-item-section>
-                <q-item-label>{{ value.path }}</q-item-label>
-                <q-item-label>詳細：{{ value.message }}</q-item-label>
-              </q-item-section>
-            </q-item>
-          </q-list>
-          <q-list separator v-if="engineErrorArray.length > 0">
+            <QItem v-for="(value, index) in writeErrorArray" :key="index">
+              <QItemSection>
+                <QItemLabel>{{ value.path }}</QItemLabel>
+                <QItemLabel>詳細：{{ value.message }}</QItemLabel>
+              </QItemSection>
+            </QItem>
+          </QList>
+          <QList separator v-if="engineErrorArray.length > 0">
             <div class="error">失敗（エンジンエラー）:</div>
-            <q-item v-for="(value, index) in engineErrorArray" :key="index">
-              <q-item-section>
-                <q-item-label>{{ value }}</q-item-label>
-              </q-item-section>
-            </q-item>
-          </q-list>
-          <q-list separator v-if="successArray.length > 0">
+            <QItem v-for="(value, index) in engineErrorArray" :key="index">
+              <QItemSection>
+                <QItemLabel>{{ value }}</QItemLabel>
+              </QItemSection>
+            </QItem>
+          </QList>
+          <QList separator v-if="successArray.length > 0">
             <div class="success">成功:</div>
-            <q-item v-for="(value, index) in successArray" :key="index">
-              <q-item-section>
-                <q-item-label>{{ value }}</q-item-label>
-              </q-item-section>
-            </q-item>
-          </q-list>
-        </q-page>
-      </q-page-container>
-      <q-footer>
-        <q-toolbar>
-          <q-space />
-          <q-btn flat dense align="right" @click="close" label="閉じる" />
-        </q-toolbar>
-      </q-footer>
-    </q-layout>
-  </q-dialog>
+            <QItem v-for="(value, index) in successArray" :key="index">
+              <QItemSection>
+                <QItemLabel>{{ value }}</QItemLabel>
+              </QItemSection>
+            </QItem>
+          </QList>
+        </QPage>
+      </QPageContainer>
+      <QFooter>
+        <QToolbar>
+          <QSpace />
+          <QBtn flat dense align="right" @click="close" label="閉じる" />
+        </QToolbar>
+      </QFooter>
+    </QLayout>
+  </QDialog>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
+<script setup lang="ts">
+import { WriteErrorTypeForSaveAllResultDialog } from "@/store/type";
 import { useDialogPluginComponent } from "quasar";
 
-export default defineComponent({
-  name: "SaveAllResultDialog",
-  props: {
-    successArray: Array,
-    writeErrorArray: Array,
-    engineErrorArray: Array,
-  },
-  emits: {
-    ...useDialogPluginComponent.emits,
-  },
-  setup() {
-    const { dialogRef, onDialogOK } = useDialogPluginComponent();
-    const close = () => onDialogOK();
-    return {
-      dialogRef,
-      close,
-    };
-  },
-});
+withDefaults(
+  defineProps<{
+    successArray: (string | undefined)[];
+    writeErrorArray: WriteErrorTypeForSaveAllResultDialog[];
+    engineErrorArray: (string | undefined)[];
+  }>(),
+  {
+    successArray: () => [],
+    writeErrorArray: () => [],
+    engineErrorArray: () => [],
+  }
+);
+const { dialogRef, onDialogOK } = useDialogPluginComponent();
+const close = () => onDialogOK();
 </script>
-
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;
 

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -1,41 +1,41 @@
 <template>
-  <q-dialog
+  <QDialog
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="setting-dialog transparent-backdrop"
     v-model="settingDialogOpenedComputed"
   >
-    <q-layout container view="hHh Lpr fFf" class="bg-background">
-      <q-page-container class="root">
-        <q-header class="q-pa-sm">
-          <q-toolbar>
-            <q-toolbar-title class="text-display"
-              >設定 / オプション</q-toolbar-title
+    <QLayout container view="hHh Lpr fFf" class="bg-background">
+      <QPageContainer class="root">
+        <QHeader class="q-pa-sm">
+          <QToolbar>
+            <QToolbarTitle class="text-display"
+              >設定 / オプション</QToolbarTitle
             >
-            <q-space />
+            <QSpace />
             <!-- close button -->
-            <q-btn
+            <QBtn
               round
               flat
               icon="close"
               color="display"
               @click="settingDialogOpenedComputed = false"
             />
-          </q-toolbar>
-        </q-header>
-        <q-page ref="scroller" class="scroller">
+          </QToolbar>
+        </QHeader>
+        <QPage ref="scroller" class="scroller">
           <div class="q-pa-md row items-start q-gutter-md">
             <!-- Engine Mode Card -->
-            <q-card flat class="setting-card">
-              <q-card-actions>
+            <QCard flat class="setting-card">
+              <QCardActions>
                 <div class="text-h5">エンジン</div>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-sm bg-surface">
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-sm bg-surface">
                 <div>エンジンモード</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -44,11 +44,11 @@
                     >
                       GPU モードの利用には GPU が必要です。Linux は
                       NVIDIA&trade; 製 GPU のみ対応しています。
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-btn-toggle
+                <QSpace />
+                <QBtnToggle
                   padding="xs md"
                   unelevated
                   v-model="engineMode"
@@ -61,19 +61,19 @@
                     { label: 'GPU', value: 'switchGPU' },
                   ]"
                 >
-                </q-btn-toggle>
-              </q-card-actions>
-            </q-card>
+                </QBtnToggle>
+              </QCardActions>
+            </QCard>
             <!-- Preservation Setting -->
-            <q-card flat class="setting-card">
-              <q-card-actions>
+            <QCard flat class="setting-card">
+              <QCardActions>
                 <div class="text-h5">操作</div>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-sm bg-surface">
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-sm bg-surface">
                 <div>パラメータの引き継ぎ</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -81,21 +81,21 @@
                       transition-hide="jump-right"
                     >
                       テキスト欄を追加する際、現在の話速等のパラメータを引き継ぎます
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-toggle
+                <QSpace />
+                <QToggle
                   :model-value="inheritAudioInfoMode"
                   @update:model-value="changeinheritAudioInfo($event)"
                 >
-                </q-toggle>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-sm bg-surface">
+                </QToggle>
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-sm bg-surface">
                 <div>再生位置を追従</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -103,12 +103,12 @@
                       transition-hide="jump-right"
                     >
                       再生位置を追従し、自動でスクロールするモードを選ぶことができます
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
+                <QSpace />
                 <div class="scroll-mode-toggle">
-                  <q-radio
+                  <QRadio
                     v-for="(obj, key) in activePointScrollModeOptions"
                     :key="key"
                     v-model="activePointScrollMode"
@@ -127,7 +127,7 @@
                       key === 'OFF' && 'border-radius: 0 3px 3px 0',
                     ]"
                   >
-                    <q-tooltip
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -136,15 +136,15 @@
                     >
                       再生位置を追従し、自動でスクロールします。
                       {{ `「${obj.label}」モードは${obj.desc}` }}
-                    </q-tooltip>
-                  </q-radio>
+                    </QTooltip>
+                  </QRadio>
                 </div>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-sm bg-surface">
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-sm bg-surface">
                 <div>テキスト分割の挙動</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -152,11 +152,11 @@
                       transition-hide="jump-right"
                     >
                       テキストを貼り付け時に行われる分割の挙動を変えます
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-btn-toggle
+                <QSpace />
+                <QBtnToggle
                   padding="xs md"
                   unelevated
                   :model-value="splitTextWhenPaste"
@@ -180,7 +180,7 @@
                   ]"
                 >
                   <template v-slot:splitTextPeriodAndNewLine>
-                    <q-tooltip
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -188,10 +188,10 @@
                       transition-hide="jump-right"
                     >
                       句点と改行を基にテキストを分割します。
-                    </q-tooltip>
+                    </QTooltip>
                   </template>
                   <template v-slot:splitTextNewLine>
-                    <q-tooltip
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -199,10 +199,10 @@
                       transition-hide="jump-right"
                     >
                       改行のみを基にテキストを分割します。
-                    </q-tooltip>
+                    </QTooltip>
                   </template>
                   <template v-slot:splitTextOFF>
-                    <q-tooltip
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -210,21 +210,21 @@
                       transition-hide="jump-right"
                     >
                       分割を行いません。
-                    </q-tooltip>
+                    </QTooltip>
                   </template>
-                </q-btn-toggle>
-              </q-card-actions>
-            </q-card>
+                </QBtnToggle>
+              </QCardActions>
+            </QCard>
             <!-- Saving Card -->
-            <q-card flat class="setting-card">
-              <q-card-actions>
+            <QCard flat class="setting-card">
+              <QCardActions>
                 <div class="text-h5">保存</div>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-sm bg-surface">
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-sm bg-surface">
                 <div>文字コード</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -232,11 +232,11 @@
                       transition-hide="jump-right"
                     >
                       文字コードを選ぶことができます
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-btn-toggle
+                <QSpace />
+                <QBtnToggle
                   padding="xs md"
                   unelevated
                   :model-value="savingSetting.fileEncoding"
@@ -252,12 +252,12 @@
                     { label: 'Shift_JIS', value: 'Shift_JIS' },
                   ]"
                 />
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>書き出し先を固定</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -265,11 +265,11 @@
                       transition-hide="jump-right"
                     >
                       音声ファイルを設定したフォルダに書き出す
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-input
+                <QSpace />
+                <QInput
                   dense
                   v-if="savingSetting.fixedExportEnabled"
                   maxheight="10px"
@@ -287,7 +287,7 @@
                   "
                 >
                   <template v-slot:append>
-                    <q-btn
+                    <QBtn
                       square
                       dense
                       flat
@@ -295,30 +295,30 @@
                       icon="folder_open"
                       @click="openFileExplore"
                     >
-                      <q-tooltip :delay="500" anchor="bottom left">
+                      <QTooltip :delay="500" anchor="bottom left">
                         フォルダ選択
-                      </q-tooltip>
-                    </q-btn>
+                      </QTooltip>
+                    </QBtn>
                   </template>
-                </q-input>
-                <q-toggle
+                </QInput>
+                <QToggle
                   :model-value="savingSetting.fixedExportEnabled"
                   @update:model-value="
                     handleSavingSettingChange('fixedExportEnabled', $event)
                   "
                 >
-                </q-toggle>
-              </q-card-actions>
+                </QToggle>
+              </QCardActions>
 
-              <file-name-pattern-dialog
+              <FileNamePatternDialog
                 v-model:open-dialog="showsFilePatternEditDialog"
               />
 
-              <q-card-actions class="q-px-md q-py-sm bg-surface">
+              <QCardActions class="q-px-md q-py-sm bg-surface">
                 <div>書き出しファイル名パターン</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -326,14 +326,14 @@
                       transition-hide="jump-right"
                     >
                       書き出すファイル名のパターンをカスタマイズする
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
+                <QSpace />
                 <div class="q-px-sm text-ellipsis">
                   {{ savingSetting.fileNamePattern }}
                 </div>
-                <q-btn
+                <QBtn
                   label="編集"
                   unelevated
                   color="background"
@@ -341,13 +341,13 @@
                   class="text-no-wrap q-mr-sm"
                   @click="showsFilePatternEditDialog = true"
                 />
-              </q-card-actions>
+              </QCardActions>
 
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>上書き防止</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -355,23 +355,23 @@
                       transition-hide="jump-right"
                     >
                       上書きせずにファイルを連番で保存します
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-toggle
+                <QSpace />
+                <QToggle
                   :model-value="savingSetting.avoidOverwrite"
                   @update:model-value="
                     handleSavingSettingChange('avoidOverwrite', $event)
                   "
                 >
-                </q-toggle>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+                </QToggle>
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>txtファイルを書き出し</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -379,24 +379,24 @@
                       transition-hide="jump-right"
                     >
                       テキストをtxtファイルとして書き出します
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-toggle
+                <QSpace />
+                <QToggle
                   :model-value="savingSetting.exportText"
                   color="primary"
                   @update:model-value="
                     handleSavingSettingChange('exportText', $event)
                   "
                 >
-                </q-toggle>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+                </QToggle>
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>labファイルを書き出し</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -404,29 +404,29 @@
                       transition-hide="jump-right"
                     >
                       リップシンク用のlabファイルを書き出します
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-toggle
+                <QSpace />
+                <QToggle
                   :model-value="savingSetting.exportLab"
                   @update:model-value="
                     handleSavingSettingChange('exportLab', $event)
                   "
                 >
-                </q-toggle>
-              </q-card-actions>
-            </q-card>
+                </QToggle>
+              </QCardActions>
+            </QCard>
             <!-- Experimental Card -->
-            <q-card flat class="setting-card">
-              <q-card-actions>
+            <QCard flat class="setting-card">
+              <QCardActions>
                 <div class="text-h5">高度な設定</div>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>音声をステレオ化</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -434,23 +434,23 @@
                       transition-hide="jump-right"
                     >
                       音声データをモノラルからステレオに変換してから再生・保存を行います
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-toggle
+                <QSpace />
+                <QToggle
                   :model-value="savingSetting.outputStereo"
                   @update:model-value="
                     handleSavingSettingChange('outputStereo', $event)
                   "
                 >
-                </q-toggle>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+                </QToggle>
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>再生デバイス</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -458,24 +458,24 @@
                       transition-hide="jump-right"
                     >
                       音声の再生デバイスを変更し再生を行います
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-select
+                <QSpace />
+                <QSelect
                   dense
                   v-model="currentAudioOutputDeviceComputed"
                   label="再生デバイス"
                   :options="availableAudioOutputDevices"
                   class="col-7"
                 >
-                </q-select>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+                </QSelect>
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>音声のサンプリングレート</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -483,11 +483,11 @@
                       transition-hide="jump-right"
                     >
                       再生・保存時の音声のサンプリングレートを変更します（サンプリングレートを上げても音声の品質は上がりません。）
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-select
+                <QSpace />
+                <QSelect
                   borderless
                   name="samplingRate"
                   :model-value="savingSetting.outputSamplingRate"
@@ -500,18 +500,18 @@
                     handleSavingSettingChange('outputSamplingRate', $event)
                   "
                 >
-                </q-select>
-              </q-card-actions>
-            </q-card>
-            <q-card flat class="setting-card">
-              <q-card-actions>
+                </QSelect>
+              </QCardActions>
+            </QCard>
+            <QCard flat class="setting-card">
+              <QCardActions>
                 <div class="text-h5">実験的機能</div>
-              </q-card-actions>
+              </QCardActions>
               <!-- 今後実験的機能を追加する場合はここに追加 -->
-              <q-card-actions class="q-px-md q-py-sm bg-surface">
+              <QCardActions class="q-px-md q-py-sm bg-surface">
                 <div>テーマ</div>
-                <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                  <q-tooltip
+                <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                  <QTooltip
                     :delay="500"
                     anchor="center left"
                     self="center right"
@@ -519,10 +519,10 @@
                     transition-hide="jump-right"
                   >
                     エディタの外観を変更します
-                  </q-tooltip>
-                </q-icon>
-                <q-space />
-                <q-btn-toggle
+                  </QTooltip>
+                </QIcon>
+                <QSpace />
+                <QBtnToggle
                   unelevated
                   padding="xs md"
                   color="background"
@@ -532,12 +532,12 @@
                   v-model="currentThemeNameComputed"
                   :options="availableThemeNameComputed"
                 />
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>プリセット機能</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -545,23 +545,23 @@
                       transition-hide="jump-right"
                     >
                       プリセット機能を有効にする
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-toggle
+                <QSpace />
+                <QToggle
                   :model-value="experimentalSetting.enablePreset"
                   @update:model-value="
                     changeExperimentalSetting('enablePreset', $event)
                   "
                 >
-                </q-toggle>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+                </QToggle>
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>疑問文を自動調整</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -569,11 +569,11 @@
                       transition-hide="jump-right"
                     >
                       疑問文のとき語尾の音高を自動的に上げる
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-toggle
+                <QSpace />
+                <QToggle
                   :model-value="experimentalSetting.enableInterrogativeUpspeak"
                   @update:model-value="
                     changeExperimentalSetting(
@@ -582,18 +582,18 @@
                     )
                   "
                 >
-                </q-toggle>
-              </q-card-actions>
-            </q-card>
-            <q-card flat class="setting-card">
-              <q-card-actions>
+                </QToggle>
+              </QCardActions>
+            </QCard>
+            <QCard flat class="setting-card">
+              <QCardActions>
                 <div class="text-h5">データ収集</div>
-              </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+              </QCardActions>
+              <QCardActions class="q-px-md q-py-none bg-surface">
                 <div>ソフトウェア利用状況のデータ収集を許可する</div>
                 <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
+                  <QIcon name="help_outline" size="sm" class="help-hover-icon">
+                    <QTooltip
                       :delay="500"
                       anchor="center left"
                       self="center right"
@@ -601,22 +601,22 @@
                       transition-hide="jump-right"
                     >
                       各UIの利用率などのデータを送信してVOICEVOXの改善に役立てます。テキストデータ・音声データは送信しません。
-                    </q-tooltip>
-                  </q-icon>
+                    </QTooltip>
+                  </QIcon>
                 </div>
-                <q-space />
-                <q-toggle v-model="acceptRetrieveTelemetryComputed" />
-              </q-card-actions>
-            </q-card>
+                <QSpace />
+                <QToggle v-model="acceptRetrieveTelemetryComputed" />
+              </QCardActions>
+            </QCard>
           </div>
-        </q-page>
-      </q-page-container>
-    </q-layout>
-  </q-dialog>
+        </QPage>
+      </QPageContainer>
+    </QLayout>
+  </QDialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, ref } from "vue";
+<script setup lang="ts">
+import { computed, ref } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
 import {
@@ -627,263 +627,219 @@ import {
 } from "@/type/preload";
 import FileNamePatternDialog from "./FileNamePatternDialog.vue";
 
-export default defineComponent({
-  name: "SettingDialog",
+const props =
+  defineProps<{
+    modelValue: boolean;
+  }>();
+const emit =
+  defineEmits<{
+    (e: "update:modelValue", v: boolean): void;
+  }>();
 
-  components: {
-    FileNamePatternDialog,
-  },
+const store = useStore();
+const $q = useQuasar();
 
-  props: {
-    modelValue: {
-      type: Boolean,
-      required: true,
-    },
-  },
+const settingDialogOpenedComputed = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
 
-  setup(props, { emit }) {
-    const store = useStore();
-    const $q = useQuasar();
-
-    const settingDialogOpenedComputed = computed({
-      get: () => props.modelValue,
-      set: (val) => emit("update:modelValue", val),
-    });
-
-    const engineMode = computed({
-      get: () => (store.state.useGpu ? "switchGPU" : "switchCPU"),
-      set: (mode: string) => {
-        changeUseGPU(mode == "switchGPU" ? true : false);
-      },
-    });
-    const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
-    const activePointScrollMode = computed({
-      get: () => store.state.activePointScrollMode,
-      set: (activePointScrollMode: ActivePointScrollMode) => {
-        store.dispatch("SET_ACTIVE_POINT_SCROLL_MODE", {
-          activePointScrollMode,
-        });
-      },
-    });
-    const activePointScrollModeOptions: Record<
-      ActivePointScrollMode,
-      {
-        label: string;
-        desc: string;
-      }
-    > = {
-      CONTINUOUSLY: {
-        label: "連続",
-        desc: "再生位置を真ん中に表示します。",
-      },
-      PAGE: {
-        label: "ページめくり",
-        desc: "再生位置が表示範囲外にある場合にスクロールします。",
-      },
-      OFF: {
-        label: "オフ",
-        desc: "自動でスクロールしません。",
-      },
-    };
-
-    const experimentalSetting = computed(() => store.state.experimentalSetting);
-
-    const currentThemeNameComputed = computed({
-      get: () => store.state.themeSetting.currentTheme,
-      set: (currentTheme: string) => {
-        store.dispatch("SET_THEME_SETTING", { currentTheme: currentTheme });
-      },
-    });
-
-    const currentThemeComputed = computed(() =>
-      store.state.themeSetting.availableThemes.find((value) => {
-        return value.name == currentThemeNameComputed.value;
-      })
-    );
-
-    const availableThemeNameComputed = computed(() => {
-      return [...store.state.themeSetting.availableThemes]
-        .sort((a, b) => a.order - b.order)
-        .map((theme) => {
-          return { label: theme.displayName, value: theme.name };
-        });
-    });
-
-    const currentAudioOutputDeviceComputed = computed<{
-      key: string;
-      label: string;
-    } | null>({
-      get: () => {
-        // 再生デバイスが見つからなかったらデフォルト値に戻す
-        const device = availableAudioOutputDevices.value?.find(
-          (device) => device.key === store.state.savingSetting.audioOutputDevice
-        );
-        if (device) {
-          return device;
-        } else {
-          handleSavingSettingChange("audioOutputDevice", "default");
-          return null;
-        }
-      },
-      set: (device) => {
-        if (device) {
-          handleSavingSettingChange("audioOutputDevice", device.key);
-        }
-      },
-    });
-
-    const availableAudioOutputDevices = ref<{ key: string; label: string }[]>();
-    const updateAudioOutputDevices = async () => {
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      availableAudioOutputDevices.value = devices
-        .filter((device) => device.kind === "audiooutput")
-        .map((device) => {
-          return { label: device.label, key: device.deviceId };
-        });
-    };
-    navigator.mediaDevices.addEventListener(
-      "devicechange",
-      updateAudioOutputDevices
-    );
-    updateAudioOutputDevices();
-
-    const acceptRetrieveTelemetryComputed = computed({
-      get: () => store.state.acceptRetrieveTelemetry == "Accepted",
-      set: (acceptRetrieveTelemetry: boolean) => {
-        store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
-          acceptRetrieveTelemetry: acceptRetrieveTelemetry
-            ? "Accepted"
-            : "Refused",
-        });
-
-        if (acceptRetrieveTelemetry) {
-          return;
-        }
-
-        $q.dialog({
-          title: "ソフトウェア利用状況のデータ収集の無効化",
-          message:
-            "ソフトウェア利用状況のデータ収集を完全に無効にするには、VOICEVOXを再起動する必要があります",
-          ok: {
-            flat: true,
-            textColor: "display",
-          },
-        });
-      },
-    });
-
-    const changeUseGPU = async (useGpu: boolean) => {
-      if (store.state.useGpu === useGpu) return;
-
-      $q.loading.show({
-        spinnerColor: "primary",
-        spinnerSize: 50,
-        boxClass: "bg-background text-display",
-        message: "起動モードを変更中です",
-      });
-
-      await store.dispatch("CHANGE_USE_GPU", { useGpu });
-
-      $q.loading.hide();
-    };
-
-    const changeinheritAudioInfo = async (inheritAudioInfo: boolean) => {
-      if (store.state.inheritAudioInfo === inheritAudioInfo) return;
-      store.dispatch("SET_INHERIT_AUDIOINFO", { inheritAudioInfo });
-    };
-
-    const changeExperimentalSetting = async (
-      key: keyof ExperimentalSetting,
-      data: boolean
-    ) => {
-      store.dispatch("SET_EXPERIMENTAL_SETTING", {
-        experimentalSetting: { ...experimentalSetting.value, [key]: data },
-      });
-    };
-
-    const restartAllEngineProcess = () => {
-      store.dispatch("RESTART_ENGINE_ALL");
-    };
-
-    const savingSetting = computed(() => store.state.savingSetting);
-
-    const handleSavingSettingChange = (
-      key: keyof SavingSetting,
-      data: string | boolean | number
-    ) => {
-      const storeDispatch = (): void => {
-        store.dispatch("SET_SAVING_SETTING", {
-          data: { ...savingSetting.value, [key]: data },
-        });
-      };
-      if (key === "outputSamplingRate" && data !== "default") {
-        $q.dialog({
-          title: "出力サンプリングレートを変更します",
-          message:
-            "出力サンプリングレートを変更しても、音質は変化しません。また、音声の生成処理に若干時間がかかる場合があります。<br />変更しますか？",
-          html: true,
-          persistent: true,
-          ok: {
-            label: "変更する",
-            flat: true,
-            textColor: "display",
-          },
-          cancel: {
-            label: "変更しない",
-            flat: true,
-            textColor: "display",
-          },
-        }).onOk(storeDispatch);
-        return;
-      }
-      storeDispatch();
-    };
-
-    const openFileExplore = async () => {
-      const path = await window.electron.showOpenDirectoryDialog({
-        title: "書き出し先のフォルダを選択",
-      });
-      if (path) {
-        store.dispatch("SET_SAVING_SETTING", {
-          data: { ...savingSetting.value, fixedExportDir: path },
-        });
-      }
-    };
-
-    const splitTextWhenPaste = computed(() => store.state.splitTextWhenPaste);
-    const changeSplitTextWhenPaste = (
-      splitTextWhenPaste: SplitTextWhenPasteType
-    ) => {
-      store.dispatch("SET_SPLIT_TEXT_WHEN_PASTE", { splitTextWhenPaste });
-    };
-
-    const showsFilePatternEditDialog = ref(false);
-
-    return {
-      settingDialogOpenedComputed,
-      engineMode,
-      inheritAudioInfoMode,
-      activePointScrollMode,
-      activePointScrollModeOptions,
-      experimentalSetting,
-      currentAudioOutputDeviceComputed,
-      availableAudioOutputDevices,
-      changeinheritAudioInfo,
-      changeExperimentalSetting,
-      restartAllEngineProcess,
-      savingSetting,
-      handleSavingSettingChange,
-      openFileExplore,
-      currentThemeNameComputed,
-      currentThemeComputed,
-      availableThemeNameComputed,
-      acceptRetrieveTelemetryComputed,
-      splitTextWhenPaste,
-      changeSplitTextWhenPaste,
-      showsFilePatternEditDialog,
-    };
+const engineMode = computed({
+  get: () => (store.state.useGpu ? "switchGPU" : "switchCPU"),
+  set: (mode: string) => {
+    changeUseGPU(mode == "switchGPU" ? true : false);
   },
 });
+const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
+const activePointScrollMode = computed({
+  get: () => store.state.activePointScrollMode,
+  set: (activePointScrollMode: ActivePointScrollMode) => {
+    store.dispatch("SET_ACTIVE_POINT_SCROLL_MODE", {
+      activePointScrollMode,
+    });
+  },
+});
+const activePointScrollModeOptions: Record<
+  ActivePointScrollMode,
+  {
+    label: string;
+    desc: string;
+  }
+> = {
+  CONTINUOUSLY: {
+    label: "連続",
+    desc: "再生位置を真ん中に表示します。",
+  },
+  PAGE: {
+    label: "ページめくり",
+    desc: "再生位置が表示範囲外にある場合にスクロールします。",
+  },
+  OFF: {
+    label: "オフ",
+    desc: "自動でスクロールしません。",
+  },
+};
+
+const experimentalSetting = computed(() => store.state.experimentalSetting);
+
+const currentThemeNameComputed = computed({
+  get: () => store.state.themeSetting.currentTheme,
+  set: (currentTheme: string) => {
+    store.dispatch("SET_THEME_SETTING", { currentTheme: currentTheme });
+  },
+});
+
+const availableThemeNameComputed = computed(() => {
+  return [...store.state.themeSetting.availableThemes]
+    .sort((a, b) => a.order - b.order)
+    .map((theme) => {
+      return { label: theme.displayName, value: theme.name };
+    });
+});
+
+const currentAudioOutputDeviceComputed = computed<{
+  key: string;
+  label: string;
+} | null>({
+  get: () => {
+    // 再生デバイスが見つからなかったらデフォルト値に戻す
+    const device = availableAudioOutputDevices.value?.find(
+      (device) => device.key === store.state.savingSetting.audioOutputDevice
+    );
+    if (device) {
+      return device;
+    } else {
+      handleSavingSettingChange("audioOutputDevice", "default");
+      return null;
+    }
+  },
+  set: (device) => {
+    if (device) {
+      handleSavingSettingChange("audioOutputDevice", device.key);
+    }
+  },
+});
+
+const availableAudioOutputDevices = ref<{ key: string; label: string }[]>();
+const updateAudioOutputDevices = async () => {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  availableAudioOutputDevices.value = devices
+    .filter((device) => device.kind === "audiooutput")
+    .map((device) => {
+      return { label: device.label, key: device.deviceId };
+    });
+};
+navigator.mediaDevices.addEventListener(
+  "devicechange",
+  updateAudioOutputDevices
+);
+updateAudioOutputDevices();
+
+const acceptRetrieveTelemetryComputed = computed({
+  get: () => store.state.acceptRetrieveTelemetry == "Accepted",
+  set: (acceptRetrieveTelemetry: boolean) => {
+    store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
+      acceptRetrieveTelemetry: acceptRetrieveTelemetry ? "Accepted" : "Refused",
+    });
+
+    if (acceptRetrieveTelemetry) {
+      return;
+    }
+
+    $q.dialog({
+      title: "ソフトウェア利用状況のデータ収集の無効化",
+      message:
+        "ソフトウェア利用状況のデータ収集を完全に無効にするには、VOICEVOXを再起動する必要があります",
+      ok: {
+        flat: true,
+        textColor: "display",
+      },
+    });
+  },
+});
+
+const changeUseGPU = async (useGpu: boolean) => {
+  if (store.state.useGpu === useGpu) return;
+
+  $q.loading.show({
+    spinnerColor: "primary",
+    spinnerSize: 50,
+    boxClass: "bg-background text-display",
+    message: "起動モードを変更中です",
+  });
+
+  await store.dispatch("CHANGE_USE_GPU", { useGpu });
+
+  $q.loading.hide();
+};
+
+const changeinheritAudioInfo = async (inheritAudioInfo: boolean) => {
+  if (store.state.inheritAudioInfo === inheritAudioInfo) return;
+  store.dispatch("SET_INHERIT_AUDIOINFO", { inheritAudioInfo });
+};
+
+const changeExperimentalSetting = async (
+  key: keyof ExperimentalSetting,
+  data: boolean
+) => {
+  store.dispatch("SET_EXPERIMENTAL_SETTING", {
+    experimentalSetting: { ...experimentalSetting.value, [key]: data },
+  });
+};
+
+const savingSetting = computed(() => store.state.savingSetting);
+
+const handleSavingSettingChange = (
+  key: keyof SavingSetting,
+  data: string | boolean | number
+) => {
+  const storeDispatch = (): void => {
+    store.dispatch("SET_SAVING_SETTING", {
+      data: { ...savingSetting.value, [key]: data },
+    });
+  };
+  if (key === "outputSamplingRate" && data !== "default") {
+    $q.dialog({
+      title: "出力サンプリングレートを変更します",
+      message:
+        "出力サンプリングレートを変更しても、音質は変化しません。また、音声の生成処理に若干時間がかかる場合があります。<br />変更しますか？",
+      html: true,
+      persistent: true,
+      ok: {
+        label: "変更する",
+        flat: true,
+        textColor: "display",
+      },
+      cancel: {
+        label: "変更しない",
+        flat: true,
+        textColor: "display",
+      },
+    }).onOk(storeDispatch);
+    return;
+  }
+  storeDispatch();
+};
+
+const openFileExplore = async () => {
+  const path = await window.electron.showOpenDirectoryDialog({
+    title: "書き出し先のフォルダを選択",
+  });
+  if (path) {
+    store.dispatch("SET_SAVING_SETTING", {
+      data: { ...savingSetting.value, fixedExportDir: path },
+    });
+  }
+};
+
+const splitTextWhenPaste = computed(() => store.state.splitTextWhenPaste);
+const changeSplitTextWhenPaste = (
+  splitTextWhenPaste: SplitTextWhenPasteType
+) => {
+  store.dispatch("SET_SPLIT_TEXT_WHEN_PASTE", { splitTextWhenPaste });
+};
+
+const showsFilePatternEditDialog = ref(false);
 </script>
 
 <style scoped lang="scss">

--- a/src/components/TitleBarButtons.vue
+++ b/src/components/TitleBarButtons.vue
@@ -1,12 +1,12 @@
 <template>
-  <q-badge
+  <QBadge
     v-if="$q.platform.is.mac"
     transparent
     color="transparent"
     text-color="display"
     class="full-height cursor-not-allowed no-border-radius"
   >
-    <q-btn
+    <QBtn
       v-if="isPinned"
       dense
       flat
@@ -17,11 +17,11 @@
       id="pinned-btn"
       @click="changePinWindow()"
     >
-      <q-tooltip :delay="500" class="text-body2" :offset="[11, 11]">
+      <QTooltip :delay="500" class="text-body2" :offset="[11, 11]">
         最前面に表示
-      </q-tooltip>
-    </q-btn>
-    <q-btn
+      </QTooltip>
+    </QBtn>
+    <QBtn
       v-else
       dense
       flat
@@ -32,12 +32,12 @@
       id="pinned-btn"
       @click="changePinWindow()"
     >
-      <q-tooltip :delay="500" class="text-body2" :offset="[11, 11]">
+      <QTooltip :delay="500" class="text-body2" :offset="[11, 11]">
         最前面に表示
-      </q-tooltip>
-    </q-btn>
-  </q-badge>
-  <q-badge
+      </QTooltip>
+    </QBtn>
+  </QBadge>
+  <QBadge
     v-else
     transparent
     color="transparent"
@@ -49,7 +49,7 @@
       title-bar-buttons-root
     "
   >
-    <q-btn
+    <QBtn
       v-if="isPinned"
       dense
       flat
@@ -60,11 +60,11 @@
       id="pinned-btn"
       @click="changePinWindow()"
     >
-      <q-tooltip :delay="500" class="text-body2" :offset="[11, 11]">
+      <QTooltip :delay="500" class="text-body2" :offset="[11, 11]">
         最前面に表示
-      </q-tooltip>
-    </q-btn>
-    <q-btn
+      </QTooltip>
+    </QBtn>
+    <QBtn
       v-else
       dense
       flat
@@ -74,37 +74,26 @@
       id="pinned-btn"
       @click="changePinWindow()"
     >
-      <q-tooltip :delay="500" class="text-body2" :offset="[11, 11]">
+      <QTooltip :delay="500" class="text-body2" :offset="[11, 11]">
         最前面に表示
-      </q-tooltip>
-    </q-btn>
-  </q-badge>
-  <min-max-close-buttons v-if="!$q.platform.is.mac" />
+      </QTooltip>
+    </QBtn>
+  </QBadge>
+  <MinMaxCloseButtons v-if="!$q.platform.is.mac" />
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import { useStore } from "@/store";
 import MinMaxCloseButtons from "@/components/MinMaxCloseButtons.vue";
 
-export default defineComponent({
-  name: "TitleBarButtons",
-  components: { MinMaxCloseButtons },
-  setup() {
-    const store = useStore();
+const store = useStore();
 
-    const changePinWindow = () => {
-      window.electron.changePinWindow();
-    };
+const changePinWindow = () => {
+  window.electron.changePinWindow();
+};
 
-    const isPinned = computed(() => store.state.isPinned);
-
-    return {
-      changePinWindow,
-      isPinned,
-    };
-  },
-});
+const isPinned = computed(() => store.state.isPinned);
 </script>
 
 <style scoped lang="scss">

--- a/src/components/ToolTip.vue
+++ b/src/components/ToolTip.vue
@@ -1,51 +1,41 @@
 <template>
   <div v-if="!tipConfirmed" style="z-index: 10">
-    <q-banner class="bg-surface text-display" dense rounded inline-actions>
+    <QBanner class="bg-surface text-display" dense rounded inline-actions>
       <template v-slot:avatar>
-        <q-icon name="info" color="primary" />
+        <QIcon name="info" color="primary" />
       </template>
       <slot></slot>
       <template v-slot:action>
-        <q-btn
+        <QBtn
           color="primary"
           text-color="display-on-primary"
           label="OK"
           @click="tipConfirmed = true"
         />
       </template>
-    </q-banner>
+    </QBanner>
   </div>
 </template>
 
-<script lang="ts">
-import { PropType, defineComponent, computed } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import { ConfirmedTips } from "@/type/preload";
 import { useStore } from "@/store";
 
-export default defineComponent({
-  name: "ToolTip",
+const props =
+  defineProps<{
+    tipKey: keyof ConfirmedTips;
+  }>();
+const store = useStore();
 
-  props: {
-    tipKey: { type: String as PropType<keyof ConfirmedTips>, required: true },
-  },
-
-  setup(props) {
-    const store = useStore();
-
-    const tipConfirmed = computed({
-      get: () => store.state.confirmedTips[props.tipKey],
-      set: (value) =>
-        store.dispatch("SET_CONFIRMED_TIPS", {
-          confirmedTips: {
-            ...store.state.confirmedTips,
-            [props.tipKey]: value,
-          },
-        }),
-    });
-
-    return {
-      tipConfirmed,
-    };
-  },
+const tipConfirmed = computed({
+  get: () => store.state.confirmedTips[props.tipKey],
+  set: (value) =>
+    store.dispatch("SET_CONFIRMED_TIPS", {
+      confirmedTips: {
+        ...store.state.confirmedTips,
+        [props.tipKey]: value,
+      },
+    }),
 });
 </script>

--- a/src/components/UpdateInfo.vue
+++ b/src/components/UpdateInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page
+  <QPage
     ref="scroller"
     class="relative-absolute-wrapper scroller markdown-body"
   >
@@ -34,33 +34,18 @@
         </p>
       </template>
     </div>
-  </q-page>
+  </QPage>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from "vue";
+<script setup lang="ts">
 import { UpdateInfo } from "../type/preload";
 
-export default defineComponent({
-  props: {
-    latestVersion: {
-      type: String,
-      required: false,
-    },
-    downloadLink: {
-      type: String,
-      required: false,
-    },
-    updateInfos: {
-      type: Array as PropType<UpdateInfo[]>,
-      required: false,
-    },
-    isUpdateAvailable: {
-      type: Boolean,
-      required: false,
-    },
-  },
-});
+defineProps<{
+  latestVersion: string;
+  downloadLink: string;
+  updateInfos: UpdateInfo[];
+  isUpdateAvailable: boolean;
+}>();
 </script>
 
 <style scoped lang="scss">

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -1,12 +1,539 @@
+<script setup lang="ts">
+import { computed, onBeforeUpdate, onMounted, ref, watch } from "vue";
+import { useStore } from "@/store";
+import draggable from "vuedraggable";
+import HeaderBar from "@/components/HeaderBar.vue";
+import AudioCell from "@/components/AudioCell.vue";
+import AudioDetail from "@/components/AudioDetail.vue";
+import AudioInfo from "@/components/AudioInfo.vue";
+import MenuBar from "@/components/MenuBar.vue";
+import HelpDialog from "@/components/HelpDialog.vue";
+import SettingDialog from "@/components/SettingDialog.vue";
+import HotkeySettingDialog from "@/components/HotkeySettingDialog.vue";
+import HeaderBarCustomDialog from "@/components/HeaderBarCustomDialog.vue";
+import CharacterPortrait from "@/components/CharacterPortrait.vue";
+import DefaultStyleSelectDialog from "@/components/DefaultStyleSelectDialog.vue";
+import CharacterOrderDialog from "@/components/CharacterOrderDialog.vue";
+import AcceptRetrieveTelemetryDialog from "@/components/AcceptRetrieveTelemetryDialog.vue";
+import AcceptTermsDialog from "@/components/AcceptTermsDialog.vue";
+import DictionaryManageDialog from "@/components/DictionaryManageDialog.vue";
+import EngineManageDialog from "@/components/EngineManageDialog.vue";
+import ProgressDialog from "@/components/ProgressDialog.vue";
+import { AudioItem, EngineState } from "@/store/type";
+import { QResizeObserver, useQuasar } from "quasar";
+import path from "path";
+import {
+  HotkeyAction,
+  HotkeyReturnType,
+  SplitterPosition,
+} from "@/type/preload";
+import { parseCombo, setHotkeyFunctions } from "@/store/setting";
+
+const store = useStore();
+const $q = useQuasar();
+
+const audioKeys = computed(() => store.state.audioKeys);
+const uiLocked = computed(() => store.getters.UI_LOCKED);
+
+const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
+
+// hotkeys handled by Mousetrap
+const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
+  [
+    "テキスト欄にフォーカスを戻す",
+    () => {
+      if (activeAudioKey.value !== undefined) {
+        focusCell({ audioKey: activeAudioKey.value });
+      }
+      return false; // this is the same with event.preventDefault()
+    },
+  ],
+]);
+
+setHotkeyFunctions(hotkeyMap);
+
+const removeAudioItem = async () => {
+  if (activeAudioKey.value == undefined) throw new Error();
+  audioCellRefs[activeAudioKey.value].removeCell();
+};
+
+// convert the hotkey array to Map to get value with keys easier
+// this only happens here where we deal with native methods
+const hotkeySettingsMap = computed(
+  () =>
+    new Map(
+      store.state.hotkeySettings.map((obj) => [obj.action, obj.combination])
+    )
+);
+
+// hotkeys handled by native, for they are made to be working while focusing input elements
+const hotkeyActionsNative = [
+  (event: KeyboardEvent) => {
+    if (
+      !event.isComposing &&
+      !uiLocked.value &&
+      parseCombo(event) == hotkeySettingsMap.value.get("テキスト欄を追加")
+    ) {
+      addAudioItem();
+      event.preventDefault();
+    }
+  },
+  (event: KeyboardEvent) => {
+    if (
+      !event.isComposing &&
+      !uiLocked.value &&
+      parseCombo(event) == hotkeySettingsMap.value.get("テキスト欄を削除")
+    ) {
+      removeAudioItem();
+      event.preventDefault();
+    }
+  },
+  (event: KeyboardEvent) => {
+    if (
+      !event.isComposing &&
+      !uiLocked.value &&
+      parseCombo(event) ==
+        hotkeySettingsMap.value.get("テキスト欄からフォーカスを外す")
+    ) {
+      if (document.activeElement instanceof HTMLInputElement) {
+        document.activeElement.blur();
+      }
+      event.preventDefault();
+    }
+  },
+];
+
+// view
+const DEFAULT_PORTRAIT_PANE_WIDTH = 25; // %
+const MIN_PORTRAIT_PANE_WIDTH = 0;
+const MAX_PORTRAIT_PANE_WIDTH = 40;
+const MIN_AUDIO_INFO_PANE_WIDTH = 160; // px
+const MAX_AUDIO_INFO_PANE_WIDTH = 250;
+const MIN_AUDIO_DETAIL_PANE_HEIGHT = 185; // px
+const MAX_AUDIO_DETAIL_PANE_HEIGHT = 500;
+
+const portraitPaneWidth = ref(0);
+const audioInfoPaneWidth = ref(0);
+const audioInfoPaneMinWidth = ref(0);
+const audioInfoPaneMaxWidth = ref(0);
+const audioDetailPaneHeight = ref(0);
+const audioDetailPaneMinHeight = ref(0);
+const audioDetailPaneMaxHeight = ref(0);
+
+const changeAudioDetailPaneMaxHeight = (height: number) => {
+  if (!activeAudioKey.value) return;
+
+  const maxHeight = height - 200;
+  if (maxHeight > MAX_AUDIO_DETAIL_PANE_HEIGHT) {
+    // 最大値以上なら最大値に設定
+    audioDetailPaneMaxHeight.value = MAX_AUDIO_DETAIL_PANE_HEIGHT;
+  } else if (height < 200 + MIN_AUDIO_DETAIL_PANE_HEIGHT) {
+    // 最低値以下になってしまう場合は無制限に
+    audioDetailPaneMaxHeight.value = Infinity;
+  } else {
+    audioDetailPaneMaxHeight.value = maxHeight;
+  }
+};
+
+const splitterPosition = computed<SplitterPosition>(
+  () => store.state.splitterPosition
+);
+
+const updateSplitterPosition = async (
+  propertyName: keyof SplitterPosition,
+  newValue: number
+) => {
+  const newSplitterPosition = {
+    ...splitterPosition.value,
+    [propertyName]: newValue,
+  };
+  store.dispatch("SET_SPLITTER_POSITION", {
+    splitterPosition: newSplitterPosition,
+  });
+};
+
+const updatePortraitPane = async (width: number) => {
+  portraitPaneWidth.value = width;
+  await updateSplitterPosition("portraitPaneWidth", width);
+};
+
+const updateAudioInfoPane = async (width: number) => {
+  audioInfoPaneWidth.value = width;
+  await updateSplitterPosition("audioInfoPaneWidth", width);
+};
+
+const updateAudioDetailPane = async (height: number) => {
+  audioDetailPaneHeight.value = height;
+  await updateSplitterPosition("audioDetailPaneHeight", height);
+};
+
+// component
+let audioCellRefs: Record<string, typeof AudioCell> = {};
+const addAudioCellRef = (audioCellRef: typeof AudioCell) => {
+  if (audioCellRef) {
+    audioCellRefs[audioCellRef.audioKey] = audioCellRef;
+  }
+};
+onBeforeUpdate(() => {
+  audioCellRefs = {};
+});
+
+const resizeObserverRef = ref<QResizeObserver>();
+
+// DaD
+const updateAudioKeys = (audioKeys: string[]) =>
+  store.dispatch("COMMAND_SET_AUDIO_KEYS", { audioKeys });
+const itemKey = (key: string) => key;
+
+// セルを追加
+const activeAudioKey = computed<string | undefined>(
+  () => store.getters.ACTIVE_AUDIO_KEY
+);
+const addAudioItem = async () => {
+  const prevAudioKey = activeAudioKey.value;
+  let engineId: string | undefined = undefined;
+  let styleId: number | undefined = undefined;
+  let presetKey: string | undefined = undefined;
+  if (prevAudioKey !== undefined) {
+    engineId = store.state.audioItems[prevAudioKey].engineId;
+    styleId = store.state.audioItems[prevAudioKey].styleId;
+    presetKey = store.state.audioItems[prevAudioKey].presetKey;
+  }
+  let baseAudioItem: AudioItem | undefined = undefined;
+  if (store.state.inheritAudioInfo) {
+    baseAudioItem = prevAudioKey
+      ? store.state.audioItems[prevAudioKey]
+      : undefined;
+  }
+  //パラメータ引き継ぎがONの場合は話速等のパラメータを引き継いでテキスト欄を作成する
+  //パラメータ引き継ぎがOFFの場合、baseAudioItemがundefinedになっているのでパラメータ引き継ぎは行われない
+  const audioItem = await store.dispatch("GENERATE_AUDIO_ITEM", {
+    engineId,
+    styleId,
+    presetKey,
+    baseAudioItem,
+  });
+
+  const newAudioKey = await store.dispatch("COMMAND_REGISTER_AUDIO_ITEM", {
+    audioItem,
+    prevAudioKey: activeAudioKey.value,
+  });
+  audioCellRefs[newAudioKey].focusTextField();
+};
+
+// Pane
+const shouldShowPanes = computed<boolean>(
+  () => store.getters.SHOULD_SHOW_PANES
+);
+watch(shouldShowPanes, (val, old) => {
+  if (val === old) return;
+
+  if (val) {
+    const clamp = (value: number, min: number, max: number) =>
+      Math.max(Math.min(value, max), min);
+
+    // 設定ファイルを書き換えれば異常な値が入り得るのですべてclampしておく
+    portraitPaneWidth.value = clamp(
+      splitterPosition.value.portraitPaneWidth ?? DEFAULT_PORTRAIT_PANE_WIDTH,
+      MIN_PORTRAIT_PANE_WIDTH,
+      MAX_PORTRAIT_PANE_WIDTH
+    );
+
+    audioInfoPaneWidth.value = clamp(
+      splitterPosition.value.audioInfoPaneWidth ?? MIN_AUDIO_INFO_PANE_WIDTH,
+      MIN_AUDIO_INFO_PANE_WIDTH,
+      MAX_AUDIO_INFO_PANE_WIDTH
+    );
+    audioInfoPaneMinWidth.value = MIN_AUDIO_INFO_PANE_WIDTH;
+    audioInfoPaneMaxWidth.value = MAX_AUDIO_INFO_PANE_WIDTH;
+
+    audioDetailPaneMinHeight.value = MIN_AUDIO_DETAIL_PANE_HEIGHT;
+    changeAudioDetailPaneMaxHeight(
+      resizeObserverRef.value?.$el.parentElement.clientHeight
+    );
+
+    audioDetailPaneHeight.value = clamp(
+      splitterPosition.value.audioDetailPaneHeight ??
+        MIN_AUDIO_DETAIL_PANE_HEIGHT,
+      audioDetailPaneMinHeight.value,
+      audioDetailPaneMaxHeight.value
+    );
+  } else {
+    portraitPaneWidth.value = 0;
+    audioInfoPaneWidth.value = 0;
+    audioInfoPaneMinWidth.value = 0;
+    audioInfoPaneMaxWidth.value = 0;
+    audioDetailPaneHeight.value = 0;
+    audioDetailPaneMinHeight.value = 0;
+    audioDetailPaneMaxHeight.value = 0;
+  }
+});
+
+// セルをフォーカス
+const focusCell = ({ audioKey }: { audioKey: string }) => {
+  audioCellRefs[audioKey].focusTextField();
+};
+
+// Electronのデフォルトのundo/redoを無効化
+const disableDefaultUndoRedo = (event: KeyboardEvent) => {
+  // ctrl+z, ctrl+shift+z, ctrl+y
+  if (
+    event.ctrlKey &&
+    (event.key == "z" || (!event.shiftKey && event.key == "y"))
+  ) {
+    event.preventDefault();
+  }
+};
+
+// ソフトウェアを初期化
+const isCompletedInitialStartup = ref(false);
+onMounted(async () => {
+  await store.dispatch("GET_ENGINE_INFOS");
+
+  let engineIds: string[];
+  if (store.state.isSafeMode) {
+    // デフォルトエンジンだけを含める
+    const main = Object.values(store.state.engineInfos).find(
+      (engine) => engine.type === "default"
+    );
+    if (!main) {
+      throw new Error("No main engine found");
+    }
+    engineIds = [main.uuid];
+  } else {
+    engineIds = store.state.engineIds;
+  }
+  await Promise.all(
+    engineIds.map(async (engineId) => {
+      await store.dispatch("START_WAITING_ENGINE", { engineId });
+
+      await store.dispatch("FETCH_AND_SET_ENGINE_MANIFEST", { engineId });
+
+      await store.dispatch("LOAD_CHARACTER", { engineId });
+    })
+  );
+  await store.dispatch("LOAD_USER_CHARACTER_ORDER");
+  await store.dispatch("LOAD_DEFAULT_STYLE_IDS");
+
+  // 辞書を同期
+  await store.dispatch("SYNC_ALL_USER_DICT");
+
+  // 新キャラが追加されている場合はキャラ並び替えダイアログを表示
+  const newCharacters = await store.dispatch("GET_NEW_CHARACTERS");
+  isCharacterOrderDialogOpenComputed.value = newCharacters.length > 0;
+
+  // 最初のAudioCellを作成
+  const audioItem: AudioItem = await store.dispatch("GENERATE_AUDIO_ITEM", {});
+  const newAudioKey = await store.dispatch("REGISTER_AUDIO_ITEM", {
+    audioItem,
+  });
+  focusCell({ audioKey: newAudioKey });
+
+  // 最初の話者を初期化
+  if (audioItem.engineId != undefined && audioItem.styleId != undefined) {
+    store.dispatch("SETUP_SPEAKER", {
+      audioKey: newAudioKey,
+      engineId: audioItem.engineId,
+      styleId: audioItem.styleId,
+    });
+  }
+
+  // ショートカットキーの設定
+  document.addEventListener("keydown", disableDefaultUndoRedo);
+
+  hotkeyActionsNative.forEach((item) => {
+    document.addEventListener("keyup", item);
+  });
+
+  isAcceptRetrieveTelemetryDialogOpenComputed.value =
+    store.state.acceptRetrieveTelemetry === "Unconfirmed";
+
+  isAcceptTermsDialogOpenComputed.value =
+    process.env.NODE_ENV == "production" &&
+    store.state.acceptTerms !== "Accepted";
+
+  isCompletedInitialStartup.value = true;
+});
+
+// エンジン待機
+// TODO: 個別のエンジンの状態をUIで確認できるようにする
+const allEngineState = computed(() => {
+  const engineStates = store.state.engineStates;
+
+  let lastEngineState: EngineState | undefined = undefined;
+
+  // 登録されているすべてのエンジンについて状態を確認する
+  for (const engineId of store.state.engineIds) {
+    const engineState: EngineState | undefined = engineStates[engineId];
+    if (engineState === undefined)
+      throw new Error(`No such engineState set: engineId == ${engineId}`);
+
+    // FIXME: 1つでも接続テストに成功していないエンジンがあれば、暫定的に起動中とする
+    if (engineState === "STARTING") {
+      return engineState;
+    }
+
+    lastEngineState = engineState;
+  }
+
+  return lastEngineState; // FIXME: 暫定的に1つのエンジンの状態を返す
+});
+
+const isEngineWaitingLong = ref<boolean>(false);
+let engineTimer: number | undefined = undefined;
+watch(allEngineState, (newEngineState) => {
+  if (engineTimer !== undefined) {
+    clearTimeout(engineTimer);
+    engineTimer = undefined;
+  }
+  if (newEngineState === "STARTING") {
+    isEngineWaitingLong.value = false;
+    engineTimer = window.setTimeout(() => {
+      isEngineWaitingLong.value = true;
+    }, 60000);
+  } else {
+    isEngineWaitingLong.value = false;
+  }
+});
+const restartAppWithSafeMode = () => {
+  store.dispatch("RESTART_APP", { isSafeMode: true });
+};
+
+const openFaq = () => {
+  window.open("https://voicevox.hiroshiba.jp/qa/", "_blank");
+};
+
+// ライセンス表示
+const isHelpDialogOpenComputed = computed({
+  get: () => store.state.isHelpDialogOpen,
+  set: (val) => store.dispatch("SET_DIALOG_OPEN", { isHelpDialogOpen: val }),
+});
+
+// 設定
+const isSettingDialogOpenComputed = computed({
+  get: () => store.state.isSettingDialogOpen,
+  set: (val) => store.dispatch("SET_DIALOG_OPEN", { isSettingDialogOpen: val }),
+});
+
+// ショートカットキー設定
+const isHotkeySettingDialogOpenComputed = computed({
+  get: () => store.state.isHotkeySettingDialogOpen,
+  set: (val) =>
+    store.dispatch("SET_DIALOG_OPEN", {
+      isHotkeySettingDialogOpen: val,
+    }),
+});
+
+// ツールバーのカスタム設定
+const isToolbarSettingDialogOpenComputed = computed({
+  get: () => store.state.isToolbarSettingDialogOpen,
+  set: (val) =>
+    store.dispatch("SET_DIALOG_OPEN", {
+      isToolbarSettingDialogOpen: val,
+    }),
+});
+
+// 利用規約表示
+const isAcceptTermsDialogOpenComputed = computed({
+  get: () => store.state.isAcceptTermsDialogOpen,
+  set: (val) =>
+    store.dispatch("SET_DIALOG_OPEN", {
+      isAcceptTermsDialogOpen: val,
+    }),
+});
+
+// キャラクター並び替え
+const orderedAllCharacterInfos = computed(
+  () => store.getters.GET_ORDERED_ALL_CHARACTER_INFOS
+);
+const isCharacterOrderDialogOpenComputed = computed({
+  get: () =>
+    !store.state.isAcceptTermsDialogOpen &&
+    store.state.isCharacterOrderDialogOpen,
+  set: (val) =>
+    store.dispatch("SET_DIALOG_OPEN", {
+      isCharacterOrderDialogOpen: val,
+    }),
+});
+
+// デフォルトスタイル選択
+const isDefaultStyleSelectDialogOpenComputed = computed({
+  get: () =>
+    !store.state.isAcceptTermsDialogOpen &&
+    !store.state.isCharacterOrderDialogOpen &&
+    store.state.isDefaultStyleSelectDialogOpen,
+  set: (val) =>
+    store.dispatch("SET_DIALOG_OPEN", {
+      isDefaultStyleSelectDialogOpen: val,
+    }),
+});
+
+// エンジン管理
+const isEngineManageDialogOpenComputed = computed({
+  get: () => store.state.isEngineManageDialogOpen,
+  set: (val) =>
+    store.dispatch("SET_DIALOG_OPEN", {
+      isEngineManageDialogOpen: val,
+    }),
+});
+
+// 読み方＆アクセント辞書
+const isDictionaryManageDialogOpenComputed = computed({
+  get: () => store.state.isDictionaryManageDialogOpen,
+  set: (val) =>
+    store.dispatch("SET_DIALOG_OPEN", {
+      isDictionaryManageDialogOpen: val,
+    }),
+});
+
+const isAcceptRetrieveTelemetryDialogOpenComputed = computed({
+  get: () =>
+    !store.state.isAcceptTermsDialogOpen &&
+    !store.state.isCharacterOrderDialogOpen &&
+    !store.state.isDefaultStyleSelectDialogOpen &&
+    store.state.isAcceptRetrieveTelemetryDialogOpen,
+  set: (val) =>
+    store.dispatch("SET_DIALOG_OPEN", {
+      isAcceptRetrieveTelemetryDialogOpen: val,
+    }),
+});
+
+// ドラッグ＆ドロップ
+const dragEventCounter = ref(0);
+const loadDraggedFile = (event?: { dataTransfer: DataTransfer }) => {
+  if (!event || event.dataTransfer.files.length === 0) return;
+  const file = event.dataTransfer.files[0];
+  switch (path.extname(file.name)) {
+    case ".txt":
+      store.dispatch("COMMAND_IMPORT_FROM_FILE", { filePath: file.path });
+      break;
+    case ".vvproj":
+      store.dispatch("LOAD_PROJECT_FILE", { filePath: file.path });
+      break;
+    default:
+      $q.dialog({
+        title: "対応していないファイルです",
+        message:
+          "テキストファイル (.txt) とVOICEVOXプロジェクトファイル (.vvproj) に対応しています。",
+        ok: {
+          label: "閉じる",
+          flat: true,
+          textColor: "display",
+        },
+      });
+  }
+};
+</script>
+
 <template>
-  <menu-bar />
+  <MenuBar />
 
-  <q-layout reveal elevated container class="layout-container">
-    <header-bar />
+  <QLayout reveal elevated container class="layout-container">
+    <HeaderBar />
 
-    <q-page-container>
-      <q-page class="main-row-panes">
-        <progress-dialog />
+    <QPageContainer>
+      <QPage class="main-row-panes">
+        <ProgressDialog />
 
         <!-- TODO: 複数エンジン対応 -->
         <div
@@ -14,7 +541,7 @@
           class="waiting-engine"
         >
           <div>
-            <q-spinner color="primary" size="2.5rem" />
+            <QSpinner color="primary" size="2.5rem" />
             <div class="q-mt-xs">
               {{
                 allEngineState === "STARTING"
@@ -24,20 +551,20 @@
             </div>
 
             <template v-if="isEngineWaitingLong">
-              <q-separator spaced />
+              <QSeparator spaced />
               エンジン起動に時間がかかっています。<br />
-              <q-btn
+              <QBtn
                 outline
                 @click="restartAppWithSafeMode"
                 v-if="isMultipleEngine"
               >
-                セーフモードで起動する</q-btn
+                セーフモードで起動する</QBtn
               >
-              <q-btn outline @click="openFaq" v-else>FAQを見る</q-btn>
+              <QBtn outline @click="openFaq" v-else>FAQを見る</QBtn>
             </template>
           </div>
         </div>
-        <q-splitter
+        <QSplitter
           horizontal
           reverse
           unit="px"
@@ -51,7 +578,7 @@
           @update:model-value="updateAudioDetailPane"
         >
           <template #before>
-            <q-splitter
+            <QSplitter
               :limits="[MIN_PORTRAIT_PANE_WIDTH, MAX_PORTRAIT_PANE_WIDTH]"
               separator-class="home-splitter"
               :separator-style="{ width: shouldShowPanes ? '3px' : 0 }"
@@ -61,10 +588,10 @@
               @update:model-value="updatePortraitPane"
             >
               <template #before>
-                <character-portrait />
+                <CharacterPortrait />
               </template>
               <template #after>
-                <q-splitter
+                <QSplitter
                   reverse
                   unit="px"
                   :limits="[audioInfoPaneMinWidth, audioInfoPaneMaxWidth]"
@@ -97,7 +624,7 @@
                         :preventOnFilter="false"
                       >
                         <template v-slot:item="{ element }">
-                          <audio-cell
+                          <AudioCell
                             class="draggable-cursor"
                             :audioKey="element"
                             :ref="addAudioCellRef"
@@ -106,678 +633,63 @@
                         </template>
                       </draggable>
                       <div class="add-button-wrapper">
-                        <q-btn
+                        <QBtn
                           fab
                           icon="add"
                           color="primary-light"
                           text-color="display-on-primary"
                           :disable="uiLocked"
                           @click="addAudioItem"
-                        ></q-btn>
+                        ></QBtn>
                       </div>
                     </div>
                   </template>
                   <template #after>
-                    <audio-info
+                    <AudioInfo
                       v-if="activeAudioKey != undefined"
                       :activeAudioKey="activeAudioKey"
                     />
                   </template>
-                </q-splitter>
+                </QSplitter>
               </template>
-            </q-splitter>
+            </QSplitter>
           </template>
           <template #after>
-            <audio-detail
+            <AudioDetail
               v-if="activeAudioKey != undefined"
               :activeAudioKey="activeAudioKey"
             />
           </template>
-        </q-splitter>
+        </QSplitter>
 
-        <q-resize-observer
+        <QResizeObserver
           ref="resizeObserverRef"
           @resize="({ height }) => changeAudioDetailPaneMaxHeight(height)"
         />
-      </q-page>
-    </q-page-container>
-  </q-layout>
-  <help-dialog v-model="isHelpDialogOpenComputed" />
-  <setting-dialog v-model="isSettingDialogOpenComputed" />
-  <hotkey-setting-dialog v-model="isHotkeySettingDialogOpenComputed" />
-  <header-bar-custom-dialog v-model="isToolbarSettingDialogOpenComputed" />
-  <character-order-dialog
+      </QPage>
+    </QPageContainer>
+  </QLayout>
+  <HelpDialog v-model="isHelpDialogOpenComputed" />
+  <SettingDialog v-model="isSettingDialogOpenComputed" />
+  <HotkeySettingDialog v-model="isHotkeySettingDialogOpenComputed" />
+  <HeaderBarCustomDialog v-model="isToolbarSettingDialogOpenComputed" />
+  <CharacterOrderDialog
     v-if="orderedAllCharacterInfos.length > 0"
     :characterInfos="orderedAllCharacterInfos"
     v-model="isCharacterOrderDialogOpenComputed"
   />
-  <default-style-select-dialog
+  <DefaultStyleSelectDialog
     v-if="orderedAllCharacterInfos.length > 0"
     :characterInfos="orderedAllCharacterInfos"
     v-model="isDefaultStyleSelectDialogOpenComputed"
   />
-  <dictionary-manage-dialog v-model="isDictionaryManageDialogOpenComputed" />
-  <engine-manage-dialog v-model="isEngineManageDialogOpenComputed" />
-  <accept-retrieve-telemetry-dialog
+  <DictionaryManageDialog v-model="isDictionaryManageDialogOpenComputed" />
+  <EngineManageDialog v-model="isEngineManageDialogOpenComputed" />
+  <AcceptRetrieveTelemetryDialog
     v-model="isAcceptRetrieveTelemetryDialogOpenComputed"
   />
-  <accept-terms-dialog v-model="isAcceptTermsDialogOpenComputed" />
+  <AcceptTermsDialog v-model="isAcceptTermsDialogOpenComputed" />
 </template>
-
-<script lang="ts">
-import {
-  computed,
-  defineComponent,
-  onBeforeUpdate,
-  onMounted,
-  ref,
-  watch,
-} from "vue";
-import { useStore } from "@/store";
-import draggable from "vuedraggable";
-import HeaderBar from "@/components/HeaderBar.vue";
-import AudioCell from "@/components/AudioCell.vue";
-import AudioDetail from "@/components/AudioDetail.vue";
-import AudioInfo from "@/components/AudioInfo.vue";
-import MenuBar from "@/components/MenuBar.vue";
-import HelpDialog from "@/components/HelpDialog.vue";
-import SettingDialog from "@/components/SettingDialog.vue";
-import HotkeySettingDialog from "@/components/HotkeySettingDialog.vue";
-import HeaderBarCustomDialog from "@/components/HeaderBarCustomDialog.vue";
-import CharacterPortrait from "@/components/CharacterPortrait.vue";
-import DefaultStyleSelectDialog from "@/components/DefaultStyleSelectDialog.vue";
-import CharacterOrderDialog from "@/components/CharacterOrderDialog.vue";
-import AcceptRetrieveTelemetryDialog from "@/components/AcceptRetrieveTelemetryDialog.vue";
-import AcceptTermsDialog from "@/components/AcceptTermsDialog.vue";
-import DictionaryManageDialog from "@/components/DictionaryManageDialog.vue";
-import EngineManageDialog from "@/components/EngineManageDialog.vue";
-import ProgressDialog from "@/components/ProgressDialog.vue";
-import { AudioItem, EngineState } from "@/store/type";
-import { QResizeObserver, useQuasar } from "quasar";
-import path from "path";
-import {
-  HotkeyAction,
-  HotkeyReturnType,
-  SplitterPosition,
-} from "@/type/preload";
-import { parseCombo, setHotkeyFunctions } from "@/store/setting";
-
-export default defineComponent({
-  name: "EditorHome",
-
-  components: {
-    draggable,
-    MenuBar,
-    HeaderBar,
-    AudioCell,
-    AudioDetail,
-    AudioInfo,
-    HelpDialog,
-    SettingDialog,
-    HotkeySettingDialog,
-    HeaderBarCustomDialog,
-    CharacterPortrait,
-    DefaultStyleSelectDialog,
-    CharacterOrderDialog,
-    AcceptRetrieveTelemetryDialog,
-    AcceptTermsDialog,
-    DictionaryManageDialog,
-    EngineManageDialog,
-    ProgressDialog,
-  },
-
-  setup() {
-    const store = useStore();
-    const $q = useQuasar();
-
-    const audioItems = computed(() => store.state.audioItems);
-    const audioKeys = computed(() => store.state.audioKeys);
-    const uiLocked = computed(() => store.getters.UI_LOCKED);
-
-    const isMultipleEngine = computed(() => store.state.engineIds.length > 1);
-
-    // hotkeys handled by Mousetrap
-    const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
-      [
-        "テキスト欄にフォーカスを戻す",
-        () => {
-          if (activeAudioKey.value !== undefined) {
-            focusCell({ audioKey: activeAudioKey.value });
-          }
-          return false; // this is the same with event.preventDefault()
-        },
-      ],
-    ]);
-
-    setHotkeyFunctions(hotkeyMap);
-
-    const removeAudioItem = async () => {
-      if (activeAudioKey.value == undefined) throw new Error();
-      audioCellRefs[activeAudioKey.value].removeCell();
-    };
-
-    // convert the hotkey array to Map to get value with keys easier
-    // this only happens here where we deal with native methods
-    const hotkeySettingsMap = computed(
-      () =>
-        new Map(
-          store.state.hotkeySettings.map((obj) => [obj.action, obj.combination])
-        )
-    );
-
-    // hotkeys handled by native, for they are made to be working while focusing input elements
-    const hotkeyActionsNative = [
-      (event: KeyboardEvent) => {
-        if (
-          !event.isComposing &&
-          !uiLocked.value &&
-          parseCombo(event) == hotkeySettingsMap.value.get("テキスト欄を追加")
-        ) {
-          addAudioItem();
-          event.preventDefault();
-        }
-      },
-      (event: KeyboardEvent) => {
-        if (
-          !event.isComposing &&
-          !uiLocked.value &&
-          parseCombo(event) == hotkeySettingsMap.value.get("テキスト欄を削除")
-        ) {
-          removeAudioItem();
-          event.preventDefault();
-        }
-      },
-      (event: KeyboardEvent) => {
-        if (
-          !event.isComposing &&
-          !uiLocked.value &&
-          parseCombo(event) ==
-            hotkeySettingsMap.value.get("テキスト欄からフォーカスを外す")
-        ) {
-          if (document.activeElement instanceof HTMLInputElement) {
-            document.activeElement.blur();
-          }
-          event.preventDefault();
-        }
-      },
-    ];
-
-    // view
-    const DEFAULT_PORTRAIT_PANE_WIDTH = 25; // %
-    const MIN_PORTRAIT_PANE_WIDTH = 0;
-    const MAX_PORTRAIT_PANE_WIDTH = 40;
-    const MIN_AUDIO_INFO_PANE_WIDTH = 160; // px
-    const MAX_AUDIO_INFO_PANE_WIDTH = 250;
-    const MIN_AUDIO_DETAIL_PANE_HEIGHT = 185; // px
-    const MAX_AUDIO_DETAIL_PANE_HEIGHT = 500;
-
-    const portraitPaneWidth = ref(0);
-    const audioInfoPaneWidth = ref(0);
-    const audioInfoPaneMinWidth = ref(0);
-    const audioInfoPaneMaxWidth = ref(0);
-    const audioDetailPaneHeight = ref(0);
-    const audioDetailPaneMinHeight = ref(0);
-    const audioDetailPaneMaxHeight = ref(0);
-
-    const changeAudioDetailPaneMaxHeight = (height: number) => {
-      if (!activeAudioKey.value) return;
-
-      const maxHeight = height - 200;
-      if (maxHeight > MAX_AUDIO_DETAIL_PANE_HEIGHT) {
-        // 最大値以上なら最大値に設定
-        audioDetailPaneMaxHeight.value = MAX_AUDIO_DETAIL_PANE_HEIGHT;
-      } else if (height < 200 + MIN_AUDIO_DETAIL_PANE_HEIGHT) {
-        // 最低値以下になってしまう場合は無制限に
-        audioDetailPaneMaxHeight.value = Infinity;
-      } else {
-        audioDetailPaneMaxHeight.value = maxHeight;
-      }
-    };
-
-    const splitterPosition = computed<SplitterPosition>(
-      () => store.state.splitterPosition
-    );
-
-    const updateSplitterPosition = async (
-      propertyName: keyof SplitterPosition,
-      newValue: number
-    ) => {
-      const newSplitterPosition = {
-        ...splitterPosition.value,
-        [propertyName]: newValue,
-      };
-      store.dispatch("SET_SPLITTER_POSITION", {
-        splitterPosition: newSplitterPosition,
-      });
-    };
-
-    const updatePortraitPane = async (width: number) => {
-      portraitPaneWidth.value = width;
-      await updateSplitterPosition("portraitPaneWidth", width);
-    };
-
-    const updateAudioInfoPane = async (width: number) => {
-      audioInfoPaneWidth.value = width;
-      await updateSplitterPosition("audioInfoPaneWidth", width);
-    };
-
-    const updateAudioDetailPane = async (height: number) => {
-      audioDetailPaneHeight.value = height;
-      await updateSplitterPosition("audioDetailPaneHeight", height);
-    };
-
-    // component
-    let audioCellRefs: Record<string, typeof AudioCell> = {};
-    const addAudioCellRef = (audioCellRef: typeof AudioCell) => {
-      if (audioCellRef) {
-        audioCellRefs[audioCellRef.audioKey] = audioCellRef;
-      }
-    };
-    onBeforeUpdate(() => {
-      audioCellRefs = {};
-    });
-
-    const resizeObserverRef = ref<QResizeObserver>();
-
-    // DaD
-    const updateAudioKeys = (audioKeys: string[]) =>
-      store.dispatch("COMMAND_SET_AUDIO_KEYS", { audioKeys });
-    const itemKey = (key: string) => key;
-
-    // セルを追加
-    const activeAudioKey = computed<string | undefined>(
-      () => store.getters.ACTIVE_AUDIO_KEY
-    );
-    const addAudioItem = async () => {
-      const prevAudioKey = activeAudioKey.value;
-      let engineId: string | undefined = undefined;
-      let styleId: number | undefined = undefined;
-      let presetKey: string | undefined = undefined;
-      if (prevAudioKey !== undefined) {
-        engineId = store.state.audioItems[prevAudioKey].engineId;
-        styleId = store.state.audioItems[prevAudioKey].styleId;
-        presetKey = store.state.audioItems[prevAudioKey].presetKey;
-      }
-      let baseAudioItem: AudioItem | undefined = undefined;
-      if (store.state.inheritAudioInfo) {
-        baseAudioItem = prevAudioKey
-          ? store.state.audioItems[prevAudioKey]
-          : undefined;
-      }
-      //パラメータ引き継ぎがONの場合は話速等のパラメータを引き継いでテキスト欄を作成する
-      //パラメータ引き継ぎがOFFの場合、baseAudioItemがundefinedになっているのでパラメータ引き継ぎは行われない
-      const audioItem = await store.dispatch("GENERATE_AUDIO_ITEM", {
-        engineId,
-        styleId,
-        presetKey,
-        baseAudioItem,
-      });
-
-      const newAudioKey = await store.dispatch("COMMAND_REGISTER_AUDIO_ITEM", {
-        audioItem,
-        prevAudioKey: activeAudioKey.value,
-      });
-      audioCellRefs[newAudioKey].focusTextField();
-    };
-
-    // Pane
-    const shouldShowPanes = computed<boolean>(
-      () => store.getters.SHOULD_SHOW_PANES
-    );
-    watch(shouldShowPanes, (val, old) => {
-      if (val === old) return;
-
-      if (val) {
-        const clamp = (value: number, min: number, max: number) =>
-          Math.max(Math.min(value, max), min);
-
-        // 設定ファイルを書き換えれば異常な値が入り得るのですべてclampしておく
-        portraitPaneWidth.value = clamp(
-          splitterPosition.value.portraitPaneWidth ??
-            DEFAULT_PORTRAIT_PANE_WIDTH,
-          MIN_PORTRAIT_PANE_WIDTH,
-          MAX_PORTRAIT_PANE_WIDTH
-        );
-
-        audioInfoPaneWidth.value = clamp(
-          splitterPosition.value.audioInfoPaneWidth ??
-            MIN_AUDIO_INFO_PANE_WIDTH,
-          MIN_AUDIO_INFO_PANE_WIDTH,
-          MAX_AUDIO_INFO_PANE_WIDTH
-        );
-        audioInfoPaneMinWidth.value = MIN_AUDIO_INFO_PANE_WIDTH;
-        audioInfoPaneMaxWidth.value = MAX_AUDIO_INFO_PANE_WIDTH;
-
-        audioDetailPaneMinHeight.value = MIN_AUDIO_DETAIL_PANE_HEIGHT;
-        changeAudioDetailPaneMaxHeight(
-          resizeObserverRef.value?.$el.parentElement.clientHeight
-        );
-
-        audioDetailPaneHeight.value = clamp(
-          splitterPosition.value.audioDetailPaneHeight ??
-            MIN_AUDIO_DETAIL_PANE_HEIGHT,
-          audioDetailPaneMinHeight.value,
-          audioDetailPaneMaxHeight.value
-        );
-      } else {
-        portraitPaneWidth.value = 0;
-        audioInfoPaneWidth.value = 0;
-        audioInfoPaneMinWidth.value = 0;
-        audioInfoPaneMaxWidth.value = 0;
-        audioDetailPaneHeight.value = 0;
-        audioDetailPaneMinHeight.value = 0;
-        audioDetailPaneMaxHeight.value = 0;
-      }
-    });
-
-    // セルをフォーカス
-    const focusCell = ({ audioKey }: { audioKey: string }) => {
-      audioCellRefs[audioKey].focusTextField();
-    };
-
-    // Electronのデフォルトのundo/redoを無効化
-    const disableDefaultUndoRedo = (event: KeyboardEvent) => {
-      // ctrl+z, ctrl+shift+z, ctrl+y
-      if (
-        event.ctrlKey &&
-        (event.key == "z" || (!event.shiftKey && event.key == "y"))
-      ) {
-        event.preventDefault();
-      }
-    };
-
-    // ソフトウェアを初期化
-    const isCompletedInitialStartup = ref(false);
-    onMounted(async () => {
-      await store.dispatch("GET_ENGINE_INFOS");
-
-      let engineIds: string[];
-      if (store.state.isSafeMode) {
-        // デフォルトエンジンだけを含める
-        const main = Object.values(store.state.engineInfos).find(
-          (engine) => engine.type === "default"
-        );
-        if (!main) {
-          throw new Error("No main engine found");
-        }
-        engineIds = [main.uuid];
-      } else {
-        engineIds = store.state.engineIds;
-      }
-      await Promise.all(
-        engineIds.map(async (engineId) => {
-          await store.dispatch("START_WAITING_ENGINE", { engineId });
-
-          await store.dispatch("FETCH_AND_SET_ENGINE_MANIFEST", { engineId });
-
-          await store.dispatch("LOAD_CHARACTER", { engineId });
-        })
-      );
-      await store.dispatch("LOAD_USER_CHARACTER_ORDER");
-      await store.dispatch("LOAD_DEFAULT_STYLE_IDS");
-
-      // 辞書を同期
-      await store.dispatch("SYNC_ALL_USER_DICT");
-
-      // 新キャラが追加されている場合はキャラ並び替えダイアログを表示
-      const newCharacters = await store.dispatch("GET_NEW_CHARACTERS");
-      isCharacterOrderDialogOpenComputed.value = newCharacters.length > 0;
-
-      // 最初のAudioCellを作成
-      const audioItem: AudioItem = await store.dispatch(
-        "GENERATE_AUDIO_ITEM",
-        {}
-      );
-      const newAudioKey = await store.dispatch("REGISTER_AUDIO_ITEM", {
-        audioItem,
-      });
-      focusCell({ audioKey: newAudioKey });
-
-      // 最初の話者を初期化
-      if (audioItem.engineId != undefined && audioItem.styleId != undefined) {
-        store.dispatch("SETUP_SPEAKER", {
-          audioKey: newAudioKey,
-          engineId: audioItem.engineId,
-          styleId: audioItem.styleId,
-        });
-      }
-
-      // ショートカットキーの設定
-      document.addEventListener("keydown", disableDefaultUndoRedo);
-
-      hotkeyActionsNative.forEach((item) => {
-        document.addEventListener("keyup", item);
-      });
-
-      isAcceptRetrieveTelemetryDialogOpenComputed.value =
-        store.state.acceptRetrieveTelemetry === "Unconfirmed";
-
-      isAcceptTermsDialogOpenComputed.value =
-        process.env.NODE_ENV == "production" &&
-        store.state.acceptTerms !== "Accepted";
-
-      isCompletedInitialStartup.value = true;
-    });
-
-    // エンジン待機
-    // TODO: 個別のエンジンの状態をUIで確認できるようにする
-    const allEngineState = computed(() => {
-      const engineStates = store.state.engineStates;
-
-      let lastEngineState: EngineState | undefined = undefined;
-
-      // 登録されているすべてのエンジンについて状態を確認する
-      for (const engineId of store.state.engineIds) {
-        const engineState: EngineState | undefined = engineStates[engineId];
-        if (engineState === undefined)
-          throw new Error(`No such engineState set: engineId == ${engineId}`);
-
-        // FIXME: 1つでも接続テストに成功していないエンジンがあれば、暫定的に起動中とする
-        if (engineState === "STARTING") {
-          return engineState;
-        }
-
-        lastEngineState = engineState;
-      }
-
-      return lastEngineState; // FIXME: 暫定的に1つのエンジンの状態を返す
-    });
-
-    const isEngineWaitingLong = ref<boolean>(false);
-    let engineTimer: number | undefined = undefined;
-    watch(allEngineState, (newEngineState) => {
-      if (engineTimer !== undefined) {
-        clearTimeout(engineTimer);
-        engineTimer = undefined;
-      }
-      if (newEngineState === "STARTING") {
-        isEngineWaitingLong.value = false;
-        engineTimer = window.setTimeout(() => {
-          isEngineWaitingLong.value = true;
-        }, 60000);
-      } else {
-        isEngineWaitingLong.value = false;
-      }
-    });
-    const restartAppWithSafeMode = () => {
-      store.dispatch("RESTART_APP", { isSafeMode: true });
-    };
-
-    const openFaq = () => {
-      window.open("https://voicevox.hiroshiba.jp/qa/", "_blank");
-    };
-
-    // ライセンス表示
-    const isHelpDialogOpenComputed = computed({
-      get: () => store.state.isHelpDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", { isHelpDialogOpen: val }),
-    });
-
-    // 設定
-    const isSettingDialogOpenComputed = computed({
-      get: () => store.state.isSettingDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", { isSettingDialogOpen: val }),
-    });
-
-    // ショートカットキー設定
-    const isHotkeySettingDialogOpenComputed = computed({
-      get: () => store.state.isHotkeySettingDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", {
-          isHotkeySettingDialogOpen: val,
-        }),
-    });
-
-    // ツールバーのカスタム設定
-    const isToolbarSettingDialogOpenComputed = computed({
-      get: () => store.state.isToolbarSettingDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", {
-          isToolbarSettingDialogOpen: val,
-        }),
-    });
-
-    // 利用規約表示
-    const isAcceptTermsDialogOpenComputed = computed({
-      get: () => store.state.isAcceptTermsDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", {
-          isAcceptTermsDialogOpen: val,
-        }),
-    });
-
-    // キャラクター並び替え
-    const orderedAllCharacterInfos = computed(
-      () => store.getters.GET_ORDERED_ALL_CHARACTER_INFOS
-    );
-    const isCharacterOrderDialogOpenComputed = computed({
-      get: () =>
-        !store.state.isAcceptTermsDialogOpen &&
-        store.state.isCharacterOrderDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", {
-          isCharacterOrderDialogOpen: val,
-        }),
-    });
-
-    // デフォルトスタイル選択
-    const isDefaultStyleSelectDialogOpenComputed = computed({
-      get: () =>
-        !store.state.isAcceptTermsDialogOpen &&
-        !store.state.isCharacterOrderDialogOpen &&
-        store.state.isDefaultStyleSelectDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", {
-          isDefaultStyleSelectDialogOpen: val,
-        }),
-    });
-
-    // エンジン管理
-    const isEngineManageDialogOpenComputed = computed({
-      get: () => store.state.isEngineManageDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", {
-          isEngineManageDialogOpen: val,
-        }),
-    });
-
-    // 読み方＆アクセント辞書
-    const isDictionaryManageDialogOpenComputed = computed({
-      get: () => store.state.isDictionaryManageDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", {
-          isDictionaryManageDialogOpen: val,
-        }),
-    });
-
-    const isAcceptRetrieveTelemetryDialogOpenComputed = computed({
-      get: () =>
-        !store.state.isAcceptTermsDialogOpen &&
-        !store.state.isCharacterOrderDialogOpen &&
-        !store.state.isDefaultStyleSelectDialogOpen &&
-        store.state.isAcceptRetrieveTelemetryDialogOpen,
-      set: (val) =>
-        store.dispatch("SET_DIALOG_OPEN", {
-          isAcceptRetrieveTelemetryDialogOpen: val,
-        }),
-    });
-
-    // ドラッグ＆ドロップ
-    const dragEventCounter = ref(0);
-    const loadDraggedFile = (event?: { dataTransfer: DataTransfer }) => {
-      if (!event || event.dataTransfer.files.length === 0) return;
-      const file = event.dataTransfer.files[0];
-      switch (path.extname(file.name)) {
-        case ".txt":
-          store.dispatch("COMMAND_IMPORT_FROM_FILE", { filePath: file.path });
-          break;
-        case ".vvproj":
-          store.dispatch("LOAD_PROJECT_FILE", { filePath: file.path });
-          break;
-        default:
-          $q.dialog({
-            title: "対応していないファイルです",
-            message:
-              "テキストファイル (.txt) とVOICEVOXプロジェクトファイル (.vvproj) に対応しています。",
-            ok: {
-              label: "閉じる",
-              flat: true,
-              textColor: "display",
-            },
-          });
-      }
-    };
-
-    return {
-      audioItems,
-      audioKeys,
-      uiLocked,
-      addAudioCellRef,
-      activeAudioKey,
-      itemKey,
-      updateAudioKeys,
-      addAudioItem,
-      shouldShowPanes,
-      focusCell,
-      changeAudioDetailPaneMaxHeight,
-      resizeObserverRef,
-      MIN_PORTRAIT_PANE_WIDTH,
-      MAX_PORTRAIT_PANE_WIDTH,
-      portraitPaneWidth,
-      audioInfoPaneWidth,
-      audioInfoPaneMinWidth,
-      audioInfoPaneMaxWidth,
-      audioDetailPaneHeight,
-      audioDetailPaneMinHeight,
-      audioDetailPaneMaxHeight,
-      updatePortraitPane,
-      updateAudioInfoPane,
-      updateAudioDetailPane,
-      isCompletedInitialStartup,
-      allEngineState,
-      isEngineWaitingLong,
-      isMultipleEngine,
-      restartAppWithSafeMode,
-      openFaq,
-      isHelpDialogOpenComputed,
-      isSettingDialogOpenComputed,
-      isHotkeySettingDialogOpenComputed,
-      isToolbarSettingDialogOpenComputed,
-      orderedAllCharacterInfos,
-      isCharacterOrderDialogOpenComputed,
-      isDefaultStyleSelectDialogOpenComputed,
-      isEngineManageDialogOpenComputed,
-      isDictionaryManageDialogOpenComputed,
-      isAcceptRetrieveTelemetryDialogOpenComputed,
-      isAcceptTermsDialogOpenComputed,
-      dragEventCounter,
-      loadDraggedFile,
-    };
-  },
-});
-</script>
 
 <style scoped lang="scss">
 @use '@/styles/variables' as vars;


### PR DESCRIPTION
## 内容

Vueの書き方を変更します。
- `<script setup>`構文を使う
- コンポーネントをキャメルケースで書くようにする
- `template`→`script`→`style`の順番にする

## 関連 Issue

- closes: #1065

## スクリーンショット・動画など

（なし）

## その他

（なし）