### PR TITLE
[release-0.13] publicディレクトリにキャラデータコピーは不要なので省く

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,42 +181,6 @@ jobs:
           ref: ${{ env.VOICEVOX_RESOURCE_VERSION }}
           path: resource
 
-      - name: Replace Character Info
-        shell: bash
-        run: |
-          cp -r resource/character_info public/characters
-          cd public/characters
-          # Explore characters directory.
-          # Character directory name is uuid, but this script can automatically detect character directory name.
-          # We don't need to change this code when add more characters.
-          # FILEPATH example: "./35b2c544-660e-401e-b503-0e14c635303a"
-          for FILEPATH in ./*
-            do
-            # Extract speaker name from metas.json by jq command
-            SPEAKER_NAME="$(jq -r '.speakerName' "$FILEPATH/metas.json")"
-            pushd "$FILEPATH/icons"
-            # Explore character icons directory.
-            # ICONPATH example: "./0.png"
-            for ICONPATH in ./*.png
-              do
-              # ":2" part is python slice like, can remove "./" part from ICONPATH
-              # For example, SPEAKER_NAME is "AAA", ICONPATH is "./0.png"
-              # If don't use ":2": "${SPEAKER_NAME}_${ICONPATH}" is "AAA_./0.png"
-              #       If use ":2": "${SPEAKER_NAME}_${ICONPATH:2}" is "AAA_0.png"
-              mv $ICONPATH "${SPEAKER_NAME}_${ICONPATH:2}"
-            done
-            popd
-            pushd "$FILEPATH/voice_samples"
-            # Explore character voice_samples directory.
-            # VOICEPATH example: "./0_000.wav"
-            for VOICEPATH in ./*.wav
-              do
-              # Same as for ICONPATH
-              mv $VOICEPATH "${SPEAKER_NAME}_${VOICEPATH:2}"
-            done
-            popd
-          done
-
       - name: Create and replace software resources
         shell: bash
         run: |


### PR DESCRIPTION
## 内容

publicディレクトリにキャラデータコピーは不要なので省きます。

昔はリソースファイルをエディタに実装していました。
キャラ名がファイル名になる設計だったらしく、`小夜/SAYO`がディレクトリ名と勘違いされてエラーになってしまいました。

おそらくコード自体不要なはずなので、消去します。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
