### PR TITLE
Improve: 辞書UIの操作感を改善

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -43,7 +43,7 @@
             <div
               v-if="wordEditing"
               class="word-list-disable-overlay"
-              @click="isWordChanged ? discardOrNotDialog(cancel) : cancel()"
+              @click="discardOrNotDialog(cancel)"
             />
             <div class="word-list-header text-no-wrap">
               <div class="row word-list-title text-h5">単語一覧</div>
@@ -228,7 +228,7 @@
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="isWordChanged ? discardOrNotDialog(cancel) : cancel()"
+                @click="discardOrNotDialog(cancel)"
                 :disable="uiLocked"
                 >キャンセル</q-btn
               >

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -20,6 +20,7 @@
               flat
               icon="close"
               color="display"
+              :disable="wordEditing"
               @click="discardOrNotDialog(closeDialog)"
             />
           </q-toolbar>
@@ -39,7 +40,11 @@
             </div>
           </div>
           <div class="col-4 word-list-col">
-            <div v-if="wordEditing" class="word-list-disable-overlay" />
+            <div
+              v-if="wordEditing"
+              class="word-list-disable-overlay"
+              @click="isWordChanged ? discardOrNotDialog(cancel) : cancel()"
+            />
             <div class="word-list-header text-no-wrap">
               <div class="row word-list-title text-h5">単語一覧</div>
               <div class="row no-wrap">
@@ -77,6 +82,7 @@
                 v-ripple
                 clickable
                 @click="selectWord(key)"
+                @dblclick="editWord"
                 :active="selectedId === key"
                 active-class="active-word"
               >


### PR DESCRIPTION
## 内容

辞書UIの操作感を改善します。
- 単語をダブルクリックで編集
- 左のペインをクリックでキャンセル
- 単語編集中は辞書UIを閉じるボタンを無効化

## 関連 Issue

（なし）

## スクリーンショット・動画など

https://user-images.githubusercontent.com/59691627/210121789-d1dfe4b8-8108-40f9-b1a8-822f77c1f532.mp4

## その他

（なし）