### PR TITLE
maintainerチームがレビュワーとして自動アサインされるように

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @VOICEVOX/maintainer


### PR DESCRIPTION
## 内容

エディタとエンジンで、 @VOICEVOX/maintainer チームのメンバー１名が自動でアサインされるようにしてみます。

## その他

チームを作ったあと自動アサインを有効にし、あとは`.github/CODEOWNERS`で設定すればOKっぽい･･･？
うまく行けば色んな所でこんな感じの設定ができるとOSSっぽそう！
