### PR TITLE
メインプロセス側のRESTART_ENGINE_ALLが使われてないので消しておく

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -891,10 +891,6 @@ ipcMainHandle("ENGINE_INFOS", () => {
  * エンジンを再起動する。
  * エンジンの起動が開始したらresolve、起動が失敗したらreject。
  */
-ipcMainHandle("RESTART_ENGINE_ALL", async () => {
-  await engineManager.restartEngineAll(win);
-});
-
 ipcMainHandle("RESTART_ENGINE", async (_, { engineId }) => {
   await engineManager.restartEngine(engineId, win);
 });

--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -379,17 +379,6 @@ export class EngineManager {
   }
 
   /**
-   * 全てのエンジンを再起動する。
-   * FIXME: winを受け取らなくても良いようにする
-   */
-  async restartEngineAll(win: BrowserWindow) {
-    const engineInfos = this.fetchEngineInfos();
-    for (const engineInfo of engineInfos) {
-      await this.restartEngine(engineInfo.uuid, win);
-    }
-  }
-
-  /**
    * エンジンを再起動する。
    * FIXME: winを受け取らなくても良いようにする
    */

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -185,10 +185,6 @@ const api: Sandbox = {
     return ipcRendererInvoke("ENGINE_INFOS");
   },
 
-  restartEngineAll: () => {
-    return ipcRendererInvoke("RESTART_ENGINE_ALL");
-  },
-
   restartEngine: (engineId: string) => {
     return ipcRendererInvoke("RESTART_ENGINE", { engineId });
   },

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -83,7 +83,6 @@ export interface Sandbox {
   logError(...params: unknown[]): void;
   logInfo(...params: unknown[]): void;
   engineInfos(): Promise<EngineInfo[]>;
-  restartEngineAll(): Promise<void>;
   restartEngine(engineId: string): Promise<void>;
   openEngineDirectory(engineId: string): void;
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;


### PR DESCRIPTION
## 内容

エンジンを全部再起動するのが２経路存在してしまっていたので、使われていない片方を消します。


## その他

残しといても良いかもなのですが、メンテされなくなったこれを使っちゃったり、間違ってこちらを使っちゃったりするのが容易に起こりそうだったので、気づいた今消しておこうかなーと･･･。
（残しといても良いのでは的な賛否両論ありそう）

- https://github.com/VOICEVOX/voicevox/pull/1062

は使われてる方の`RESTART_ENGINE_ALL`を変更しているのですが、こちらとコンフリクトしない（つまり完全に独立してる）ことは確認済みです。