### PR TITLE
ログをブラウザのconsole.logにも出力

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -878,6 +878,10 @@ ipcMainHandle("LOG_ERROR", (_, ...params) => {
   log.error(...params);
 });
 
+ipcMainHandle("LOG_WARN", (_, ...params) => {
+  log.warn(...params);
+});
+
 ipcMainHandle("LOG_INFO", (_, ...params) => {
   log.info(...params);
 });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -174,10 +174,17 @@ const api: Sandbox = {
   },
 
   logError: (...params) => {
+    console.error(...params);
     return ipcRenderer.invoke("LOG_ERROR", ...params);
   },
 
+  logWarn: (...params) => {
+    console.warn(...params);
+    return ipcRenderer.invoke("LOG_WARN", ...params);
+  },
+
   logInfo: (...params) => {
+    console.log(...params);
     return ipcRenderer.invoke("LOG_INFO", ...params);
   },
 

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -184,7 +184,7 @@ const api: Sandbox = {
   },
 
   logInfo: (...params) => {
-    console.log(...params);
+    console.info(...params);
     return ipcRenderer.invoke("LOG_INFO", ...params);
   },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -267,6 +267,12 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
     },
   },
 
+  LOG_WARN: {
+    action(_, ...params: unknown[]) {
+      window.electron.logWarn(...params);
+    },
+  },
+
   LOG_INFO: {
     action(_, ...params: unknown[]) {
       window.electron.logInfo(...params);

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -833,6 +833,10 @@ export type IndexStoreTypes = {
     action(...payload: unknown[]): void;
   };
 
+  LOG_WARN: {
+    action(...payload: unknown[]): void;
+  };
+
   LOG_INFO: {
     action(...payload: unknown[]): void;
   };

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -97,7 +97,9 @@ export const uiStore = createPartialStore<UiStoreTypes>({
         state.uiLockCount--;
       } else {
         // eslint-disable-next-line no-console
-        console.warn("UNLOCK_UI is called when state.uiLockCount == 0");
+        window.electron.logWarn(
+          "UNLOCK_UI is called when state.uiLockCount == 0"
+        );
       }
     },
     action({ commit }) {

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -178,6 +178,11 @@ export type IpcIHData = {
     return: void;
   };
 
+  LOG_WARN: {
+    args: [...params: unknown[]];
+    return: void;
+  };
+
   LOG_INFO: {
     args: [...params: unknown[]];
     return: void;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -81,6 +81,7 @@ export interface Sandbox {
   minimizeWindow(): void;
   maximizeWindow(): void;
   logError(...params: unknown[]): void;
+  logWarn(...params: unknown[]): void;
   logInfo(...params: unknown[]): void;
   engineInfos(): Promise<EngineInfo[]>;
   restartEngineAll(): Promise<void>;


### PR DESCRIPTION
## 内容

window.electron.errorなどはコンソールにエラーを出しますが、コードジャンプができないのでちょっと不便です。
electron側（ブラウザ側）にも表示すれば便利かなと思ったのでそうしてみました。

ついでにlogWarnを作っています。

## その他
