### PR TITLE
0.14でconfig.jsonの場所が変わるのでマイグレーション

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -36,6 +36,7 @@ import dayjs from "dayjs";
 import windowStateKeeper from "electron-window-state";
 import EngineManager from "./background/engineManager";
 import VvppManager from "./background/vvppManager";
+import configMigration014 from "./background/configMigration014";
 
 type SingleInstanceLockData = {
   filePath: string | undefined;
@@ -44,6 +45,7 @@ type SingleInstanceLockData = {
 const isDevelopment = process.env.NODE_ENV !== "production";
 
 // Electronの設定ファイルの保存場所を変更
+const beforeUserDataDir = app.getPath("userData"); // 設定ファイルのマイグレーション用
 const fixedUserDataDir = path.join(
   app.getPath("appData"),
   `voicevox${isDevelopment ? "-dev" : ""}`
@@ -52,6 +54,7 @@ if (!fs.existsSync(fixedUserDataDir)) {
   fs.mkdirSync(fixedUserDataDir);
 }
 app.setPath("userData", fixedUserDataDir);
+configMigration014({ fixedUserDataDir, beforeUserDataDir }); // 以前のファイルがあれば持ってくる
 
 // silly以上のログをコンソールに出力
 log.transports.console.format = "[{h}:{i}:{s}.{ms}] [{level}] {text}";

--- a/src/background.ts
+++ b/src/background.ts
@@ -54,7 +54,9 @@ if (!fs.existsSync(fixedUserDataDir)) {
   fs.mkdirSync(fixedUserDataDir);
 }
 app.setPath("userData", fixedUserDataDir);
-configMigration014({ fixedUserDataDir, beforeUserDataDir }); // 以前のファイルがあれば持ってくる
+if (!isDevelopment) {
+  configMigration014({ fixedUserDataDir, beforeUserDataDir }); // 以前のファイルがあれば持ってくる
+}
 
 // silly以上のログをコンソールに出力
 log.transports.console.format = "[{h}:{i}:{s}.{ms}] [{level}] {text}";

--- a/src/background/configMigration014.ts
+++ b/src/background/configMigration014.ts
@@ -4,6 +4,14 @@ import path from "path";
 
 import semver from "semver";
 
+function _logInfo(message: string) {
+  console.info(`configMigration014: ${message}`);
+}
+
+function _logError(message: string) {
+  console.error(`configMigration014: ${message}`);
+}
+
 export default function ({
   fixedUserDataDir,
   beforeUserDataDir,
@@ -22,9 +30,7 @@ export default function ({
       }
 
       if (semver.satisfies(config.__internal__.migrations.version, ">=0.14")) {
-        console.info(
-          `configMigration014: >=0.14 ${configPath} exists, do nothing`
-        );
+        _logInfo(`>=0.14 ${configPath} exists, do nothing`);
         return;
       }
     }
@@ -35,22 +41,18 @@ export default function ({
       // 今のconfigがあれば念のためバックアップ
       if (fs.existsSync(configPath)) {
         const backupPath = path.join(fixedUserDataDir, "config-backup.json");
-        console.info(`configMigration014: backup to ${backupPath}`);
+        _logInfo(`backup to ${backupPath}`);
         fs.copyFileSync(configPath, backupPath);
       }
 
-      console.info(
-        `configMigration014: copy from ${beforeConfigPath} to ${configPath}`
-      );
+      _logInfo(`copy from ${beforeConfigPath} to ${configPath}`);
       fs.copyFileSync(beforeConfigPath, configPath);
       return;
     } else {
-      console.info(
-        `configMigration014: ${beforeConfigPath} not exists, do nothing`
-      );
+      _logInfo(`${beforeConfigPath} not exists, do nothing`);
     }
   } catch (e) {
-    console.error("configMigration014: error!");
+    _logError("error!");
     console.error(e);
   }
 }

--- a/src/background/configMigration014.ts
+++ b/src/background/configMigration014.ts
@@ -1,0 +1,56 @@
+// configファイルの場所が0.14で変わったので、以前のファイルを持ってくる
+import fs from "fs";
+import path from "path";
+
+import semver from "semver";
+
+export default function ({
+  fixedUserDataDir,
+  beforeUserDataDir,
+}: {
+  fixedUserDataDir: string;
+  beforeUserDataDir: string;
+}) {
+  try {
+    // ファイルが存在していてバージョン0.14以上であれば何もしない
+    const configPath = path.join(fixedUserDataDir, "config.json");
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+
+      if (config?.__internal__?.migrations?.version === undefined) {
+        throw new Error("configMigration014: config.json is invalid");
+      }
+
+      if (semver.satisfies(config.__internal__.migrations.version, ">=0.14")) {
+        console.info(
+          `configMigration014: >=0.14 ${configPath} exists, do nothing`
+        );
+        return;
+      }
+    }
+
+    // 以前のファイルが存在していればコピー
+    const beforeConfigPath = path.join(beforeUserDataDir, "config.json");
+    if (fs.existsSync(beforeConfigPath)) {
+      // 今のconfigがあれば念のためバックアップ
+      if (fs.existsSync(configPath)) {
+        const backupPath = path.join(fixedUserDataDir, "config-backup.json");
+        console.info(`configMigration014: backup to ${backupPath}`);
+        fs.copyFileSync(configPath, backupPath);
+      }
+
+      console.info(
+        `configMigration014: copy from ${beforeConfigPath} to ${configPath}`
+      );
+      fs.copyFileSync(beforeConfigPath, configPath);
+      return;
+    } else {
+      console.info(
+        `configMigration014: ${beforeConfigPath} not exists, do nothing`
+      );
+    }
+  } catch (e) {
+    console.error("configMigration014: error!");
+    console.error(e);
+  }
+}


### PR DESCRIPTION
## 内容

config.jsonの場所（設定の場所）が、以前はデバイス依存でディレクトリ名が変わっていたのが、0.14で`%appdata%/voicevox`に固定されます。

- https://github.com/VOICEVOX/voicevox/issues/1008

このPRでは、以前の場所にconfig.jsonがあればコピーするようにします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1008
- https://github.com/VOICEVOX/voicevox/pull/1005

close #1008

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

開発バージョンの場合、以前は`%appdata%/voicevox`、今は`%appdata%/voiecvox-dev`になっています。
なので`voicevox/config.json`を消したり`voiecvox-dev/config.json`のバージョンを変えたりでデバッグできると思います。

あまり興味持たれない場所だと思うので、ある程度時間が経ってから見直されたときにわかるよう、ちょっと丁寧にログ出力しています。
