### PR TITLE
EngineId、SpeakerId、StyleIdの説明が間違ってるところを修正

### DIFF
--- a/docs/細かい設計方針.md
+++ b/docs/細かい設計方針.md
@@ -8,10 +8,11 @@
 
 EngineId はエンジンが持つ ID で、世界で唯一かつ不変です。
 SpeakerId は話者が持つ ID で、世界で唯一かつ不変。エンジン間でも同じ ID を持ちます。
-StyleId はスタイルごとの ID で、話者ごとに唯一であれば良いです。
+StyleId はスタイルごとの ID で、エンジンごとに唯一であれば良いです。
 
 声を一意に決めるには、(EngineId, SpeakerId, StyleId)の３組が揃っている必要がある、という仕様を目指しています。
 現状は、音声合成APIに SpeakerId 引数が無いため、(EngineId, StyleId)の２組で一意に声が決まっています。
+現状は StyleId はエンジンごとに唯一である必要がありますが、話者ごとに唯一であれば良いという仕様を目指しています。
 
 VOICEVOX は歴史的経緯により、 SpeakerId と StyleId が混同していることがあります。
 特に型が整数値になっている SpeakerId は StyleId と混同している場合があります。


### PR DESCRIPTION
## 内容

StyleIdが話者ごとに唯一であれば良い、という説明は実際と乖離しているので修正します。
理想はそうなったら嬉しいなということなので、その点を追記しました。
