### PR TITLE
複数エンジン対応：再起動ボタンをエラー時に押せるように

### DIFF
--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -317,7 +317,7 @@
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
                 @click="restartSelectedEngine"
-                :disable="uiLocked || engineStates[selectedId] !== 'READY'"
+                :disable="uiLocked || engineStates[selectedId] === 'STARTING'"
                 >再起動</q-btn
               >
             </div>


### PR DESCRIPTION
## 内容

再起動ボタンをエンジンがエラー落ちしたときに押せるようにします。

## 関連 Issue

- ref: voicevox/voicevox_project#2

## スクリーンショット・動画など

（なし）

## その他

（なし）