### PR TITLE
vvpp経由でインストールされたエンジンをmacとlinuxでも起動できるようにする

### DIFF
--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -13,17 +13,11 @@ import {
   EngineInfo,
   ElectronStoreType,
   EngineDirValidationResult,
+  MinimumEngineManifest,
 } from "@/type/preload";
 
 import log from "electron-log";
 import { z } from "zod";
-
-type MinimumEngineManifest = {
-  name: string;
-  uuid: string;
-  command: string;
-  port: string;
-};
 
 type EngineProcessContainer = {
   willQuitEngine: boolean;

--- a/src/background/vvppManager.ts
+++ b/src/background/vvppManager.ts
@@ -1,18 +1,13 @@
-import { EngineManifest } from "@/openapi";
 import fs from "fs";
 import path from "path";
 import log from "electron-log";
 import { moveFile } from "move-file";
 import { Extract } from "unzipper";
 import { dialog } from "electron";
-import { EngineInfo } from "@/type/preload";
+import { EngineInfo, MinimumEngineManifest } from "@/type/preload";
 import MultiStream from "multistream";
 import glob, { glob as callbackGlob } from "glob";
 import { spawn } from "child_process";
-
-type EngineManifestJson = EngineManifest & {
-  command: string;
-};
 
 const isNotWin = process.platform !== "win32";
 
@@ -75,12 +70,12 @@ export class VvppManager {
     this.willDeleteEngineIds.add(engineId);
   }
 
-  toValidDirName(manifest: EngineManifestJson) {
+  toValidDirName(manifest: MinimumEngineManifest) {
     // フォルダに使用できない文字が含まれている場合は置換する
     return `${manifest.name.replace(/[\s<>:"/\\|?*]+/g, "_")}+${manifest.uuid}`;
   }
 
-  isEngineDirName(dir: string, manifest: EngineManifestJson) {
+  isEngineDirName(dir: string, manifest: MinimumEngineManifest) {
     return dir.endsWith(`+${manifest.uuid}`);
   }
 
@@ -103,7 +98,7 @@ export class VvppManager {
 
   async extractVvpp(
     vvppPath: string
-  ): Promise<{ outputDir: string; manifest: EngineManifestJson }> {
+  ): Promise<{ outputDir: string; manifest: MinimumEngineManifest }> {
     const nonce = new Date().getTime().toString();
     const outputDir = path.join(this.vvppEngineDir, ".tmp", nonce);
 
@@ -151,7 +146,7 @@ export class VvppManager {
         path.join(outputDir, "engine_manifest.json"),
         "utf-8"
       )
-    ) as EngineManifestJson;
+    ) as MinimumEngineManifest;
     return {
       outputDir,
       manifest,

--- a/src/background/vvppManager.ts
+++ b/src/background/vvppManager.ts
@@ -7,7 +7,7 @@ import { dialog } from "electron";
 import { EngineInfo, MinimumEngineManifest } from "@/type/preload";
 import MultiStream from "multistream";
 import glob, { glob as callbackGlob } from "glob";
-import { spawn } from "child_process";
+import { spawnSync } from "child_process";
 
 const isNotWin = process.platform !== "win32";
 
@@ -168,7 +168,7 @@ export class VvppManager {
       await moveFile(outputDir, engineDirectory);
     }
     if (isNotWin) {
-      spawn("chmod", ["u+x", manifest.command], {
+      spawnSync("chmod", ["u+x", manifest.command], {
         cwd: engineDirectory,
       });
     }

--- a/src/background/vvppManager.ts
+++ b/src/background/vvppManager.ts
@@ -8,6 +8,13 @@ import { dialog } from "electron";
 import { EngineInfo } from "@/type/preload";
 import MultiStream from "multistream";
 import glob, { glob as callbackGlob } from "glob";
+import { spawn } from "child_process";
+
+type EngineManifestJson = EngineManifest & {
+  command: string;
+};
+
+const isNotWin = process.platform !== "win32";
 
 // globのPromise化
 const globAsync = (pattern: string, options?: glob.IOptions) => {
@@ -68,12 +75,12 @@ export class VvppManager {
     this.willDeleteEngineIds.add(engineId);
   }
 
-  toValidDirName(manifest: EngineManifest) {
+  toValidDirName(manifest: EngineManifestJson) {
     // フォルダに使用できない文字が含まれている場合は置換する
     return `${manifest.name.replace(/[\s<>:"/\\|?*]+/g, "_")}+${manifest.uuid}`;
   }
 
-  isEngineDirName(dir: string, manifest: EngineManifest) {
+  isEngineDirName(dir: string, manifest: EngineManifestJson) {
     return dir.endsWith(`+${manifest.uuid}`);
   }
 
@@ -96,7 +103,7 @@ export class VvppManager {
 
   async extractVvpp(
     vvppPath: string
-  ): Promise<{ outputDir: string; manifest: EngineManifest }> {
+  ): Promise<{ outputDir: string; manifest: EngineManifestJson }> {
     const nonce = new Date().getTime().toString();
     const outputDir = path.join(this.vvppEngineDir, ".tmp", nonce);
 
@@ -144,7 +151,7 @@ export class VvppManager {
         path.join(outputDir, "engine_manifest.json"),
         "utf-8"
       )
-    ) as EngineManifest;
+    ) as EngineManifestJson;
     return {
       outputDir,
       manifest,
@@ -164,6 +171,11 @@ export class VvppManager {
       this.markWillMove(outputDir, dirName);
     } else {
       await moveFile(outputDir, engineDirectory);
+    }
+    if (isNotWin) {
+      spawn("chmod", ["u+x", manifest.command], {
+        cwd: engineDirectory,
+      });
     }
   }
 

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -264,6 +264,13 @@ export type DefaultStyleId = {
   defaultStyleId: number;
 };
 
+export type MinimumEngineManifest = {
+  name: string;
+  uuid: string;
+  command: string;
+  port: string;
+};
+
 export type EngineInfo = {
   uuid: string;
   host: string;


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り
エンジンの実行ファイルに実行権限が付与されないために、エンジンの起動に失敗する問題があったので、それを修正しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- ref #991 
- ref #1058 
- ref voicevox/voicevox_project#2

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

エンジンのAPIから帰ってくる`engine_manifest`と`engine_manifest.json`は実態が全然違うので、本来は分けて型定義すべきな気がするので、FIXMEやTODOにするべき...?
