### PR TITLE
vvppエンジンへの実行権限付与に`spawnSync`ではなく`fs.promises.chmod`を使うようにする

### DIFF
--- a/src/background/vvppManager.ts
+++ b/src/background/vvppManager.ts
@@ -7,7 +7,6 @@ import { dialog } from "electron";
 import { EngineInfo, MinimumEngineManifest } from "@/type/preload";
 import MultiStream from "multistream";
 import glob, { glob as callbackGlob } from "glob";
-import { spawnSync } from "child_process";
 
 const isNotWin = process.platform !== "win32";
 
@@ -168,9 +167,10 @@ export class VvppManager {
       await moveFile(outputDir, engineDirectory);
     }
     if (isNotWin) {
-      spawnSync("chmod", ["u+x", manifest.command], {
-        cwd: engineDirectory,
-      });
+      await fs.promises.chmod(
+        path.join(engineDirectory, manifest.command),
+        "755"
+      );
     }
   }
 


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通りです
今まではユーザーに対して実行権限を付与するようなコードでしたが、`fs.chmod`ではそのような書き方ができなかったので、`755`(ユーザーは読み書きと実行、それ以外は読みと実行ができる)にしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- ref #1112 

