### PR TITLE
複数エンジン対応: テキスト読み込みを複数エンジンに対応

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -143,7 +143,7 @@ const store = new Store<ElectronStoreType>({
       store.set(
         "defaultStyleIds",
         prevDefaultStyleIds.map((defaultStyle) => ({
-          engineId: defaultStyle.engineId ?? engineId,
+          engineId: engineId,
           speakerUuid: defaultStyle.speakerUuid,
           defaultStyleId: defaultStyle.defaultStyleId,
         }))

--- a/src/background.ts
+++ b/src/background.ts
@@ -134,6 +134,16 @@ const store = new Store<ElectronStoreType>({
       if (store.get("savingSetting").outputSamplingRate == 24000) {
         store.set("savingSetting.outputSamplingRate", "engineDefault");
       }
+      const engineId = "074fc39e-678b-4c13-8916-ffca8d505d1d";
+      const prevDefaultStyleIds = store.get("defaultStyleIds");
+      store.set(
+        "defaultStyleIds",
+        prevDefaultStyleIds.map((defaultStyle) => ({
+          engineId: defaultStyle.engineId ?? engineId,
+          speakerUuid: defaultStyle.speakerUuid,
+          defaultStyleId: defaultStyle.defaultStyleId,
+        }))
+      );
     },
   },
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -134,7 +134,11 @@ const store = new Store<ElectronStoreType>({
       if (store.get("savingSetting").outputSamplingRate == 24000) {
         store.set("savingSetting.outputSamplingRate", "engineDefault");
       }
-      const engineId = "074fc39e-678b-4c13-8916-ffca8d505d1d";
+      // できるならEngineManagerからEnginIDを取得したい
+      const engineId = JSON.parse(process.env.DEFAULT_ENGINE_INFOS ?? "[]")[0]
+        .uuid;
+      if (engineId == undefined)
+        throw new Error("DEFAULT_ENGINE_INFOS[0].uuid == undefined");
       const prevDefaultStyleIds = store.get("defaultStyleIds");
       store.set(
         "defaultStyleIds",

--- a/src/background.ts
+++ b/src/background.ts
@@ -134,7 +134,7 @@ const store = new Store<ElectronStoreType>({
       if (store.get("savingSetting").outputSamplingRate == 24000) {
         store.set("savingSetting.outputSamplingRate", "engineDefault");
       }
-      // できるならEngineManagerからEnginIDを取得したい
+      // FIXME: できるならEngineManagerからEnginIDを取得したい
       const engineId = JSON.parse(process.env.DEFAULT_ENGINE_INFOS ?? "[]")[0]
         .uuid;
       if (engineId == undefined)

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -288,10 +288,11 @@ export default defineComponent({
         JSON.stringify(store.state.defaultStyleIds)
       ) as DefaultStyleId[];
       multiStyleCharacterInfos.value.forEach((info, idx) => {
+        const defaultStyleKey = selectedStyleIndexes.value[idx] ?? 0;
         const defaultStyleInfo = {
+          engineId: info.metas.styles[defaultStyleKey].engineId,
           speakerUuid: info.metas.speakerUuid,
-          defaultStyleId:
-            info.metas.styles[selectedStyleIndexes.value[idx] ?? 0].styleId,
+          defaultStyleId: info.metas.styles[defaultStyleKey].styleId,
         };
         const nowSettingIndex = defaultStyleIds.findIndex(
           (s) => s.speakerUuid === info.metas.speakerUuid

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -115,7 +115,6 @@ function parseTextFile(
       continue;
     }
 
-    // FIXME: engineIdの追加
     audioItems.push({
       text: splitText,
       engineId: lastStyle.engineId,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -107,7 +107,7 @@ function parseTextFile(
   let lastStyle = uuid2StyleIds.get(
     userOrderedCharacterInfos[0].metas.speakerUuid
   );
-  if (lastStyle == undefined) throw new Error(`lastStyleId is undefined.`);
+  if (lastStyle == undefined) throw new Error(`lastStyle is undefined.`);
   for (const splitText of body.split(new RegExp(`${seps.join("|")}`, "g"))) {
     const styleId = characters.get(splitText);
     if (styleId !== undefined) {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -68,28 +68,35 @@ function parseTextFile(
   defaultStyleIds: DefaultStyleId[],
   userOrderedCharacterInfos: CharacterInfo[]
 ): AudioItem[] {
-  const characters = new Map<string, number>();
-  const uuid2StyleIds = new Map<string, number>();
+  const characters = new Map<string, { engineId: string; styleId: number }>();
+  const uuid2StyleIds = new Map<
+    string,
+    { engineId: string; styleId: number }
+  >();
   for (const defaultStyleId of defaultStyleIds) {
     const speakerUuid = defaultStyleId.speakerUuid;
+    const engineId = defaultStyleId.engineId;
     const styleId = defaultStyleId.defaultStyleId;
-    uuid2StyleIds.set(speakerUuid, styleId);
+    uuid2StyleIds.set(speakerUuid, { engineId, styleId });
   }
   // setup default characters
   for (const characterInfo of userOrderedCharacterInfos) {
     const uuid = characterInfo.metas.speakerUuid;
-    const styleId = uuid2StyleIds.get(uuid);
+    const style = uuid2StyleIds.get(uuid);
     const speakerName = characterInfo.metas.speakerName;
-    if (styleId == undefined)
+    if (style == undefined)
       throw new Error(`styleId is undefined. speakerUuid: ${uuid}`);
-    characters.set(speakerName, styleId);
+    characters.set(speakerName, {
+      engineId: style.engineId,
+      styleId: style.styleId,
+    });
   }
   // setup characters with style name
   for (const characterInfo of userOrderedCharacterInfos) {
     for (const style of characterInfo.metas.styles) {
       characters.set(
         `${characterInfo.metas.speakerName}(${style.styleName || "ノーマル"})`,
-        style.styleId
+        { engineId: style.engineId, styleId: style.styleId }
       );
     }
   }
@@ -97,19 +104,23 @@ function parseTextFile(
 
   const audioItems: AudioItem[] = [];
   const seps = [",", "\r\n", "\n"];
-  let lastStyleId = uuid2StyleIds.get(
+  let lastStyle = uuid2StyleIds.get(
     userOrderedCharacterInfos[0].metas.speakerUuid
   );
-  if (lastStyleId == undefined) throw new Error(`lastStyleId is undefined.`);
+  if (lastStyle == undefined) throw new Error(`lastStyleId is undefined.`);
   for (const splitText of body.split(new RegExp(`${seps.join("|")}`, "g"))) {
     const styleId = characters.get(splitText);
     if (styleId !== undefined) {
-      lastStyleId = styleId;
+      lastStyle = styleId;
       continue;
     }
 
     // FIXME: engineIdの追加
-    audioItems.push({ text: splitText, styleId: lastStyleId });
+    audioItems.push({
+      text: splitText,
+      engineId: lastStyle.engineId,
+      styleId: lastStyle.styleId,
+    });
   }
   return audioItems;
 }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -85,7 +85,7 @@ function parseTextFile(
     const style = uuid2StyleIds.get(uuid);
     const speakerName = characterInfo.metas.speakerName;
     if (style == undefined)
-      throw new Error(`styleId is undefined. speakerUuid: ${uuid}`);
+      throw new Error(`style is undefined. speakerUuid: ${uuid}`);
     characters.set(speakerName, {
       engineId: style.engineId,
       styleId: style.styleId,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -158,9 +158,7 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
 
   LOAD_DEFAULT_STYLE_IDS: {
     async action({ commit, getters }) {
-      let defaultStyleIds = (await window.electron.getSetting(
-        "defaultStyleIds"
-      )) as DefaultStyleId[];
+      let defaultStyleIds = await window.electron.getSetting("defaultStyleIds");
 
       const allCharacterInfos = getters.GET_ALL_CHARACTER_INFOS;
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -158,7 +158,9 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
 
   LOAD_DEFAULT_STYLE_IDS: {
     async action({ commit, getters }) {
-      let defaultStyleIds = await window.electron.getSetting("defaultStyleIds");
+      let defaultStyleIds = (await window.electron.getSetting(
+        "defaultStyleIds"
+      )) as DefaultStyleId[];
 
       const allCharacterInfos = getters.GET_ALL_CHARACTER_INFOS;
 
@@ -177,6 +179,7 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
             );
           }
           return {
+            engineId: characterInfo.metas.styles[0].engineId,
             speakerUuid: speakerUuid,
             defaultStyleId: characterInfo.metas.styles[0].styleId,
           };

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -258,8 +258,8 @@ export type SavingSetting = {
   audioOutputDevice: string;
 };
 
-// FIXME: engineIdを追加
 export type DefaultStyleId = {
+  engineId: string;
   speakerUuid: string;
   defaultStyleId: number;
 };
@@ -448,7 +448,11 @@ export const electronStoreSchema = z
       .default(defaultToolbarButtonSetting),
     userCharacterOrder: z.string().array().default([]),
     defaultStyleIds: z
-      .object({ speakerUuid: z.string(), defaultStyleId: z.number() })
+      .object({
+        engineId: z.string().uuid().optional(),
+        speakerUuid: z.string().uuid(),
+        defaultStyleId: z.number(),
+      })
       .array()
       .default([]),
     presets: z

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -451,7 +451,7 @@ export const electronStoreSchema = z
     defaultStyleIds: z
       .object({
         // FIXME: マイグレーション前にバリテーションされてしまう問題に対処したら".default(NIL_UUID)"を外す
-        engineId: z.string().uuid().default(NIL_UUID),
+        engineId: z.string().uuid().or(z.literal("")).default(""),
         speakerUuid: z.string().uuid(),
         defaultStyleId: z.number(),
       })

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -1,5 +1,6 @@
 import { IpcRenderer, IpcRendererEvent } from "electron";
 import { IpcSOData } from "./ipc";
+import { NIL as NIL_UUID } from "uuid";
 import { z } from "zod";
 
 export const isMac = process.platform === "darwin";
@@ -449,7 +450,8 @@ export const electronStoreSchema = z
     userCharacterOrder: z.string().array().default([]),
     defaultStyleIds: z
       .object({
-        engineId: z.string().uuid().optional(),
+        // FIXME: マイグレーション前にバリテーションされてしまう問題に対処したら".default(NIL_UUID)"を外す
+        engineId: z.string().uuid().default(NIL_UUID),
         speakerUuid: z.string().uuid(),
         defaultStyleId: z.number(),
       })

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -1,6 +1,5 @@
 import { IpcRenderer, IpcRendererEvent } from "electron";
 import { IpcSOData } from "./ipc";
-import { NIL as NIL_UUID } from "uuid";
 import { z } from "zod";
 
 export const isMac = process.platform === "darwin";
@@ -450,7 +449,7 @@ export const electronStoreSchema = z
     userCharacterOrder: z.string().array().default([]),
     defaultStyleIds: z
       .object({
-        // FIXME: マイグレーション前にバリテーションされてしまう問題に対処したら".default(NIL_UUID)"を外す
+        // FIXME: マイグレーション前にバリテーションされてしまう問題に対処したら".or(z.literal("")).default("")"を外す
         engineId: z.string().uuid().or(z.literal("")).default(""),
         speakerUuid: z.string().uuid(),
         defaultStyleId: z.number(),


### PR DESCRIPTION
## 内容

テキストファイルの読み込み機能が複数エンジンに対応できていなかったので対応させました。
また、テキストファイルの読み込みに利用している`DEFAULT_STYLE_IDS`にEngineIDが追加されていませんでしたので追加しました。

## その他

とりあえず急ぎで対応させたので無駄が多いかもしれません。