### PR TITLE
FIX: 連続再生時にエラーが正しく表示されない問題を修正

### DIFF
--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -111,8 +111,11 @@ export default defineComponent({
         await store.dispatch("PLAY_CONTINUOUSLY_AUDIO");
       } catch (e) {
         let msg: string | undefined;
-        if (e instanceof Error && e.message !== "") {
-          msg = e.message;
+        // FIXME: GENERATE_AUDIO_FROM_AUDIO_ITEMのエラーを変えた場合変更する
+        if (e instanceof Error && e.message === "VALID_MOPHING_ERROR") {
+          msg = "モーフィングの設定が無効です。";
+        } else {
+          window.electron.logError(e);
         }
         $q.dialog({
           title: "再生に失敗しました",


### PR DESCRIPTION
## 内容

連続再生時にエラーが発生すると投げられたエラーメッセージがそのまま表示されてしまう。
https://twitter.com/BEAT_CAT2/status/1615474061781630978

## その他

モーフィングUI作成時にエラーハンドリングを何度か変更したのですが最終的に変更を忘れてしまったことが原因です。
