### PR TITLE
Fix: 画像フォーマットの推論を修正

### DIFF
--- a/src/helpers/imageHelper.ts
+++ b/src/helpers/imageHelper.ts
@@ -1,15 +1,15 @@
 function detectImageTypeFromBase64(data: string): string {
   switch (data[0]) {
     case "/":
-      return "image/svg+xml";
+      return "image/jpeg";
     case "R":
       return "image/gif";
     case "i":
       return "image/png";
-    case "D":
-      return "image/jpeg";
+    case "U":
+      return "image/webp";
     default:
-      return "";
+      throw new Error("Unsupported image type");
   }
 }
 


### PR DESCRIPTION
## 内容

画像フォーマットの推論を修正します。

```
❯ rb ./__gi_image.rb
jpg: /9j/4
png: iVBOR
gif: R0lGO
webp: UklGR
```

<details>
<summary> `__gi_image.rb` </summary>

```rb
require "base64"
formats = %w[jpg png gif webp]
formats.each do |format|
  system "magick -size 100x100 xc:white __gi_image.#{format}"
  base64 = Base64.strict_encode64(File.read("__gi_image.#{format}"))[0, 5]
  puts "#{format}: #{base64}"
end
```

</details>


## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）