### PR TITLE
辞書単語登録時の半角スペースを全角スペースに変換

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -378,6 +378,9 @@ const accentPhrase = ref<AccentPhrase | undefined>();
 const accentPhraseTable = ref<HTMLElement>();
 
 const convertHankakuToZenkaku = (text: string) => {
+  // " "などの目に見えない文字をまとめて全角スペース(0x3000)に置き換える
+  text = text.replace(/\p{Z}/u, () => String.fromCharCode(0x3000));
+
   // "!"から"~"までの範囲の文字(数字やアルファベット)を全角に置き換える
   return text.replace(/[\u0021-\u007e]/g, (s) => {
     return String.fromCharCode(s.charCodeAt(0) + 0xfee0);


### PR DESCRIPTION
## 内容
単語登録時に含まれている半角スペースを全角スペースに変換するようにしました。

## 関連 Issue
ref #1115 

## スクリーンショット・動画など
入力時
![image](https://user-images.githubusercontent.com/79092292/213847511-d8e7f653-8b0d-4f7e-a3ee-fc8e589e0b82.png)

入力後
![image](https://user-images.githubusercontent.com/79092292/213847538-9a52ef21-75e3-4cec-8a50-875acdd94dd4.png)

## その他
目に見えないような文字で同じような問題が起こるのを防ぐために、
半角スペースだけではなくUnicodeプロパティがSeparatorのものすべて全角スペースに変換するようにしました。

何か問題等ございましたら微力ながら対応いたします。