### PR TITLE
[macOS] テーマを改善 #1132

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -354,9 +354,6 @@ async function createWindow() {
   }
   if (isDevelopment) win.webContents.openDevTools();
 
-  // Macではdarkモードかつウィンドウが非アクティブのときに閉じるボタンなどが見えなくなるので、lightテーマに固定
-  if (isMac) nativeTheme.themeSource = "light";
-
   win.on("maximize", () => win.webContents.send("DETECT_MAXIMIZED"));
   win.on("unmaximize", () => win.webContents.send("DETECT_UNMAXIMIZED"));
   win.on("enter-full-screen", () =>
@@ -714,6 +711,10 @@ ipcMainHandle("GET_SETTING", (_, key) => {
 ipcMainHandle("SET_SETTING", (_, key, newValue) => {
   store.set(key, newValue);
   return store.get(key);
+});
+
+ipcMainHandle("SET_NATIVE_THEME", (_, source) => {
+  nativeTheme.themeSource = source;
 });
 
 ipcMainHandle("INSTALL_VVPP_ENGINE", async (_, path: string) => {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -220,6 +220,10 @@ const api: Sandbox = {
     return await ipcRendererInvoke("GET_DEFAULT_TOOLBAR_SETTING");
   },
 
+  setNativeTheme: (source) => {
+    ipcRendererInvoke("SET_NATIVE_THEME", source);
+  },
+
   theme: (newData) => {
     return ipcRenderer.invoke("THEME", { newData });
   },

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -221,7 +221,7 @@ const api: Sandbox = {
   },
 
   setNativeTheme: (source) => {
-    ipcRendererInvoke("SET_NATIVE_THEME", source);
+    ipcRenderer.invoke("SET_NATIVE_THEME", source);
   },
 
   theme: (newData) => {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -217,6 +217,8 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         theme.isDark ? "true" : "false"
       );
 
+      window.electron.setNativeTheme(theme.isDark ? "dark" : "light");
+
       commit("SET_THEME_SETTING", {
         currentTheme: currentTheme,
       });

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -8,7 +8,7 @@ import {
   ToolbarSetting,
   UpdateInfo,
   WriteFileErrorResult,
-  NativeThemeType
+  NativeThemeType,
 } from "@/type/preload";
 
 /**

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -8,6 +8,7 @@ import {
   ToolbarSetting,
   UpdateInfo,
   WriteFileErrorResult,
+  NativeThemeType
 } from "@/type/preload";
 
 /**
@@ -257,7 +258,7 @@ export type IpcIHData = {
   };
 
   SET_NATIVE_THEME: {
-    args: [source: "system" | "light" | "dark"];
+    args: [source: NativeThemeType];
     return: void;
   };
 

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -257,9 +257,7 @@ export type IpcIHData = {
   };
 
   SET_NATIVE_THEME: {
-    args: [
-      source: ('system' | 'light' | 'dark')
-    ];
+    args: [source: "system" | "light" | "dark"];
   };
 
   INSTALL_VVPP_ENGINE: {

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -256,6 +256,12 @@ export type IpcIHData = {
     return: ElectronStoreType[keyof ElectronStoreType];
   };
 
+  SET_NATIVE_THEME: {
+    args: [
+      source: ('system' | 'light' | 'dark')
+    ];
+  };
+
   INSTALL_VVPP_ENGINE: {
     args: [path: string];
     return: Promise<boolean>;

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -258,6 +258,7 @@ export type IpcIHData = {
 
   SET_NATIVE_THEME: {
     args: [source: "system" | "light" | "dark"];
+    return: void;
   };
 
   INSTALL_VVPP_ENGINE: {

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -368,7 +368,7 @@ export type ToolbarButtonTagType = z.infer<typeof toolbarButtonTagSchema>;
 export const toolbarSettingSchema = toolbarButtonTagSchema;
 export type ToolbarSetting = z.infer<typeof toolbarSettingSchema>[];
 
-export type NativeThemeType = typeof nativeTheme["themeSource"]
+export type NativeThemeType = typeof nativeTheme["themeSource"];
 
 export type MoraDataType =
   | "consonant"

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -1,4 +1,4 @@
-import { IpcRenderer, IpcRendererEvent } from "electron";
+import { IpcRenderer, IpcRendererEvent, nativeTheme } from "electron";
 import { IpcSOData } from "./ipc";
 import { z } from "zod";
 
@@ -173,7 +173,7 @@ export interface Sandbox {
   changePinWindow(): void;
   getDefaultHotkeySettings(): Promise<HotkeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
-  setNativeTheme(source: "system" | "light" | "dark"): void;
+  setNativeTheme(source: NativeThemeType): void;
   theme(newData?: string): Promise<ThemeSetting | void>;
   vuexReady(): void;
   getSetting<Key extends keyof ElectronStoreType>(
@@ -367,6 +367,8 @@ export type ToolbarButtonTagType = z.infer<typeof toolbarButtonTagSchema>;
 
 export const toolbarSettingSchema = toolbarButtonTagSchema;
 export type ToolbarSetting = z.infer<typeof toolbarSettingSchema>[];
+
+export type NativeThemeType = typeof nativeTheme["themeSource"]
 
 export type MoraDataType =
   | "consonant"

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -173,7 +173,7 @@ export interface Sandbox {
   changePinWindow(): void;
   getDefaultHotkeySettings(): Promise<HotkeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
-  setNativeTheme(source: ('system' | 'light' | 'dark')): void;
+  setNativeTheme(source: "system" | "light" | "dark"): void;
   theme(newData?: string): Promise<ThemeSetting | void>;
   vuexReady(): void;
   getSetting<Key extends keyof ElectronStoreType>(

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -173,6 +173,7 @@ export interface Sandbox {
   changePinWindow(): void;
   getDefaultHotkeySettings(): Promise<HotkeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
+  setNativeTheme(source: ('system' | 'light' | 'dark')): void;
   theme(newData?: string): Promise<ThemeSetting | void>;
   vuexReady(): void;
   getSetting<Key extends keyof ElectronStoreType>(


### PR DESCRIPTION
## 内容

macOS環境で、ChromiumのテーマをVOICEVOXのテーマに合わせるように変更しました。

Chromiumのテーマを変更するにはメインプロセスから値を代入する必要がありますが、レンダラープロセスから操作できるように新しくipcを生やしました。
より良い方法があれば修正したいので、教えていただけますと幸いです。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #1132 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
<img width="716" alt="スクリーンショット 0005-01-21 午後4 00 46" src="https://user-images.githubusercontent.com/45391880/213848653-dd406b70-8859-4844-b0a1-c882fecd250b.png">
<img width="715" alt="スクリーンショット 0005-01-21 午後4 01 01" src="https://user-images.githubusercontent.com/45391880/213848663-9f9ca919-571c-4ccc-be1f-44ba1513b41b.png">


<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
