### PR TITLE
複数エンジン対応：分割vvppファイルの拡張子をvvpppに

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -435,6 +435,13 @@ cat << EOS > "${MIME_INSTALL_DIR}/packages/voicevox.xml"
         <glob pattern="*.vvpp" />
         <icon name="voicevox" />
     </mime-type>
+    <mime-type type="application/x-voicevox-plugin-package-part">
+        <comment>VOICEVOX Plugin package (part)</comment>
+        <comment xml:lang="ja">VOICEVOX プラグインパッケージ（分割）</comment>
+        <sub-class-of type="application/zip" />
+        <glob pattern="*.vvppp" />
+        <icon name="voicevox" />
+    </mime-type>
 </mime-info>
 EOS
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -40,7 +40,7 @@ import windowStateKeeper from "electron-window-state";
 import zodToJsonSchema from "zod-to-json-schema";
 
 import EngineManager from "./background/engineManager";
-import VvppManager from "./background/vvppManager";
+import VvppManager, { isVvppFile } from "./background/vvppManager";
 import configMigration014 from "./background/configMigration014";
 
 type SingleInstanceLockData = {
@@ -509,7 +509,9 @@ ipcMainHandle("SHOW_VVPP_OPEN_DIALOG", async (_, { title, defaultPath }) => {
   const result = await dialog.showOpenDialog(win, {
     title,
     defaultPath,
-    filters: [{ name: "VOICEVOX Plugin Package", extensions: ["vvpp"] }],
+    filters: [
+      { name: "VOICEVOX Plugin Package", extensions: ["vvpp", "vvppp"] },
+    ],
     properties: ["openFile", "createDirectory", "treatPackageAsDirectory"],
   });
   return result.filePaths[0];
@@ -897,7 +899,7 @@ app.on("ready", async () => {
     return;
   }
 
-  if (filePath?.endsWith(".vvpp")) {
+  if (filePath && isVvppFile(filePath)) {
     await installVvppEngine(filePath);
   }
 
@@ -909,7 +911,7 @@ app.on("second-instance", async (event, argv, workDir, rawData) => {
   const data = rawData as SingleInstanceLockData;
   if (!data.filePath) {
     log.info("No file path sent");
-  } else if (data.filePath.endsWith(".vvpp")) {
+  } else if (isVvppFile(data.filePath)) {
     log.info("Second instance launched with vvpp file");
     await installVvppEngine(data.filePath);
     dialog

--- a/src/background/vvppManager.ts
+++ b/src/background/vvppManager.ts
@@ -104,16 +104,16 @@ export class VvppManager {
   }
 
   async extractVvpp(
-    vvpppPath: string
+    vvppLikeFilePath: string
   ): Promise<{ outputDir: string; manifest: MinimumEngineManifest }> {
     const nonce = new Date().getTime().toString();
     const outputDir = path.join(this.vvppEngineDir, ".tmp", nonce);
 
     const streams: fs.ReadStream[] = [];
     // 名前.数値.vvpppの場合は分割されているとみなして連結する
-    if (vvpppPath.match(/\.[0-9]+\.vvppp$/)) {
+    if (vvppLikeFilePath.match(/\.[0-9]+\.vvppp$/)) {
       log.log("vvpp is split, finding other parts...");
-      const vvpppPathGlob = vvpppPath
+      const vvpppPathGlob = vvppLikeFilePath
         .replace(/\.[0-9]+\.vvppp$/, ".*.vvppp")
         .replace(/\\/g, "/"); // node-globはバックスラッシュを使えないので、スラッシュに置換する
       const filePaths: string[] = [];
@@ -137,7 +137,7 @@ export class VvppManager {
       }
     } else {
       log.log("Not a split file");
-      streams.push(fs.createReadStream(vvpppPath));
+      streams.push(fs.createReadStream(vvppLikeFilePath));
     }
 
     log.log("Extracting vvpp to", outputDir);

--- a/vue.config.js
+++ b/vue.config.js
@@ -39,6 +39,12 @@ module.exports = {
             description: "VOICEVOX Plugin package",
             role: "Editor",
           },
+          {
+            ext: "vvppp",
+            name: "VOICEVOX Plugin package (part)",
+            description: "VOICEVOX Plugin package (part)",
+            role: "Editor",
+          },
         ],
         extraFiles: [
           { from: "build/README.txt", to: "README.txt" },


### PR DESCRIPTION
## 内容

タイトル通り。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

理由としては、
`engine.0.vvpp`の場合、バージョンを名前に入れている場合、`engine.1.0.0.vvpp`と`engine.1.0.1.vvpp`が分割vvppとして認識されてしまっていたためです。
