### PR TITLE
#298 CPU版でGPUモードへの切り替えを不可能に

### DIFF
--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -724,12 +724,7 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
-    const allEngineCanUseGPU = computed({
-      get: () => store.state.allEngineCanUseGPU,
-      set: () => {
-        undefined;
-      },
-    });
+    const allEngineCanUseGPU = computed(() => store.state.allEngineCanUseGPU);
 
     onMounted(() => store.dispatch("SET_ALL_ENGINE_CAN_USE_GPU"));
 

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -69,7 +69,7 @@
                     transition-hide="jump-right"
                     :target="!canUseGPU"
                   >
-                    お使いのデバイスではGPUモードを利用できません。
+                    お使いのソフトウェアはCPU版のためGPUモードを利用できません。
                   </q-tooltip>
                 </q-btn-toggle>
               </q-card-actions>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -689,7 +689,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, onMounted } from "vue";
+import { defineComponent, computed, ref } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
 import {
@@ -724,9 +724,9 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
-    const allEngineCanUseGPU = computed(() => store.state.allEngineCanUseGPU);
-
-    onMounted(() => store.dispatch("SET_ALL_ENGINE_CAN_USE_GPU"));
+    const allEngineCanUseGPU = computed(
+      () => store.getters.ALL_ENGINE_CAN_USE_GPU
+    );
 
     const engineMode = computed({
       get: () => (store.state.useGpu ? "switchGPU" : "switchCPU"),

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -69,7 +69,7 @@
                     transition-hide="jump-right"
                     :target="!allEngineCanUseGPU"
                   >
-                    お使いのソフトウェアはCPU版のためGPUモードを利用できません。
+                    お使いのエンジンはCPU版のためGPUモードを利用できません。
                   </q-tooltip>
                 </q-btn-toggle>
               </q-card-actions>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -715,12 +715,7 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
-    const canUseGPU = computed({
-      get: () => !store.state.canUseGPU,
-      set: (useGPU: boolean) => {
-        useGPU;
-      },
-    });
+    const canUseGPU = store.state.canUseGPU;
 
     const engineMode = computed({
       get: () => (store.state.useGpu ? "switchGPU" : "switchCPU"),

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -60,6 +60,7 @@
                     { label: 'CPU', value: 'switchCPU' },
                     { label: 'GPU', value: 'switchGPU' },
                   ]"
+                  :disable="canUseGPU"
                 >
                 </q-btn-toggle>
               </q-card-actions>
@@ -714,6 +715,13 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
+    const canUseGPU = computed({
+      get: () => !store.state.canUseGPU,
+      set: (useGPU: boolean) => {
+        useGPU;
+      },
+    });
+
     const engineMode = computed({
       get: () => (store.state.useGpu ? "switchGPU" : "switchCPU"),
       set: (mode: string) => {
@@ -948,6 +956,7 @@ export default defineComponent({
 
     return {
       settingDialogOpenedComputed,
+      canUseGPU,
       engineMode,
       inheritAudioInfoMode,
       activePointScrollMode,

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -60,8 +60,17 @@
                     { label: 'CPU', value: 'switchCPU' },
                     { label: 'GPU', value: 'switchGPU' },
                   ]"
-                  :disable="canUseGPU"
+                  :disable="!canUseGPU"
                 >
+                  <q-tooltip
+                    anchor="center start"
+                    self="center right"
+                    transition-show="jump-left"
+                    transition-hide="jump-right"
+                    :target="!canUseGPU"
+                  >
+                    お使いのデバイスではGPUモードを利用できません。
+                  </q-tooltip>
                 </q-btn-toggle>
               </q-card-actions>
             </q-card>
@@ -680,7 +689,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref } from "vue";
+import { defineComponent, computed, ref, onMounted } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
 import {
@@ -715,7 +724,14 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
-    const canUseGPU = store.state.canUseGPU;
+    const canUseGPU = computed({
+      get: () => store.state.canUseGPU,
+      set: () => {
+        store.dispatch("SET_CAN_USE_GPU");
+      },
+    });
+
+    onMounted(() => store.dispatch("SET_CAN_USE_GPU"));
 
     const engineMode = computed({
       get: () => (store.state.useGpu ? "switchGPU" : "switchCPU"),

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -60,14 +60,14 @@
                     { label: 'CPU', value: 'switchCPU' },
                     { label: 'GPU', value: 'switchGPU' },
                   ]"
-                  :disable="!canUseGPU"
+                  :disable="!allEngineCanUseGPU"
                 >
                   <q-tooltip
                     anchor="center start"
                     self="center right"
                     transition-show="jump-left"
                     transition-hide="jump-right"
-                    :target="!canUseGPU"
+                    :target="!allEngineCanUseGPU"
                   >
                     お使いのソフトウェアはCPU版のためGPUモードを利用できません。
                   </q-tooltip>
@@ -724,14 +724,14 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
-    const canUseGPU = computed({
-      get: () => store.state.canUseGPU,
+    const allEngineCanUseGPU = computed({
+      get: () => store.state.allEngineCanUseGPU,
       set: () => {
-        store.dispatch("SET_CAN_USE_GPU");
+        undefined;
       },
     });
 
-    onMounted(() => store.dispatch("SET_CAN_USE_GPU"));
+    onMounted(() => store.dispatch("SET_ALL_ENGINE_CAN_USE_GPU"));
 
     const engineMode = computed({
       get: () => (store.state.useGpu ? "switchGPU" : "switchCPU"),
@@ -967,7 +967,7 @@ export default defineComponent({
 
     return {
       settingDialogOpenedComputed,
-      canUseGPU,
+      allEngineCanUseGPU,
       engineMode,
       inheritAudioInfoMode,
       activePointScrollMode,

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -196,6 +196,9 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
           if (state.engineStates[engineId] === "STARTING") {
             await dispatch("START_WAITING_ENGINE", { engineId });
             await dispatch("FETCH_AND_SET_ENGINE_MANIFEST", { engineId });
+            await dispatch("FETCH_AND_SET_ENGINE_SUPPORTED_DEVICES", {
+              engineId,
+            });
             await dispatch("LOAD_CHARACTER", { engineId });
           }
 

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -6,6 +6,7 @@ import type { EngineInfo } from "@/type/preload";
 
 export const engineStoreState: EngineStoreState = {
   engineStates: {},
+  canUseGPU: false,
 };
 
 export const engineStore = createPartialStore<EngineStoreTypes>({
@@ -358,6 +359,45 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
           instance.invoke("engineManifestEngineManifestGet")({})
         ),
       });
+    },
+  },
+
+  SET_CAN_USE_GPU: {
+    mutation(state, { canUseGPU }) {
+      state.canUseGPU = canUseGPU;
+    },
+    async action({ commit, dispatch }) {
+      const engineInfos = await window.electron.engineInfos();
+
+      const engineIds = engineInfos.map((engineInfo) => engineInfo.uuid);
+
+      const canUseCudaOrDMLPromises = engineIds.map(async (engineId) =>
+        dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId })
+          .then(
+            async (instance) =>
+              await instance.invoke("supportedDevicesSupportedDevicesGet")({})
+          )
+          .catch((e) => e)
+      );
+
+      const canUseCudaOrDMLArray = await Promise.all(canUseCudaOrDMLPromises);
+
+      const canUseGPU = canUseCudaOrDMLArray.reduce(
+        (prev, supportedDevices) => {
+          if (supportedDevices instanceof Error) {
+            return false;
+          }
+
+          const { cuda, dml } = supportedDevices;
+          const canEngineUseGPU = cuda || dml;
+
+          return prev && canEngineUseGPU;
+        },
+        true
+      );
+
+      // すべてのエンジンでcudaかdmlが利用可能ならtrue
+      commit("SET_CAN_USE_GPU", { canUseGPU: canUseGPU });
     },
   },
 });

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -378,19 +378,15 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     async action({ dispatch, commit }, { engineId }) {
       const supportedDevices = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineId,
-      })
-        .then(
-          async (instance) =>
-            await instance.invoke("supportedDevicesSupportedDevicesGet")({})
-        )
-        .catch((e) => e);
+      }).then(
+        async (instance) =>
+          await instance.invoke("supportedDevicesSupportedDevicesGet")({})
+      );
 
-      if (!(supportedDevices instanceof Error)) {
-        commit("SET_ENGINE_SUPPORTED_DEVICES", {
-          engineId,
-          supportedDevices: supportedDevices,
-        });
-      }
+      commit("SET_ENGINE_SUPPORTED_DEVICES", {
+        engineId,
+        supportedDevices: supportedDevices,
+      });
     },
   },
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -691,7 +691,10 @@ export type CommandStoreTypes = {
 
 export type EngineStoreState = {
   engineStates: Record<string, EngineState>;
-  canUseGPU: boolean;
+  engineCanUseGPU: Record<string, boolean>;
+
+  // TODO:エンジン毎の設定が可能になれば消す
+  allEngineCanUseGPU: boolean;
 };
 
 export type EngineStoreTypes = {
@@ -789,8 +792,14 @@ export type EngineStoreTypes = {
     action(payload: { engineId: string }): void;
   };
 
-  SET_CAN_USE_GPU: {
-    mutation: { canUseGPU: boolean };
+  SET_ENGINE_CAN_USE_GPU: {
+    mutation: { engineId: string; engineCanUseGPU: boolean };
+    action(payload: { engineId: string }): void;
+  };
+
+  // TODO:エンジン毎の設定が可能になれば消す
+  SET_ALL_ENGINE_CAN_USE_GPU: {
+    mutation: { allEngineCanUseGPU: boolean };
     action(): void;
   };
 };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -11,6 +11,7 @@ import {
   AccentPhrase,
   AudioQuery,
   EngineManifest,
+  SupportedDevicesInfo,
   UserDictWord,
 } from "@/openapi";
 import { createCommandMutationTree, PayloadRecipeTree } from "./command";
@@ -691,10 +692,7 @@ export type CommandStoreTypes = {
 
 export type EngineStoreState = {
   engineStates: Record<string, EngineState>;
-  engineCanUseGPU: Record<string, boolean>;
-
-  // TODO:エンジン毎の設定が可能になれば消す
-  allEngineCanUseGPU: boolean;
+  engineSupportedDevices: Record<string, SupportedDevicesInfo>;
 };
 
 export type EngineStoreTypes = {
@@ -792,15 +790,20 @@ export type EngineStoreTypes = {
     action(payload: { engineId: string }): void;
   };
 
-  SET_ENGINE_CAN_USE_GPU: {
-    mutation: { engineId: string; engineCanUseGPU: boolean };
+  SET_ENGINE_SUPPORTED_DEVICES: {
+    mutation: { engineId: string; supportedDevices: SupportedDevicesInfo };
+  };
+
+  FETCH_AND_SET_ENGINE_SUPPORTED_DEVICES: {
     action(payload: { engineId: string }): void;
   };
 
-  // TODO:エンジン毎の設定が可能になれば消す
-  SET_ALL_ENGINE_CAN_USE_GPU: {
-    mutation: { allEngineCanUseGPU: boolean };
-    action(): void;
+  ENGINE_CAN_USE_GPU: {
+    getter: (engineId: string) => boolean;
+  };
+
+  ALL_ENGINE_CAN_USE_GPU: {
+    getter: boolean;
   };
 };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -691,6 +691,7 @@ export type CommandStoreTypes = {
 
 export type EngineStoreState = {
   engineStates: Record<string, EngineState>;
+  canUseGPU: boolean;
 };
 
 export type EngineStoreTypes = {
@@ -786,6 +787,11 @@ export type EngineStoreTypes = {
 
   FETCH_AND_SET_ENGINE_MANIFEST: {
     action(payload: { engineId: string }): void;
+  };
+
+  SET_CAN_USE_GPU: {
+    mutation: { canUseGPU: boolean };
+    action(): void;
   };
 };
 
@@ -1017,7 +1023,6 @@ export type SettingStoreTypes = {
 export type UiStoreState = {
   uiLockCount: number;
   dialogLockCount: number;
-  canUseGPU: boolean;
   useGpu: boolean;
   inheritAudioInfo: boolean;
   activePointScrollMode: ActivePointScrollMode;
@@ -1184,11 +1189,6 @@ export type UiStoreTypes = {
   };
 
   RESET_PROGRESS: {
-    action(): void;
-  };
-
-  SET_CAN_USE_GPU: {
-    mutation: { canUseGPU: boolean };
     action(): void;
   };
 };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1017,6 +1017,7 @@ export type SettingStoreTypes = {
 export type UiStoreState = {
   uiLockCount: number;
   dialogLockCount: number;
+  canUseGPU: boolean;
   useGpu: boolean;
   inheritAudioInfo: boolean;
   activePointScrollMode: ActivePointScrollMode;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1186,6 +1186,11 @@ export type UiStoreTypes = {
   RESET_PROGRESS: {
     action(): void;
   };
+
+  SET_CAN_USE_GPU: {
+    mutation: { canUseGPU: boolean };
+    action(): void;
+  };
 };
 
 /*

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -36,6 +36,7 @@ export function withProgress<T>(
 export const uiStoreState: UiStoreState = {
   uiLockCount: 0,
   dialogLockCount: 0,
+  canUseGPU: false,
   useGpu: false,
   inheritAudioInfo: true,
   activePointScrollMode: "OFF",

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -369,4 +369,13 @@ export const uiStore = createPartialStore<UiStoreTypes>({
       dispatch("SET_PROGRESS", { progress: -1 });
     },
   },
+
+  SET_CAN_USE_GPU: {
+    mutation(state, { canUseGPU }) {
+      state.canUseGPU = canUseGPU;
+    },
+    action({ commit }) {
+      // ここにGPUが使えるかどうかの処理を書く
+    },
+  },
 });

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -36,7 +36,6 @@ export function withProgress<T>(
 export const uiStoreState: UiStoreState = {
   uiLockCount: 0,
   dialogLockCount: 0,
-  canUseGPU: false,
   useGpu: false,
   inheritAudioInfo: true,
   activePointScrollMode: "OFF",
@@ -367,45 +366,6 @@ export const uiStore = createPartialStore<UiStoreTypes>({
     action({ dispatch }) {
       // -1で非表示
       dispatch("SET_PROGRESS", { progress: -1 });
-    },
-  },
-
-  SET_CAN_USE_GPU: {
-    mutation(state, { canUseGPU }) {
-      state.canUseGPU = canUseGPU;
-    },
-    async action({ commit, dispatch }) {
-      const engineInfos = await window.electron.engineInfos();
-
-      const engineIds = engineInfos.map((engineInfo) => engineInfo.uuid);
-
-      const canUseCudaOrDMLPromises = engineIds.map(async (engineId) =>
-        dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId })
-          .then(
-            async (instance) =>
-              await instance.invoke("supportedDevicesSupportedDevicesGet")({})
-          )
-          .catch((e) => e)
-      );
-
-      const canUseCudaOrDMLArray = await Promise.all(canUseCudaOrDMLPromises);
-
-      const canUseGPU = canUseCudaOrDMLArray.reduce(
-        (prev, supportedDevices) => {
-          if (supportedDevices instanceof Error) {
-            return false;
-          }
-
-          const { cuda, dml } = supportedDevices;
-          const canEngineUseGPU = cuda || dml;
-
-          return prev && canEngineUseGPU;
-        },
-        true
-      );
-
-      // すべてのエンジンでcudaかdmlが利用可能ならtrue
-      commit("SET_CAN_USE_GPU", { canUseGPU: canUseGPU });
     },
   },
 });

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -22,6 +22,11 @@ describe("store/vuex.js test", () => {
         engineStates: {
           "88022f86-c823-436e-85a3-500c629749c4": "STARTING",
         },
+        engineCanUseGPU: {},
+
+        // TODO:エンジン毎の設定が可能になれば消す
+        allEngineCanUseGPU: false,
+
         characterInfos: {},
         defaultStyleIds: [],
         userCharacterOrder: [],
@@ -34,7 +39,6 @@ describe("store/vuex.js test", () => {
         nowPlayingContinuously: false,
         undoCommands: [],
         redoCommands: [],
-        canUseGPU: false,
         useGpu: false,
         inheritAudioInfo: true,
         activePointScrollMode: "OFF",

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -22,11 +22,7 @@ describe("store/vuex.js test", () => {
         engineStates: {
           "88022f86-c823-436e-85a3-500c629749c4": "STARTING",
         },
-        engineCanUseGPU: {},
-
-        // TODO:エンジン毎の設定が可能になれば消す
-        allEngineCanUseGPU: false,
-
+        engineSupportedDevices: {},
         characterInfos: {},
         defaultStyleIds: [],
         userCharacterOrder: [],

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -34,6 +34,7 @@ describe("store/vuex.js test", () => {
         nowPlayingContinuously: false,
         undoCommands: [],
         redoCommands: [],
+        canUseGPU: false,
         useGpu: false,
         inheritAudioInfo: true,
         activePointScrollMode: "OFF",


### PR DESCRIPTION
## 内容
cudaかDirectMLが利用できないときに、GPUモードへの切り替えをできないようにしました

## 関連 Issue
ref #298

## スクリーンショット・動画など
- cudaかDirectMLを利用できるとき(GPUがないので手動で状態を変えています)
![image](https://user-images.githubusercontent.com/79092292/214037538-fa71097f-0584-46ba-a678-0527e9ea9044.png)

- cudaかDirectMLを利用できないとき
![image](https://user-images.githubusercontent.com/79092292/214037668-14c0963b-8b6a-4892-92f7-06a1e2827ecf.png)


<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
- GPUがないためCPU環境のみでの検証しています。GPUを持っているどなたか確認していただければ...
- Vue初心者なのでとんでもないコードを書いているかもしれません。お伝えいただければ修正いたします。
