### PR TITLE
システムテーマに合わせるオプションを追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,14 @@ export default defineComponent({
       },
       { immediate: true }
     );
+
+    // システムテーマに追従
+    window.electron.nativeThemeUpdated(async () => {
+      if (!store.state.themeSetting.useSystemTheme) return;
+      const isDark = await window.electron.getShouldUseDarkColors();
+      const newData = isDark ? "Dark" : "Default";
+      store.dispatch("SET_RENDER_THEME", { newData });
+    });
   },
 });
 </script>

--- a/src/background.ts
+++ b/src/background.ts
@@ -708,9 +708,9 @@ ipcMainHandle("GET_SHOULD_USE_DARK_COLORS", () => {
 });
 
 nativeTheme.on("updated", () => {
-  console.log("updated");
   if (lock.pop()) return;
   win.webContents.send("NATIVE_THEME_UPDATED");
+  console.log("Native Theme Updated");
 });
 
 ipcMainHandle("ON_VUEX_READY", () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -666,6 +666,7 @@ ipcMainHandle("HOTKEY_SETTINGS", (_, { newData }) => {
   return store.get("hotkeySettings");
 });
 
+// テーマ関係
 ipcMainHandle("THEME", (_, newData) => {
   let earlyReturn = false;
   if (newData.useSystemTheme !== undefined) {
@@ -692,6 +693,15 @@ ipcMainHandle("THEME", (_, newData) => {
     currentTheme: store.get("currentTheme"),
     availableThemes: themes,
   };
+});
+
+ipcMainHandle("NATIVE_THEME", (_, source) => {
+  nativeTheme.themeSource = source;
+});
+
+nativeTheme.on("updated", () => {
+  win.webContents.send("NATIVE_THEME_UPDATED");
+  console.log("Color Theme Updated");
 });
 
 ipcMainHandle("ON_VUEX_READY", () => {
@@ -724,10 +734,6 @@ ipcMainHandle("GET_SETTING", (_, key) => {
 ipcMainHandle("SET_SETTING", (_, key, newValue) => {
   store.set(key, newValue);
   return store.get(key);
-});
-
-ipcMainHandle("SET_NATIVE_THEME", (_, source) => {
-  nativeTheme.themeSource = source;
 });
 
 ipcMainHandle("INSTALL_VVPP_ENGINE", async (_, path: string) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -710,7 +710,6 @@ ipcMainHandle("GET_SHOULD_USE_DARK_COLORS", () => {
 nativeTheme.on("updated", () => {
   if (lock.pop()) return;
   win.webContents.send("NATIVE_THEME_UPDATED");
-  console.log("Native Theme Updated");
 });
 
 ipcMainHandle("ON_VUEX_READY", () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -669,14 +669,14 @@ ipcMainHandle("HOTKEY_SETTINGS", (_, { newData }) => {
 });
 
 // テーマ関係
-ipcMainHandle("THEME", (_, newData) => {
+ipcMainHandle("THEME", (_, obj) => {
   let earlyReturn = false;
-  if (newData.useSystemTheme !== undefined) {
-    store.set("useSystemTheme", newData.useSystemTheme);
+  if (obj.useSystemTheme !== undefined) {
+    store.set("useSystemTheme", obj.useSystemTheme);
     earlyReturn = true;
   }
-  if (newData.currentTheme !== undefined) {
-    store.set("currentTheme", newData.currentTheme);
+  if (obj.currentTheme !== undefined) {
+    store.set("currentTheme", obj.currentTheme);
     earlyReturn = true;
   }
   // 値がセットされた場合はvoidを返す
@@ -697,10 +697,10 @@ ipcMainHandle("THEME", (_, newData) => {
   };
 });
 
-const lock: boolean[] = [];
+const lockNativeThemeUpdated: boolean[] = [];
 ipcMainHandle("SET_NATIVE_THEME", (_, source) => {
   nativeTheme.themeSource = source;
-  lock.push(true);
+  lockNativeThemeUpdated.push(true);
 });
 
 ipcMainHandle("GET_SHOULD_USE_DARK_COLORS", () => {
@@ -708,7 +708,7 @@ ipcMainHandle("GET_SHOULD_USE_DARK_COLORS", () => {
 });
 
 nativeTheme.on("updated", () => {
-  if (lock.pop()) return;
+  if (lockNativeThemeUpdated.pop()) return;
   win.webContents.send("NATIVE_THEME_UPDATED");
 });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -695,13 +695,20 @@ ipcMainHandle("THEME", (_, newData) => {
   };
 });
 
-ipcMainHandle("NATIVE_THEME", (_, source) => {
+const lock: boolean[] = [];
+ipcMainHandle("SET_NATIVE_THEME", (_, source) => {
   nativeTheme.themeSource = source;
+  lock.push(true);
+});
+
+ipcMainHandle("GET_SHOULD_USE_DARK_COLORS", () => {
+  return nativeTheme.shouldUseDarkColors;
 });
 
 nativeTheme.on("updated", () => {
+  console.log("updated");
+  if (lock.pop()) return;
   win.webContents.send("NATIVE_THEME_UPDATED");
-  console.log("Color Theme Updated");
 });
 
 ipcMainHandle("ON_VUEX_READY", () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -666,11 +666,19 @@ ipcMainHandle("HOTKEY_SETTINGS", (_, { newData }) => {
   return store.get("hotkeySettings");
 });
 
-ipcMainHandle("THEME", (_, { newData }) => {
-  if (newData !== undefined) {
-    store.set("currentTheme", newData);
-    return;
+ipcMainHandle("THEME", (_, newData) => {
+  let earlyReturn = false;
+  if (newData.useSystemTheme !== undefined) {
+    store.set("useSystemTheme", newData.useSystemTheme);
+    earlyReturn = true;
   }
+  if (newData.currentTheme !== undefined) {
+    store.set("currentTheme", newData.currentTheme);
+    earlyReturn = true;
+  }
+  // 値がセットされた場合はvoidを返す
+  if (earlyReturn) return;
+
   const dir = path.join(__static, "themes");
   const themes: ThemeConf[] = [];
   const files = fs.readdirSync(dir);
@@ -678,7 +686,12 @@ ipcMainHandle("THEME", (_, { newData }) => {
     const theme = JSON.parse(fs.readFileSync(path.join(dir, file)).toString());
     themes.push(theme);
   });
-  return { currentTheme: store.get("currentTheme"), availableThemes: themes };
+
+  return {
+    useSystemTheme: store.get("useSystemTheme"),
+    currentTheme: store.get("currentTheme"),
+    availableThemes: themes,
+  };
 });
 
 ipcMainHandle("ON_VUEX_READY", () => {

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -884,7 +884,6 @@ export default defineComponent({
 
     const changeuseSystemTheme = async (useSystemTheme: boolean) => {
       if (store.state.themeSetting.useSystemTheme === useSystemTheme) return;
-      console.log(`CHANGEUSESYSTEMTHEME: ${useSystemTheme}`);
       store.dispatch("SET_THEME_SETTING", { useSystemTheme });
     };
 

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -452,29 +452,6 @@
               </q-card-actions>
 
               <q-card-actions class="q-px-md q-py-sm bg-surface">
-                <div>システムテーマを使う</div>
-                <div>
-                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
-                    <q-tooltip
-                      :delay="500"
-                      anchor="center left"
-                      self="center right"
-                      transition-show="jump-left"
-                      transition-hide="jump-right"
-                    >
-                      テーマをシステムに合わせます
-                    </q-tooltip>
-                  </q-icon>
-                </div>
-                <q-space />
-                <q-toggle
-                  :model-value="useSystemThemeMode"
-                  @update:model-value="changeuseSystemTheme($event)"
-                >
-                </q-toggle>
-              </q-card-actions>
-
-              <q-card-actions class="q-px-md q-py-sm bg-surface">
                 <div>フォント</div>
                 <div>
                   <q-icon name="help_outline" size="sm" class="help-hover-icon">
@@ -744,9 +721,6 @@ export default defineComponent({
       },
     });
     const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
-    const useSystemThemeMode = computed(
-      () => store.state.themeSetting.useSystemTheme
-    );
     const activePointScrollMode = computed({
       get: () => store.state.activePointScrollMode,
       set: (activePointScrollMode: ActivePointScrollMode) => {
@@ -779,9 +753,23 @@ export default defineComponent({
     const experimentalSetting = computed(() => store.state.experimentalSetting);
 
     const currentThemeNameComputed = computed({
-      get: () => store.state.themeSetting.currentTheme,
+      get: () => {
+        if (store.state.themeSetting.useSystemTheme) {
+          return "system";
+        } else {
+          return store.state.themeSetting.currentTheme;
+        }
+      },
       set: (currentTheme: string) => {
-        store.dispatch("SET_THEME_SETTING", { currentTheme: currentTheme });
+        console.log(currentTheme);
+        if (currentTheme === "system") {
+          store.dispatch("SET_THEME_SETTING", { useSystemTheme: true });
+        } else {
+          store.dispatch("SET_THEME_SETTING", {
+            currentTheme: currentTheme,
+            useSystemTheme: false,
+          });
+        }
       },
     });
 
@@ -792,11 +780,12 @@ export default defineComponent({
     );
 
     const availableThemeNameComputed = computed(() => {
-      return [...store.state.themeSetting.availableThemes]
+      const themes = [...store.state.themeSetting.availableThemes]
         .sort((a, b) => a.order - b.order)
         .map((theme) => {
           return { label: theme.displayName, value: theme.name };
         });
+      return [{ label: "システムに合わせる", value: "system" }].concat(themes);
     });
 
     const currentAudioOutputDeviceComputed = computed<{
@@ -880,11 +869,6 @@ export default defineComponent({
     const changeinheritAudioInfo = async (inheritAudioInfo: boolean) => {
       if (store.state.inheritAudioInfo === inheritAudioInfo) return;
       store.dispatch("SET_INHERIT_AUDIOINFO", { inheritAudioInfo });
-    };
-
-    const changeuseSystemTheme = async (useSystemTheme: boolean) => {
-      if (store.state.themeSetting.useSystemTheme === useSystemTheme) return;
-      store.dispatch("SET_THEME_SETTING", { useSystemTheme });
     };
 
     const changeExperimentalSetting = async (
@@ -981,14 +965,12 @@ export default defineComponent({
       settingDialogOpenedComputed,
       engineMode,
       inheritAudioInfoMode,
-      useSystemThemeMode,
       activePointScrollMode,
       activePointScrollModeOptions,
       experimentalSetting,
       currentAudioOutputDeviceComputed,
       availableAudioOutputDevices,
       changeinheritAudioInfo,
-      changeuseSystemTheme,
       changeExperimentalSetting,
       restartAllEngineProcess,
       savingSetting,

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -452,6 +452,29 @@
               </q-card-actions>
 
               <q-card-actions class="q-px-md q-py-sm bg-surface">
+                <div>システムテーマを使う</div>
+                <div>
+                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      テーマをシステムに合わせます
+                    </q-tooltip>
+                  </q-icon>
+                </div>
+                <q-space />
+                <q-toggle
+                  :model-value="useSystemThemeMode"
+                  @update:model-value="changeuseSystemTheme($event)"
+                >
+                </q-toggle>
+              </q-card-actions>
+
+              <q-card-actions class="q-px-md q-py-sm bg-surface">
                 <div>フォント</div>
                 <div>
                   <q-icon name="help_outline" size="sm" class="help-hover-icon">
@@ -721,6 +744,9 @@ export default defineComponent({
       },
     });
     const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
+    const useSystemThemeMode = computed(
+      () => store.state.themeSetting.useSystemTheme
+    );
     const activePointScrollMode = computed({
       get: () => store.state.activePointScrollMode,
       set: (activePointScrollMode: ActivePointScrollMode) => {
@@ -856,6 +882,12 @@ export default defineComponent({
       store.dispatch("SET_INHERIT_AUDIOINFO", { inheritAudioInfo });
     };
 
+    const changeuseSystemTheme = async (useSystemTheme: boolean) => {
+      if (store.state.themeSetting.useSystemTheme === useSystemTheme) return;
+      console.log(`CHANGEUSESYSTEMTHEME: ${useSystemTheme}`);
+      store.dispatch("SET_THEME_SETTING", { useSystemTheme });
+    };
+
     const changeExperimentalSetting = async (
       key: keyof ExperimentalSetting,
       data: boolean
@@ -950,12 +982,14 @@ export default defineComponent({
       settingDialogOpenedComputed,
       engineMode,
       inheritAudioInfoMode,
+      useSystemThemeMode,
       activePointScrollMode,
       activePointScrollModeOptions,
       experimentalSetting,
       currentAudioOutputDeviceComputed,
       availableAudioOutputDevices,
       changeinheritAudioInfo,
+      changeuseSystemTheme,
       changeExperimentalSetting,
       restartAllEngineProcess,
       savingSetting,

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -773,12 +773,6 @@ export default defineComponent({
       },
     });
 
-    const currentThemeComputed = computed(() =>
-      store.state.themeSetting.availableThemes.find((value) => {
-        return value.name == currentThemeNameComputed.value;
-      })
-    );
-
     const availableThemeNameComputed = computed(() => {
       const themes = [...store.state.themeSetting.availableThemes]
         .sort((a, b) => a.order - b.order)
@@ -979,7 +973,6 @@ export default defineComponent({
       handleSavingSettingChange,
       openFileExplore,
       currentThemeNameComputed,
-      currentThemeComputed,
       availableThemeNameComputed,
       acceptRetrieveTelemetryComputed,
       splitTextWhenPaste,

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -221,7 +221,11 @@ const api: Sandbox = {
   },
 
   setNativeTheme: (source) => {
-    ipcRenderer.invoke("NATIVE_THEME", source);
+    return ipcRenderer.invoke("SET_NATIVE_THEME", source);
+  },
+
+  getShouldUseDarkColors: () => {
+    return ipcRenderer.invoke("GET_SHOULD_USE_DARK_COLORS");
   },
 
   nativeThemeUpdated: (callback) =>

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -221,8 +221,11 @@ const api: Sandbox = {
   },
 
   setNativeTheme: (source) => {
-    ipcRenderer.invoke("SET_NATIVE_THEME", source);
+    ipcRenderer.invoke("NATIVE_THEME", source);
   },
+
+  nativeThemeUpdated: (callback) =>
+    ipcRenderer.on("NATIVE_THEME_UPDATED", callback),
 
   theme: (newData) => {
     return ipcRenderer.invoke("THEME", newData);

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -225,7 +225,7 @@ const api: Sandbox = {
   },
 
   theme: (newData) => {
-    return ipcRenderer.invoke("THEME", { newData });
+    return ipcRenderer.invoke("THEME", newData);
   },
 
   vuexReady: () => {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -184,13 +184,13 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
 
   SET_THEME_SETTING: {
     mutation(state, { useSystemTheme, currentTheme, themes }) {
-      if (useSystemTheme) {
+      if (useSystemTheme !== undefined) {
         state.themeSetting.useSystemTheme = useSystemTheme;
       }
-      if (currentTheme) {
+      if (currentTheme !== undefined) {
         state.themeSetting.currentTheme = currentTheme;
       }
-      if (themes) {
+      if (themes !== undefined) {
         state.themeSetting.availableThemes = themes;
       }
     },
@@ -198,34 +198,37 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
       // storeに保存
       window.electron.theme({ useSystemTheme, currentTheme });
 
-      const theme = state.themeSetting.availableThemes.find((value) => {
-        return value.name == currentTheme;
-      });
-
-      if (theme == undefined) {
-        throw Error("Theme not found");
-      }
-
-      for (const key in theme.colors) {
-        const color = theme.colors[key as ThemeColorType];
-        const { r, g, b } = colors.hexToRgb(color);
-        document.documentElement.style.setProperty(`--color-${key}`, color);
-        document.documentElement.style.setProperty(
-          `--color-${key}-rgb`,
-          `${r}, ${g}, ${b}`
+      if (currentTheme !== undefined) {
+        const theme = state.themeSetting.availableThemes.find(
+          (value) => value.name == currentTheme
         );
+
+        if (theme == undefined) {
+          throw Error("Theme not found");
+        }
+
+        for (const key in theme.colors) {
+          const color = theme.colors[key as ThemeColorType];
+          const { r, g, b } = colors.hexToRgb(color);
+          document.documentElement.style.setProperty(`--color-${key}`, color);
+          document.documentElement.style.setProperty(
+            `--color-${key}-rgb`,
+            `${r}, ${g}, ${b}`
+          );
+        }
+        Dark.set(theme.isDark);
+        setCssVar("primary", theme.colors["primary"]);
+        setCssVar("warning", theme.colors["warning"]);
+
+        document.documentElement.setAttribute(
+          "is-dark-theme",
+          theme.isDark ? "true" : "false"
+        );
+
+        window.electron.setNativeTheme(theme.isDark ? "dark" : "light");
       }
-      Dark.set(theme.isDark);
-      setCssVar("primary", theme.colors["primary"]);
-      setCssVar("warning", theme.colors["warning"]);
 
-      document.documentElement.setAttribute(
-        "is-dark-theme",
-        theme.isDark ? "true" : "false"
-      );
-
-      window.electron.setNativeTheme(theme.isDark ? "dark" : "light");
-
+      console.log(`DISPATCH!!! ${useSystemTheme} ${currentTheme}`);
       commit("SET_THEME_SETTING", { useSystemTheme, currentTheme });
     },
   },

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -7,6 +7,7 @@ import {
   ThemeColorType,
   ThemeConf,
   ToolbarSetting,
+  NativeThemeType,
 } from "@/type/preload";
 import { SettingStoreState, SettingStoreTypes } from "./type";
 import Mousetrap from "mousetrap";
@@ -196,15 +197,15 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         state.themeSetting.availableThemes = themes;
       }
     },
-    action({ dispatch, commit }, { useSystemTheme, currentTheme }) {
+    async action({ dispatch, commit }, { useSystemTheme, currentTheme }) {
       // storeに保存
       window.electron.theme({ useSystemTheme, currentTheme });
+
+      commit("SET_THEME_SETTING", { useSystemTheme, currentTheme });
 
       if (currentTheme !== undefined) {
         dispatch("SET_RENDER_THEME", { newData: currentTheme });
       }
-
-      commit("SET_THEME_SETTING", { useSystemTheme, currentTheme });
     },
   },
 
@@ -240,11 +241,13 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         theme.isDark ? "true" : "false"
       );
 
-      const nativeTheme = state.themeSetting.useSystemTheme
-        ? "system"
-        : theme.isDark
-        ? "dark"
-        : "light";
+      let nativeTheme: NativeThemeType;
+      if (state.themeSetting.useSystemTheme) {
+        nativeTheme = "system";
+      } else {
+        nativeTheme = theme.isDark ? "dark" : "light";
+      }
+      console.log(nativeTheme);
       window.electron.setNativeTheme(nativeTheme);
       commit("SET_RENDER_THEME", { newData });
     },

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -215,6 +215,7 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
       state.themeSetting.renderTheme = newData;
     },
     action({ state, commit }, { newData }) {
+      console.log("Theme color set");
       const theme = state.themeSetting.availableThemes.find(
         (value) => value.name == newData
       );
@@ -247,7 +248,6 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
       } else {
         nativeTheme = theme.isDark ? "dark" : "light";
       }
-      console.log(nativeTheme);
       window.electron.setNativeTheme(nativeTheme);
       commit("SET_RENDER_THEME", { newData });
     },

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -36,6 +36,7 @@ export const settingStoreState: SettingStoreState = {
   engineInfos: {},
   engineManifests: {},
   themeSetting: {
+    useSystemTheme: true,
     currentTheme: "Default",
     availableThemes: [],
   },
@@ -68,13 +69,15 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         });
       });
 
-      const theme = await window.electron.theme();
+      const theme = await window.electron.theme({});
       if (theme) {
         commit("SET_THEME_SETTING", {
+          useSystemTheme: theme.useSystemTheme,
           currentTheme: theme.currentTheme,
           themes: theme.availableThemes,
         });
         dispatch("SET_THEME_SETTING", {
+          useSystemTheme: theme.useSystemTheme,
           currentTheme: theme.currentTheme,
         });
       }
@@ -180,17 +183,21 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
   },
 
   SET_THEME_SETTING: {
-    mutation(
-      state,
-      { currentTheme, themes }: { currentTheme: string; themes?: ThemeConf[] }
-    ) {
+    mutation(state, { useSystemTheme, currentTheme, themes }) {
+      if (useSystemTheme) {
+        state.themeSetting.useSystemTheme = useSystemTheme;
+      }
+      if (currentTheme) {
+        state.themeSetting.currentTheme = currentTheme;
+      }
       if (themes) {
         state.themeSetting.availableThemes = themes;
       }
-      state.themeSetting.currentTheme = currentTheme;
     },
-    action({ state, commit }, { currentTheme }: { currentTheme: string }) {
-      window.electron.theme(currentTheme);
+    action({ state, commit }, { useSystemTheme, currentTheme }) {
+      // storeに保存
+      window.electron.theme({ useSystemTheme, currentTheme });
+
       const theme = state.themeSetting.availableThemes.find((value) => {
         return value.name == currentTheme;
       });
@@ -219,9 +226,7 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
 
       window.electron.setNativeTheme(theme.isDark ? "dark" : "light");
 
-      commit("SET_THEME_SETTING", {
-        currentTheme: currentTheme,
-      });
+      commit("SET_THEME_SETTING", { useSystemTheme, currentTheme });
     },
   },
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -964,8 +964,12 @@ export type SettingStoreTypes = {
   };
 
   SET_THEME_SETTING: {
-    mutation: { currentTheme: string; themes?: ThemeConf[] };
-    action(payload: { currentTheme: string }): void;
+    mutation: {
+      useSystemTheme?: boolean;
+      currentTheme?: string;
+      themes?: ThemeConf[];
+    };
+    action(payload: { useSystemTheme?: boolean; currentTheme?: string }): void;
   };
 
   SET_EDITOR_FONT: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -972,6 +972,11 @@ export type SettingStoreTypes = {
     action(payload: { useSystemTheme?: boolean; currentTheme?: string }): void;
   };
 
+  SET_RENDER_THEME: {
+    mutation: { newData: string };
+    action(payload: { newData: string }): void;
+  };
+
   SET_EDITOR_FONT: {
     mutation: { editorFont: EditorFontType };
     action(payload: { editorFont: EditorFontType }): void;

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -235,6 +235,11 @@ export type IpcIHData = {
     return: ToolbarSetting;
   };
 
+  NATIVE_THEME: {
+    args: [source: NativeThemeType];
+    return: void;
+  };
+
   THEME: {
     args: [obj: IpcThemeType];
     return: ThemeSetting | void;
@@ -256,11 +261,6 @@ export type IpcIHData = {
       newValue: ElectronStoreType[keyof ElectronStoreType]
     ];
     return: ElectronStoreType[keyof ElectronStoreType];
-  };
-
-  SET_NATIVE_THEME: {
-    args: [source: NativeThemeType];
-    return: void;
   };
 
   INSTALL_VVPP_ENGINE: {

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -235,9 +235,14 @@ export type IpcIHData = {
     return: ToolbarSetting;
   };
 
-  NATIVE_THEME: {
+  SET_NATIVE_THEME: {
     args: [source: NativeThemeType];
     return: void;
+  };
+
+  GET_SHOULD_USE_DARK_COLORS: {
+    args: [];
+    return: boolean;
   };
 
   THEME: {

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -9,6 +9,7 @@ import {
   UpdateInfo,
   WriteFileErrorResult,
   NativeThemeType,
+  IpcThemeType,
 } from "@/type/preload";
 
 /**
@@ -235,7 +236,7 @@ export type IpcIHData = {
   };
 
   THEME: {
-    args: [obj: { newData?: string }];
+    args: [obj: IpcThemeType];
     return: ThemeSetting | void;
   };
 

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -496,7 +496,7 @@ export const electronStoreSchema = z
         keys: z.string().uuid().array().default([]),
       })
       .default({}),
-    useSystemTheme: z.boolean().default(true),
+    useSystemTheme: z.boolean().default(false),
     currentTheme: z.string().default("Default"),
     editorFont: z.enum(["default", "os"]).default("default"),
     experimentalSetting: z

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -174,6 +174,8 @@ export interface Sandbox {
   getDefaultHotkeySettings(): Promise<HotkeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
   setNativeTheme(source: NativeThemeType): void;
+  // FIXME: anyを消す
+  nativeThemeUpdated(callback: any): Electron.IpcRenderer;
   theme(newData: IpcThemeType): Promise<ThemeSetting | void>;
   vuexReady(): void;
   getSetting<Key extends keyof ElectronStoreType>(
@@ -407,6 +409,7 @@ export type ThemeConf = {
 
 export type ThemeSetting = {
   useSystemTheme: boolean;
+  renderTheme: string;
   currentTheme: string;
   availableThemes: ThemeConf[];
 };

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -174,7 +174,7 @@ export interface Sandbox {
   getDefaultHotkeySettings(): Promise<HotkeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
   setNativeTheme(source: NativeThemeType): void;
-  theme(newData?: string): Promise<ThemeSetting | void>;
+  theme(newData: IpcThemeType): Promise<ThemeSetting | void>;
   vuexReady(): void;
   getSetting<Key extends keyof ElectronStoreType>(
     key: Key
@@ -368,6 +368,11 @@ export type ToolbarButtonTagType = z.infer<typeof toolbarButtonTagSchema>;
 export const toolbarSettingSchema = toolbarButtonTagSchema;
 export type ToolbarSetting = z.infer<typeof toolbarSettingSchema>[];
 
+// newDataの型 (設定したい値だけ入れる)
+export type IpcThemeType = {
+  useSystemTheme?: boolean;
+  currentTheme?: string;
+};
 export type NativeThemeType = typeof nativeTheme["themeSource"];
 
 export type MoraDataType =
@@ -401,6 +406,7 @@ export type ThemeConf = {
 };
 
 export type ThemeSetting = {
+  useSystemTheme: boolean;
   currentTheme: string;
   availableThemes: ThemeConf[];
 };
@@ -486,6 +492,7 @@ export const electronStoreSchema = z
         keys: z.string().uuid().array().default([]),
       })
       .default({}),
+    useSystemTheme: z.boolean().default(true),
     currentTheme: z.string().default("Default"),
     editorFont: z.enum(["default", "os"]).default("default"),
     experimentalSetting: z

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -174,6 +174,7 @@ export interface Sandbox {
   getDefaultHotkeySettings(): Promise<HotkeySetting[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSetting>;
   setNativeTheme(source: NativeThemeType): void;
+  getShouldUseDarkColors(): Promise<boolean>;
   // FIXME: anyを消す
   nativeThemeUpdated(callback: any): Electron.IpcRenderer;
   theme(newData: IpcThemeType): Promise<ThemeSetting | void>;


### PR DESCRIPTION
## 内容

#1139 の実装です。
#1139 での説明から、次の箇所を変更しています

・設定画面の変更
・デフォルト値を変更
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

#1139

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<img width="724" alt="スクリーンショット 0005-01-23 午後10 27 00" src="https://user-images.githubusercontent.com/45391880/214051136-07d0a224-f70b-46fa-a892-02b9a91845f8.png">
<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
イベント周りで動作が怪しい箇所があるので、確認するまでDraftとします
また、テーマ周りの構成を大きく変更しているため、後ほど詳細な説明をこのPRに追加します