### PR TITLE
Promiseのエラーハンドリングを改善

### DIFF
--- a/src/components/ErrorBoundary.vue
+++ b/src/components/ErrorBoundary.vue
@@ -15,8 +15,17 @@ export default defineComponent({
     };
 
     onMounted(() => {
+      // FIXME: Promiseのエラーハンドリングもっと考える
       const handlePromiseRejectionEvent = (event: PromiseRejectionEvent) => {
-        logError(event.reason);
+        if (event.reason instanceof Error) {
+          logError(event.reason);
+        } else if (event.reason instanceof Response) {
+          logError(
+            new Error(`HTTP ${event.reason.status} at ${event.reason.url}`)
+          );
+        } else {
+          logError(new Error(event.reason));
+        }
       };
       window.addEventListener("error", (event: ErrorEvent) => {
         logError(event.error);


### PR DESCRIPTION
## 内容

`ErrorBoundary`にある`unhandledrejection`イベントはPromiseでrejectされたときのオブジェクトが`event.reason`に渡ってくる。
objectの型はerror型じゃないこともあり、その場合は何が起こったか全くわからない（`.stack`がundefinedになる）

error型が返った場合はlogErrorに、そうでない場合はErrorに包むようにした。
ついでにhttp通信エラーによる`Response`の場合はURLがlogErrorに書かれるようにした。

## その他

そもそも全てのrejectでErrorを返すべきな気がしますが、かなり大変だしコーディングが面倒そうなので、とりあえずFIXMEコメントを書いています。
