### PR TITLE
Fix: ビルドが通らないのを修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,9 @@ jobs:
           LINUX_ARTIFACT_NAME: ${{ matrix.linux_artifact_name }}
           LINUX_EXECUTABLE_NAME: ${{ matrix.linux_executable_name }}
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
+
+          # https://github.com/electron-userland/electron-builder/issues/3179
+          USE_HARD_LINKS: false
         run: npm run electron:build_pnever -- --dir
 
       - name: Reset Code Signing Envs

--- a/build/generateLicenses.js
+++ b/build/generateLicenses.js
@@ -57,7 +57,7 @@ const licenseJson = execFileSync(
   ],
   {
     encoding: "utf-8",
-    maxBuffer: 1024 * 1024 * 10,
+    maxBuffer: 1024 * 1024 * 10, // FIXME: stdoutではなくファイル出力にする
   }
 );
 

--- a/build/generateLicenses.js
+++ b/build/generateLicenses.js
@@ -57,6 +57,7 @@ const licenseJson = execFileSync(
   ],
   {
     encoding: "utf-8",
+    maxBuffer: 1024 * 1024 * 10,
   }
 );
 


### PR DESCRIPTION
## 内容

タイトル通り。

- MacのビルドがEEXISTで落ちていたのを修正します。参考：https://github.com/electron-userland/electron-builder/issues/3179
- ライセンス生成がENOBUFで落ちていたのを修正します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

ライセンス生成は、適当なファイルに書き出すようにして、それを読むようにした方が良いかもしれません。
今の実装だとライセンスのjsonが10MiBを超えると死ぬはずです。