### PR TITLE
isEngineWaitingLongの初期値がtrueになっていた

### DIFF
--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -600,7 +600,7 @@ export default defineComponent({
       return lastEngineState; // FIXME: 暫定的に1つのエンジンの状態を返す
     });
 
-    const isEngineWaitingLong = ref<boolean>(true);
+    const isEngineWaitingLong = ref<boolean>(false);
     let engineTimer: number | undefined = undefined;
     watch(allEngineState, (newEngineState) => {
       if (engineTimer !== undefined) {


### PR DESCRIPTION
## 内容
isEngineWaitingLongの初期値がtrueになっていたので修正。
エンジン起動開始したらfalseに戻るけど、変なので。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

thx @sevenc-nanashi ！
