### PR TITLE
Hotfix: タイトルバーとエンジン選択を修正

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -85,7 +85,6 @@ const isMultiEngineOffMode = computed(() => store.state.isMultiEngineOffMode);
 const uiLocked = computed(() => store.getters.UI_LOCKED);
 const menubarLocked = computed(() => store.getters.MENUBAR_LOCKED);
 const projectName = computed(() => store.getters.PROJECT_NAME);
-const useGpu = computed(() => store.state.useGpu);
 const isEdited = computed(() => store.getters.IS_EDITED);
 const isFullscreen = computed(() => store.getters.IS_FULLSCREEN);
 const engineIds = computed(() => store.state.engineIds);
@@ -100,8 +99,7 @@ const titleText = computed(
     (isEdited.value ? "*" : "") +
     (projectName.value !== undefined ? projectName.value + " - " : "") +
     "VOICEVOX" +
-    (currentVersion.value ? " - Ver. " + currentVersion.value + " - " : "") +
-    (useGpu.value ? "GPU" : "CPU") +
+    (currentVersion.value ? " - Ver. " + currentVersion.value : "") +
     (isMultiEngineOffMode.value ? " - マルチエンジンオフ" : "")
 );
 

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -30,7 +30,7 @@
             <q-card flat class="setting-card">
               <q-card-actions>
                 <div class="text-h5">エンジン</div>
-                <template v-if="engineIds.length > 0">
+                <template v-if="engineIds.length > 1">
                   <q-space />
                   <q-select
                     borderless


### PR DESCRIPTION
## 内容

- タイトルバーのCPU/GPU表記が常にCPU表記になっている（削除することで対応、 @Hiroshiba さんからの同意も得ています）
- エンジン選択のセレクトメニューが常に表示されている

のを修正します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）