### PR TITLE
Q&Aの一部表記がぶれていたので修正

### DIFF
--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -137,7 +137,7 @@ VOICEVOX Twitter アカウント [@voicevox_pj](https://twitter.com/voicevox_pj)
 
 `/Users/(ユーザー名)/Library/Application Support/voicevox/logs`
 
-### `ubuntu 22.04`で動きません。
+### Q. ubuntu 22.04 で動きません。
 
 `libfuse2`をインストールすることで解決するかもしれません。
 


### PR DESCRIPTION
## 内容

「Q.」が抜けて見づらい感じになっていたので修正です。

![image](https://user-images.githubusercontent.com/4987327/215946604-ec7922a6-9adc-4b55-b820-e6e2d757d4b6.png)
