### PR TITLE
EngineIdをユニークな型にする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -134,8 +134,10 @@ const store = new Store<ElectronStoreType>({
     },
     ">=0.14": (store) => {
       // FIXME: できるならEngineManagerからEnginIDを取得したい
+      if (process.env.DEFAULT_ENGINE_INFOS == undefined)
+        throw new Error("DEFAULT_ENGINE_INFOS == undefined");
       const engineId = EngineId(
-        JSON.parse(process.env.DEFAULT_ENGINE_INFOS ?? "[]")[0].uuid
+        JSON.parse(process.env.DEFAULT_ENGINE_INFOS)[0].uuid
       );
       if (engineId == undefined)
         throw new Error("DEFAULT_ENGINE_INFOS[0].uuid == undefined");

--- a/src/background.ts
+++ b/src/background.ts
@@ -32,7 +32,7 @@ import {
   defaultHotkeySettings,
   isMac,
   defaultToolbarButtonSetting,
-  engineSetting,
+  engineSettingSchema,
 } from "./type/preload";
 
 import log from "electron-log";
@@ -495,7 +495,7 @@ async function start() {
   for (const engineInfo of engineInfos) {
     if (!engineSettings[engineInfo.uuid]) {
       // 空オブジェクトをパースさせることで、デフォルト値を取得する
-      engineSettings[engineInfo.uuid] = engineSetting.parse({});
+      engineSettings[engineInfo.uuid] = engineSettingSchema.parse({});
     }
   }
   store.set("engineSettings", engineSettings);

--- a/src/background.ts
+++ b/src/background.ts
@@ -33,6 +33,7 @@ import {
   isMac,
   defaultToolbarButtonSetting,
   engineSettingSchema,
+  EngineId,
 } from "./type/preload";
 
 import log from "electron-log";
@@ -133,15 +134,16 @@ const store = new Store<ElectronStoreType>({
     },
     ">=0.14": (store) => {
       // FIXME: できるならEngineManagerからEnginIDを取得したい
-      const engineId = JSON.parse(process.env.DEFAULT_ENGINE_INFOS ?? "[]")[0]
-        .uuid;
+      const engineId = EngineId(
+        JSON.parse(process.env.DEFAULT_ENGINE_INFOS ?? "[]")[0].uuid
+      );
       if (engineId == undefined)
         throw new Error("DEFAULT_ENGINE_INFOS[0].uuid == undefined");
       const prevDefaultStyleIds = store.get("defaultStyleIds");
       store.set(
         "defaultStyleIds",
         prevDefaultStyleIds.map((defaultStyle) => ({
-          engineId: engineId,
+          engineId,
           speakerUuid: defaultStyle.speakerUuid,
           defaultStyleId: defaultStyle.defaultStyleId,
         }))
@@ -178,7 +180,7 @@ const engineManager = new EngineManager({
 const vvppManager = new VvppManager({ vvppEngineDir });
 
 // エンジンのフォルダを開く
-function openEngineDirectory(engineId: string) {
+function openEngineDirectory(engineId: EngineId) {
   const engineDirectory = engineManager.fetchEngineDirectory(engineId);
 
   // Windows環境だとスラッシュ区切りのパスが動かない。
@@ -270,7 +272,7 @@ function checkMultiEngineEnabled(): boolean {
  * VVPPエンジンをアンインストールする。
  * 関数を呼んだタイミングでアンインストール処理を途中まで行い、アプリ終了時に完遂する。
  */
-async function uninstallVvppEngine(engineId: string) {
+async function uninstallVvppEngine(engineId: EngineId) {
   let engineInfo: EngineInfo | undefined = undefined;
   try {
     engineInfo = engineManager.fetchEngineInfo(engineId);
@@ -820,7 +822,7 @@ ipcMainHandle("INSTALL_VVPP_ENGINE", async (_, path: string) => {
   return await installVvppEngine(path);
 });
 
-ipcMainHandle("UNINSTALL_VVPP_ENGINE", async (_, engineId: string) => {
+ipcMainHandle("UNINSTALL_VVPP_ENGINE", async (_, engineId: EngineId) => {
   return await uninstallVvppEngine(engineId);
 });
 

--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -14,6 +14,8 @@ import {
   ElectronStoreType,
   EngineDirValidationResult,
   MinimumEngineManifest,
+  EngineId,
+  engineIdSchema,
 } from "@/type/preload";
 
 import log from "electron-log";
@@ -33,7 +35,7 @@ function createDefaultEngineInfos(defaultEngineDir: string): EngineInfo[] {
 
   const envSchema = z
     .object({
-      uuid: z.string().uuid(),
+      uuid: engineIdSchema,
       host: z.string(),
       name: z.string(),
       executionEnabled: z.boolean(),
@@ -62,7 +64,7 @@ export class EngineManager {
   vvppEngineDir: string;
 
   defaultEngineInfos: EngineInfo[];
-  engineProcessContainers: Record<string, EngineProcessContainer>;
+  engineProcessContainers: Record<EngineId, EngineProcessContainer>;
 
   constructor({
     store,
@@ -160,7 +162,7 @@ export class EngineManager {
   /**
    * エンジンの情報を取得する。存在しない場合はエラーを返す。
    */
-  fetchEngineInfo(engineId: string): EngineInfo {
+  fetchEngineInfo(engineId: EngineId): EngineInfo {
     const engineInfos = this.fetchEngineInfos();
     const engineInfo = engineInfos.find(
       (engineInfo) => engineInfo.uuid === engineId
@@ -174,7 +176,7 @@ export class EngineManager {
   /**
    * エンジンのディレクトリを取得する。存在しない場合はエラーを返す。
    */
-  fetchEngineDirectory(engineId: string): string {
+  fetchEngineDirectory(engineId: EngineId): string {
     const engineInfo = this.fetchEngineInfo(engineId);
     const engineDirectory = engineInfo.path;
     if (engineDirectory == null) {
@@ -202,7 +204,7 @@ export class EngineManager {
    * エンジンを起動する。
    * FIXME: winを受け取らなくても良いようにする
    */
-  async runEngine(engineId: string, win: BrowserWindow) {
+  async runEngine(engineId: EngineId, win: BrowserWindow) {
     const engineInfos = this.fetchEngineInfos();
     const engineInfo = engineInfos.find(
       (engineInfo) => engineInfo.uuid === engineId
@@ -233,7 +235,11 @@ export class EngineManager {
     const engineProcessContainer = this.engineProcessContainers[engineId];
     engineProcessContainer.willQuitEngine = false;
 
-    const useGpu = this.store.get("engineSettings")[engineId].useGpu;
+    const engineSetting = this.store.get("engineSettings")[engineId];
+    if (engineSetting == undefined)
+      throw new Error(`No such engineSetting: engineId == ${engineId}`);
+
+    const useGpu = engineSetting.useGpu;
     log.info(`ENGINE ${engineId} mode: ${useGpu ? "GPU" : "CPU"}`);
 
     // エンジンプロセスの起動
@@ -286,10 +292,11 @@ export class EngineManager {
   /**
    * 全てのエンジンに対し、各エンジンを終了するPromiseを返す。
    */
-  killEngineAll(): Record<string, Promise<void>> {
-    const killingProcessPromises: Record<string, Promise<void>> = {};
+  killEngineAll(): Record<EngineId, Promise<void>> {
+    const killingProcessPromises: Record<EngineId, Promise<void>> = {};
 
-    for (const engineId of Object.keys(this.engineProcessContainers)) {
+    for (const engineIdStr of Object.keys(this.engineProcessContainers)) {
+      const engineId = EngineId(engineIdStr);
       const promise = this.killEngine(engineId);
       if (promise === undefined) continue;
 
@@ -307,7 +314,7 @@ export class EngineManager {
    * Promise.reject: エンジンプロセスのキルに失敗した（非同期）
    * undefined: エンジンプロセスのキルが開始されなかった＝エンジンプロセスがすでに停止している（同期）
    */
-  killEngine(engineId: string): Promise<void> | undefined {
+  killEngine(engineId: EngineId): Promise<void> | undefined {
     const engineProcessContainer = this.engineProcessContainers[engineId];
     if (!engineProcessContainer) {
       log.error(`No such engineProcessContainer: engineId == ${engineId}`);
@@ -364,7 +371,7 @@ export class EngineManager {
    * エンジンを再起動する。
    * FIXME: winを受け取らなくても良いようにする
    */
-  async restartEngine(engineId: string, win: BrowserWindow) {
+  async restartEngine(engineId: EngineId, win: BrowserWindow) {
     // FIXME: killEngine関数を使い回すようにする
     await new Promise<void>((resolve, reject) => {
       const engineProcessContainer: EngineProcessContainer | undefined =

--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -295,6 +295,7 @@ export class EngineManager {
   killEngineAll(): Record<EngineId, Promise<void>> {
     const killingProcessPromises: Record<EngineId, Promise<void>> = {};
 
+    // FIXME: engineProcessContainersをMapにする
     for (const engineIdStr of Object.keys(this.engineProcessContainers)) {
       const engineId = EngineId(engineIdStr);
       const promise = this.killEngine(engineId);

--- a/src/background/vvppManager.ts
+++ b/src/background/vvppManager.ts
@@ -4,7 +4,7 @@ import log from "electron-log";
 import { moveFile } from "move-file";
 import { Extract } from "unzipper";
 import { dialog } from "electron";
-import { EngineInfo, MinimumEngineManifest } from "@/type/preload";
+import { EngineId, EngineInfo, MinimumEngineManifest } from "@/type/preload";
 import MultiStream from "multistream";
 import glob, { glob as callbackGlob } from "glob";
 
@@ -57,7 +57,7 @@ export const isVvppFile = (filePath: string) => {
 export class VvppManager {
   vvppEngineDir: string;
 
-  willDeleteEngineIds: Set<string>;
+  willDeleteEngineIds: Set<EngineId>;
   willReplaceEngineDirs: Array<{ from: string; to: string }>;
 
   constructor({ vvppEngineDir }: { vvppEngineDir: string }) {
@@ -73,7 +73,7 @@ export class VvppManager {
     });
   }
 
-  markWillDelete(engineId: string) {
+  markWillDelete(engineId: EngineId) {
     this.willDeleteEngineIds.add(engineId);
   }
 

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -400,6 +400,7 @@ export default defineComponent({
     watch(
       [engineInfos, engineStates, engineManifests],
       async () => {
+        // FIXME: engineInfosをMapにする
         for (const idStr of Object.keys(engineInfos.value)) {
           const id = EngineId(idStr);
           if (engineStates.value[id] !== "READY") continue;

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -395,7 +395,7 @@ export default defineComponent({
         ])
       )
     );
-    const engineVersions = ref<Record<string, string>>({});
+    const engineVersions = ref<Record<EngineId, string>>({});
 
     watch(
       [engineInfos, engineStates, engineManifests],

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -76,8 +76,9 @@
 import { useStore } from "@/store";
 import { computed, defineComponent, ref } from "vue";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
+import { EngineId } from "@/type/preload";
 
-type DetailKey = { engine: string; character: string };
+type DetailKey = { engine: EngineId; character: string };
 
 export default defineComponent({
   setup() {
@@ -96,16 +97,19 @@ export default defineComponent({
       () =>
         new Map(
           Object.entries(store.state.characterInfos).map(
-            ([engineId, characterInfos]) => [
-              engineId,
-              {
+            ([engineIdStr, characterInfos]) => {
+              const engineId = EngineId(engineIdStr);
+              return [
                 engineId,
-                name: store.state.engineManifests[engineId].name,
-                characterInfos: new Map(
-                  characterInfos.map((ci) => [ci.metas.speakerUuid, ci])
-                ),
-              },
-            ]
+                {
+                  engineId,
+                  name: store.state.engineManifests[engineId].name,
+                  characterInfos: new Map(
+                    characterInfos.map((ci) => [ci.metas.speakerUuid, ci])
+                  ),
+                },
+              ];
+            }
           )
         )
     );

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -730,6 +730,7 @@ import {
   ActivePointScrollMode,
   SplitTextWhenPasteType,
   EditorFontType,
+  EngineId,
 } from "@/type/preload";
 import FileNamePatternDialog from "./FileNamePatternDialog.vue";
 
@@ -921,7 +922,7 @@ export default defineComponent({
       { label: "GPU", value: true },
     ];
 
-    const gpuSwitchEnabled = (engineId: string) => {
+    const gpuSwitchEnabled = (engineId: EngineId) => {
       // CPU版でもGPUモードからCPUモードに変更できるようにする
       return store.getters.ENGINE_CAN_USE_GPU(engineId) || engineUseGpu.value;
     };
@@ -1023,16 +1024,16 @@ export default defineComponent({
 
     const showsFilePatternEditDialog = ref(false);
 
-    const selectedEngineIdRaw = ref("");
+    const selectedEngineIdRaw = ref<EngineId | undefined>(undefined);
     const selectedEngineId = computed({
       get: () => {
         return selectedEngineIdRaw.value || engineIds.value[0];
       },
-      set: (engineId: string) => {
+      set: (engineId: EngineId) => {
         selectedEngineIdRaw.value = engineId;
       },
     });
-    const renderEngineNameLabel = (engineId: string) => {
+    const renderEngineNameLabel = (engineId: EngineId) => {
       return engineInfos.value[engineId].name;
     };
 

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -5,7 +5,7 @@ import {
   IpcRendererEvent,
 } from "electron";
 
-import { Sandbox, ElectronStoreType } from "@/type/preload";
+import { Sandbox, ElectronStoreType, EngineId } from "@/type/preload";
 import { IpcIHData, IpcSOData } from "@/type/ipc";
 
 function ipcRendererInvoke<T extends keyof IpcIHData>(
@@ -192,11 +192,11 @@ const api: Sandbox = {
     return ipcRendererInvoke("ENGINE_INFOS");
   },
 
-  restartEngine: (engineId: string) => {
+  restartEngine: (engineId: EngineId) => {
     return ipcRendererInvoke("RESTART_ENGINE", { engineId });
   },
 
-  openEngineDirectory: (engineId: string) => {
+  openEngineDirectory: (engineId: EngineId) => {
     return ipcRendererInvoke("OPEN_ENGINE_DIRECTORY", { engineId });
   },
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -17,6 +17,7 @@ import {
   CharacterInfo,
   DefaultStyleId,
   Encoding as EncodingType,
+  EngineId,
   MoraDataType,
   MorphingInfo,
   StyleInfo,
@@ -71,10 +72,10 @@ function parseTextFile(
   defaultStyleIds: DefaultStyleId[],
   userOrderedCharacterInfos: CharacterInfo[]
 ): AudioItem[] {
-  const characters = new Map<string, { engineId: string; styleId: number }>();
+  const characters = new Map<string, { engineId: EngineId; styleId: number }>();
   const uuid2StyleIds = new Map<
     string,
-    { engineId: string; styleId: number }
+    { engineId: EngineId; styleId: number }
   >();
   for (const defaultStyleId of defaultStyleIds) {
     const speakerUuid = defaultStyleId.speakerUuid;
@@ -181,7 +182,7 @@ function generateWriteErrorMessage(writeFileErrorResult: WriteFileErrorResult) {
 // TODO: GETTERに移動する。buildFileNameから参照されているので、そちらも一緒に移動する。
 export function getCharacterInfo(
   state: State,
-  engineId: string,
+  engineId: EngineId,
   styleId: number
 ): CharacterInfo | undefined {
   const engineCharacterInfos = state.characterInfos[engineId];
@@ -319,7 +320,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       {
         engineId,
         characterInfos,
-      }: { engineId: string; characterInfos: CharacterInfo[] }
+      }: { engineId: EngineId; characterInfos: CharacterInfo[] }
     ) {
       state.characterInfos[engineId] = characterInfos;
     },
@@ -484,7 +485,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       { state, getters, dispatch },
       payload: {
         text?: string;
-        engineId?: string;
+        engineId?: EngineId;
         styleId?: number;
         presetKey?: string;
         baseAudioItem?: AudioItem;
@@ -798,7 +799,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         text,
         engineId,
         styleId,
-      }: { text: string; engineId: string; styleId: number }
+      }: { text: string; engineId: EngineId; styleId: number }
     ) {
       return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineId,
@@ -826,7 +827,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         audioKey,
         engineId,
         styleId,
-      }: { audioKey: string; engineId: string; styleId: number }
+      }: { audioKey: string; engineId: EngineId; styleId: number }
     ) {
       state.audioItems[audioKey].engineId = engineId;
       state.audioItems[audioKey].styleId = styleId;
@@ -857,7 +858,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         isKana,
       }: {
         text: string;
-        engineId: string;
+        engineId: EngineId;
         styleId: number;
         isKana?: boolean;
       }
@@ -992,7 +993,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         accentPhrases,
         engineId,
         styleId,
-      }: { accentPhrases: AccentPhrase[]; engineId: string; styleId: number }
+      }: { accentPhrases: AccentPhrase[]; engineId: EngineId; styleId: number }
     ) {
       return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
         engineId,
@@ -1025,7 +1026,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         copyIndexes,
       }: {
         accentPhrases: AccentPhrase[];
-        engineId: string;
+        engineId: EngineId;
         styleId: number;
         copyIndexes: number[];
       }
@@ -1207,7 +1208,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         { dispatch, state },
         { encodedBlobs }: { encodedBlobs: string[] }
       ) => {
-        const engineId: string | undefined = state.engineIds[0]; // TODO: 複数エンジン対応, 暫定的に音声結合機能は0番目のエンジンのみを使用する
+        const engineId: EngineId | undefined = state.engineIds[0]; // TODO: 複数エンジン対応, 暫定的に音声結合機能は0番目のエンジンのみを使用する
         if (engineId === undefined)
           throw new Error(`No such engine registered: index == 0`);
 
@@ -2016,7 +2017,7 @@ export const audioCommandStore = transformCommandStore(
     COMMAND_CHANGE_STYLE_ID: {
       mutation(
         draft,
-        payload: { engineId: string; styleId: number; audioKey: string } & (
+        payload: { engineId: EngineId; styleId: number; audioKey: string } & (
           | { update: "StyleId" }
           | { update: "AccentPhrases"; accentPhrases: AccentPhrase[] }
           | { update: "AudioQuery"; query: AudioQuery }
@@ -2048,7 +2049,7 @@ export const audioCommandStore = transformCommandStore(
           audioKey,
           engineId,
           styleId,
-        }: { audioKey: string; engineId: string; styleId: number }
+        }: { audioKey: string; engineId: EngineId; styleId: number }
       ) {
         const query = state.audioItems[audioKey].query;
         try {
@@ -2821,7 +2822,7 @@ export const audioCommandStore = transformCommandStore(
           }: {
             prevAudioKey: string;
             texts: string[];
-            engineId: string;
+            engineId: EngineId;
             styleId: number;
           }
         ) => {

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -1,5 +1,6 @@
 import { UserDictWord, UserDictWordToJSON } from "@/openapi";
 import { DictionaryStoreState, DictionaryStoreTypes } from "@/store/type";
+import { EngineId } from "@/type/preload";
 import { createPartialStore } from "./vuex";
 
 export const dictionaryStoreState: DictionaryStoreState = {};
@@ -64,7 +65,7 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
       { surface, pronunciation, accentType, priority }
     ) {
       // 同じ単語IDで登録するために、１つのエンジンで登録したあと全エンジンに同期する。
-      const engineId: string | undefined = state.engineIds[0];
+      const engineId: EngineId | undefined = state.engineIds[0];
 
       if (engineId === undefined)
         throw new Error(`No such engine registered: index == 0`);

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -65,7 +65,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
   SET_ENGINE_MANIFESTS: {
     mutation(
       state,
-      { engineManifests }: { engineManifests: Record<string, EngineManifest> }
+      { engineManifests }: { engineManifests: Record<EngineId, EngineManifest> }
     ) {
       state.engineManifests = engineManifests;
     },

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -2,7 +2,7 @@ import { EngineState, EngineStoreState, EngineStoreTypes } from "./type";
 import { createUILockAction } from "./ui";
 import { createPartialStore } from "./vuex";
 import type { EngineManifest } from "@/openapi";
-import type { EngineInfo } from "@/type/preload";
+import type { EngineId, EngineInfo } from "@/type/preload";
 
 export const engineStoreState: EngineStoreState = {
   engineStates: {},
@@ -15,7 +15,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
       const engineInfos = await window.electron.engineInfos();
 
       // マルチエンジンオフモード時はengineIdsをデフォルトエンジンのIDだけにする。
-      let engineIds: string[];
+      let engineIds: EngineId[];
       if (state.isMultiEngineOffMode) {
         engineIds = engineInfos
           .filter((engineInfo) => engineInfo.type === "default")
@@ -50,7 +50,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
       {
         engineIds,
         engineInfos,
-      }: { engineIds: string[]; engineInfos: EngineInfo[] }
+      }: { engineIds: EngineId[]; engineInfos: EngineInfo[] }
     ) {
       state.engineIds = engineIds;
       state.engineInfos = Object.fromEntries(
@@ -256,7 +256,10 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
   SET_ENGINE_STATE: {
     mutation(
       state,
-      { engineId, engineState }: { engineId: string; engineState: EngineState }
+      {
+        engineId,
+        engineState,
+      }: { engineId: EngineId; engineState: EngineState }
     ) {
       state.engineStates[engineId] = engineState;
     },
@@ -347,7 +350,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
       {
         engineId,
         engineManifest,
-      }: { engineId: string; engineManifest: EngineManifest }
+      }: { engineId: EngineId; engineManifest: EngineManifest }
     ) {
       state.engineManifests = {
         ...state.engineManifests,

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -6,6 +6,7 @@ import { createPartialStore } from "./vuex";
 
 import { AccentPhrase } from "@/openapi";
 import { z } from "zod";
+import { EngineId, engineIdSchema } from "@/type/preload";
 
 const DEFAULT_SAMPLING_RATE = 24000;
 
@@ -112,7 +113,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           };
 
           // Migration
-          const engineId = "074fc39e-678b-4c13-8916-ffca8d505d1d";
+          const engineId = EngineId("074fc39e-678b-4c13-8916-ffca8d505d1d");
 
           if (
             semver.satisfies(projectAppVersion, "<0.4", semverSatisfiesOptions)
@@ -416,14 +417,14 @@ const audioQuerySchema = z.object({
 
 const morphingInfoSchema = z.object({
   rate: z.number(),
-  targetEngineId: z.string(),
+  targetEngineId: engineIdSchema,
   targetSpeakerId: z.string(),
   targetStyleId: z.number(),
 });
 
 const audioItemSchema = z.object({
   text: z.string(),
-  engineId: z.string().optional(),
+  engineId: engineIdSchema.optional(),
   styleId: z.number().optional(),
   query: audioQuerySchema.optional(),
   presetKey: z.string().optional(),

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -119,6 +119,7 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         confirmedTips: await window.electron.getSetting("confirmedTips"),
       });
 
+      // FIXME: engineSettingsをMapにする
       for (const [engineIdStr, engineSetting] of Object.entries(
         await window.electron.getSetting("engineSettings")
       )) {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -7,6 +7,7 @@ import {
   ThemeColorType,
   ThemeConf,
   ToolbarSetting,
+  EngineId,
 } from "@/type/preload";
 import { SettingStoreState, SettingStoreTypes } from "./type";
 import Mousetrap from "mousetrap";
@@ -118,11 +119,15 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         confirmedTips: await window.electron.getSetting("confirmedTips"),
       });
 
-      for (const [engineId, engineSetting] of Object.entries(
+      for (const [engineIdStr, engineSetting] of Object.entries(
         await window.electron.getSetting("engineSettings")
       )) {
+        if (engineSetting == undefined)
+          throw new Error(
+            `engineSetting is undefined. engineIdStr: ${engineIdStr}`
+          );
         commit("SET_ENGINE_SETTING", {
-          engineId,
+          engineId: EngineId(engineIdStr),
           engineSetting,
         });
       }

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -111,7 +111,7 @@ export type QuasarDialog = QVueGlobals["dialog"];
  */
 
 export type AudioStoreState = {
-  characterInfos: Record<string, CharacterInfo[]>;
+  characterInfos: Record<EngineId, CharacterInfo[]>;
   morphableTargetsInfo: Record<string, MorphableTargetInfoTable>;
   audioKeyInitializingSpeaker?: string;
   audioItems: Record<string, AudioItem>;
@@ -719,7 +719,7 @@ export type EngineStoreTypes = {
   };
 
   SET_ENGINE_MANIFESTS: {
-    mutation: { engineManifests: Record<string, EngineManifest> };
+    mutation: { engineManifests: Record<EngineId, EngineManifest> };
   };
 
   FETCH_AND_SET_ENGINE_MANIFESTS: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -42,6 +42,7 @@ import {
   EngineSettings,
   MorphableTargetInfoTable,
   EngineSetting,
+  EngineId,
 } from "@/type/preload";
 import { IEngineConnectorFactory } from "@/infrastructures/EngineConnector";
 import { QVueGlobals } from "quasar";
@@ -56,7 +57,7 @@ export type EditorAudioQuery = Omit<AudioQuery, "outputSamplingRate"> & {
 // FIXME: SpeakerIdを追加する
 export type AudioItem = {
   text: string;
-  engineId?: string;
+  engineId?: EngineId;
   styleId?: number;
   query?: EditorAudioQuery;
   presetKey?: string;
@@ -140,15 +141,15 @@ export type AudioStoreTypes = {
   };
 
   LOAD_CHARACTER: {
-    action(payload: { engineId: string }): void;
+    action(payload: { engineId: EngineId }): void;
   };
 
   SET_CHARACTER_INFOS: {
-    mutation: { engineId: string; characterInfos: CharacterInfo[] };
+    mutation: { engineId: EngineId; characterInfos: CharacterInfo[] };
   };
 
   CHARACTER_INFO: {
-    getter(engineId: string, styleId: number): CharacterInfo | undefined;
+    getter(engineId: EngineId, styleId: number): CharacterInfo | undefined;
   };
 
   USER_ORDERED_CHARACTER_INFOS: {
@@ -162,7 +163,7 @@ export type AudioStoreTypes = {
   SETUP_SPEAKER: {
     action(payload: {
       audioKey: string;
-      engineId: string;
+      engineId: EngineId;
       styleId: number;
     }): void;
   };
@@ -196,7 +197,7 @@ export type AudioStoreTypes = {
   GENERATE_AUDIO_ITEM: {
     action(payload: {
       text?: string;
-      engineId?: string;
+      engineId?: EngineId;
       styleId?: number;
       presetKey?: string;
       baseAudioItem?: AudioItem;
@@ -274,12 +275,12 @@ export type AudioStoreTypes = {
   };
 
   LOAD_MORPHABLE_TARGETS: {
-    action(payload: { engineId: string; baseStyleId: number }): void;
+    action(payload: { engineId: EngineId; baseStyleId: number }): void;
   };
 
   SET_MORPHABLE_TARGETS: {
     mutation: {
-      engineId: string;
+      engineId: EngineId;
       baseStyleId: number;
       morphableTargets?: Exclude<
         { [key: number]: MorphableTargetInfo },
@@ -311,13 +312,13 @@ export type AudioStoreTypes = {
   FETCH_AUDIO_QUERY: {
     action(payload: {
       text: string;
-      engineId: string;
+      engineId: EngineId;
       styleId: number;
     }): Promise<AudioQuery>;
   };
 
   SET_AUDIO_STYLE_ID: {
-    mutation: { audioKey: string; engineId: string; styleId: number };
+    mutation: { audioKey: string; engineId: EngineId; styleId: number };
   };
 
   SET_ACCENT_PHRASES: {
@@ -327,7 +328,7 @@ export type AudioStoreTypes = {
   FETCH_ACCENT_PHRASES: {
     action(payload: {
       text: string;
-      engineId: string;
+      engineId: EngineId;
       styleId: number;
       isKana?: boolean;
     }): Promise<AccentPhrase[]>;
@@ -358,7 +359,7 @@ export type AudioStoreTypes = {
   FETCH_MORA_DATA: {
     action(payload: {
       accentPhrases: AccentPhrase[];
-      engineId: string;
+      engineId: EngineId;
       styleId: number;
     }): Promise<AccentPhrase[]>;
   };
@@ -366,7 +367,7 @@ export type AudioStoreTypes = {
   FETCH_AND_COPY_MORA_DATA: {
     action(payload: {
       accentPhrases: AccentPhrase[];
-      engineId: string;
+      engineId: EngineId;
       styleId: number;
       copyIndexes: number[];
     }): Promise<AccentPhrase[]>;
@@ -506,14 +507,14 @@ export type AudioCommandStoreTypes = {
   };
 
   COMMAND_CHANGE_STYLE_ID: {
-    mutation: { engineId: string; styleId: number; audioKey: string } & (
+    mutation: { engineId: EngineId; styleId: number; audioKey: string } & (
       | { update: "StyleId" }
       | { update: "AccentPhrases"; accentPhrases: AccentPhrase[] }
       | { update: "AudioQuery"; query: AudioQuery }
     );
     action(payload: {
       audioKey: string;
-      engineId: string;
+      engineId: EngineId;
       styleId: number;
     }): void;
   };
@@ -663,7 +664,7 @@ export type AudioCommandStoreTypes = {
     action(payload: {
       prevAudioKey: string;
       texts: string[];
-      engineId: string;
+      engineId: EngineId;
       styleId: number;
     }): string[];
   };
@@ -711,8 +712,8 @@ export type CommandStoreTypes = {
  */
 
 export type EngineStoreState = {
-  engineStates: Record<string, EngineState>;
-  engineSupportedDevices: Record<string, SupportedDevicesInfo>;
+  engineStates: Record<EngineId, EngineState>;
+  engineSupportedDevices: Record<EngineId, SupportedDevicesInfo>;
 };
 
 export type EngineStoreTypes = {
@@ -737,45 +738,45 @@ export type EngineStoreTypes = {
   };
 
   IS_ENGINE_READY: {
-    getter(engineId: string): boolean;
+    getter(engineId: EngineId): boolean;
   };
 
   START_WAITING_ENGINE: {
-    action(payload: { engineId: string }): void;
+    action(payload: { engineId: EngineId }): void;
   };
 
   RESTART_ENGINES: {
-    action(payload: { engineIds: string[] }): Promise<{
+    action(payload: { engineIds: EngineId[] }): Promise<{
       success: boolean;
       anyNewCharacters: boolean;
     }>;
   };
 
   POST_ENGINE_START: {
-    action(payload: { engineIds: string[] }): Promise<{
+    action(payload: { engineIds: EngineId[] }): Promise<{
       success: boolean;
       anyNewCharacters: boolean;
     }>;
   };
 
   DETECTED_ENGINE_ERROR: {
-    action(payload: { engineId: string }): void;
+    action(payload: { engineId: EngineId }): void;
   };
 
   OPEN_ENGINE_DIRECTORY: {
-    action(payload: { engineId: string }): void;
+    action(payload: { engineId: EngineId }): void;
   };
 
   SET_ENGINE_STATE: {
-    mutation: { engineId: string; engineState: EngineState };
+    mutation: { engineId: EngineId; engineState: EngineState };
   };
 
   IS_INITIALIZED_ENGINE_SPEAKER: {
-    action(payload: { engineId: string; styleId: number }): Promise<boolean>;
+    action(payload: { engineId: EngineId; styleId: number }): Promise<boolean>;
   };
 
   INITIALIZE_ENGINE_SPEAKER: {
-    action(payload: { engineId: string; styleId: number }): void;
+    action(payload: { engineId: EngineId; styleId: number }): void;
   };
 
   VALIDATE_ENGINE_DIR: {
@@ -795,31 +796,31 @@ export type EngineStoreTypes = {
   };
 
   UNINSTALL_VVPP_ENGINE: {
-    action: (engineId: string) => Promise<boolean>;
+    action: (engineId: EngineId) => Promise<boolean>;
   };
 
   SET_ENGINE_INFOS: {
-    mutation: { engineIds: string[]; engineInfos: EngineInfo[] };
+    mutation: { engineIds: EngineId[]; engineInfos: EngineInfo[] };
   };
 
   SET_ENGINE_MANIFEST: {
-    mutation: { engineId: string; engineManifest: EngineManifest };
+    mutation: { engineId: EngineId; engineManifest: EngineManifest };
   };
 
   FETCH_AND_SET_ENGINE_MANIFEST: {
-    action(payload: { engineId: string }): void;
+    action(payload: { engineId: EngineId }): void;
   };
 
   SET_ENGINE_SUPPORTED_DEVICES: {
-    mutation: { engineId: string; supportedDevices: SupportedDevicesInfo };
+    mutation: { engineId: EngineId; supportedDevices: SupportedDevicesInfo };
   };
 
   FETCH_AND_SET_ENGINE_SUPPORTED_DEVICES: {
-    action(payload: { engineId: string }): void;
+    action(payload: { engineId: EngineId }): void;
   };
 
   ENGINE_CAN_USE_GPU: {
-    getter: (engineId: string) => boolean;
+    getter: (engineId: EngineId) => boolean;
   };
 };
 
@@ -965,9 +966,9 @@ export type SettingStoreState = {
   savingSetting: SavingSetting;
   hotkeySettings: HotkeySetting[];
   toolbarSetting: ToolbarSetting;
-  engineIds: string[];
-  engineInfos: Record<string, EngineInfo>;
-  engineManifests: Record<string, EngineManifest>;
+  engineIds: EngineId[];
+  engineInfos: Record<EngineId, EngineInfo>;
+  engineManifests: Record<EngineId, EngineManifest>;
   themeSetting: ThemeSetting;
   editorFont: EditorFontType;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
@@ -1041,15 +1042,15 @@ export type SettingStoreTypes = {
   };
 
   SET_ENGINE_SETTING: {
-    mutation: { engineSetting: EngineSetting; engineId: string };
+    mutation: { engineSetting: EngineSetting; engineId: EngineId };
     action(payload: {
       engineSetting: EngineSetting;
-      engineId: string;
+      engineId: EngineId;
     }): Promise<void>;
   };
 
   CHANGE_USE_GPU: {
-    action(payload: { useGpu: boolean; engineId: string }): Promise<void>;
+    action(payload: { useGpu: boolean; engineId: EngineId }): Promise<void>;
   };
 };
 
@@ -1276,7 +1277,7 @@ export type DictionaryStoreState = Record<string, unknown>;
 export type DictionaryStoreTypes = {
   LOAD_USER_DICT: {
     action(payload: {
-      engineId: string;
+      engineId: EngineId;
     }): Promise<Record<string, UserDictWord>>;
   };
   LOAD_ALL_USER_DICT: {
@@ -1328,7 +1329,7 @@ type IEngineConnectorFactoryActionsMapper = <
 export type ProxyStoreTypes = {
   INSTANTIATE_ENGINE_CONNECTOR: {
     action(payload: {
-      engineId: string;
+      engineId: EngineId;
     }): Promise<{ invoke: IEngineConnectorFactoryActionsMapper }>;
   };
 };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -43,6 +43,7 @@ import {
   MorphableTargetInfoTable,
   EngineSetting,
   Voice,
+  EngineId,
 } from "@/type/preload";
 import { IEngineConnectorFactory } from "@/infrastructures/EngineConnector";
 import { QVueGlobals } from "quasar";

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -10,6 +10,7 @@ import {
   WriteFileErrorResult,
   NativeThemeType,
   EngineSetting,
+  EngineId,
 } from "@/type/preload";
 
 /**
@@ -201,12 +202,12 @@ export type IpcIHData = {
   };
 
   RESTART_ENGINE: {
-    args: [obj: { engineId: string }];
+    args: [obj: { engineId: EngineId }];
     return: void;
   };
 
   OPEN_ENGINE_DIRECTORY: {
-    args: [obj: { engineId: string }];
+    args: [obj: { engineId: EngineId }];
     return: void;
   };
 
@@ -259,7 +260,7 @@ export type IpcIHData = {
   };
 
   SET_ENGINE_SETTING: {
-    args: [engineId: string, engineSetting: EngineSetting];
+    args: [engineId: EngineId, engineSetting: EngineSetting];
     return: void;
   };
 
@@ -274,7 +275,7 @@ export type IpcIHData = {
   };
 
   UNINSTALL_VVPP_ENGINE: {
-    args: [engineId: string];
+    args: [engineId: EngineId];
     return: Promise<boolean>;
   };
 
@@ -324,7 +325,7 @@ export type IpcSOData = {
   };
 
   DETECTED_ENGINE_ERROR: {
-    args: [obj: { engineId: string }];
+    args: [obj: { engineId: EngineId }];
     return: void;
   };
 

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -3,6 +3,11 @@ import { IpcSOData } from "./ipc";
 import { z } from "zod";
 
 export const isMac = process.platform === "darwin";
+
+export const engineIdSchema = z.string().uuid().brand<"EngineId">();
+export type EngineId = z.infer<typeof engineIdSchema>;
+export const EngineId = (id: string): EngineId => engineIdSchema.parse(id);
+
 // ホットキーを追加したときは設定のマイグレーションが必要
 export const defaultHotkeySettings: HotkeySetting[] = [
   {
@@ -166,8 +171,8 @@ export interface Sandbox {
   logWarn(...params: unknown[]): void;
   logInfo(...params: unknown[]): void;
   engineInfos(): Promise<EngineInfo[]>;
-  restartEngine(engineId: string): Promise<void>;
-  openEngineDirectory(engineId: string): void;
+  restartEngine(engineId: EngineId): Promise<void>;
+  openEngineDirectory(engineId: EngineId): void;
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   checkFileExists(file: string): Promise<boolean>;
   changePinWindow(): void;
@@ -184,11 +189,11 @@ export interface Sandbox {
     newValue: ElectronStoreType[Key]
   ): Promise<ElectronStoreType[Key]>;
   setEngineSetting(
-    engineId: string,
+    engineId: EngineId,
     engineSetting: EngineSetting
   ): Promise<void>;
   installVvppEngine(path: string): Promise<boolean>;
-  uninstallVvppEngine(engineId: string): Promise<boolean>;
+  uninstallVvppEngine(engineId: EngineId): Promise<boolean>;
   validateEngineDir(engineDir: string): Promise<EngineDirValidationResult>;
   restartApp(obj: { isMultiEngineOffMode: boolean }): void;
 }
@@ -203,7 +208,7 @@ export type StyleInfo = {
   styleId: number;
   iconPath: string;
   portraitPath: string | undefined;
-  engineId: string;
+  engineId: EngineId;
   voiceSamplePaths: string[];
 };
 
@@ -230,7 +235,7 @@ export type UpdateInfo = {
 };
 
 export type Voice = {
-  engineId: string;
+  engineId: EngineId;
   speakerId: string;
   styleId: number;
 };
@@ -272,23 +277,23 @@ export const engineSettingSchema = z
       .default("engineDefault"),
   })
   .passthrough();
-export type EngineSetting = z.infer<typeof engineSetting>;
+export type EngineSetting = z.infer<typeof engineSettingSchema>;
 
 export type DefaultStyleId = {
-  engineId: string;
+  engineId: EngineId;
   speakerUuid: string;
   defaultStyleId: number;
 };
 
 export type MinimumEngineManifest = {
   name: string;
-  uuid: string;
+  uuid: EngineId;
   command: string;
   port: string;
 };
 
 export type EngineInfo = {
-  uuid: string;
+  uuid: EngineId;
   host: string;
   name: string;
   path?: string; // エンジンディレクトリのパス
@@ -315,7 +320,7 @@ export type Preset = {
 
 export type MorphingInfo = {
   rate: number;
-  targetEngineId: string;
+  targetEngineId: EngineId;
   targetSpeakerId: string;
   targetStyleId: number;
 };
@@ -475,12 +480,12 @@ export const electronStoreSchema = z
     toolbarSetting: toolbarSettingSchema
       .array()
       .default(defaultToolbarButtonSetting),
-    engineSettings: z.record(engineSetting).default({}),
+    engineSettings: z.record(engineIdSchema, engineSettingSchema).default({}),
     userCharacterOrder: z.string().array().default([]),
     defaultStyleIds: z
       .object({
         // FIXME: マイグレーション前にバリテーションされてしまう問題に対処したら".or(z.literal("")).default("")"を外す
-        engineId: z.string().uuid().or(z.literal("")).default(""),
+        engineId: engineIdSchema,
         speakerUuid: z.string().uuid(),
         defaultStyleId: z.number(),
       })
@@ -504,7 +509,7 @@ export const electronStoreSchema = z
                 morphingInfo: z
                   .object({
                     rate: z.number(),
-                    targetEngineId: z.string().uuid(),
+                    targetEngineId: engineIdSchema,
                     targetSpeakerId: z.string().uuid(),
                     targetStyleId: z.number(),
                   })

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -264,7 +264,7 @@ export type SavingSetting = {
 
 export type EngineSettings = Record<string, EngineSetting>;
 
-export const engineSetting = z
+export const engineSettingSchema = z
   .object({
     useGpu: z.boolean().default(false),
     outputSamplingRate: z

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -267,7 +267,7 @@ export type SavingSetting = {
   audioOutputDevice: string;
 };
 
-export type EngineSettings = Record<string, EngineSetting>;
+export type EngineSettings = Record<EngineId, EngineSetting>;
 
 export const engineSettingSchema = z
   .object({

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -484,8 +484,10 @@ export const electronStoreSchema = z
     userCharacterOrder: z.string().array().default([]),
     defaultStyleIds: z
       .object({
-        // FIXME: マイグレーション前にバリテーションされてしまう問題に対処したら".or(z.literal("")).default("")"を外す
-        engineId: engineIdSchema,
+        // FIXME: マイグレーション前にバリテーションされてしまう問題に対処したら.or(z.literal)を外す
+        engineId: engineIdSchema
+          .or(z.literal(EngineId("00000000-0000-0000-0000-000000000000")))
+          .default(EngineId("00000000-0000-0000-0000-000000000000")),
         speakerUuid: z.string().uuid(),
         defaultStyleId: z.number(),
       })

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -196,6 +196,7 @@ import { AudioItem, EngineState } from "@/store/type";
 import { QResizeObserver, useQuasar } from "quasar";
 import path from "path";
 import {
+  EngineId,
   HotkeyAction,
   HotkeyReturnType,
   SplitterPosition,

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -199,6 +199,7 @@ import {
   HotkeyAction,
   HotkeyReturnType,
   SplitterPosition,
+  EngineId,
 } from "@/type/preload";
 import { parseCombo, setHotkeyFunctions } from "@/store/setting";
 import cloneDeep from "clone-deep";
@@ -402,7 +403,7 @@ export default defineComponent({
     );
     const addAudioItem = async () => {
       const prevAudioKey = activeAudioKey.value;
-      let engineId: string | undefined = undefined;
+      let engineId: EngineId | undefined = undefined;
       let styleId: number | undefined = undefined;
       let presetKey: string | undefined = undefined;
       if (prevAudioKey !== undefined) {
@@ -519,7 +520,7 @@ export default defineComponent({
     onMounted(async () => {
       await store.dispatch("GET_ENGINE_INFOS");
 
-      let engineIds: string[];
+      let engineIds: EngineId[];
       if (store.state.isMultiEngineOffMode) {
         // デフォルトエンジンだけを含める
         const main = Object.values(store.state.engineInfos).find(

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -12,15 +12,17 @@ import { assert } from "chai";
 import { proxyStore } from "@/store/proxy";
 import { dictionaryStore } from "@/store/dictionary";
 import { engineStore } from "@/store/engine";
+import { EngineId } from "@/type/preload";
 const isDevelopment = process.env.NODE_ENV == "development";
 // TODO: Swap external files to Mock
 
 describe("store/vuex.js test", () => {
   it("create store", () => {
+    const engineId = EngineId("88022f86-c823-436e-85a3-500c629749c4");
     const store = createStore<State, AllGetters, AllActions, AllMutations>({
       state: {
         engineStates: {
-          "88022f86-c823-436e-85a3-500c629749c4": "STARTING",
+          [engineId]: "STARTING",
         },
         engineSupportedDevices: {},
         characterInfos: {},
@@ -63,7 +65,7 @@ describe("store/vuex.js test", () => {
           audioOutputDevice: "default",
         },
         engineSettings: {
-          "88022f86-c823-436e-85a3-500c629749c4": {
+          [engineId]: {
             outputSamplingRate: "engineDefault",
             useGpu: false,
           },
@@ -81,10 +83,10 @@ describe("store/vuex.js test", () => {
         toolbarSetting: [],
         acceptRetrieveTelemetry: "Unconfirmed",
         acceptTerms: "Unconfirmed",
-        engineIds: ["88022f86-c823-436e-85a3-500c629749c4"],
+        engineIds: [engineId],
         engineInfos: {
-          "88022f86-c823-436e-85a3-500c629749c4": {
-            uuid: "88022f86-c823-436e-85a3-500c629749c4",
+          [engineId]: {
+            uuid: engineId,
             name: "Engine 1",
             executionEnabled: false,
             executionFilePath: "",
@@ -94,7 +96,7 @@ describe("store/vuex.js test", () => {
           },
         },
         engineManifests: {
-          "88022f86-c823-436e-85a3-500c629749c4": {
+          [engineId]: {
             manifestVersion: "0.13.0",
             name: "DUMMY VOICEVOX ENGINE",
             brandName: "DUMMY VOICEVOX",


### PR DESCRIPTION
## 内容

EngineIdをただのstringからユニークな型（brand型）に変更します。
これによりRecordのキーなどの変数が厳密になり、コーディングミスを失くしやすくなるはず･･･！

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1148

## その他

方針としては、string型になっていたところを全てEngineIdにしています。
またzod schemaが必要なとろろはengineIdSchemaを指定しています。

一部undefinableにする必要があり、throw Errorするロジック周りがたされていたりします。
