### PR TITLE
選択中のキャラが一番上に表示されるようにした

### DIFF
--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -24,7 +24,7 @@
       transition-show="none"
       transition-hide="none"
     >
-      <q-list style="min-width: max-content">
+      <q-list style="min-width: max-content" class="item-container">
         <q-item
           v-if="selectedStyleInfo == undefined && !emptiable"
           class="row no-wrap items-center"
@@ -57,6 +57,12 @@
           v-for="(characterInfo, characterIndex) in characterInfos"
           :key="characterIndex"
           class="q-pa-none"
+          :class="
+            selectedCharacter != undefined &&
+            characterInfo.metas.speakerUuid ===
+              selectedCharacter.metas.speakerUuid &&
+            'selected-row'
+          "
         >
           <q-btn-group flat class="col full-width">
             <q-btn
@@ -349,6 +355,11 @@ export default defineComponent({
 }
 
 .character-menu {
+  .item-container {
+    display: flex;
+    flex-direction: column;
+  }
+
   .q-item {
     color: colors.$display;
   }
@@ -361,6 +372,10 @@ export default defineComponent({
     > div:last-child:hover {
       background-color: rgba(colors.$primary-rgb, 0.1);
     }
+  }
+
+  .selected-row {
+    order: -1;
   }
 
   .selected-character-item,

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -232,12 +232,10 @@ export default defineComponent({
       return character;
     });
 
-    const isSelectedItem = computed(
-      () => (characterInfo: CharacterInfo) =>
-        selectedCharacter.value != undefined &&
-        characterInfo.metas.speakerUuid ===
-          selectedCharacter.value?.metas.speakerUuid
-    );
+    const isSelectedItem = (charcterInfo: CharacterInfo) =>
+      selectedCharacter.value != undefined &&
+      charcterInfo.metas.speakerUuid ===
+        selectedCharacter.value?.metas.speakerUuid;
 
     const selectedStyleInfo = computed(() => {
       const selectedVoice = props.selectedVoice;

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -57,12 +57,7 @@
           v-for="(characterInfo, characterIndex) in characterInfos"
           :key="characterIndex"
           class="q-pa-none"
-          :class="
-            selectedCharacter != undefined &&
-            characterInfo.metas.speakerUuid ===
-              selectedCharacter.metas.speakerUuid &&
-            'selected-row'
-          "
+          :class="isSelectedItem(characterInfo) && 'selected-row'"
         >
           <q-btn-group flat class="col full-width">
             <q-btn
@@ -71,10 +66,7 @@
               v-close-popup
               class="col-grow"
               :class="
-                selectedCharacter != undefined &&
-                characterInfo.metas.speakerUuid ===
-                  selectedCharacter.metas.speakerUuid &&
-                'selected-character-item'
+                isSelectedItem(characterInfo) && 'selected-character-item'
               "
               @click="onSelectSpeaker(characterInfo.metas.speakerUuid)"
               @mouseover="reassignSubMenuOpen(-1)"
@@ -240,6 +232,11 @@ export default defineComponent({
       return character;
     });
 
+    const isSelectedItem = (characterInfo: CharacterInfo) =>
+      selectedCharacter.value != undefined &&
+      characterInfo.metas.speakerUuid ===
+        selectedCharacter.value?.metas.speakerUuid;
+
     const selectedStyleInfo = computed(() => {
       const selectedVoice = props.selectedVoice;
       const style = selectedCharacter.value?.metas.styles.find(
@@ -303,6 +300,7 @@ export default defineComponent({
       selectedCharacter,
       selectedStyleInfo,
       engineIcons,
+      isSelectedItem,
       getDefaultStyle,
       onSelectSpeaker,
       subMenuOpenFlags,

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -232,10 +232,12 @@ export default defineComponent({
       return character;
     });
 
-    const isSelectedItem = (characterInfo: CharacterInfo) =>
-      selectedCharacter.value != undefined &&
-      characterInfo.metas.speakerUuid ===
-        selectedCharacter.value?.metas.speakerUuid;
+    const isSelectedItem = computed(
+      () => (charcterInfo: CharacterInfo) =>
+        selectedCharacter.value != undefined &&
+        charcterInfo.metas.speakerUuid ===
+          selectedCharacter.value?.metas.speakerUuid
+    );
 
     const selectedStyleInfo = computed(() => {
       const selectedVoice = props.selectedVoice;

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -232,9 +232,9 @@ export default defineComponent({
       return character;
     });
 
-    const isSelectedItem = (charcterInfo: CharacterInfo) =>
+    const isSelectedItem = (characterInfo: CharacterInfo) =>
       selectedCharacter.value != undefined &&
-      charcterInfo.metas.speakerUuid ===
+      characterInfo.metas.speakerUuid ===
         selectedCharacter.value?.metas.speakerUuid;
 
     const selectedStyleInfo = computed(() => {

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -24,7 +24,7 @@
       transition-show="none"
       transition-hide="none"
     >
-      <q-list style="min-width: max-content" class="item-container">
+      <q-list style="min-width: max-content" class="character-item-container">
         <q-item
           v-if="selectedStyleInfo == undefined && !emptiable"
           class="row no-wrap items-center"
@@ -353,7 +353,7 @@ export default defineComponent({
 }
 
 .character-menu {
-  .item-container {
+  .character-item-container {
     display: flex;
     flex-direction: column;
   }

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -233,9 +233,9 @@ export default defineComponent({
     });
 
     const isSelectedItem = computed(
-      () => (charcterInfo: CharacterInfo) =>
+      () => (characterInfo: CharacterInfo) =>
         selectedCharacter.value != undefined &&
-        charcterInfo.metas.speakerUuid ===
+        characterInfo.metas.speakerUuid ===
           selectedCharacter.value?.metas.speakerUuid
     );
 


### PR DESCRIPTION
## 内容
キャラ選択ダイアログを開いた時、現在のキャラがリストの一番上に来るようにしました。
これにより、ダイアログ下側のキャラをスクロールせずにスタイル変更できるようになります。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
ref #897 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
- 例1
![image](https://user-images.githubusercontent.com/79092292/216775256-23d69196-f292-4aaf-b358-ea71f96f3fee.png)

- 例2
![image](https://user-images.githubusercontent.com/79092292/216775935-5b78789c-b2c0-4c7f-8adc-753dfb31c4a9.png)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
実装やクラス名が非常に残念な感じになってしまいました。お伝えいただければ修正いたします。

クラスを出し分けしているところは下にあったものをコピペしたので変数にまとめたほうが良いかもしれません。