### PR TITLE
FIX: 最初に設定されるキャラクターが正しく選択されない問題を修正

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -486,7 +486,14 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
       const text = payload.text ?? "";
 
-      const defaultStyleId = state.defaultStyleIds[0];
+      const defaultSpeakerId =
+        getters.USER_ORDERED_CHARACTER_INFOS[0].metas.speakerUuid;
+      const defaultStyleId = state.defaultStyleIds.find(
+        (styleId) => styleId.speakerUuid === defaultSpeakerId
+      );
+      if (defaultStyleId == undefined)
+        throw new Error("defaultStyleId == undefined");
+
       const voice = payload.voice ?? {
         engineId: defaultStyleId.engineId,
         speakerId: defaultStyleId.speakerUuid,


### PR DESCRIPTION
## 内容

デフォルトエンジン以外のキャラクターが先頭になっていると正しくキャラクターが選ばれない問題を修正します。

## 関連 Issue

- close #1167 

## その他

`0.14`では選択される`EngineId`がデフォルトのエンジンに固定されているため先頭にしているstyleIDがCOICEVOXにない場合は無効なスタイルが選択されてしまいます。

- #1092 

の変更で無効なスタイルになることはなくなりましたが、ミスでキャラクターの順番が反映されなくなってしまいました。
https://github.com/VOICEVOX/voicevox/blob/a22046c731dbd88794a0e2e0d0a632b977bf5e29/src/store/audio.ts#L489-L494