### PR TITLE
ENH: テキスト読み込みで最初に選択されるスタイルを引き継ぎするようにした

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -68,7 +68,8 @@ async function generateUniqueIdAndQuery(
 function parseTextFile(
   body: string,
   defaultStyleIds: DefaultStyleId[],
-  userOrderedCharacterInfos: CharacterInfo[]
+  userOrderedCharacterInfos: CharacterInfo[],
+  initVoice?: Voice
 ): AudioItem[] {
   const name2Voice = new Map<string, Voice>();
   const uuid2Voice = new Map<string, Voice>();
@@ -104,9 +105,8 @@ function parseTextFile(
 
   const audioItems: AudioItem[] = [];
   const seps = [",", "\r\n", "\n"];
-  let lastVoice = uuid2Voice.get(
-    userOrderedCharacterInfos[0].metas.speakerUuid
-  );
+  let lastVoice =
+    initVoice ?? uuid2Voice.get(userOrderedCharacterInfos[0].metas.speakerUuid);
   if (lastVoice == undefined) throw new Error(`lastStyle is undefined.`);
   for (const splitText of body.split(new RegExp(`${seps.join("|")}`, "g"))) {
     const voice = name2Voice.get(splitText);
@@ -2699,7 +2699,8 @@ export const audioCommandStore = transformCommandStore(
           for (const { text, voice } of parseTextFile(
             body,
             state.defaultStyleIds,
-            getters.USER_ORDERED_CHARACTER_INFOS
+            getters.USER_ORDERED_CHARACTER_INFOS,
+            baseAudioItem?.voice
           )) {
             //パラメータ引き継ぎがONの場合は話速等のパラメータを引き継いでテキスト欄を作成する
             //パラメータ引き継ぎがOFFの場合、baseAudioItemがundefinedになっているのでパラメータ引き継ぎは行われない


### PR DESCRIPTION
## 内容

テキストの読み込みを行った場合の最初のキャラクターが常にキャラクター順の先頭のものでした。
これを引き継ぎ元のキャラクターを選択するようにします。

## その他

https://twitter.com/efusuku/status/1616358760607514625
