### PR TITLE
Fix: Node.jsのバージョン取得にnode-version-fileを使うように

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,15 +131,10 @@ jobs:
           echo "${str_config//$'\n'/\\n}" | "${{ matrix.sed_name }}" -e 's/from: VOICEVOX_ENGINE_DIR,\\n[ ]*to: ""/from: VOICEVOX_ENGINE_DIR, to: "MacOS\/"/' -e s/'\\n'/\\$'\n'/g > vue.config.js
           cat vue.config.js
 
-      - name: Set output Node version
-        id: node-version
-        shell: bash
-        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.node-version.outputs.NODE_VERSION }}"
+          node-version-file: ".node-version"
 
       - name: Cache Node packages
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,15 +319,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set output Node version
-        id: node-version
-        shell: bash
-        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.node-version.outputs.NODE_VERSION }}"
+          node-version-file: ".node-version"
 
       - name: Cache Node packages
         uses: actions/cache@v3
@@ -621,15 +616,10 @@ jobs:
         run: |
           df -h
 
-      - name: Set output Node version
-        id: node-version
-        shell: bash
-        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.node-version.outputs.NODE_VERSION }}"
+          node-version-file: ".node-version"
 
       - name: Cache Node packages
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: node-version
+        shell: bash
         run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       ELECTRON_BUILDER_CACHE: .cache/electron-builder
       cache-version: v2
     steps:
+      - uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,10 @@ jobs:
       ELECTRON_BUILDER_CACHE: .cache/electron-builder
       cache-version: v2
     steps:
-      - uses: actions/checkout@v3
-      - id: node-version
-        shell: bash
-        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
-
-      - uses: actions/setup-node@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.node-version.outputs.NODE_VERSION }}"
+          node-version-file: ".node-version"
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
## 内容

タイトル通り。
参照： https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file 

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

これを機にNode.jsを18にあげてもいいかもしれない？