### PR TITLE
ショートカットキーの初期化のtext-colorをdisplayにした

### DIFF
--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -337,12 +337,12 @@ export default defineComponent({
         ok: {
           label: "初期値に戻す",
           flat: true,
-          textColor: "secondary",
+          textColor: "display",
         },
         cancel: {
           label: "初期値に戻さない",
           flat: true,
-          textColor: "secondary",
+          textColor: "display",
         },
       }).onOk(() => {
         window.electron


### PR DESCRIPTION
## 内容
ダークモード時のショートカットキー初期化ダイアログのボタンの視認性が悪かったので、text-colorをsecondaryからdisplayに変更しました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
ref #1193 
close #1193
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
![スクリーンショット 2023-02-16 20-48-51](https://user-images.githubusercontent.com/8833998/219357407-3b70ae61-eba0-42e8-9290-64babcc56296.png)
![スクリーンショット 2023-02-16 20-49-33](https://user-images.githubusercontent.com/8833998/219357427-f8e89aff-56ad-4f09-bb4f-6fdd889418df.png)

## その他
