### PR TITLE
Fix: e2eテストの細かい挙動を修正

### DIFF
--- a/tests/e2e/example.spec.ts
+++ b/tests/e2e/example.spec.ts
@@ -16,7 +16,7 @@ test("起動したら「利用規約に関するお知らせ」が表示され�
       await fs.access("./dist/background.js");
       break;
     } catch (e) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,68 +8,73 @@ import electron from "vite-plugin-electron";
 import tsconfigPaths from "vite-tsconfig-paths";
 import vue from "@vitejs/plugin-vue";
 import checker from "vite-plugin-checker";
+import { defineConfig } from "rollup";
 
 rmSync(path.resolve(__dirname, "dist"), { recursive: true, force: true });
 
 const isElectron = process.env.VITE_IS_ELECTRON === "true";
 
-const config: UserConfig = {
-  root: path.resolve(__dirname, "src"),
-  build: {
-    outDir: path.resolve(__dirname, "dist"),
-    chunkSizeWarningLimit: 10000,
-  },
-  publicDir: path.resolve(__dirname, "public"),
-  css: {
-    preprocessorOptions: {
-      scss: {
-        includePaths: [path.resolve(__dirname, "node_modules")],
-      },
+export default defineConfig((options) => {
+  return {
+    root: path.resolve(__dirname, "src"),
+    build: {
+      outDir: path.resolve(__dirname, "dist"),
+      chunkSizeWarningLimit: 10000,
     },
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "src/"),
-    },
-  },
-  test: {
-    include: [
-      path.resolve(__dirname, "tests/unit/**/*.spec.ts").replace(/\\/g, "/"),
-    ],
-    environment: "happy-dom",
-  },
-
-  plugins: [
-    vue(),
-    checker({
-      overlay: false,
-      eslint: {
-        lintCommand: "eslint --ext .ts,.vue .",
-      },
-      typescript: true,
-      // FIXME: vue-tscの型エラーを解決したら有効化する
-      // vueTsc: true,
-    }),
-    isElectron &&
-      electron({
-        entry: ["./src/background.ts", "./src/electron/preload.ts"],
-        // ref: https://github.com/electron-vite/vite-plugin-electron/pull/122
-        onstart: (options) => {
-          // @ts-expect-error vite-electron-pluginがprocess.electronAppを定義していない
-          const pid = process.electronApp?.pid;
-          if (pid) {
-            treeKill(pid);
-          }
-          options.startup([".", "--no-sandbox"]);
+    publicDir: path.resolve(__dirname, "public"),
+    css: {
+      preprocessorOptions: {
+        scss: {
+          includePaths: [path.resolve(__dirname, "node_modules")],
         },
-        vite: {
-          plugins: [tsconfigPaths({ root: __dirname })],
-          build: {
-            outDir: path.resolve(__dirname, "dist"),
+      },
+    },
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "src/"),
+      },
+    },
+    test: {
+      include: [
+        path.resolve(__dirname, "tests/unit/**/*.spec.ts").replace(/\\/g, "/"),
+      ],
+      environment: "happy-dom",
+    },
+
+    plugins: [
+      vue(),
+      options.mode !== "test" &&
+        checker({
+          overlay: false,
+          eslint: {
+            lintCommand: "eslint --ext .ts,.vue .",
           },
-        },
-      }),
-  ],
-};
-
-export default config;
+          typescript: true,
+          // FIXME: vue-tscの型エラーを解決したら有効化する
+          // vueTsc: true,
+        }),
+      isElectron &&
+        electron({
+          entry: ["./src/background.ts", "./src/electron/preload.ts"],
+          // ref: https://github.com/electron-vite/vite-plugin-electron/pull/122
+          onstart: ({ startup }) => {
+            // @ts-expect-error vite-electron-pluginはprocess.electronAppにelectronのプロセスを格納している。
+            //   しかし、型定義はないので、ts-expect-errorで回避する。
+            const pid = process.electronApp?.pid;
+            if (pid) {
+              treeKill(pid);
+            }
+            if (options.mode !== "test") {
+              startup([".", "--no-sandbox"]);
+            }
+          },
+          vite: {
+            plugins: [tsconfigPaths({ root: __dirname })],
+            build: {
+              outDir: path.resolve(__dirname, "dist"),
+            },
+          },
+        }),
+    ],
+  };
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 /// <reference types="vitest" />
 import path from "path";
-import type { UserConfig } from "vite";
 import treeKill from "tree-kill";
 import { rmSync } from "fs";
 
@@ -8,7 +7,7 @@ import electron from "vite-plugin-electron";
 import tsconfigPaths from "vite-tsconfig-paths";
 import vue from "@vitejs/plugin-vue";
 import checker from "vite-plugin-checker";
-import { defineConfig } from "rollup";
+import { defineConfig } from "vite";
 
 rmSync(path.resolve(__dirname, "dist"), { recursive: true, force: true });
 


### PR DESCRIPTION
## 内容

e2eテストを走らせたときの細かい挙動を修正します。
- vite-plugin-electron側でelectronを立ち上げないようにします。
- ESLint/tscのチェックを消します。（テストが9秒くらい遅くなっている、ログが流れる、専用のscriptがある）

## 関連 Issue

- ref: #182

## スクリーンショット・動画など

（なし）

## その他

（なし）