### PR TITLE
ENH: エンジンの設定UIをブラウザで開くボタンを追加

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -766,6 +766,11 @@ ipcMainHandle("OPEN_ENGINE_DIRECTORY", async (_, { engineId }) => {
   openEngineDirectory(engineId);
 });
 
+ipcMainHandle("GET_ENGINE_SETTING_URL", (_, { engineId }) => {
+  const engineInfo = engineManager.fetchEngineInfo(engineId);
+  return engineInfo.host + "/setting";
+});
+
 ipcMainHandle("HOTKEY_SETTINGS", (_, { newData }) => {
   if (newData !== undefined) {
     const hotkeySettings = store.get("hotkeySettings");

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -321,6 +321,14 @@
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
+                @click="openSelectedEngineSettingWindow"
+                :disable="uiLocked || engineStates[selectedId] !== 'READY'"
+                >設定を開く</q-btn
+              >
+              <q-btn
+                outline
+                text-color="display"
+                class="text-no-wrap text-bold q-mr-sm"
                 @click="restartSelectedEngine"
                 :disable="uiLocked || engineStates[selectedId] === 'STARTING'"
                 >再起動</q-btn
@@ -566,6 +574,14 @@ const openSelectedEngineDirectory = () => {
   if (selectedId.value == undefined)
     throw new Error("assert selectedId.value != undefined");
   store.dispatch("OPEN_ENGINE_DIRECTORY", { engineId: selectedId.value });
+};
+
+const openSelectedEngineSettingWindow = () => {
+  if (selectedId.value == undefined)
+    throw new Error("assert selectedId.value != undefined");
+  store.dispatch("OPEN_ENGINE_SETTING_URL", {
+    engineId: selectedId.value,
+  });
 };
 
 const restartSelectedEngine = () => {

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -440,6 +440,16 @@ async function updateEngines() {
         },
         disableWhenUiLocked: false,
       },
+      {
+        type: "button",
+        label: "エンジンの設定を開く",
+        onClick: () => {
+          store.dispatch("OPEN_ENGINE_SETTING_URL", {
+            engineId: engineInfo.uuid,
+          });
+        },
+        disableWhenUiLocked: true,
+      },
     ].filter((x) => x) as MenuItemData[];
   } else {
     engineMenu.subMenu = [
@@ -471,6 +481,16 @@ async function updateEngines() {
                   });
                 },
                 disableWhenUiLocked: false,
+              },
+              {
+                type: "button",
+                label: "エンジンの設定を開く",
+                onClick: () => {
+                  store.dispatch("OPEN_ENGINE_SETTING_URL", {
+                    engineId: engineInfo.uuid,
+                  });
+                },
+                disableWhenUiLocked: true,
               },
             ].filter((x) => x),
           } as MenuItemRoot)

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -200,6 +200,10 @@ const api: Sandbox = {
     return ipcRendererInvoke("OPEN_ENGINE_DIRECTORY", { engineId });
   },
 
+  getEngineSettingUrl: (engineId: EngineId) => {
+    return ipcRendererInvoke("GET_ENGINE_SETTING_URL", { engineId });
+  },
+
   checkFileExists: (file) => {
     return ipcRenderer.invoke("CHECK_FILE_EXISTS", { file });
   },

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -253,6 +253,13 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
+  OPEN_ENGINE_SETTING_URL: {
+    async action(_, { engineId }) {
+      const url = await window.electron.getEngineSettingUrl(engineId);
+      window.open(url, "_blank");
+    },
+  },
+
   SET_ENGINE_STATE: {
     mutation(
       state,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -769,6 +769,10 @@ export type EngineStoreTypes = {
     action(payload: { engineId: EngineId }): void;
   };
 
+  OPEN_ENGINE_SETTING_URL: {
+    action(payload: { engineId: EngineId }): void;
+  };
+
   SET_ENGINE_STATE: {
     mutation: { engineId: EngineId; engineState: EngineState };
   };

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -211,6 +211,11 @@ export type IpcIHData = {
     return: void;
   };
 
+  GET_ENGINE_SETTING_URL: {
+    args: [obj: { engineId: EngineId }];
+    return: string;
+  };
+
   CHECK_FILE_EXISTS: {
     args: [obj: { file: string }];
     return: boolean;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -188,6 +188,7 @@ export interface Sandbox {
   engineInfos(): Promise<EngineInfo[]>;
   restartEngine(engineId: EngineId): Promise<void>;
   openEngineDirectory(engineId: EngineId): void;
+  getEngineSettingUrl(engineId: EngineId): Promise<string>;
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   checkFileExists(file: string): Promise<boolean>;
   changePinWindow(): void;


### PR DESCRIPTION
## 内容

エンジンの設定UIが実装されましたがエディタで存在することが一切分からないのでとりあえず追加しました。

## 関連 Issue

- ref VOICEVOX/voicevox_engine#531

## スクリーンショット・動画など

![マルチエンジン無効](https://user-images.githubusercontent.com/102559104/221532458-7b83fed2-a613-4bb3-93d1-b1156085ff3c.png)
![マルチエンジン有効](https://user-images.githubusercontent.com/102559104/221532560-324ce5dd-0e02-41eb-8449-35496a3ca7a7.png)
![エンジンの管理](https://user-images.githubusercontent.com/102559104/221532564-e6dc2176-31bf-4c5b-9adf-42c34b01e51f.png)
![マルチエンジン](https://user-images.githubusercontent.com/102559104/221532568-672b0299-2c95-4905-ba30-7c3028b629f4.png)

## その他

できればエディタUIで操作できた方がいいかもしれませんが、とりあえず仮UIとして?
