### PR TITLE
ENH: 未保存時のダイアログを改善

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -672,7 +672,7 @@ ipcMainHandle("SHOW_MESSAGE_DIALOG", (_, { type, title, message }) => {
 
 ipcMainHandle(
   "SHOW_QUESTION_DIALOG",
-  (_, { type, title, message, buttons, cancelId }) => {
+  (_, { type, title, message, buttons, cancelId, defaultId }) => {
     return dialog
       .showMessageBox(win, {
         type,
@@ -681,6 +681,7 @@ ipcMainHandle(
         message,
         noLink: true,
         cancelId,
+        defaultId,
       })
       .then((value) => {
         return value.response;

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -123,13 +123,21 @@ const api: Sandbox = {
     return ipcRendererInvoke("SHOW_MESSAGE_DIALOG", { type, title, message });
   },
 
-  showQuestionDialog: ({ type, title, message, buttons, cancelId }) => {
+  showQuestionDialog: ({
+    type,
+    title,
+    message,
+    buttons,
+    cancelId,
+    defaultId,
+  }) => {
     return ipcRendererInvoke("SHOW_QUESTION_DIALOG", {
       type,
       title,
       message,
       buttons,
       cancelId,
+      defaultId,
     });
   },
 

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -376,6 +376,9 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
   },
 
   SAVE_PROJECT_FILE: {
+    /**
+     * プロジェクトファイルを保存する。保存の成否が返る。
+     */
     action: createUILockAction(
       async (context, { overwrite }: { overwrite?: boolean }) => {
         let filePath = context.state.projectFilePath;
@@ -396,7 +399,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             defaultPath,
           });
           if (ret == undefined) {
-            return;
+            return false;
           }
           filePath = ret;
         }
@@ -427,7 +430,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           "SET_SAVED_LAST_COMMAND_UNIX_MILLISEC",
           context.getters.LAST_COMMAND_UNIX_MILLISEC
         );
-        return;
+        return true;
       }
     ),
   },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -948,7 +948,7 @@ export type ProjectStoreTypes = {
   };
 
   SAVE_PROJECT_FILE: {
-    action(payload: { overwrite?: boolean }): void;
+    action(payload: { overwrite?: boolean }): boolean;
   };
 
   IS_EDITED: {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -298,18 +298,25 @@ export const uiStore = createPartialStore<UiStoreTypes>({
   },
 
   CHECK_EDITED_AND_NOT_SAVE: {
-    async action({ getters }) {
+    async action({ dispatch, getters }) {
       if (getters.IS_EDITED) {
         const result: number = await window.electron.showQuestionDialog({
           type: "info",
           title: "警告",
           message:
             "プロジェクトの変更が保存されていません。\n" +
-            "変更を破棄してもよろしいですか？",
-          buttons: ["破棄", "キャンセル"],
-          cancelId: 1,
+            "変更を保存しますか？",
+          buttons: ["保存", "破棄", "キャンセル"],
+          cancelId: 2,
+          defaultId: 2,
         });
-        if (result == 1) {
+        if (result == 0) {
+          const saved = await dispatch("SAVE_PROJECT_FILE", {
+            overwrite: true,
+          });
+          if (saved == false) return;
+        }
+        if (result == 2) {
           return;
         }
       }

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -121,6 +121,7 @@ export type IpcIHData = {
         message: string;
         buttons: string[];
         cancelId?: number;
+        defaultId?: number;
       }
     ];
     return: number;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -165,6 +165,7 @@ export interface Sandbox {
     message: string;
     buttons: string[];
     cancelId?: number;
+    defaultId?: number;
   }): Promise<number>;
   showImportFileDialog(obj: { title: string }): Promise<string | undefined>;
   writeFile(obj: {


### PR DESCRIPTION
## 内容

Twitterでこのような要望をみかけたためある程度改善してみました。
https://twitter.com/HanoMotoCraft/status/1629101061415006209

- デフォルトのカーソルをキャンセルに変更。
- 保存ボタンを追加して保存が成功した場合はそのまま終了、キャンセルした場合は警告をキャンセルした場合と同じ状態へ。

(Windowsのメモ帳と大体同じ動作?)

## スクリーンショット・動画など

![現在のUI](https://user-images.githubusercontent.com/102559104/221698873-d3340a8c-4998-4c11-aeba-2ca0bc5eae0c.png)
![変更後のUI](https://user-images.githubusercontent.com/102559104/221698881-430d316e-574b-4f05-8c0c-1ac443107a73.png)

## その他

Windows以外の環境での表示は確認できていません。