### PR TITLE
プロジェクトの変更を保存するかを聞く部分を統一化

### DIFF
--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -40,16 +40,8 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
     action: createUILockAction(
       async (context, { confirm }: { confirm?: boolean }) => {
         if (confirm !== false && context.getters.IS_EDITED) {
-          const result: number = await window.electron.showQuestionDialog({
-            type: "info",
-            title: "警告",
-            message:
-              "プロジェクトの変更が保存されていません。\n" +
-              "変更を破棄してもよろしいですか？",
-            buttons: ["破棄", "キャンセル"],
-            cancelId: 1,
-          });
-          if (result == 1) {
+          const result = await context.dispatch("SAVE_OR_DISCARD_PROJECT_FILE");
+          if (result == "canceled") {
             return;
           }
         }
@@ -326,16 +318,10 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           }
 
           if (confirm !== false && context.getters.IS_EDITED) {
-            const result: number = await window.electron.showQuestionDialog({
-              type: "info",
-              title: "警告",
-              message:
-                "プロジェクトをロードすると現在のプロジェクトは破棄されます。\n" +
-                "変更を破棄してもよろしいですか？",
-              buttons: ["破棄", "キャンセル"],
-              cancelId: 1,
-            });
-            if (result == 1) {
+            const result = await context.dispatch(
+              "SAVE_OR_DISCARD_PROJECT_FILE"
+            );
+            if (result == "canceled") {
               return false;
             }
           }
@@ -433,6 +419,35 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
         return true;
       }
     ),
+  },
+
+  /**
+   * プロジェクトファイルを保存するか破棄するかキャンセルするかのダイアログを出して、保存する場合は保存する。
+   * 何を選択したかが返る。
+   * 保存に失敗した場合はキャンセル扱いになる。
+   */
+  SAVE_OR_DISCARD_PROJECT_FILE: {
+    action: createUILockAction(async ({ dispatch }) => {
+      const result: number = await window.electron.showQuestionDialog({
+        type: "info",
+        title: "警告",
+        message:
+          "プロジェクトの変更が保存されていません。\n" + "変更を保存しますか？",
+        buttons: ["保存", "破棄", "キャンセル"],
+        cancelId: 2,
+        defaultId: 2,
+      });
+      if (result == 0) {
+        const saved = await dispatch("SAVE_PROJECT_FILE", {
+          overwrite: true,
+        });
+        return saved ? "saved" : "canceled";
+      } else if (result == 1) {
+        return "discarded";
+      } else {
+        return "canceled";
+      }
+    }),
   },
 
   IS_EDITED: {

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -40,7 +40,10 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
     action: createUILockAction(
       async (context, { confirm }: { confirm?: boolean }) => {
         if (confirm !== false && context.getters.IS_EDITED) {
-          const result = await context.dispatch("SAVE_OR_DISCARD_PROJECT_FILE");
+          const result = await context.dispatch(
+            "SAVE_OR_DISCARD_PROJECT_FILE",
+            {}
+          );
           if (result == "canceled") {
             return;
           }
@@ -319,7 +322,11 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
 
           if (confirm !== false && context.getters.IS_EDITED) {
             const result = await context.dispatch(
-              "SAVE_OR_DISCARD_PROJECT_FILE"
+              "SAVE_OR_DISCARD_PROJECT_FILE",
+              {
+                additionalMessage:
+                  "プロジェクトをロードすると現在のプロジェクトは破棄されます。",
+              }
             );
             if (result == "canceled") {
               return false;
@@ -427,12 +434,17 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
    * 保存に失敗した場合はキャンセル扱いになる。
    */
   SAVE_OR_DISCARD_PROJECT_FILE: {
-    action: createUILockAction(async ({ dispatch }) => {
+    action: createUILockAction(async ({ dispatch }, { additionalMessage }) => {
+      let message = "プロジェクトの変更が保存されていません。";
+      if (additionalMessage) {
+        message += "\n" + additionalMessage;
+      }
+      message += "\n変更を保存しますか？";
+
       const result: number = await window.electron.showQuestionDialog({
         type: "info",
         title: "警告",
-        message:
-          "プロジェクトの変更が保存されていません。\n" + "変更を保存しますか？",
+        message,
         buttons: ["保存", "破棄", "キャンセル"],
         cancelId: 2,
         defaultId: 2,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -952,7 +952,9 @@ export type ProjectStoreTypes = {
   };
 
   SAVE_OR_DISCARD_PROJECT_FILE: {
-    action(): "saved" | "discarded" | "canceled";
+    action(palyoad: {
+      additionalMessage?: string;
+    }): "saved" | "discarded" | "canceled";
   };
 
   IS_EDITED: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -951,6 +951,10 @@ export type ProjectStoreTypes = {
     action(payload: { overwrite?: boolean }): boolean;
   };
 
+  SAVE_OR_DISCARD_PROJECT_FILE: {
+    action(): "saved" | "discarded" | "canceled";
+  };
+
   IS_EDITED: {
     getter: boolean;
   };

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -300,23 +300,8 @@ export const uiStore = createPartialStore<UiStoreTypes>({
   CHECK_EDITED_AND_NOT_SAVE: {
     async action({ dispatch, getters }) {
       if (getters.IS_EDITED) {
-        const result: number = await window.electron.showQuestionDialog({
-          type: "info",
-          title: "警告",
-          message:
-            "プロジェクトの変更が保存されていません。\n" +
-            "変更を保存しますか？",
-          buttons: ["保存", "破棄", "キャンセル"],
-          cancelId: 2,
-          defaultId: 2,
-        });
-        if (result == 0) {
-          const saved = await dispatch("SAVE_PROJECT_FILE", {
-            overwrite: true,
-          });
-          if (saved == false) return;
-        }
-        if (result == 2) {
+        const result = await dispatch("SAVE_OR_DISCARD_PROJECT_FILE");
+        if (result == "canceled") {
           return;
         }
       }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -300,7 +300,7 @@ export const uiStore = createPartialStore<UiStoreTypes>({
   CHECK_EDITED_AND_NOT_SAVE: {
     async action({ dispatch, getters }) {
       if (getters.IS_EDITED) {
-        const result = await dispatch("SAVE_OR_DISCARD_PROJECT_FILE");
+        const result = await dispatch("SAVE_OR_DISCARD_PROJECT_FILE", {});
         if (result == "canceled") {
           return;
         }


### PR DESCRIPTION
## 内容

プロジェクトの変更を破棄するかを聞く箇所は３箇所あり、その１箇所が良い感じになりました。

- https://github.com/VOICEVOX/voicevox/pull/1238

このPRでは処理を共通化し、残り２箇所も良い感じにします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/1238

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
