### PR TITLE
FIX: エンジン追加後にプロジェクトの保存をキャンセルすると同じエンジンを複数登録できてしまう問題を修正

### DIFF
--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -593,6 +593,7 @@ const requireRestart = (message: string) => {
     },
   })
     .onOk(() => {
+      toInitialState();
       store.dispatch("RESTART_APP", {});
     })
     .onCancel(() => {

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -153,7 +153,11 @@
                   </template>
                   <template v-slot:error>
                     {{
-                      getEngineDirValidationMessage(newEngineDirValidationState)
+                      newEngineDirValidationState
+                        ? getEngineDirValidationMessage(
+                            newEngineDirValidationState
+                          )
+                        : undefined
                     }}
                   </template>
                 </q-input>
@@ -168,7 +172,7 @@
                   dense
                   readonly
                   :error="
-                    newEngineDirValidationState &&
+                    newEngineDirValidationState != undefined &&
                     newEngineDirValidationState !== 'ok'
                   "
                   placeholder="エンジンフォルダの場所"
@@ -190,7 +194,11 @@
                   </template>
                   <template v-slot:error>
                     {{
-                      getEngineDirValidationMessage(newEngineDirValidationState)
+                      newEngineDirValidationState
+                        ? getEngineDirValidationMessage(
+                            newEngineDirValidationState
+                          )
+                        : undefined
                     }}
                   </template>
                 </q-input>


### PR DESCRIPTION
## 内容

同じエンジンを重複して保存できてしまう問題を修正します。

### 再現方法

1. テキストの追加等をして未保存状態(閉じようとすると保存ダイアログが表示される状態)にする
2. EngineManageDialog開きエンジンを追加する
3. 再起動のダイアログが表示されるので再起動ボタンを押す
4. プロジェクトの保存を確認するダイアログが表示されるのでキャンセルする
5. 追加ボタンが押せる状態なので押すともう一度追加操作ができてしまう

特に既存エンジンを重複登録すると同じエンジンを同時に起動させようとしてしまうため起動が不可能になってしまいます。

## その他

ついでに型エラーを修正しておきましたがこの辺りのいい対処方法が分からなかったのでエラーのままにしています。
https://github.com/VOICEVOX/voicevox/blob/cb7203df19b407ca9c7d086ea02cf7748cff2ee4/src/components/EngineManageDialog.vue#L280-L285
