### PR TITLE
ubuntu18の脱却

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             linux_artifact_name: "VOICEVOX.${ext}"
             linux_executable_name: voicevox
             sed_name: sed
-            os: ubuntu-18.04
+            os: ubuntu-20.04
           # Linux CPU
           - artifact_name: linux-cpu-prepackage
             artifact_path: dist_electron/linux-unpacked
@@ -67,7 +67,7 @@ jobs:
             linux_artifact_name: "VOICEVOX.${ext}"
             linux_executable_name: voicevox
             sed_name: sed
-            os: ubuntu-18.04
+            os: ubuntu-20.04
           # Windows CUDA
           - artifact_name: windows-nvidia-prepackage
             artifact_path: dist_electron/win-unpacked
@@ -408,7 +408,7 @@ jobs:
             linux_artifact_name: "VOICEVOX.${ext}"
             linux_executable_name: voicevox
             sed_name: sed
-            os: ubuntu-18.04
+            os: ubuntu-20.04
           # Linux CPU
           - artifact_name: linux-cpu-appimage
             engine_artifact_name: linux-cpu-prepackage
@@ -416,7 +416,7 @@ jobs:
             linux_artifact_name: "VOICEVOX.${ext}"
             linux_executable_name: voicevox
             sed_name: sed
-            os: ubuntu-18.04
+            os: ubuntu-20.04
           # Windows NVIDIA GPU
           - artifact_name: windows-nvidia-nsis-web
             engine_artifact_name: windows-nvidia-prepackage
@@ -634,7 +634,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         artifact_name:
           - linux-nvidia-appimage
           - linux-cpu-appimage

--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -10,7 +10,7 @@ Windows／Mac／Linux 搭載の PC に対応しています。
 
 ※Windows：Windows 10・Windows 11  
 ※Mac：macOS Catalina 以降  
-※Linux：Ubuntu 18.04・Ubuntu 20.04
+※Linux：Ubuntu 20.04
 
 ### GPU版
 


### PR DESCRIPTION
## 内容

ubuntu 18がGithub Actionsから4/1に消えるので、脱却します。

- https://github.com/VOICEVOX/voicevox/issues/913

## 関連 Issue

close #913

## その他

現在お試しビルド中です

2023/03/11 19:18　ビルドが完了しました
https://github.com/Hiroshiba/voicevox/releases/tag/0.15.0-remote-ubuntu18.0