### PR TITLE
[project-s] 歌ボ形式で歌声合成する機能を追加

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -861,7 +861,7 @@ async function createWindow() {
   win.on("close", (event) => {
     if (!willQuit) {
       event.preventDefault();
-      ipcMainSend(win, "CHECK_EDITED_AND_NOT_SAVE");
+      ipcMainSend(win, "PROCESS_BEFORE_QUITTING");
       return;
     }
   });
@@ -1214,7 +1214,7 @@ app.on("window-all-closed", () => {
 app.on("before-quit", (event) => {
   if (!willQuit) {
     event.preventDefault();
-    ipcMainSend(win, "CHECK_EDITED_AND_NOT_SAVE");
+    ipcMainSend(win, "PROCESS_BEFORE_QUITTING");
     return;
   }
 

--- a/src/components/AcceptTermsDialog.vue
+++ b/src/components/AcceptTermsDialog.vue
@@ -87,7 +87,9 @@ export default defineComponent({
       store.dispatch("SET_ACCEPT_TERMS", {
         acceptTerms: acceptTerms ? "Accepted" : "Rejected",
       });
-      !acceptTerms ? store.dispatch("CHECK_EDITED_AND_NOT_SAVE") : undefined;
+      if (!acceptTerms) {
+        store.dispatch("PROCESS_BEFORE_QUITTING");
+      }
 
       modelValueComputed.value = false;
     };

--- a/src/components/MinMaxCloseButtons.vue
+++ b/src/components/MinMaxCloseButtons.vue
@@ -95,8 +95,8 @@ export default defineComponent({
   setup() {
     const store = useStore();
 
-    const closeWindow = async () => {
-      store.dispatch("CHECK_EDITED_AND_NOT_SAVE");
+    const closeWindow = () => {
+      store.dispatch("PROCESS_BEFORE_QUITTING");
     };
     const minimizeWindow = () => window.electron.minimizeWindow();
     const maximizeWindow = () => window.electron.maximizeWindow();

--- a/src/components/Sing/MenuBar.vue
+++ b/src/components/Sing/MenuBar.vue
@@ -11,6 +11,8 @@
         root.type === 'button' ? (subMenuOpenFlags[index] = false) : undefined
       "
     />
+    <q-space />
+    <min-max-close-buttons v-if="!$q.platform.is.mac" />
   </q-bar>
 </template>
 
@@ -18,6 +20,7 @@
 import { defineComponent, ref, computed, ComputedRef } from "vue";
 import { useStore } from "@/store";
 import MenuButton from "@/components/MenuButton.vue";
+import MinMaxCloseButtons from "@/components/MinMaxCloseButtons.vue";
 import { HotkeyAction, HotkeyReturnType } from "@/type/preload";
 import { setHotkeyFunctions } from "@/store/setting";
 
@@ -57,6 +60,7 @@ export default defineComponent({
 
   components: {
     MenuButton,
+    MinMaxCloseButtons,
   },
 
   setup() {

--- a/src/helpers/singHelper.ts
+++ b/src/helpers/singHelper.ts
@@ -66,3 +66,7 @@ export function round(value: number, digits: number) {
   const powerOf10 = 10 ** digits;
   return Math.round(value * powerOf10) / powerOf10;
 }
+
+export function midiToFrequency(midi: number) {
+  return 440 * 2 ** ((midi - 69) / 12);
+}

--- a/src/infrastructures/AudioRenderer.ts
+++ b/src/infrastructures/AudioRenderer.ts
@@ -273,6 +273,45 @@ export class OfflineTransport implements BaseTransport {
   }
 }
 
+export type AudioEvent = {
+  readonly time: number;
+  readonly buffer: AudioBuffer;
+};
+
+export class AudioSequence implements SoundSequence {
+  private readonly audioPlayer: AudioPlayer;
+  private readonly audioEvents: AudioEvent[];
+
+  constructor(audioPlayer: AudioPlayer, audioEvents: AudioEvent[]) {
+    this.audioPlayer = audioPlayer;
+    this.audioEvents = audioEvents;
+  }
+
+  // スケジュール可能なイベントを生成する
+  generateEvents(startTime: number) {
+    return this.audioEvents
+      .sort((a, b) => a.time - b.time)
+      .filter((value) => {
+        const audioEndTime = value.time + value.buffer.duration;
+        return audioEndTime > startTime;
+      })
+      .map((value): SchedulableEvent => {
+        const offset = Math.max(startTime - value.time, 0);
+        return {
+          time: Math.max(value.time, startTime),
+          schedule: (contextTime: number) => {
+            this.audioPlayer.play(contextTime, offset, value.buffer);
+          },
+        };
+      });
+  }
+
+  // シーケンスの停止をスケジュールする
+  scheduleStop(contextTime: number) {
+    this.audioPlayer.allStop(contextTime);
+  }
+}
+
 export interface Instrument {
   noteOn(contextTime: number, midi: number): void;
   noteOff(contextTime: number, midi: number): void;
@@ -317,9 +356,98 @@ export class NoteSequence implements SoundSequence {
       .sort((a, b) => a.time - b.time);
   }
 
-  // シーケンス（楽器）の停止をスケジュールする
+  // シーケンスの停止をスケジュールする
   scheduleStop(contextTime: number) {
     this.instrument.allSoundOff(contextTime);
+  }
+}
+
+class AudioPlayerVoice {
+  private readonly audioBufferSourceNode: AudioBufferSourceNode;
+  private readonly buffer: AudioBuffer;
+
+  private _isStopped = false;
+  private stopContextTime?: number;
+
+  get isStopped() {
+    return this._isStopped;
+  }
+
+  constructor(audioContext: BaseAudioContext, buffer: AudioBuffer) {
+    this.audioBufferSourceNode = audioContext.createBufferSource();
+    this.audioBufferSourceNode.buffer = buffer;
+    this.audioBufferSourceNode.onended = () => {
+      this._isStopped = true;
+    };
+    this.buffer = buffer;
+  }
+
+  connect(destination: AudioNode) {
+    this.audioBufferSourceNode.connect(destination);
+  }
+
+  play(contextTime: number, offset: number) {
+    this.audioBufferSourceNode.start(contextTime, offset);
+    this.stopContextTime = contextTime + this.buffer.duration;
+  }
+
+  stop(contextTime?: number) {
+    if (this.stopContextTime === undefined) {
+      throw new Error("Not started.");
+    }
+    if (contextTime === undefined || contextTime < this.stopContextTime) {
+      this.audioBufferSourceNode.stop(contextTime);
+      this.stopContextTime = contextTime ?? 0;
+    }
+  }
+}
+
+export type AudioPlayerOptions = {
+  readonly volume: number;
+};
+
+export class AudioPlayer {
+  private readonly audioContext: BaseAudioContext;
+  private readonly gainNode: GainNode;
+
+  private voices: AudioPlayerVoice[] = [];
+
+  constructor(context: Context, options: AudioPlayerOptions = { volume: 1.0 }) {
+    this.audioContext = context.audioContext;
+
+    this.gainNode = this.audioContext.createGain();
+    this.gainNode.gain.value = options.volume;
+  }
+
+  connect(destination: AudioNode) {
+    this.gainNode.connect(destination);
+  }
+
+  disconnect() {
+    this.gainNode.disconnect();
+  }
+
+  play(contextTime: number, offset: number, buffer: AudioBuffer) {
+    const voice = new AudioPlayerVoice(this.audioContext, buffer);
+    this.voices = this.voices.filter((value) => {
+      return !value.isStopped;
+    });
+    this.voices.push(voice);
+    voice.connect(this.gainNode);
+    voice.play(contextTime, offset);
+  }
+
+  allStop(contextTime?: number) {
+    if (contextTime === undefined) {
+      this.voices.forEach((value) => {
+        value.stop();
+      });
+      this.voices = [];
+    } else {
+      this.voices.forEach((value) => {
+        value.stop(contextTime);
+      });
+    }
   }
 }
 
@@ -371,8 +499,8 @@ class SynthVoice {
     return 440 * 2 ** ((midi - 69) / 12);
   }
 
-  connect(inputNode: AudioNode) {
-    this.gainNode.connect(inputNode);
+  connect(destination: AudioNode) {
+    this.gainNode.connect(destination);
   }
 
   noteOn(contextTime: number) {
@@ -530,6 +658,10 @@ export class AudioRenderer {
       audioContext: this.onlineContext.audioContext,
       transport: this.onlineContext.transport,
     };
+  }
+
+  get audioContext() {
+    return this.onlineContext.audioContext;
   }
 
   get transport() {

--- a/src/plugins/ipcMessageReceiverPlugin.ts
+++ b/src/plugins/ipcMessageReceiverPlugin.ts
@@ -44,8 +44,8 @@ export const ipcMessageReceiver: Plugin = {
       options.store.dispatch("DETECT_LEAVE_FULLSCREEN")
     );
 
-    window.electron.onReceivedIPCMsg("CHECK_EDITED_AND_NOT_SAVE", () => {
-      options.store.dispatch("CHECK_EDITED_AND_NOT_SAVE");
+    window.electron.onReceivedIPCMsg("PROCESS_BEFORE_QUITTING", () => {
+      options.store.dispatch("PROCESS_BEFORE_QUITTING");
     });
 
     window.electron.onReceivedIPCMsg(

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -840,11 +840,6 @@ export type SingingStoreTypes = {
     action(payload: { volume: number }): void;
   };
 
-  SET_RENDERING_ENABLED: {
-    mutation: { renderingEnabled: boolean };
-    action(payload: { renderingEnabled: boolean }): void;
-  };
-
   SET_RENDERING_REQUESTED: {
     mutation: { renderingRequested: boolean };
   };
@@ -863,6 +858,11 @@ export type SingingStoreTypes = {
 
   STOP_RENDERING: {
     action(): void;
+  };
+
+  SET_RENDERING_ENABLED: {
+    mutation: { renderingEnabled: boolean };
+    action(payload: { renderingEnabled: boolean }): void;
   };
 };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -77,11 +77,6 @@ export type Score = {
   notes: Note[];
 };
 
-export type RenderPhrase = {
-  renderNotes: Note[];
-  query?: AudioQuery;
-};
-
 export type Command = {
   unixMillisec: number;
   undoPatches: Patch[];
@@ -697,7 +692,6 @@ export type SingingStoreState = {
   engineId?: string;
   styleId?: number;
   score?: Score;
-  renderPhrases: RenderPhrase[];
   // NOTE: UIの状態などは分割・統合した方がよさそうだが、ボイス側と混在させないためいったん局所化する
   isShowSinger: boolean;
   // NOTE: オーディオ再生はボイスと同様もしくは拡張して使う？
@@ -710,6 +704,10 @@ export type SingingStoreState = {
   volume: number;
   leftLocatorPosition: number;
   rightLocatorPosition: number;
+  renderingEnabled: boolean;
+  renderingRequested: boolean;
+  renderingStopRequested: boolean;
+  nowRendering: boolean;
 };
 
 export type SingingStoreTypes = {
@@ -840,6 +838,31 @@ export type SingingStoreTypes = {
   SET_VOLUME: {
     mutation: { volume: number };
     action(payload: { volume: number }): void;
+  };
+
+  SET_RENDERING_ENABLED: {
+    mutation: { renderingEnabled: boolean };
+    action(payload: { renderingEnabled: boolean }): void;
+  };
+
+  SET_RENDERING_REQUESTED: {
+    mutation: { renderingRequested: boolean };
+  };
+
+  SET_RENDERING_STOP_REQUESTED: {
+    mutation: { renderingStopRequested: boolean };
+  };
+
+  SET_NOW_RENDERING: {
+    mutation: { nowRendering: boolean };
+  };
+
+  RENDER: {
+    action(): void;
+  };
+
+  STOP_RENDERING: {
+    action(): void;
   };
 };
 
@@ -1269,6 +1292,10 @@ export type UiStoreTypes = {
   };
 
   CHECK_EDITED_AND_NOT_SAVE: {
+    action(): Promise<void>;
+  };
+
+  PROCESS_BEFORE_QUITTING: {
     action(): Promise<void>;
   };
 };

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -530,6 +530,14 @@ export const uiStore = createPartialStore<UiStoreTypes>({
           return;
         }
       }
+    },
+  },
+
+  PROCESS_BEFORE_QUITTING: {
+    async action({ dispatch }) {
+      await dispatch("SING_STOP_AUDIO");
+      await dispatch("CHECK_EDITED_AND_NOT_SAVE");
+      await dispatch("STOP_RENDERING");
 
       window.electron.closeWindow();
     },

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -292,7 +292,7 @@ export type IpcSOData = {
     return: void;
   };
 
-  CHECK_EDITED_AND_NOT_SAVE: {
+  PROCESS_BEFORE_QUITTING: {
     args: [];
     return: void;
   };

--- a/src/views/SingerHome.vue
+++ b/src/views/SingerHome.vue
@@ -62,6 +62,7 @@ export default defineComponent({
       await store.dispatch("SET_RIGHT_LOCATOR_POSITION", {
         position: 480 * 4 * 16,
       });
+      await store.dispatch("SET_RENDERING_ENABLED", { renderingEnabled: true });
       return {};
     });
   },

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -32,7 +32,6 @@ describe("store/vuex.js test", () => {
         uiLockCount: 0,
         dialogLockCount: 0,
         nowPlayingContinuously: false,
-        renderPhrases: [],
         undoCommands: [],
         redoCommands: [],
         useGpu: false,
@@ -128,6 +127,10 @@ describe("store/vuex.js test", () => {
         volume: 0,
         leftLocatorPosition: 0,
         rightLocatorPosition: 0,
+        renderingEnabled: false,
+        renderingRequested: false,
+        renderingStopRequested: false,
+        nowRendering: false,
       },
       getters: {
         ...uiStore.getters,
@@ -189,8 +192,6 @@ describe("store/vuex.js test", () => {
     assert.equal(store.state.audioPlayStartPoint, 0);
     assert.equal(store.state.uiLockCount, 0);
     assert.equal(store.state.nowPlayingContinuously, false);
-    assert.isArray(store.state.renderPhrases);
-    assert.isEmpty(store.state.renderPhrases);
     assert.isArray(store.state.undoCommands);
     assert.isEmpty(store.state.undoCommands);
     assert.isArray(store.state.redoCommands);


### PR DESCRIPTION
## 内容

歌ボ形式で歌声合成（レンダリング）する機能を追加します。

- 歌詞を休符で区切って複数のフレーズに変換
- 各フレーズを音声合成
  - ノートとモーラの数が一致しないフレーズは音声合成しない
- 各フレーズの音声をミックスして再生
  - 音声合成が完了するまではシンセで再生
- シンガー・スコア変更時に変更部分のみレンダリング
  - アプリケーション終了時に再生・レンダリングを停止

長いノートは、長音で伸ばすなど色々試したのですが上手く合成できなかったので、
とりあえずノート自体を短くするようにしています。
また、高い音（C5くらいから）も上手く合成できませんが、
とりあえずノートナンバーから算出した値をそのままピッチに設定しています。

## 関連 Issue

ref #1254
