### PR TITLE
ボイボ系ソフトに関する名称の方針を追記

### DIFF
--- a/docs/UX・UIデザインの方針.md
+++ b/docs/UX・UIデザインの方針.md
@@ -54,3 +54,5 @@
   - VOICEVOX API 準拠エンジンのことは「エンジン」
     - VOICEVOX のエンジンなのか準拠エンジンなのかわからない場合は「VOICEVOX 準拠エンジン」
   - VVPP ファイルはそのまま「VVPP ファイル」、説明が必要なら「VOICEVOX 準拠エンジンパッケージ」
+- VOICEVOX の UI ソフトの総称は「VOICEVOX 系ソフトウェア」
+  - 正式名称は「VOICEVOX 系統 UI ソフトウェア」、長いのでほぼ使わない

--- a/docs/UX・UIデザインの方針.md
+++ b/docs/UX・UIデザインの方針.md
@@ -54,5 +54,5 @@
   - VOICEVOX API 準拠エンジンのことは「エンジン」
     - VOICEVOX のエンジンなのか準拠エンジンなのかわからない場合は「VOICEVOX 準拠エンジン」
   - VVPP ファイルはそのまま「VVPP ファイル」、説明が必要なら「VOICEVOX 準拠エンジンパッケージ」
-- VOICEVOX の UI ソフトの総称は「VOICEVOX 系ソフトウェア」
+- VOICEVOX エディターと同じ UI を用いたソフトウェアの総称は「VOICEVOX 系ソフトウェア」
   - 正式名称は「VOICEVOX 系統 UI ソフトウェア」、長いのでほぼ使わない


### PR DESCRIPTION
## 内容

ボイボ系ソフトに関する名称の方針について、COEIROINK・SHAREVOX・LMROID・ITVOICEの方々とは連絡を取っていたのですが、そういえばドキュメントに書いていなかったので追記してみました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/issues/2

## その他

（ドキュメントは別リポジトリに移したいですね･･･ 😇 ）
