### PR TITLE
[release-0.14] ubuntu18脱却漏れ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
         #   - ${{ env.VOICEVOX_ENGINE_REPO_URL }}
         # voicevox_engine_version:
         #   - ${{ env.VOICEVOX_ENGINE_VERSION }}
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         artifact_name:
           - linux-nvidia-prepackage
           - linux-cpu-prepackage


### PR DESCRIPTION
## 内容

release-0.14ブランチはまだbuild.ymlのJobの一本化がされておらず、mainブランチでは一本化後にubuntu18脱却をしていたため、ubuntu18の部分が残ってしまっていました。
その部分の修正です。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/913
