### PR TITLE
Fix: テキスト欄削除ショートカットが動かないのを修正

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -72,6 +72,9 @@ defineExpose({
   focusTextField: () => {
     textfield.value?.focus();
   },
+  removeCell: () => {
+    removeCell();
+  },
 });
 
 const store = useStore();


### PR DESCRIPTION
## 内容

タイトル通り。

## 関連 Issue

- close: #1268 

## スクリーンショット・動画など

（なし）

## その他

（なし）