### PR TITLE
コンポーネントのrefを追加する関数の型を修正

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -264,6 +264,7 @@ import {
   onUnmounted,
   reactive,
   ref,
+  VNodeRef,
   watch,
 } from "vue";
 import { useQuasar } from "quasar";
@@ -529,8 +530,8 @@ const nowPlayingContinuously = computed(
 
 const audioDetail = ref<HTMLElement>();
 let accentPhraseElems: HTMLElement[] = [];
-const addAccentPhraseElem = (elem: HTMLElement) => {
-  if (elem) {
+const addAccentPhraseElem: VNodeRef = (elem) => {
+  if (elem instanceof HTMLElement) {
     accentPhraseElems.push(elem);
   }
 };

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -166,7 +166,7 @@
 
 <script setup lang="ts">
 import path from "path";
-import { computed, onBeforeUpdate, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUpdate, onMounted, ref, VNodeRef, watch } from "vue";
 import draggable from "vuedraggable";
 import { QResizeObserver, useQuasar } from "quasar";
 import cloneDeep from "clone-deep";
@@ -353,12 +353,12 @@ const updateAudioDetailPane = async (height: number) => {
   audioDetailPaneHeight.value = height;
   await updateSplitterPosition("audioDetailPaneHeight", height);
 };
-
 // component
-let audioCellRefs: Record<AudioKey, typeof AudioCell> = {};
-const addAudioCellRef = (audioCellRef: typeof AudioCell) => {
-  if (audioCellRef) {
-    audioCellRefs[audioCellRef.audioKey] = audioCellRef;
+let audioCellRefs: Record<AudioKey, InstanceType<typeof AudioCell>> = {};
+const addAudioCellRef: VNodeRef = (audioCellRef) => {
+  if (audioCellRef && !(audioCellRef instanceof Element)) {
+    const typedAudioCellRef = audioCellRef as InstanceType<typeof AudioCell>;
+    audioCellRefs[typedAudioCellRef.audioKey] = typedAudioCellRef;
   }
 };
 onBeforeUpdate(() => {


### PR DESCRIPTION
- #1271 の修正です

## 内容

`ref` の型定義はこうなっています。
```
ref: VNodeRef

type VNodeRef = string | Ref | ((ref: Element | ComponentPublicInstance | null, refs: Record<string, any>) => void);
```
`addAudioCellRef` の型は `(audioCellRef: typeof AudioCell) => void` です。（ `typeof AudioCell ≒ ComponenPublicInstance` ）
これが `(ref: Element | ComponentPublicInstance | null, refs: Record<string, any>) => void` と互換性がなくエラーになっていました

（ `(A | B) => void` を要求しているところに `A => void` は入れられない。 `(A => void) | (B => void)` ならOK）


`addAudioCellRef` の型は `VNodeRef` にしておき、中で型の絞り込みを行っています。
また、 `AudioCell` であることも分からないのでtype assertionしています。
`<audio-cell>` コンポーネントの `ref` を指定しているんだからvueが推論して欲しい気もしますね・・・

## 関連 Issue
- close #1271 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
