### PR TITLE
デフォルトプリセット周りのリファクタ

### DIFF
--- a/src/composables/useDefaultPreset.ts
+++ b/src/composables/useDefaultPreset.ts
@@ -6,9 +6,6 @@ export const useDefaultPreset = () => {
   const store = useStore();
 
   const defaultPresetKeys = computed(() => store.state.defaultPresetKeys);
-  const defaultPresetKeySets = computed(
-    () => new Set(Object.values(store.state.defaultPresetKeys))
-  );
 
   const getDefaultPresetKeyForVoice = (voice: Voice): string => {
     const voiceId = VoiceId(voice);
@@ -16,7 +13,7 @@ export const useDefaultPreset = () => {
   };
 
   const isDefaultPresetKey = (presetKey: PresetKey): boolean => {
-    return defaultPresetKeySets.value.has(presetKey);
+    return store.getters.DEFAULT_PRESET_KEY_SETS.has(presetKey);
   };
 
   return {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -192,15 +192,12 @@ export function getCharacterInfo(
  * 与えたAudioItemを元に、Presetを適用した新しいAudioItemを返す
  */
 export function applyAudioPresetToAudioItem(
-  audioItem: AudioItem | undefined,
-  presetItem: Preset | undefined
+  audioItem: AudioItem,
+  presetItem: Preset
 ) {
-  if (
-    audioItem == undefined ||
-    audioItem.presetKey == undefined ||
-    audioItem.query == undefined
-  )
-    return;
+  if (audioItem.query == undefined) {
+    throw new Error("audioItem.query is undefined");
+  }
   if (presetItem == undefined) return;
 
   const newAudioItem = { ...audioItem };

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -333,6 +333,12 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
+  DEFAULT_PRESET_KEY_SETS: {
+    getter: (state) => {
+      return new Set(Object.values(state.defaultPresetKeys));
+    },
+  },
+
   LOAD_CHARACTER: {
     action: createUILockAction(async ({ commit, dispatch }, { engineId }) => {
       const speakers = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -584,11 +584,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       if (shouldApplyPreset) {
         if (nextPresetKey) {
           const preset = state.presetItems[nextPresetKey];
-          const result = applyAudioPresetToAudioItem(newAudioItem, preset);
-
-          if (result) {
-            return result;
-          }
+          return applyAudioPresetToAudioItem(newAudioItem, preset);
         }
       }
 
@@ -1028,9 +1024,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       const presetItem = state.presetItems[audioItem.presetKey];
       const newAudioItem = applyAudioPresetToAudioItem(audioItem, presetItem);
 
-      if (newAudioItem) {
-        state.audioItems[audioKey] = newAudioItem;
-      }
+      state.audioItems[audioKey] = newAudioItem;
     },
   },
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1019,7 +1019,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     mutation(state, { audioKey }: { audioKey: AudioKey }) {
       const audioItem = state.audioItems[audioKey];
 
-      if (!audioItem || !audioItem.presetKey) return;
+      if (!audioItem.presetKey) return;
 
       const presetItem = state.presetItems[audioItem.presetKey];
       const newAudioItem = applyAudioPresetToAudioItem(audioItem, presetItem);

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -192,7 +192,10 @@ export function getCharacterInfo(
  * configを参照して割り当てるべきpresetKeyとそのPresetを適用すべきかどうかを返す
  */
 export function determineNextPresetKey(
-  state: State,
+  state: Pick<
+    State,
+    "defaultPresetKeys" | "experimentalSetting" | "inheritAudioInfo"
+  >,
   voice: Voice,
   presetKeyCandidate: PresetKey | undefined,
   operation: "generate" | "copy" | "changeVoice"

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -199,8 +199,6 @@ export function applyAudioPresetToAudioItem(
     throw new Error("audioItem.query is undefined");
   }
 
-  const newAudioItem = { ...audioItem };
-
   // Filter name property from presetItem in order to extract audioInfos.
   const { name: _, morphingInfo, ...presetAudioInfos } = presetItem;
 
@@ -210,6 +208,7 @@ export function applyAudioPresetToAudioItem(
     "accentPhrases" | "outputSamplingRate" | "outputStereo" | "kana"
   > = presetAudioInfos;
 
+  const newAudioItem = { ...audioItem };
   newAudioItem.query = { ...audioItem.query, ...audioInfos };
   newAudioItem.morphingInfo = morphingInfo;
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -198,7 +198,6 @@ export function applyAudioPresetToAudioItem(
   if (audioItem.query == undefined) {
     throw new Error("audioItem.query is undefined");
   }
-  if (presetItem == undefined) return;
 
   const newAudioItem = { ...audioItem };
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -194,7 +194,7 @@ export function getCharacterInfo(
 export function applyAudioPresetToAudioItem(
   audioItem: AudioItem,
   presetItem: Preset
-) {
+): AudioItem {
   if (audioItem.query == undefined) {
     throw new Error("audioItem.query is undefined");
   }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -210,7 +210,7 @@ export function applyAudioPresetToAudioItem(
 
   const newAudioItem = { ...audioItem };
   newAudioItem.query = { ...audioItem.query, ...audioInfos };
-  newAudioItem.morphingInfo = morphingInfo;
+  newAudioItem.morphingInfo = morphingInfo ? { ...morphingInfo } : undefined;
 
   return newAudioItem;
 }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -191,7 +191,7 @@ export function getCharacterInfo(
 /**
  * configを参照して割り当てるべきpresetKeyとそのPresetを適用すべきかどうかを返す
  */
-export function determineNextPresetKey(
+function determineNextPresetKey(
   state: Pick<
     State,
     "defaultPresetKeys" | "experimentalSetting" | "inheritAudioInfo"

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -264,12 +264,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
-  DEFAULT_PRESET_KEY_SETS: {
-    getter: (state) => {
-      return new Set(Object.values(state.defaultPresetKeys));
-    },
-  },
-
   LOAD_CHARACTER: {
     action: createUILockAction(async ({ commit, dispatch }, { engineId }) => {
       const speakers = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {

--- a/src/store/preset.ts
+++ b/src/store/preset.ts
@@ -1,7 +1,76 @@
 import { v4 as uuidv4 } from "uuid";
 import { createPartialStore } from "./vuex";
-import { PresetStoreState, PresetStoreTypes } from "@/store/type";
-import { Preset, PresetKey, VoiceId } from "@/type/preload";
+import { PresetStoreState, PresetStoreTypes, State } from "@/store/type";
+import { Preset, PresetKey, Voice, VoiceId } from "@/type/preload";
+
+/**
+ * configを参照して割り当てるべきpresetKeyとそのPresetを適用すべきかどうかを返す
+ */
+export function determineNextPresetKey(
+  state: Pick<
+    State,
+    "defaultPresetKeys" | "experimentalSetting" | "inheritAudioInfo"
+  >,
+  voice: Voice,
+  presetKeyCandidate: PresetKey | undefined,
+  operation: "generate" | "copy" | "changeVoice"
+): {
+  nextPresetKey: PresetKey | undefined;
+  shouldApplyPreset: boolean;
+} {
+  const defaultPresetKeyForCurrentVoice =
+    state.defaultPresetKeys[VoiceId(voice)];
+
+  switch (operation) {
+    case "generate": {
+      // 初回作成時
+      return {
+        nextPresetKey: defaultPresetKeyForCurrentVoice,
+        shouldApplyPreset: state.experimentalSetting.enablePreset,
+      };
+    }
+    case "copy": {
+      // 元となるAudioItemがある場合
+      if (state.inheritAudioInfo) {
+        // パラメータ引継ぎがONならそのまま引き継ぐ
+        return {
+          nextPresetKey: presetKeyCandidate,
+          shouldApplyPreset: false,
+        };
+      }
+
+      // それ以外はデフォルトプリセットを割り当て、適用するかはプリセットのON/OFFに依存
+      return {
+        nextPresetKey: defaultPresetKeyForCurrentVoice,
+        shouldApplyPreset: state.experimentalSetting.enablePreset,
+      };
+    }
+    case "changeVoice": {
+      // ボイス切り替え時
+      if (state.experimentalSetting.shouldApplyDefaultPresetOnVoiceChanged) {
+        // デフォルトプリセットを適用する
+        return {
+          nextPresetKey: defaultPresetKeyForCurrentVoice,
+          shouldApplyPreset: true,
+        };
+      }
+
+      const isDefaultPreset = Object.values(state.defaultPresetKeys).some(
+        (key) => key === presetKeyCandidate
+      );
+
+      // 引き継ぎ元が他スタイルのデフォルトプリセットだった場合
+      // 別キャラのデフォルトプリセットを引き継がないようにする
+      // それ以外は指定そのまま
+      return {
+        nextPresetKey: isDefaultPreset
+          ? defaultPresetKeyForCurrentVoice
+          : presetKeyCandidate,
+        shouldApplyPreset: false,
+      };
+    }
+  }
+}
 
 export const presetStoreState: PresetStoreState = {
   presetItems: {},

--- a/src/store/preset.ts
+++ b/src/store/preset.ts
@@ -83,6 +83,12 @@ export const presetStoreState: PresetStoreState = {
 };
 
 export const presetStore = createPartialStore<PresetStoreTypes>({
+  DEFAULT_PRESET_KEY_SETS: {
+    getter: (state) => {
+      return new Set(Object.values(state.defaultPresetKeys));
+    },
+  },
+
   SET_PRESET_ITEMS: {
     mutation(
       state,

--- a/src/store/preset.ts
+++ b/src/store/preset.ts
@@ -5,6 +5,10 @@ import { Preset, PresetKey, Voice, VoiceId } from "@/type/preload";
 
 /**
  * configを参照して割り当てるべきpresetKeyとそのPresetを適用すべきかどうかを返す
+ *
+ * generate: プロジェクト新規作成時、空のAudioItemを作成する場合
+ * copy: 元となるAudioItemがある場合（＋ボタンで作成したとき）
+ * changeVoice: ボイス切り替え時
  */
 export function determineNextPresetKey(
   state: Pick<

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -359,11 +359,6 @@ export type AudioStoreTypes = {
     };
   };
 
-  APPLY_AUDIO_PRESET_TO_AUDIO_ITEM: {
-    mutation: { audioItem: AudioItem };
-    action(payload: { audioItem: AudioItem }): void;
-  };
-
   APPLY_AUDIO_PRESET: {
     mutation: { audioKey: AudioKey };
   };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -144,6 +144,10 @@ export type AudioStoreTypes = {
     getter: number | undefined;
   };
 
+  DEFAULT_PRESET_KEY_SETS: {
+    getter: Set<PresetKey>;
+  };
+
   LOAD_CHARACTER: {
     action(payload: { engineId: EngineId }): void;
   };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -144,10 +144,6 @@ export type AudioStoreTypes = {
     getter: number | undefined;
   };
 
-  DEFAULT_PRESET_KEY_SETS: {
-    getter: Set<PresetKey>;
-  };
-
   LOAD_CHARACTER: {
     action(payload: { engineId: EngineId }): void;
   };
@@ -1262,6 +1258,9 @@ export type PresetStoreState = {
 };
 
 export type PresetStoreTypes = {
+  DEFAULT_PRESET_KEY_SETS: {
+    getter: Set<PresetKey>;
+  };
   SET_PRESET_ITEMS: {
     mutation: {
       presetItems: Record<PresetKey, Preset>;


### PR DESCRIPTION
## 内容
- #1247 

で後回しにしたリファクタを行いました。
以下は上記issueのコピペです

### 問題一覧
- **mutation内で渡した引数を直接書き換えているコードをどうにかする**
   - https://github.com/VOICEVOX/voicevox/pull/1228#discussion_r1129821236
   - 同コメントのツリー内に修正方針をコメント済み
- **`determineNextPresetKey` の引数を整理する**
   - https://github.com/VOICEVOX/voicevox/pull/1228#discussion_r1125717135
- **defaultPresetか判定する関数がcomposablesに存在するが、vuexでも同様の判定をしていて重複している**
   - https://github.com/VOICEVOX/voicevox/pull/1228#discussion_r1131799080
   - getterにO(1)で判定できるようにしたデータの中間表現を置いて、それを使って判定できるようにすると良さそう

### 補足

引数で渡したaudioItemを直接書き換えていた問題  https://github.com/VOICEVOX/voicevox/pull/1228#discussion_r1129821236 は、「audioItemと presetItemを取ってプリセット適用済みの新しいaudioItemを返す関数」に切り出すことで解決しました。
該当コミット： 92bf9ad

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #1247 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

