### PR TITLE
Electronのmain processで直接動作するコード以外からelectronに関する型を排除する

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,18 @@ module.exports = {
       },
     ],
     "import/order": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["electron"],
+            message:
+              "electronに依存する型はelectronで動作するコード内にのみ含みます",
+          },
+        ],
+      },
+    ],
   },
   overrides: [
     {
@@ -62,6 +74,16 @@ module.exports = {
       ],
       rules: {
         "no-console": "off",
+      },
+    },
+    {
+      files: [
+        "./src/background.ts",
+        "./src/background/*.ts",
+        "./src/electron/*.ts",
+      ],
+      rules: {
+        "no-restricted-imports": "off",
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,18 +52,6 @@ module.exports = {
       },
     ],
     "import/order": "error",
-    "no-restricted-imports": [
-      "error",
-      {
-        patterns: [
-          {
-            group: ["electron"],
-            message:
-              "このファイル内でelectronはimportできません。許可されているファイル内へ移すか、ESLintの設定を見直してください",
-          },
-        ],
-      },
-    ],
   },
   overrides: [
     {
@@ -76,14 +64,27 @@ module.exports = {
         "no-console": "off",
       },
     },
+    // Electronのメインプロセス以外でelectronのimportを禁止する
     {
-      files: [
+      files: ["./src/**/*.ts", "./src/**/*.vue"],
+      excludedFiles: [
         "./src/background.ts",
         "./src/background/*.ts",
         "./src/electron/*.ts",
       ],
       rules: {
-        "no-restricted-imports": "off",
+        "no-restricted-imports": [
+          "error",
+          {
+            patterns: [
+              {
+                group: ["electron"],
+                message:
+                  "このファイル内でelectronはimportできません。許可されているファイル内へ移すか、ESLintの設定を見直してください",
+              },
+            ],
+          },
+        ],
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,7 +59,7 @@ module.exports = {
           {
             group: ["electron"],
             message:
-              "electronに依存する型はelectronで動作するコード内にのみ含みます",
+              "このファイル内でelectronはimportできません。許可されているファイル内へ移すか、ESLintの設定を見直してください",
           },
         ],
       },

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -5,7 +5,12 @@ import {
   IpcRendererEvent,
 } from "electron";
 
-import { Sandbox, ElectronStoreType, EngineId } from "@/type/preload";
+import {
+  Sandbox,
+  ElectronStoreType,
+  EngineId,
+  SandboxKey,
+} from "@/type/preload";
 import { IpcIHData, IpcSOData } from "@/type/ipc";
 
 function ipcRendererInvoke<T extends keyof IpcIHData>(
@@ -286,4 +291,4 @@ const api: Sandbox = {
   },
 };
 
-contextBridge.exposeInMainWorld("electron", api);
+contextBridge.exposeInMainWorld(SandboxKey, api);

--- a/src/type/globals.d.ts
+++ b/src/type/globals.d.ts
@@ -1,5 +1,6 @@
 // Include global variables to build immer source code
 export * from "immer/src/types/globals";
+import { SandboxKey } from "./preload";
 
 declare global {
   interface HTMLAudioElement {
@@ -7,6 +8,6 @@ declare global {
   }
 
   interface Window {
-    readonly electron: import("./preload").Sandbox;
+    readonly [SandboxKey]: import("./preload").Sandbox;
   }
 }

--- a/src/type/globals.d.ts
+++ b/src/type/globals.d.ts
@@ -5,4 +5,8 @@ declare global {
   interface HTMLAudioElement {
     setSinkId(deviceID: string): Promise<undefined>; // setSinkIdを認識してくれないため
   }
+
+  interface Window {
+    readonly electron: import("./preload").Sandbox;
+  }
 }

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -11,6 +11,7 @@ import {
   NativeThemeType,
   EngineSetting,
   EngineId,
+  MessageBoxReturnValue,
 } from "@/type/preload";
 
 /**
@@ -110,7 +111,7 @@ export type IpcIHData = {
         message: string;
       }
     ];
-    return: Electron.MessageBoxReturnValue;
+    return: MessageBoxReturnValue;
   };
 
   SHOW_QUESTION_DIALOG: {
@@ -134,7 +135,7 @@ export type IpcIHData = {
         message: string;
       }
     ];
-    return: Electron.MessageBoxReturnValue;
+    return: MessageBoxReturnValue;
   };
 
   SHOW_ERROR_DIALOG: {
@@ -144,7 +145,7 @@ export type IpcIHData = {
         message: string;
       }
     ];
-    return: Electron.MessageBoxReturnValue;
+    return: MessageBoxReturnValue;
   };
 
   OPEN_TEXT_EDIT_CONTEXT_MENU: {

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -1,4 +1,4 @@
-import { IpcRenderer, IpcRendererEvent, nativeTheme } from "electron";
+import { nativeTheme } from "electron";
 import { z } from "zod";
 import { IpcSOData } from "./ipc";
 
@@ -187,8 +187,8 @@ export interface Sandbox {
   isMaximizedWindow(): Promise<boolean>;
   onReceivedIPCMsg<T extends keyof IpcSOData>(
     channel: T,
-    listener: (event: IpcRendererEvent, ...args: IpcSOData[T]["args"]) => void
-  ): IpcRenderer;
+    listener: (event: unknown, ...args: IpcSOData[T]["args"]) => void
+  ): void;
   closeWindow(): void;
   minimizeWindow(): void;
   maximizeWindow(): void;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -626,3 +626,5 @@ export interface MessageBoxReturnValue {
   response: number;
   checkboxChecked: boolean;
 }
+
+export const SandboxKey = "electron" as const;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -1,4 +1,3 @@
-import { nativeTheme } from "electron";
 import { z } from "zod";
 import { IpcSOData } from "./ipc";
 
@@ -436,7 +435,8 @@ export type ToolbarButtonTagType = z.infer<typeof toolbarButtonTagSchema>;
 export const toolbarSettingSchema = toolbarButtonTagSchema;
 export type ToolbarSetting = z.infer<typeof toolbarSettingSchema>[];
 
-export type NativeThemeType = typeof nativeTheme["themeSource"];
+// base: typeof electron.nativeTheme["themeSource"];
+export type NativeThemeType = "system" | "light" | "dark";
 
 export type MoraDataType =
   | "consonant"

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -619,3 +619,10 @@ export type EngineDirValidationResult =
   | "alreadyExists";
 
 export type VvppFilePathValidationResult = "ok" | "fileNotFound";
+
+// base: Electron.MessageBoxReturnValue
+// FIXME: MessageBoxUIの戻り値として使用したい値が決まったら書き換える
+export interface MessageBoxReturnValue {
+  response: number;
+  checkboxChecked: boolean;
+}

--- a/src/type/shims-vue.d.ts
+++ b/src/type/shims-vue.d.ts
@@ -5,7 +5,3 @@ declare module "*.vue" {
 
   export default component;
 }
-
-interface Window {
-  readonly electron: import("./preload").Sandbox;
-}


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

Electron非依存でEditorUIを動作させるのに、型的にも非依存であることが示されていると進めやすいため、型の調整を行いました。
また今後electronのモジュールをimportしてしまわぬようにlintでも弾くようにしています。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

ref: https://github.com/VOICEVOX/voicevox/issues/1204

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
