### PR TITLE
ENH: CharacterButtonのメニューが常に下方向に展開されるようにする

### DIFF
--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -295,6 +295,7 @@ const reassignSubMenuOpen = debounce((idx: number) => {
   subMenuOpenFlags.value = arr;
 }, 100);
 
+// 高さを制限してメニューが下方向に展開されるようにする
 const buttonRef: Ref<InstanceType<typeof QBtn> | undefined> = ref();
 const heightLimit = "65vh"; // QMenuのデフォルト値
 const maxMenuHeight = ref(heightLimit);

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -307,6 +307,7 @@ const updateMenuHeight = () => {
   const buttonRect = el.getBoundingClientRect();
   // QMenuは展開する方向のスペースが不足している場合、自動的に展開方向を変更してしまうためmax-heightで制限する。
   // AudioDetailよりボタンが下に来ることはないのでその最低高185pxに余裕を持たせた170pxを最小の高さにする。
+  // pxで指定するとウインドウサイズ変更に追従できないので ウインドウの高さの96% - ボタンの下端の座標 でメニューの高さを決定する。
   maxMenuHeight.value = `max(170px, min(${heightLimit}, calc(96vh - ${buttonRect.bottom}px)))`;
 };
 </script>

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -2,6 +2,7 @@
   <q-btn
     flat
     class="q-pa-none character-button"
+    ref="buttonRef"
     :disable="uiLocked"
     :class="{ opaque: loading }"
   >
@@ -23,6 +24,8 @@
       class="character-menu"
       transition-show="none"
       transition-hide="none"
+      :max-height="maxMenuHeight"
+      @before-show="updateMenuHeight"
     >
       <q-list style="min-width: max-content" class="character-item-container">
         <q-item
@@ -179,8 +182,8 @@
 </template>
 
 <script setup lang="ts">
-import { debounce } from "quasar";
-import { computed, ref } from "vue";
+import { debounce, QBtn } from "quasar";
+import { computed, Ref, ref } from "vue";
 import { base64ImageToUri } from "@/helpers/imageHelper";
 import { useStore } from "@/store";
 import { CharacterInfo, SpeakerId, Voice } from "@/type/preload";
@@ -291,6 +294,18 @@ const reassignSubMenuOpen = debounce((idx: number) => {
   arr[idx] = true;
   subMenuOpenFlags.value = arr;
 }, 100);
+
+const buttonRef: Ref<InstanceType<typeof QBtn> | undefined> = ref();
+const heightLimit = "65vh"; // QMenuのデフォルト値
+const maxMenuHeight = ref(heightLimit);
+const updateMenuHeight = () => {
+  if (buttonRef.value == undefined)
+    throw new Error("buttonRef.value == undefined");
+  const el = buttonRef.value.$el;
+  if (!(el instanceof Element)) throw new Error("!(el instanceof Element)");
+  const buttonRect = el.getBoundingClientRect();
+  maxMenuHeight.value = `max(170px, min(${heightLimit}, calc(96vh - ${buttonRect.bottom}px)))`;
+};
 </script>
 
 <style scoped lang="scss">

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -305,6 +305,8 @@ const updateMenuHeight = () => {
   const el = buttonRef.value.$el;
   if (!(el instanceof Element)) throw new Error("!(el instanceof Element)");
   const buttonRect = el.getBoundingClientRect();
+  // QMenuは展開する方向のスペースが不足している場合、自動的に展開方向を変更してしまうためmax-heightで制限する。
+  // AudioDetailよりボタンが下に来ることはないのでその最低高185pxに余裕を持たせた170pxを最小の高さにする。
   maxMenuHeight.value = `max(170px, min(${heightLimit}, calc(96vh - ${buttonRect.bottom}px)))`;
 };
 </script>


### PR DESCRIPTION
## 内容

キャラクター選択メニューが常に下方向に展開されるようにすることで以下の問題を解決します。
- 選択しやすいように先頭の方に配置したキャラクターが逆に選択しにくくなる。
- タイトルバーにメニューが被りタイトルバーに操作が吸われてしまう。

## 関連 Issue

- fix #1110 
- ref #1030

## その他

ウインドウサイズを変更したときは可能な限り追従するようになっています。