### PR TITLE
Fix: 辞書の単語入力で全てのスペースを置換するようにする #1300

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -378,7 +378,7 @@ const accentPhraseTable = ref<HTMLElement>();
 
 const convertHankakuToZenkaku = (text: string) => {
   // " "などの目に見えない文字をまとめて全角スペース(0x3000)に置き換える
-  text = text.replace(/\p{Z}/u, () => String.fromCharCode(0x3000));
+  text = text.replace(/\p{Z}/gu, () => String.fromCharCode(0x3000));
 
   // "!"から"~"までの範囲の文字(数字やアルファベット)を全角に置き換える
   return text.replace(/[\u0021-\u007e]/g, (s) => {


### PR DESCRIPTION
## 内容

辞書登録時の正規表現によるスペースのチェックで最初のみではなく全ての一致にマッチするようにしました

## 関連 Issue


close #1300
