### PR TITLE
ENH: 表示範囲外のAudioCellがアクティブになったとき表示範囲内までスクロールするようにする

### DIFF
--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -89,6 +89,7 @@
                     >
                       <draggable
                         class="audio-cells"
+                        ref="cellsRef"
                         :modelValue="audioKeys"
                         @update:modelValue="updateAudioKeys"
                         :itemKey="itemKey"
@@ -778,6 +779,23 @@ const loadDraggedFile = (event: { dataTransfer: DataTransfer | null }) => {
       });
   }
 };
+
+// AudioCellの自動スクロール
+const cellsRef = ref<InstanceType<typeof draggable> | undefined>();
+watch(activeAudioKey, (audioKey) => {
+  if (audioKey == undefined) return;
+  const activeCellElement = audioCellRefs[audioKey].$el;
+  const cellsElement = cellsRef.value?.$el;
+  if (activeCellElement instanceof Element && cellsElement instanceof Element) {
+    const activeCellRect = activeCellElement.getBoundingClientRect();
+    const cellsRect = cellsElement.getBoundingClientRect();
+    const overflowTop = activeCellRect.top <= cellsRect.top;
+    const overflowBottom = activeCellRect.bottom >= cellsRect.bottom;
+    if (overflowTop || overflowBottom) {
+      activeCellElement.scrollIntoView(overflowTop || !overflowBottom);
+    }
+  }
+});
 </script>
 
 <style scoped lang="scss">

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -786,14 +786,19 @@ watch(activeAudioKey, (audioKey) => {
   if (audioKey == undefined) return;
   const activeCellElement = audioCellRefs[audioKey].$el;
   const cellsElement = cellsRef.value?.$el;
-  if (activeCellElement instanceof Element && cellsElement instanceof Element) {
-    const activeCellRect = activeCellElement.getBoundingClientRect();
-    const cellsRect = cellsElement.getBoundingClientRect();
-    const overflowTop = activeCellRect.top <= cellsRect.top;
-    const overflowBottom = activeCellRect.bottom >= cellsRect.bottom;
-    if (overflowTop || overflowBottom) {
-      activeCellElement.scrollIntoView(overflowTop || !overflowBottom);
-    }
+  if (
+    !(activeCellElement instanceof Element) ||
+    !(cellsElement instanceof Element)
+  )
+    throw new Error(
+      `invalid element: activeCellElement=${activeCellElement}, cellsElement=${cellsElement}`
+    );
+  const activeCellRect = activeCellElement.getBoundingClientRect();
+  const cellsRect = cellsElement.getBoundingClientRect();
+  const overflowTop = activeCellRect.top <= cellsRect.top;
+  const overflowBottom = activeCellRect.bottom >= cellsRect.bottom;
+  if (overflowTop || overflowBottom) {
+    activeCellElement.scrollIntoView(overflowTop || !overflowBottom);
   }
 });
 </script>


### PR DESCRIPTION
## 内容

アクティブなセルが切り替わったときそのセルが表示範囲外なら表示範囲内に自動的にスクロールするように修正します。
これにより連続再生時に再生しているテキスト欄が追従します。

## 関連 Issue

- fix #530

## その他

[このツイート](https://twitter.com/kishimi_284304/status/1652867748958212097)を見てボタンのある行を表示範囲外にするつもりでしたが移動範囲が大きくて使いにくくなった気がしたので止めました。