### PR TITLE
FIX: デフォルトプリセットが正常に生成されない問題を修正

### DIFF
--- a/src/store/preset.ts
+++ b/src/store/preset.ts
@@ -202,12 +202,12 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
     async action({ state, dispatch, getters }) {
       const voices = getters.GET_ALL_VOICES;
 
-      for await (const voice of voices) {
+      for (const voice of voices) {
         const voiceId = VoiceId(voice);
         const defaultPresetKey = state.defaultPresetKeys[voiceId];
 
         if (state.presetKeys.includes(defaultPresetKey)) {
-          return defaultPresetKey;
+          continue;
         }
 
         const characterName = getters.VOICE_NAME(voice);
@@ -229,8 +229,6 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
             [voiceId]: newPresetKey,
           },
         });
-
-        return newPresetKey;
       }
     },
   },


### PR DESCRIPTION
## 内容

エンジン起動時に一括作成されるはずのデフォルトプリセットが一番最初のキャラクターしか作成されていなかったのでそれを修正します。

## 関連 Issue

- ref https://github.com/VOICEVOX/voicevox/issues/956#issuecomment-1441530269
- ref #1228
