### PR TITLE
FIX: エンジンの再起動時にEngineInfoを更新する

### DIFF
--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -31,6 +31,26 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
+  UPDATE_ENGINE_INFO: {
+    mutation(state, { engineId, engineInfo }) {
+      state.engineInfos[engineId] = engineInfo;
+    },
+  },
+
+  UPDATE_ENGINE_INFOS: {
+    async action({ commit }, { engineIds }) {
+      const engineInfos = await window.electron.engineInfos();
+      for (const engineInfo of engineInfos) {
+        if (engineIds.includes(engineInfo.uuid)) {
+          commit("UPDATE_ENGINE_INFO", {
+            engineId: engineInfo.uuid,
+            engineInfo,
+          });
+        }
+      }
+    },
+  },
+
   GET_SORTED_ENGINE_INFOS: {
     getter: (state) => {
       return Object.values(state.engineInfos).sort((a, b) => {
@@ -187,6 +207,8 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
           }
         })
       );
+
+      await dispatch("UPDATE_ENGINE_INFOS", { engineIds });
 
       const result = await dispatch("POST_ENGINE_START", {
         engineIds,

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -31,18 +31,18 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
-  UPDATE_ENGINE_INFO: {
+  SET_ENGINE_INFO: {
     mutation(state, { engineId, engineInfo }) {
       state.engineInfos[engineId] = engineInfo;
     },
   },
 
-  UPDATE_ENGINE_INFOS: {
+  GET_ONLY_ENGINE_INFOS: {
     async action({ commit }, { engineIds }) {
       const engineInfos = await window.electron.engineInfos();
       for (const engineInfo of engineInfos) {
         if (engineIds.includes(engineInfo.uuid)) {
-          commit("UPDATE_ENGINE_INFO", {
+          commit("SET_ENGINE_INFO", {
             engineId: engineInfo.uuid,
             engineInfo,
           });
@@ -208,7 +208,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
         })
       );
 
-      await dispatch("UPDATE_ENGINE_INFOS", { engineIds });
+      await dispatch("GET_ONLY_ENGINE_INFOS", { engineIds });
 
       const result = await dispatch("POST_ENGINE_START", {
         engineIds,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -735,11 +735,11 @@ export type EngineStoreTypes = {
     action(): void;
   };
 
-  UPDATE_ENGINE_INFO: {
+  SET_ENGINE_INFO: {
     mutation: { engineId: EngineId; engineInfo: EngineInfo };
   };
 
-  UPDATE_ENGINE_INFOS: {
+  GET_ONLY_ENGINE_INFOS: {
     action: (payload: { engineIds: EngineId[] }) => Promise<void>;
   };
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -735,6 +735,14 @@ export type EngineStoreTypes = {
     action(): void;
   };
 
+  UPDATE_ENGINE_INFO: {
+    mutation: { engineId: EngineId; engineInfo: EngineInfo };
+  };
+
+  UPDATE_ENGINE_INFOS: {
+    action: (payload: { engineIds: EngineId[] }) => Promise<void>;
+  };
+
   GET_SORTED_ENGINE_INFOS: {
     getter: EngineInfo[];
   };


### PR DESCRIPTION
## 内容

エンジン再起動時にポートが切り替わった場合接続するポートが切り替わらない問題を修正します。

## 関連 Issue

- fix #1308

## その他

#1310 の問題により追加エンジンの動作確認ができていません。