### PR TITLE
Fix: ボイスの紹介・並べ替え画面のボタンをアクセシブルにする

### DIFF
--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -77,6 +77,7 @@
                           : 0
                       ].iconPath
                     "
+                    :alt="characterInfosMap[speakerUuid].metas.speakerName"
                     class="style-icon"
                   />
                   <span class="text-subtitle1 q-ma-sm">{{
@@ -100,8 +101,9 @@
                         selectCharacter(speakerUuid);
                         rollStyleIndex(speakerUuid, -1);
                       "
+                      aria-label="前のボイススタイル"
                     />
-                    <span>{{
+                    <span aria-live="polite">{{
                       selectedStyles[speakerUuid].styleName || "ノーマル"
                     }}</span>
                     <q-btn
@@ -116,6 +118,7 @@
                         selectCharacter(speakerUuid);
                         rollStyleIndex(speakerUuid, 1);
                       "
+                      aria-label="次のボイススタイル"
                     />
                   </div>
                   <div class="voice-samples">
@@ -145,6 +148,7 @@
                           voiceSampleIndex
                         );
                       "
+                      :aria-label="`ボイスサンプル${voiceSampleIndex + 1}`"
                     />
                   </div>
                   <div

--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -101,7 +101,7 @@
                         selectCharacter(speakerUuid);
                         rollStyleIndex(speakerUuid, -1);
                       "
-                      aria-label="前のボイススタイル"
+                      aria-label="前のスタイル"
                     />
                     <span aria-live="polite">{{
                       selectedStyles[speakerUuid].styleName || "ノーマル"
@@ -118,7 +118,7 @@
                         selectCharacter(speakerUuid);
                         rollStyleIndex(speakerUuid, 1);
                       "
-                      aria-label="次のボイススタイル"
+                      aria-label="次のスタイル"
                     />
                   </div>
                   <div class="voice-samples">
@@ -148,7 +148,7 @@
                           voiceSampleIndex
                         );
                       "
-                      :aria-label="`ボイスサンプル${voiceSampleIndex + 1}`"
+                      :aria-label="`サンプルボイス${voiceSampleIndex + 1}`"
                     />
                   </div>
                   <div


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

Voiceboxを初めて起動したときに表示される画面を、スクリーンリーダーで正しく操作できるようにしました。並べ替えのD&Dは即対応が難しいのと、頑張れば操作できるのでなにも触っていません。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

ref #46 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

本業の開発では React を使用しているので、 Vue のお作法はあまりわかっていません（というか、今日初めて書きました）。違うところがあればご指摘ください。

少しずつPRを出させてもらって、ほかの画面もアクセシブルにしていきたいと思っています。差分は毎回このぐらいの小さいものになると思います。
