### PR TITLE
WIP: #1267 のリファクタリング + ポートの割り当て可能の判定を修正

### DIFF
--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -9,7 +9,12 @@ import { app, BrowserWindow, dialog } from "electron";
 
 import log from "electron-log";
 import { z } from "zod";
-import { PortManager } from "./portManager";
+import {
+  findAltPort,
+  getPidFromPort,
+  getProcessNameFromPid,
+  url2HostInfo,
+} from "./portManager";
 import { ipcMainSend } from "@/electron/ipc";
 
 import {
@@ -229,33 +234,30 @@ export class EngineManager {
       return;
     }
 
-    const engineInfoUrl = new URL(engineInfo.host);
-    const portManager = new PortManager(
-      engineInfoUrl.hostname,
-      parseInt(engineInfoUrl.port)
-    );
+    // { hostname (localhost), port (50021) } <- url (http://localhost:50021)
+    const engineHostInfo = url2HostInfo(new URL(engineInfo.host));
 
     log.info(
-      `ENGINE ${engineId}: Checking whether port ${engineInfoUrl.port} is assignable...`
+      `ENGINE ${engineId}: Checking whether port ${engineHostInfo.port} is assignable...`
     );
 
-    // ポートを既に割り当てられているプロセスidの取得: undefined → ポートが空いている
-    const processId = await portManager.getProcessIdFromPort();
-    if (processId !== undefined) {
-      const processName = await portManager.getProcessNameFromPid(processId);
+    // ポートを既に割り当てているプロセスidの取得: undefined → ポートが空いている
+    const pid = await getPidFromPort(engineHostInfo);
+    if (pid != null) {
+      const processName = await getProcessNameFromPid(engineHostInfo, pid);
       log.warn(
-        `ENGINE ${engineId}: Port ${engineInfoUrl.port} has already been assigned by ${processName} (pid=${processId})`
+        `ENGINE ${engineId}: Port ${engineHostInfo.port} has already been assigned by ${processName} (pid=${pid})`
       );
 
-      // 代替ポート検索
-      const altPort = await portManager.findAltPort();
+      // 代替ポートの検索
+      const altPort = await findAltPort(engineHostInfo);
 
       // 代替ポートが見つからないとき
-      if (!altPort) {
+      if (altPort == null) {
         log.error(`ENGINE ${engineId}: No Alternative Port Found`);
         dialog.showErrorBox(
           `${engineInfo.name} の起動に失敗しました`,
-          `${engineInfoUrl.port}番ポートの代わりに利用可能なポートが見つかりませんでした。PCを再起動してください。`
+          `${engineHostInfo.port}番ポートの代わりに利用可能なポートが見つかりませんでした。PCを再起動してください。`
         );
         app.exit(1);
         throw new Error("No Alternative Port Found");
@@ -263,14 +265,14 @@ export class EngineManager {
 
       // 代替ポートの情報
       this.altPortInfo[engineId] = {
-        from: parseInt(engineInfoUrl.port),
+        from: engineHostInfo.port,
         to: altPort,
       };
 
       // 代替ポートを設定
-      engineInfo.host = `http://${engineInfoUrl.hostname}:${altPort}`;
+      engineInfo.host = `http://${engineHostInfo.hostname}:${altPort}`;
       log.warn(
-        `ENGINE ${engineId}: Applied Alternative Port: ${engineInfoUrl.port} -> ${altPort}`
+        `ENGINE ${engineId}: Applied Alternative Port: ${engineHostInfo.port} -> ${altPort}`
       );
     }
 


### PR DESCRIPTION
## 内容

#1267 のリファクタリングとポートの割り当てが可能かどうかの判定を修正します.

具体的には以下のことを行います:

1. **メインエンジンの** `altPort` をタイトルバーに表示する  
   現状, デフォルトエンジンに関係なく, 0 番目のエンジンの代替ポートを表示しているのでそれを改善する.  
   → ref: [#1310: その他](https://github.com/VOICEVOX/voicevox/issues/1310#:~:text=%E8%B5%B7%E5%8B%95%E6%99%82%E3%81%AB%E8%BF%BD%E5%8A%A0%E3%82%A8%E3%83%B3%E3%82%B8%E3%83%B3%E3%81%AE%E3%81%BF%E3%83%9D%E3%83%BC%E3%83%88%E3%81%AE%E5%88%87%E3%82%8A%E6%9B%BF%E3%81%88%E3%81%8C%E8%B5%B7%E3%81%93%E3%82%8B%E3%81%A8%E3%82%BF%E3%82%A4%E3%83%88%E3%83%AB%E3%83%90%E3%83%BC%E3%81%AB%E8%BF%BD%E5%8A%A0%E3%82%A8%E3%83%B3%E3%82%B8%E3%83%B3%E3%81%AE%E3%83%9D%E3%83%BC%E3%83%88%E3%81%8C%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%81%BE%E3%82%8B%E3%81%A7VOICEVOX%E3%81%AE%E3%83%9D%E3%83%BC%E3%83%88%E3%81%8C%E8%BF%BD%E5%8A%A0%E3%82%A8%E3%83%B3%E3%82%B8%E3%83%B3%E3%81%AE%E4%BB%A3%E6%9B%BF%E3%83%9D%E3%83%BC%E3%83%88%E3%81%A7%E3%81%82%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%81%A6%E3%81%97%E3%81%BE%E3%81%84%E3%81%BE%E3%81%99%E3%80%82)

1. `PortManager` を整理 (余計なインスタンスを生成しないようにする)  
   → ref: [#1267: コメント](https://github.com/VOICEVOX/voicevox/pull/1267#discussion_r1174612000)

1. `getProcessIdFromPort` の整理 (os での分岐, stdout の命名をどうにかする)
   → ref: [#1267: コメント](https://github.com/VOICEVOX/voicevox/pull/1267#discussion_r1176804841)

1. ポートの割り当てが可能かどうかの判定を修正 (windows)  
   エディターを落としたあとすぐに起動すると, TCP の状態が `TIME_WAIT` になっているので, 他のプロセスが使用していて割り当て不可と判定してしまうのを修正します.
   ref: #1307

## 関連 Issue

ref: #1267, #1310
fix: #1307

## スクリーンショット・動画など

_なし_

## その他

あまりにも diff が大きい場合, メンテナーさんが大変になってしまうので, もしそうなったら分割したいと思います！  
(いじるファイル数は少ないはず…！)