### PR TITLE
設定画面に “表示済みのヒントを全て再表示する” ボタンを追加

### DIFF
--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -263,6 +263,7 @@
                 <div>表示済みのヒントを全て再表示する</div>
                 <div>
                   <q-icon name="help_outline" size="sm" class="help-hover-icon">
+                    <!-- FIXME: なぜか tooltip が左側に出る -->
                     <q-tooltip
                       :delay="500"
                       anchor="center left"
@@ -279,7 +280,7 @@
                   name="check"
                   size="sm"
                   color="primary-light"
-                  style="margin-right: 5px"
+                  style="margin-right: 8px"
                   v-if="isDefaultConfirmedTips && hasResetConfirmedTip"
                 >
                 </q-icon>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -259,6 +259,46 @@
                   </template>
                 </q-btn-toggle>
               </q-card-actions>
+              <q-card-actions class="q-px-md q-py-sm bg-surface">
+                <div>表示済みのヒントを全て再表示する</div>
+                <div>
+                  <q-icon name="help_outline" size="sm" class="help-hover-icon">
+                    <q-tooltip
+                      :delay="500"
+                      anchor="center left"
+                      self="center right"
+                      transition-show="jump-left"
+                      transition-hide="jump-right"
+                    >
+                      過去に表示したヒントを全て再表示します。
+                    </q-tooltip>
+                  </q-icon>
+                </div>
+                <q-space />
+                <q-icon
+                  name="check"
+                  size="sm"
+                  color="primary-light"
+                  style="margin-right: 5px"
+                  v-if="isDefaultConfirmedTips && hasResetConfirmedTip"
+                >
+                </q-icon>
+                <q-btn
+                  label="再表示する"
+                  unelevated
+                  color="background"
+                  text-color="display"
+                  class="text-no-wrap q-mr-sm"
+                  @click="
+                    () => {
+                      store.dispatch('RESET_CONFIRMED_TIPS');
+                      hasResetConfirmedTip = true;
+                    }
+                  "
+                  :disable="isDefaultConfirmedTips"
+                >
+                </q-btn>
+              </q-card-actions>
             </q-card>
             <!-- Saving Card -->
             <q-card flat class="setting-card">
@@ -844,6 +884,14 @@ const activePointScrollModeOptions: Record<
 };
 
 const experimentalSetting = computed(() => store.state.experimentalSetting);
+
+// 表示済みのヒント
+const hasResetConfirmedTip = ref(false);
+
+const isDefaultConfirmedTips = computed(() => {
+  const confirmedTips = store.state.confirmedTips;
+  return Object.values(confirmedTips).every((v) => !v);
+});
 
 // 外観
 const currentThemeNameComputed = computed({

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -14,6 +14,7 @@ import {
   ThemeConf,
   ToolbarSetting,
   EngineId,
+  ConfirmedTips,
 } from "@/type/preload";
 
 const hotkeyFunctionCache: Record<string, () => HotkeyReturnType> = {};
@@ -343,6 +344,23 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
     action({ commit }, { confirmedTips }) {
       window.electron.setSetting("confirmedTips", confirmedTips);
       commit("SET_CONFIRMED_TIPS", { confirmedTips });
+    },
+  },
+
+  RESET_CONFIRMED_TIPS: {
+    async action({ state, dispatch }) {
+      const confirmedTips: { [key: string]: boolean } = {
+        ...state.confirmedTips,
+      };
+
+      // 全てのヒントを未確認にする
+      for (const key in confirmedTips) {
+        confirmedTips[key] = false;
+      }
+
+      dispatch("SET_CONFIRMED_TIPS", {
+        confirmedTips: confirmedTips as ConfirmedTips,
+      });
     },
   },
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1083,6 +1083,10 @@ export type SettingStoreTypes = {
     action(payload: { confirmedTips: ConfirmedTips }): void;
   };
 
+  RESET_CONFIRMED_TIPS: {
+    action(): void;
+  };
+
   SET_ENGINE_SETTING: {
     mutation: { engineSetting: EngineSetting; engineId: EngineId };
     action(payload: {


### PR DESCRIPTION
## 内容

現状,

- マウスホイールでの微調整ができること
- 代替ポート情報のトースト通知をする

などの表示済みのヒントを再表示する方法が, 設定ファイルをいじる以外ないので, 再表示するボタンを設定画面に追加します.

## 関連 Issue

ref: https://github.com/VOICEVOX/voicevox/pull/1317#discussion_r1198658272

## スクリーンショット・動画など

![image](https://github.com/VOICEVOX/voicevox/assets/86721991/c348fc35-c141-47cb-9f39-5a2555b3901c)


## その他
