### PR TITLE
適用中のプリセット名表示欄になぜか横幅制限があるので外す

### DIFF
--- a/src/components/AudioInfo.vue
+++ b/src/components/AudioInfo.vue
@@ -1184,6 +1184,5 @@ const adjustSliderValue = (
   overflow: hidden;
   text-overflow: ellipsis;
   width: fit-content;
-  max-width: 8rem;
 }
 </style>


### PR DESCRIPTION
## 内容

プリセット名表示欄になぜか横幅制限があったので外します。
AudioInfo欄を広げたときにプリセット欄に表示されるテキスト数も自動的に増えていたのですが、このスタイルの影響で１文字ほど表示されるテキスト数が少なくなっていそうでした。

（もしかしたらなにか意図があったのかも･･･？）

## 関連 Issue

@sevenc-nanashi さんのPRに不要なことを教えてもらいました。
https://github.com/VOICEVOX/voicevox_mobile/pull/24#discussion_r1199625833

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

こちらの @Segu-g さんのPRっぽみです。

- https://github.com/VOICEVOX/voicevox/pull/428/files#diff-21392cf965830cf5140c9f694b14d53ba51086d861e77b7a7b7a2f1384ed4e16R683

なにか覚えていらっしゃったりしたらコメント頂けると！！