### PR TITLE
Update: 音声書き出し成功時にトーストを表示 (#1329)

### DIFF
--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -135,22 +135,28 @@ const generateAndSaveOneAudio = async () => {
   await generateAndSaveOneAudioWithDialog({
     audioKey: activeAudioKey.value,
     quasarDialog: $q.dialog,
+    quasarNotify: $q.notify,
     dispatch: store.dispatch,
     encoding: store.state.savingSetting.fileEncoding,
+    confirmedTips: store.state.confirmedTips,
   });
 };
 const generateAndSaveAllAudio = async () => {
   await generateAndSaveAllAudioWithDialog({
     quasarDialog: $q.dialog,
+    quasarNotify: $q.notify,
     dispatch: store.dispatch,
     encoding: store.state.savingSetting.fileEncoding,
+    confirmedTips: store.state.confirmedTips,
   });
 };
 const generateAndConnectAndSaveAudio = async () => {
   await generateAndConnectAndSaveAudioWithDialog({
     quasarDialog: $q.dialog,
     dispatch: store.dispatch,
+    quasarNotify: $q.notify,
     encoding: store.state.savingSetting.fileEncoding,
+    confirmedTips: store.state.confirmedTips,
   });
 };
 const saveProject = async () => {

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -132,7 +132,9 @@ const generateAndSaveAllAudio = async () => {
   if (!uiLocked.value) {
     await generateAndSaveAllAudioWithDialog({
       encoding: store.state.savingSetting.fileEncoding,
+      confirmedTips: store.state.confirmedTips,
       quasarDialog: $q.dialog,
+      quasarNotify: $q.notify,
       dispatch: store.dispatch,
     });
   }
@@ -142,8 +144,10 @@ const generateAndConnectAndSaveAllAudio = async () => {
   if (!uiLocked.value) {
     await generateAndConnectAndSaveAudioWithDialog({
       quasarDialog: $q.dialog,
+      quasarNotify: $q.notify,
       dispatch: store.dispatch,
       encoding: store.state.savingSetting.fileEncoding,
+      confirmedTips: store.state.confirmedTips,
     });
   }
 };
@@ -169,6 +173,8 @@ const generateAndSaveOneAudio = async () => {
     audioKey: activeAudioKey,
     encoding: store.state.savingSetting.fileEncoding,
     quasarDialog: $q.dialog,
+    quasarNotify: $q.notify,
+    confirmedTips: store.state.confirmedTips,
     dispatch: store.dispatch,
   });
 };
@@ -177,8 +183,10 @@ const connectAndExportText = async () => {
   if (!uiLocked.value) {
     await connectAndExportTextWithDialog({
       quasarDialog: $q.dialog,
+      quasarNotify: $q.notify,
       dispatch: store.dispatch,
       encoding: store.state.savingSetting.fileEncoding,
+      confirmedTips: store.state.confirmedTips,
     });
   }
 };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -59,6 +59,7 @@ export const settingStoreState: SettingStoreState = {
   confirmedTips: {
     tweakableSliderByScroll: false,
     engineStartedOnAltPort: false,
+    notifyOnGenerateAudio: false,
   },
   engineSettings: {},
 };

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -497,6 +497,7 @@ export type SplitterPosition = z.infer<typeof splitterPositionSchema>;
 export type ConfirmedTips = {
   tweakableSliderByScroll: boolean;
   engineStartedOnAltPort: boolean; // エンジンのポート変更の通知
+  notifyOnGenerateAudio: boolean; // 音声書き出し時の通知
 };
 
 export const electronStoreSchema = z
@@ -587,6 +588,7 @@ export const electronStoreSchema = z
       .object({
         tweakableSliderByScroll: z.boolean().default(false),
         engineStartedOnAltPort: z.boolean().default(false),
+        notifyOnGenerateAudio: z.boolean().default(false),
       })
       .passthrough()
       .default({}),

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -137,6 +137,7 @@ describe("store/vuex.js test", () => {
         confirmedTips: {
           tweakableSliderByScroll: false,
           engineStartedOnAltPort: false,
+          notifyOnGenerateAudio: false,
         },
         progress: -1,
         isVuexReady: false,
@@ -255,5 +256,6 @@ describe("store/vuex.js test", () => {
     assert.propertyVal(store.state.splitterPosition, "portraitPaneWidth", 50);
     assert.equal(store.state.confirmedTips.tweakableSliderByScroll, false);
     assert.equal(store.state.confirmedTips.engineStartedOnAltPort, false);
+    assert.equal(store.state.confirmedTips.notifyOnGenerateAudio, false);
   });
 });


### PR DESCRIPTION
## 内容
音声・テキスト書き出し成功時にトーストを表示するよう変更しました。
トーストには `今後この通知をしない` ボタンを追加し、非表示に設定できるようにしています。

### 変更箇所
- メニュー
  - `音声書き出し` ボタン・書き出し成功時
  - `一つだけ書き出し` ボタン・書き出し成功時
  - `テキストを繋げて書き出し` ボタン・書き出し成功時
- ヘッダー
  - `１つ書き出し` ボタン・書き出し成功時

## 関連 Issue

ref #1329 

## スクリーンショット・動画など
![スクリーンショット 2023-06-11 163943](https://github.com/VOICEVOX/voicevox/assets/78523393/6e704364-b5e4-456f-a894-5bfb077c0cb5)

## その他
書き出し先を固定していなくても、成功時にはトーストを表示するようにしました。（書き出し先設定でフィードバックを出し分けするとユーザーが混乱するため）