### PR TITLE
Github Actionsでshell: bashを毎回書かなくても良いようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ env:
     |- # releaseタグ名か、workflow_dispatchでのバージョン名か、999.999.999-developが入る
     ${{ github.event.release.tag_name || github.event.inputs.version || '999.999.999-develop' }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-and-upload:
     environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment（false時の挙動は2022年7月10日時点で未定義動作）
@@ -124,7 +128,6 @@ jobs:
       #       so you need to install GNU sed.
       - name: Install GNU sed on macOS
         if: startsWith(matrix.os, 'macos-')
-        shell: bash
         run: |
           brew install gnu-sed
           echo "/usr/local/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
@@ -137,7 +140,6 @@ jobs:
       #       Files with the same name cannot be uploaded to a single GitHub Release,
       #       so different package/product names should be used for CPU/DirectML/GPU builds.
       - name: Replace package name & version
-        shell: bash
         run: |
           sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
           # sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
@@ -167,13 +169,7 @@ jobs:
             ${{ env.cache-version }}-${{ runner.os }}--electron-builder-cache-
 
       - name: Install dependencies
-        shell: bash
         run: npm ci
-
-      - name: Show disk space (debug info)
-        shell: bash
-        run: |
-          df -h
 
       - name: Checkout Product Version Resource
         uses: actions/checkout@v3
@@ -183,7 +179,6 @@ jobs:
           path: resource
 
       - name: Create and replace software resources
-        shell: bash
         run: |
           rm build/README.txt
           rm public/policy.md
@@ -199,31 +194,22 @@ jobs:
 
       - name: Overwrite .env.production for Linux and macOS
         if: startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-')
-        shell: bash
         run: |
           sed -i 's|run.exe|./run|g' .env.production
 
       - name: Replace .env.production infomations
-        shell: bash
         run: |
           # GTM ID
           gtm_id=$(jq -r '.gtm_container_id' resource/editor/metas.json)
           sed -i 's/VITE_GTM_CONTAINER_ID=.*/VITE_GTM_CONTAINER_ID='"$gtm_id"'/' .env.production
 
       - name: Generate public/licenses.json
-        shell: bash
         run: npm run license:generate -- -o public/licenses.json
-
-      - name: Show disk space (debug info)
-        shell: bash
-        run: |
-          df -h
 
       # build electronでコード署名するには環境変数を指定が必要だけど、
       # コード署名しない場合に環境変数を定義するとエラーになるので、動的に環境変数を足す
       - name: Define Code Signing Envs
         if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing == 'true'
-        shell: bash
         run: |
           # 複数行の文字列を環境変数に代入
           echo 'CSC_LINK<<EOF' >> $GITHUB_ENV
@@ -234,7 +220,6 @@ jobs:
 
       # Build result will be exported to ${{ matrix.artifact_path }}
       - name: Build Electron
-        shell: bash
         env:
           NSIS_WEB_ARTIFACT_NAME: ${{ matrix.nsis_web_artifact_name }}
           LINUX_ARTIFACT_NAME: ${{ matrix.linux_artifact_name }}
@@ -247,13 +232,11 @@ jobs:
 
       - name: Reset Code Signing Envs
         if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing == 'true'
-        shell: bash
         run: |
           echo 'CSC_LINK=' >> $GITHUB_ENV
           echo 'CSC_KEY_PASSWORD=' >> $GITHUB_ENV
 
       - name: Rename NoEngine Prepackage
-        shell: bash
         run: |
           mv ${{ matrix.artifact_path }} ./prepackage
 
@@ -268,7 +251,6 @@ jobs:
 
       # FIXME: asarをextract/packせず、ビルド前にengine_licenses.jsonとlicenses.jsonを結合する
       - name: Merge licenses.json (ENGINE, VOICEVOX)
-        shell: bash
         run: |
           # Unpack asar
           npx asar extract "${{ matrix.app_asar_dir }}/app.asar" "${{ matrix.app_asar_dir }}/app"
@@ -283,33 +265,24 @@ jobs:
 
       - name: Merge VOICEVOX ENGINE into prepackage/
         if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'linux-')
-        shell: bash
         run: |
           mv voicevox_engine/* prepackage/
           rm -rf voicevox_engine
 
       - name: Merge VOICEVOX ENGINE into prepackage/VOICEVOX.app/Contents/MacOS/
         if: startsWith(matrix.artifact_name, 'macos-')
-        shell: bash
         run: |
           mv voicevox_engine/* prepackage/VOICEVOX.app/Contents/MacOS/
           rm -rf voicevox_engine
 
-      - name: Show disk space (debug info)
-        shell: bash
-        run: |
-          df -h
-
       - name: Recover file permissions
         if: startsWith(matrix.artifact_name, 'linux-') # linux
-        shell: bash
         run: |
           chmod +x "prepackage/${{ matrix.linux_executable_name }}"
           chmod +x "prepackage/run"
 
       - name: Recover file permissions for macOS build
         if: startsWith(matrix.artifact_name, 'macos-') # macOS
-        shell: bash
         run: |
           chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/${{ matrix.macos_executable_name }}"
           chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/run"
@@ -322,12 +295,10 @@ jobs:
       #       Make `ja.lproj` directory because it is necessary for Japanese localization on macOS.
       - name: Make .lproj directories in Resources directory of VOICEVOX.app
         if: startsWith(matrix.artifact_name, 'macos-')
-        shell: bash
         run: mkdir -p prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
 
       - name: Create Linux tar.gz (without nvidia)
         if: startsWith(matrix.artifact_name, 'linux-') && !contains(matrix.artifact_name, 'nvidia')
-        shell: bash
         run: |
           name="${{ matrix.compressed_artifact_name }}-${{ env.VOICEVOX_EDITOR_VERSION }}"
           7z a -ttar $name.tar prepackage/
@@ -355,13 +326,11 @@ jobs:
 
       - name: Delete Linux tar.gz (without nvidia)
         if: startsWith(matrix.artifact_name, 'linux-') && !contains(matrix.artifact_name, 'nvidia')
-        shell: bash
         run: |
           rm ${{ matrix.compressed_artifact_name }}-${{ env.VOICEVOX_EDITOR_VERSION }}.tar.gz
 
       - name: Create Windows & Mac zip (without nvidia)
         if: (startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'macos-')) && !contains(matrix.artifact_name, 'nvidia')
-        shell: bash
         run: |
           name="${{ matrix.compressed_artifact_name }}-${{ env.VOICEVOX_EDITOR_VERSION }}"
           7z a -tzip $name.zip prepackage/
@@ -387,20 +356,13 @@ jobs:
 
       - name: Delete Windows & Mac zip (without nvidia)
         if: (startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'macos-')) && !contains(matrix.artifact_name, 'nvidia')
-        shell: bash
         run: |
           rm ${{ matrix.compressed_artifact_name }}-${{ env.VOICEVOX_EDITOR_VERSION }}.zip
-
-      - name: Show disk space (debug info)
-        shell: bash
-        run: |
-          df -h
 
       # build electronでコード署名するには環境変数を指定が必要だけど、
       # コード署名しない場合に環境変数を定義するとエラーになるので、動的に環境変数を足す
       - name: Define Code Signing Envs
         if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing == 'true'
-        shell: bash
         run: |
           # 複数行の文字列を環境変数に代入
           echo 'CSC_LINK<<EOF' >> $GITHUB_ENV
@@ -412,7 +374,6 @@ jobs:
       # NOTE: prepackage can be removed before splitting nsis-web archive
       - name: Build Electron
         if: endsWith(matrix.installer_artifact_name, '-nsis-web') || endsWith(matrix.installer_artifact_name, '-appimage') # windows and linux
-        shell: bash
         env:
           NSIS_WEB_ARTIFACT_NAME: ${{ matrix.nsis_web_artifact_name }}
           LINUX_ARTIFACT_NAME: ${{ matrix.linux_artifact_name }}
@@ -422,7 +383,6 @@ jobs:
 
       - name: Build Electron (for macOS)
         if: endsWith(matrix.installer_artifact_name, '-dmg') # macOS
-        shell: bash
         env:
           MACOS_ARTIFACT_NAME: ${{ matrix.macos_artifact_name }}
         run: |
@@ -430,19 +390,12 @@ jobs:
 
       - name: Reset Code Signing Envs
         if: startsWith(matrix.os, 'windows-') && github.event.inputs.code_signing == 'true'
-        shell: bash
         run: |
           echo 'CSC_LINK=' >> $GITHUB_ENV
           echo 'CSC_KEY_PASSWORD=' >> $GITHUB_ENV
 
-      - name: Show disk space (debug info)
-        shell: bash
-        run: |
-          df -h
-
       - name: Create Linux AppImage split
         if: endsWith(matrix.installer_artifact_name, '-appimage')
-        shell: bash
         run: |
           cd dist_electron/
 
@@ -500,7 +453,6 @@ jobs:
 
       - name: Create Windows NSIS Web artifact directory
         if: endsWith(matrix.installer_artifact_name, '-nsis-web')
-        shell: bash
         run: |
           mkdir -p nsis-web-artifact
           mv dist_electron/nsis-web/out/*.7z.* nsis-web-artifact/
@@ -509,7 +461,6 @@ jobs:
       # Rename file name like "VOICEVOX Web Setup X.X.X.exe" to "VOICEVOX.Web.Setup.X.X.X.exe".
       - name: Rename Windows NSIS Web Installer
         if: endsWith(matrix.installer_artifact_name, '-nsis-web')
-        shell: bash
         run: |
           cd nsis-web-artifact
           OLD_NAME=`find . -maxdepth 1 -name '*.exe'`

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -7,6 +7,10 @@ on:
       - "/package.json"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+    
 jobs:
   check_node_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
 env:
   VOICEVOX_ENGINE_VERSION: 0.14.4
 
+defaults:
+  run:
+    shell: bash
+    
 jobs:
   build-test:
     runs-on: windows-latest
@@ -36,7 +40,6 @@ jobs:
           dest: ${{ github.workspace }}/voicevox_engine
 
       - name: Run npm run test:e2e
-        shell: bash
         run: |
           cp .env.test .env
           sed -i -e 's|"../voicevox_engine/run.exe"|"${{ steps.download-engine.outputs.run_path }}"|' .env

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  typos:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,6 +7,10 @@ on:
       - '**'
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+    
 jobs:
   typos:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 内容

`shell: bash`を不要にできるオプションがあったので指定してみました。
とりあえずubuntu以外でのOSで実行していたworkflowにのみ付けています。
https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun

ついでにディスク容量の心配がなくなっていたので`df -h`を消してみました。

2023/06/19 14:30追記
shell: bashを付けるか付けないかでubuntu/mac上の挙動が変わり、かつ付けたときのほうが良さそうなので全部に付けました。