### PR TITLE
バグ修正、editorFontの同期ができてなかった

### DIFF
--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -86,6 +86,10 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         });
       }
 
+      dispatch("SET_EDITOR_FONT", {
+        editorFont: await window.electron.getSetting("editorFont"),
+      });
+
       dispatch("SET_SHOW_TEXT_LINE_NUMBER", {
         showTextLineNumber: await window.electron.getSetting(
           "showTextLineNumber"


### PR DESCRIPTION
## 内容

editorFontの同期ができてなかったののバグ修正です。
フォント設定が毎回リセットされる感じになります。

ref: https://twitter.com/mayA9896/status/1670167566537621504
