### PR TITLE
Refactor: `src/components/Dialog.ts` の引数を変更

### DIFF
--- a/src/components/Dialog.ts
+++ b/src/components/Dialog.ts
@@ -1,9 +1,5 @@
 import { QVueGlobals } from "quasar";
-import {
-  AudioKey,
-  ConfirmedTips,
-  Encoding as EncodingType,
-} from "@/type/preload";
+import { AudioKey, Encoding as EncodingType } from "@/type/preload";
 import {
   AllActions,
   SaveResultObject,
@@ -23,7 +19,7 @@ export async function generateAndSaveOneAudioWithDialog({
   dispatch,
   filePath,
   encoding,
-  confirmedTips,
+  notifyOnGenerateAudio,
 }: {
   audioKey: AudioKey;
   quasarDialog: QuasarDialog;
@@ -31,7 +27,7 @@ export async function generateAndSaveOneAudioWithDialog({
   dispatch: Dispatch<AllActions>;
   filePath?: string;
   encoding?: EncodingType;
-  confirmedTips: ConfirmedTips;
+  notifyOnGenerateAudio: boolean;
 }): Promise<void> {
   const result: SaveResultObject = await withProgress(
     dispatch("GENERATE_AND_SAVE_AUDIO", {
@@ -46,7 +42,7 @@ export async function generateAndSaveOneAudioWithDialog({
 
   if (result.result === "SUCCESS") {
     // "今後この通知をしない" 有効時
-    if (confirmedTips.notifyOnGenerateAudio) return;
+    if (notifyOnGenerateAudio) return;
 
     // 書き出し成功時に通知をする
     quasarNotify({
@@ -60,9 +56,8 @@ export async function generateAndSaveOneAudioWithDialog({
           label: "今後この通知をしない",
           textColor: "toast-button-display",
           handler: () => {
-            dispatch("SET_CONFIRMED_TIPS", {
-              confirmedTips: {
-                ...confirmedTips,
+            dispatch("SET_CONFIRMED_TIP", {
+              confirmedTip: {
                 notifyOnGenerateAudio: true,
               },
             });
@@ -109,14 +104,14 @@ export async function generateAndSaveAllAudioWithDialog({
   dispatch,
   dirPath,
   encoding,
-  confirmedTips,
+  notifyOnGenerateAudio,
 }: {
   quasarDialog: QuasarDialog;
   quasarNotify: QuasarNotify;
   dispatch: Dispatch<AllActions>;
   dirPath?: string;
   encoding?: EncodingType;
-  confirmedTips: ConfirmedTips;
+  notifyOnGenerateAudio: boolean;
 }): Promise<void> {
   const result = await withProgress(
     dispatch("GENERATE_AND_SAVE_ALL_AUDIO", {
@@ -160,7 +155,7 @@ export async function generateAndSaveAllAudioWithDialog({
 
   if (successArray.length === result?.length) {
     // "今後この通知をしない" 有効時
-    if (confirmedTips.notifyOnGenerateAudio) return;
+    if (notifyOnGenerateAudio) return;
 
     // 書き出し成功時に通知をする
     quasarNotify({
@@ -174,9 +169,8 @@ export async function generateAndSaveAllAudioWithDialog({
           label: "今後この通知をしない",
           textColor: "toast-button-display",
           handler: () => {
-            dispatch("SET_CONFIRMED_TIPS", {
-              confirmedTips: {
-                ...confirmedTips,
+            dispatch("SET_CONFIRMED_TIP", {
+              confirmedTip: {
                 notifyOnGenerateAudio: true,
               },
             });
@@ -204,14 +198,14 @@ export async function generateAndConnectAndSaveAudioWithDialog({
   dispatch,
   filePath,
   encoding,
-  confirmedTips,
+  notifyOnGenerateAudio,
 }: {
   quasarDialog: QuasarDialog;
   quasarNotify: QuasarNotify;
   dispatch: Dispatch<AllActions>;
   filePath?: string;
   encoding?: EncodingType;
-  confirmedTips: ConfirmedTips;
+  notifyOnGenerateAudio: boolean;
 }): Promise<void> {
   const result = await withProgress(
     dispatch("GENERATE_AND_CONNECT_AND_SAVE_AUDIO", {
@@ -227,7 +221,7 @@ export async function generateAndConnectAndSaveAudioWithDialog({
 
   if (result.result === "SUCCESS") {
     // "今後この通知をしない" 有効時
-    if (confirmedTips.notifyOnGenerateAudio) return;
+    if (notifyOnGenerateAudio) return;
 
     // 書き出し成功時に通知をする
     quasarNotify({
@@ -241,9 +235,8 @@ export async function generateAndConnectAndSaveAudioWithDialog({
           label: "今後この通知をしない",
           textColor: "toast-button-display",
           handler: () => {
-            dispatch("SET_CONFIRMED_TIPS", {
-              confirmedTips: {
-                ...confirmedTips,
+            dispatch("SET_CONFIRMED_TIP", {
+              confirmedTip: {
                 notifyOnGenerateAudio: true,
               },
             });
@@ -290,14 +283,14 @@ export async function connectAndExportTextWithDialog({
   dispatch,
   filePath,
   encoding,
-  confirmedTips,
+  notifyOnGenerateAudio,
 }: {
   quasarDialog: QuasarDialog;
   quasarNotify: QuasarNotify;
   dispatch: Dispatch<AllActions>;
   filePath?: string;
   encoding?: EncodingType;
-  confirmedTips: ConfirmedTips;
+  notifyOnGenerateAudio: boolean;
 }): Promise<void> {
   const result = await dispatch("CONNECT_AND_EXPORT_TEXT", {
     filePath,
@@ -308,7 +301,7 @@ export async function connectAndExportTextWithDialog({
 
   if (result.result === "SUCCESS") {
     // "今後この通知をしない" 有効時
-    if (confirmedTips.notifyOnGenerateAudio) return;
+    if (notifyOnGenerateAudio) return;
 
     // 書き出し成功時に通知をする
     quasarNotify({
@@ -322,9 +315,8 @@ export async function connectAndExportTextWithDialog({
           label: "今後この通知をしない",
           textColor: "toast-button-display",
           handler: () => {
-            dispatch("SET_CONFIRMED_TIPS", {
-              confirmedTips: {
-                ...confirmedTips,
+            dispatch("SET_CONFIRMED_TIP", {
+              confirmedTip: {
                 notifyOnGenerateAudio: true,
               },
             });

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -138,7 +138,7 @@ const generateAndSaveOneAudio = async () => {
     quasarNotify: $q.notify,
     dispatch: store.dispatch,
     encoding: store.state.savingSetting.fileEncoding,
-    confirmedTips: store.state.confirmedTips,
+    notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
   });
 };
 const generateAndSaveAllAudio = async () => {
@@ -147,7 +147,7 @@ const generateAndSaveAllAudio = async () => {
     quasarNotify: $q.notify,
     dispatch: store.dispatch,
     encoding: store.state.savingSetting.fileEncoding,
-    confirmedTips: store.state.confirmedTips,
+    notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
   });
 };
 const generateAndConnectAndSaveAudio = async () => {
@@ -156,7 +156,7 @@ const generateAndConnectAndSaveAudio = async () => {
     dispatch: store.dispatch,
     quasarNotify: $q.notify,
     encoding: store.state.savingSetting.fileEncoding,
-    confirmedTips: store.state.confirmedTips,
+    notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
   });
 };
 const saveProject = async () => {

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -132,7 +132,7 @@ const generateAndSaveAllAudio = async () => {
   if (!uiLocked.value) {
     await generateAndSaveAllAudioWithDialog({
       encoding: store.state.savingSetting.fileEncoding,
-      confirmedTips: store.state.confirmedTips,
+      notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
       quasarDialog: $q.dialog,
       quasarNotify: $q.notify,
       dispatch: store.dispatch,
@@ -147,7 +147,7 @@ const generateAndConnectAndSaveAllAudio = async () => {
       quasarNotify: $q.notify,
       dispatch: store.dispatch,
       encoding: store.state.savingSetting.fileEncoding,
-      confirmedTips: store.state.confirmedTips,
+      notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
     });
   }
 };
@@ -174,7 +174,7 @@ const generateAndSaveOneAudio = async () => {
     encoding: store.state.savingSetting.fileEncoding,
     quasarDialog: $q.dialog,
     quasarNotify: $q.notify,
-    confirmedTips: store.state.confirmedTips,
+    notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
     dispatch: store.dispatch,
   });
 };
@@ -186,7 +186,7 @@ const connectAndExportText = async () => {
       quasarNotify: $q.notify,
       dispatch: store.dispatch,
       encoding: store.state.savingSetting.fileEncoding,
-      confirmedTips: store.state.confirmedTips,
+      notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
     });
   }
 };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -348,6 +348,19 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
     },
   },
 
+  SET_CONFIRMED_TIP: {
+    action({ state, dispatch }, { confirmedTip }) {
+      const confirmedTips = {
+        ...state.confirmedTips,
+        ...confirmedTip,
+      };
+
+      dispatch("SET_CONFIRMED_TIPS", {
+        confirmedTips: confirmedTips as ConfirmedTips,
+      });
+    },
+  },
+
   RESET_CONFIRMED_TIPS: {
     async action({ state, dispatch }) {
       const confirmedTips: { [key: string]: boolean } = {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1090,6 +1090,10 @@ export type SettingStoreTypes = {
     action(payload: { confirmedTips: ConfirmedTips }): void;
   };
 
+  SET_CONFIRMED_TIP: {
+    action(payload: { confirmedTip: Partial<ConfirmedTips> }): void;
+  };
+
   RESET_CONFIRMED_TIPS: {
     action(): void;
   };


### PR DESCRIPTION
## 内容

### 概要

#1335 での実装では引数に `confirmedTips` を利用しており関数の役割が明確でない状態でした。
今回の改修では `Dialog.ts` で `confirmedTips` を参照せずに `notifyOnGenerateAudio` を更新できるよう、 `SET_CONFIRMED_TIP` を作成しています。

```typescript
// 変更前
dispatch("SET_CONFIRMED_TIPS", {
    confirmedTips: {
        ...confirmedTips, // この部分ために引数で受け取る必要があった
        notifyOnGenerateAudio: true,
    },
});

// 変更後
dispatch("SET_CONFIRMED_TIP", {
    confirmedTip: {
        notifyOnGenerateAudio: true,
    },
});
```
### 関連コメント
https://github.com/VOICEVOX/voicevox/pull/1335#discussion_r1228905078

### 変更
- `src/store/setting.ts` に `SET_CONFIRMED_TIP` を追加
-  `src/components/Dialog.ts` 内の関数で受け取る引数を `notifyOnGenerateAudio` に変更

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

ref #1329

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
別でIssueとして上がっている `Dialog.ts` の処理共通化とは別のタスクとしてPR出しました。
そのため、変更差分が内容に対して少し大きくなってしまっています。。。