### PR TITLE
publicディレクトリに配置しているファイルのファイル名を定数に切り出す

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -40,11 +40,11 @@ import {
   ContactTextFileName,
   HowToUseTextFileName,
   OssCommunityInfosFileName,
-  OssLicensesFileName,
+  OssLicensesJsonFileName,
   PolicyTextFileName,
   PrivacyPolicyTextFileName,
   QAndATextFileName,
-  UpdateInfosFileName,
+  UpdateInfosJsonFileName,
 } from "./type/staticResources";
 
 import EngineManager from "./background/engineManager";
@@ -360,7 +360,7 @@ const policyText = fs.readFileSync(
 
 // OSSライセンス情報の読み込み
 const ossLicenses = JSON.parse(
-  fs.readFileSync(path.join(__static, OssLicensesFileName), {
+  fs.readFileSync(path.join(__static, OssLicensesJsonFileName), {
     encoding: "utf-8",
   })
 );
@@ -379,7 +379,7 @@ const qAndAText = fs.readFileSync(
 
 // アップデート情報の読み込み
 const updateInfos = JSON.parse(
-  fs.readFileSync(path.join(__static, UpdateInfosFileName), {
+  fs.readFileSync(path.join(__static, UpdateInfosJsonFileName), {
     encoding: "utf-8",
   })
 );

--- a/src/background.ts
+++ b/src/background.ts
@@ -36,6 +36,16 @@ import {
   engineSettingSchema,
   EngineId,
 } from "./type/preload";
+import {
+  ContactTextFileName,
+  HowToUseTextFileName,
+  OssCommunityInfosFileName,
+  OssLicensesFileName,
+  PolicyTextFileName,
+  PrivacyPolicyTextFileName,
+  QAndATextFileName,
+  UpdateInfosFileName,
+} from "./type/staticResources";
 
 import EngineManager from "./background/engineManager";
 import VvppManager, { isVvppFile } from "./background/vvppManager";
@@ -332,39 +342,50 @@ if (!fs.existsSync(tempDir)) {
 
 // 使い方テキストの読み込み
 const howToUseText = fs.readFileSync(
-  path.join(__static, "howtouse.md"),
+  path.join(__static, HowToUseTextFileName),
   "utf-8"
 );
 
 // OSSコミュニティ情報の読み込み
 const ossCommunityInfos = fs.readFileSync(
-  path.join(__static, "ossCommunityInfos.md"),
+  path.join(__static, OssCommunityInfosFileName),
   "utf-8"
 );
 
 // 利用規約テキストの読み込み
-const policyText = fs.readFileSync(path.join(__static, "policy.md"), "utf-8");
+const policyText = fs.readFileSync(
+  path.join(__static, PolicyTextFileName),
+  "utf-8"
+);
 
 // OSSライセンス情報の読み込み
 const ossLicenses = JSON.parse(
-  fs.readFileSync(path.join(__static, "licenses.json"), { encoding: "utf-8" })
+  fs.readFileSync(path.join(__static, OssLicensesFileName), {
+    encoding: "utf-8",
+  })
 );
 
 // 問い合わせの読み込み
-const contactText = fs.readFileSync(path.join(__static, "contact.md"), "utf-8");
+const contactText = fs.readFileSync(
+  path.join(__static, ContactTextFileName),
+  "utf-8"
+);
 
 // Q&Aの読み込み
-const qAndAText = fs.readFileSync(path.join(__static, "qAndA.md"), "utf-8");
+const qAndAText = fs.readFileSync(
+  path.join(__static, QAndATextFileName),
+  "utf-8"
+);
 
 // アップデート情報の読み込み
 const updateInfos = JSON.parse(
-  fs.readFileSync(path.join(__static, "updateInfos.json"), {
+  fs.readFileSync(path.join(__static, UpdateInfosFileName), {
     encoding: "utf-8",
   })
 );
 
 const privacyPolicyText = fs.readFileSync(
-  path.join(__static, "privacyPolicy.md"),
+  path.join(__static, PrivacyPolicyTextFileName),
   "utf-8"
 );
 

--- a/src/type/staticResources.ts
+++ b/src/type/staticResources.ts
@@ -1,0 +1,8 @@
+export const HowToUseTextFileName = "howtouse.md";
+export const OssCommunityInfosFileName = "ossCommunityInfos.md";
+export const PolicyTextFileName = "policy.md";
+export const OssLicensesFileName = "licenses.json";
+export const ContactTextFileName = "contact.md";
+export const QAndATextFileName = "qAndA.md";
+export const UpdateInfosFileName = "updateInfos.json";
+export const PrivacyPolicyTextFileName = "privacyPolicy.md";

--- a/src/type/staticResources.ts
+++ b/src/type/staticResources.ts
@@ -1,8 +1,8 @@
 export const HowToUseTextFileName = "howtouse.md";
 export const OssCommunityInfosFileName = "ossCommunityInfos.md";
 export const PolicyTextFileName = "policy.md";
-export const OssLicensesFileName = "licenses.json";
+export const OssLicensesJsonFileName = "licenses.json";
 export const ContactTextFileName = "contact.md";
 export const QAndATextFileName = "qAndA.md";
-export const UpdateInfosFileName = "updateInfos.json";
+export const UpdateInfosJsonFileName = "updateInfos.json";
 export const PrivacyPolicyTextFileName = "privacyPolicy.md";


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

ブラウザ版の実装にあたり、public に配置しているファイルの読み込み処理の実装が必要になった。
もしも public に配置しているファイル名が変わった場合、2箇所の変更が必要になるため、定数に切り出し、その値を使うようにリファクタリングを行った。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

ref https://github.com/VOICEVOX/voicevox/issues/1204

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
