### PR TITLE
Refactor: `src/components/Dialog.ts` をリファクタ

### DIFF
--- a/src/components/Dialog.ts
+++ b/src/components/Dialog.ts
@@ -3,6 +3,7 @@ import { AudioKey, Encoding as EncodingType } from "@/type/preload";
 import {
   AllActions,
   SaveResultObject,
+  SaveResult,
   ErrorTypeForSaveAllResultDialog,
 } from "@/store/type";
 import SaveAllResultDialog from "@/components/SaveAllResultDialog.vue";
@@ -49,37 +50,9 @@ export async function generateAndSaveOneAudioWithDialog({
       quasarNotify,
       dispatch,
     });
-    return;
+  } else {
+    showDialog({ mediaType: "audio", result, quasarDialog });
   }
-
-  let msg = "";
-
-  switch (result.result) {
-    case "WRITE_ERROR":
-      if (result.errorMessage) {
-        msg = result.errorMessage;
-      } else {
-        msg = "何らかの理由で書き出しに失敗しました。ログを参照してください。";
-      }
-      break;
-    case "ENGINE_ERROR":
-      if (result.errorMessage) {
-        msg = result.errorMessage;
-      } else {
-        msg =
-          "エンジンのエラーによって失敗しました。エンジンの再起動をお試しください。";
-      }
-      break;
-  }
-  quasarDialog({
-    title: "書き出しに失敗しました。",
-    message: msg,
-    ok: {
-      label: "閉じる",
-      flat: true,
-      textColor: "secondary",
-    },
-  });
 }
 
 export async function generateAndSaveAllAudioWithDialog({
@@ -107,37 +80,30 @@ export async function generateAndSaveAllAudioWithDialog({
     dispatch
   );
 
-  const successArray: Array<string | undefined> = [];
-  const writeErrorArray: Array<ErrorTypeForSaveAllResultDialog> = [];
-  const engineErrorArray: Array<ErrorTypeForSaveAllResultDialog> = [];
+  if (result === undefined) return;
 
-  if (result) {
-    for (const item of result) {
-      let msg = "";
-      if (item.errorMessage) {
-        msg = item.errorMessage;
-      }
+  // 書き出し成功時の出力先パスを配列に格納
+  const successArray: Array<string | undefined> = result.flatMap((result) =>
+    result.result === "SUCCESS" ? result.path : []
+  );
 
-      let path = "";
-      if (item.path) {
-        path = item.path;
-      }
+  // 書き込みエラーを配列に格納
+  const writeErrorArray: Array<ErrorTypeForSaveAllResultDialog> =
+    result.flatMap((result) =>
+      result.result === "WRITE_ERROR"
+        ? { path: result.path ?? "", message: result.errorMessage ?? "" }
+        : []
+    );
 
-      switch (item.result) {
-        case "SUCCESS":
-          successArray.push(path);
-          break;
-        case "WRITE_ERROR":
-          writeErrorArray.push({ path: path, message: msg });
-          break;
-        case "ENGINE_ERROR":
-          engineErrorArray.push({ path: path, message: msg });
-          break;
-      }
-    }
-  }
+  // エンジンエラーを配列に格納
+  const engineErrorArray: Array<ErrorTypeForSaveAllResultDialog> =
+    result.flatMap((result) =>
+      result.result === "ENGINE_ERROR"
+        ? { path: result.path ?? "", message: result.errorMessage ?? "" }
+        : []
+    );
 
-  if (successArray.length === result?.length) {
+  if (successArray.length === result.length) {
     // 書き出し成功時に通知をする
     showNotify({
       mediaType: "audio",
@@ -187,44 +153,15 @@ export async function generateAndConnectAndSaveAudioWithDialog({
   if (result === undefined || result.result === "CANCELED") return;
 
   if (result.result === "SUCCESS") {
-    // 書き出し成功時に通知をする
     showNotify({
       mediaType: "audio",
       notifyOnGenerateAudio,
       quasarNotify,
       dispatch,
     });
-    return;
+  } else {
+    showDialog({ mediaType: "audio", result, quasarDialog });
   }
-
-  let msg = "";
-  switch (result.result) {
-    case "WRITE_ERROR":
-      if (result.errorMessage != undefined) {
-        msg = result.errorMessage;
-      } else {
-        msg = "何らかの理由で書き出しに失敗しました。ログを参照してください。";
-      }
-      break;
-    case "ENGINE_ERROR":
-      if (result.errorMessage != undefined) {
-        msg = result.errorMessage;
-      } else {
-        msg =
-          "エンジンのエラーによって失敗しました。エンジンの再起動をお試しください。";
-      }
-      break;
-  }
-
-  quasarDialog({
-    title: "書き出しに失敗しました。",
-    message: msg,
-    ok: {
-      label: "閉じる",
-      flat: true,
-      textColor: "secondary",
-    },
-  });
 }
 
 export async function connectAndExportTextWithDialog({
@@ -256,26 +193,9 @@ export async function connectAndExportTextWithDialog({
       quasarNotify,
       dispatch,
     });
-    return;
+  } else {
+    showDialog({ mediaType: "text", result, quasarDialog });
   }
-
-  let msg = "";
-  switch (result.result) {
-    case "WRITE_ERROR":
-      msg =
-        "書き込みエラーによって失敗しました。空き容量があることや、書き込み権限があることをご確認ください。";
-      break;
-  }
-
-  quasarDialog({
-    title: "テキストの書き出しに失敗しました。",
-    message: msg,
-    ok: {
-      label: "閉じる",
-      flat: true,
-      textColor: "secondary",
-    },
-  });
 }
 
 // 成功時の通知を表示
@@ -317,5 +237,49 @@ const showNotify = ({
         },
       },
     ],
+  });
+};
+
+// 書き出し失敗時のダイアログを表示
+const showDialog = ({
+  mediaType,
+  result,
+  quasarDialog,
+}: {
+  mediaType: MediaType;
+  result: SaveResultObject;
+  quasarDialog: QuasarDialog;
+}) => {
+  if (result.result === "WRITE_ERROR" && mediaType === "text") {
+    // テキスト書き出し時のエラーを出力
+    quasarDialog({
+      title: "テキストの書き出しに失敗しました。",
+      message:
+        "書き込みエラーによって失敗しました。空き容量があることや、書き込み権限があることをご確認ください。",
+      ok: {
+        label: "閉じる",
+        flat: true,
+        textColor: "secondary",
+      },
+    });
+    return;
+  }
+
+  const defaultErrorMessages: Partial<Record<SaveResult, string>> = {
+    WRITE_ERROR:
+      "何らかの理由で書き出しに失敗しました。ログを参照してください。",
+    ENGINE_ERROR:
+      "エンジンのエラーによって失敗しました。エンジンの再起動をお試しください。",
+  };
+
+  // 音声書き出し時のエラーを出力
+  quasarDialog({
+    title: "書き出しに失敗しました。",
+    message: result.errorMessage ?? defaultErrorMessages[result.result],
+    ok: {
+      label: "閉じる",
+      flat: true,
+      textColor: "secondary",
+    },
   });
 };

--- a/src/components/Dialog.ts
+++ b/src/components/Dialog.ts
@@ -11,6 +11,7 @@ import { withProgress } from "@/store/ui";
 
 type QuasarDialog = QVueGlobals["dialog"];
 type QuasarNotify = QVueGlobals["notify"];
+type MediaType = "audio" | "text";
 
 export async function generateAndSaveOneAudioWithDialog({
   audioKey,
@@ -41,29 +42,12 @@ export async function generateAndSaveOneAudioWithDialog({
   if (result.result === "CANCELED") return;
 
   if (result.result === "SUCCESS") {
-    // "今後この通知をしない" 有効時
-    if (notifyOnGenerateAudio) return;
-
     // 書き出し成功時に通知をする
-    quasarNotify({
-      message: "音声を書き出しました",
-      color: "toast",
-      textColor: "toast-display",
-      icon: "info",
-      timeout: 5000,
-      actions: [
-        {
-          label: "今後この通知をしない",
-          textColor: "toast-button-display",
-          handler: () => {
-            dispatch("SET_CONFIRMED_TIP", {
-              confirmedTip: {
-                notifyOnGenerateAudio: true,
-              },
-            });
-          },
-        },
-      ],
+    showNotify({
+      mediaType: "audio",
+      notifyOnGenerateAudio,
+      quasarNotify,
+      dispatch,
     });
     return;
   }
@@ -154,29 +138,12 @@ export async function generateAndSaveAllAudioWithDialog({
   }
 
   if (successArray.length === result?.length) {
-    // "今後この通知をしない" 有効時
-    if (notifyOnGenerateAudio) return;
-
     // 書き出し成功時に通知をする
-    quasarNotify({
-      message: "音声を書き出しました",
-      color: "toast",
-      textColor: "toast-display",
-      icon: "info",
-      timeout: 5000,
-      actions: [
-        {
-          label: "今後この通知をしない",
-          textColor: "toast-button-display",
-          handler: () => {
-            dispatch("SET_CONFIRMED_TIP", {
-              confirmedTip: {
-                notifyOnGenerateAudio: true,
-              },
-            });
-          },
-        },
-      ],
+    showNotify({
+      mediaType: "audio",
+      notifyOnGenerateAudio,
+      quasarNotify,
+      dispatch,
     });
   }
 
@@ -220,29 +187,12 @@ export async function generateAndConnectAndSaveAudioWithDialog({
   if (result === undefined || result.result === "CANCELED") return;
 
   if (result.result === "SUCCESS") {
-    // "今後この通知をしない" 有効時
-    if (notifyOnGenerateAudio) return;
-
     // 書き出し成功時に通知をする
-    quasarNotify({
-      message: "音声を書き出しました",
-      color: "toast",
-      textColor: "toast-display",
-      icon: "info",
-      timeout: 5000,
-      actions: [
-        {
-          label: "今後この通知をしない",
-          textColor: "toast-button-display",
-          handler: () => {
-            dispatch("SET_CONFIRMED_TIP", {
-              confirmedTip: {
-                notifyOnGenerateAudio: true,
-              },
-            });
-          },
-        },
-      ],
+    showNotify({
+      mediaType: "audio",
+      notifyOnGenerateAudio,
+      quasarNotify,
+      dispatch,
     });
     return;
   }
@@ -300,29 +250,11 @@ export async function connectAndExportTextWithDialog({
   if (result === undefined || result.result === "CANCELED") return;
 
   if (result.result === "SUCCESS") {
-    // "今後この通知をしない" 有効時
-    if (notifyOnGenerateAudio) return;
-
-    // 書き出し成功時に通知をする
-    quasarNotify({
-      message: "テキストを書き出しました",
-      color: "toast",
-      textColor: "toast-display",
-      icon: "info",
-      timeout: 5000,
-      actions: [
-        {
-          label: "今後この通知をしない",
-          textColor: "toast-button-display",
-          handler: () => {
-            dispatch("SET_CONFIRMED_TIP", {
-              confirmedTip: {
-                notifyOnGenerateAudio: true,
-              },
-            });
-          },
-        },
-      ],
+    showNotify({
+      mediaType: "text",
+      notifyOnGenerateAudio,
+      quasarNotify,
+      dispatch,
     });
     return;
   }
@@ -345,3 +277,45 @@ export async function connectAndExportTextWithDialog({
     },
   });
 }
+
+// 成功時の通知を表示
+const showNotify = ({
+  mediaType,
+  notifyOnGenerateAudio,
+  quasarNotify,
+  dispatch,
+}: {
+  mediaType: MediaType;
+  notifyOnGenerateAudio: boolean;
+  quasarNotify: QuasarNotify;
+  dispatch: Dispatch<AllActions>;
+}): void => {
+  // "今後この通知をしない" 有効時
+  if (notifyOnGenerateAudio) return;
+
+  const mediaTypeNames: Record<MediaType, string> = {
+    audio: "音声",
+    text: "テキスト",
+  };
+
+  quasarNotify({
+    message: `${mediaTypeNames[mediaType]}を書き出しました`,
+    color: "toast",
+    textColor: "toast-display",
+    icon: "info",
+    timeout: 5000,
+    actions: [
+      {
+        label: "今後この通知をしない",
+        textColor: "toast-button-display",
+        handler: () => {
+          dispatch("SET_CONFIRMED_TIP", {
+            confirmedTip: {
+              notifyOnGenerateAudio: true,
+            },
+          });
+        },
+      },
+    ],
+  });
+};

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -138,7 +138,7 @@ const generateAndSaveOneAudio = async () => {
     quasarNotify: $q.notify,
     dispatch: store.dispatch,
     encoding: store.state.savingSetting.fileEncoding,
-    notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
+    disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
   });
 };
 const generateAndSaveAllAudio = async () => {
@@ -147,7 +147,7 @@ const generateAndSaveAllAudio = async () => {
     quasarNotify: $q.notify,
     dispatch: store.dispatch,
     encoding: store.state.savingSetting.fileEncoding,
-    notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
+    disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
   });
 };
 const generateAndConnectAndSaveAudio = async () => {
@@ -156,7 +156,7 @@ const generateAndConnectAndSaveAudio = async () => {
     dispatch: store.dispatch,
     quasarNotify: $q.notify,
     encoding: store.state.savingSetting.fileEncoding,
-    notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
+    disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
   });
 };
 const saveProject = async () => {

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -132,7 +132,7 @@ const generateAndSaveAllAudio = async () => {
   if (!uiLocked.value) {
     await generateAndSaveAllAudioWithDialog({
       encoding: store.state.savingSetting.fileEncoding,
-      notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
+      disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
       quasarDialog: $q.dialog,
       quasarNotify: $q.notify,
       dispatch: store.dispatch,
@@ -147,7 +147,7 @@ const generateAndConnectAndSaveAllAudio = async () => {
       quasarNotify: $q.notify,
       dispatch: store.dispatch,
       encoding: store.state.savingSetting.fileEncoding,
-      notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
+      disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
     });
   }
 };
@@ -174,7 +174,7 @@ const generateAndSaveOneAudio = async () => {
     encoding: store.state.savingSetting.fileEncoding,
     quasarDialog: $q.dialog,
     quasarNotify: $q.notify,
-    notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
+    disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
     dispatch: store.dispatch,
   });
 };
@@ -186,7 +186,7 @@ const connectAndExportText = async () => {
       quasarNotify: $q.notify,
       dispatch: store.dispatch,
       encoding: store.state.savingSetting.fileEncoding,
-      notifyOnGenerateAudio: store.state.confirmedTips.notifyOnGenerateAudio,
+      disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
     });
   }
 };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -59,7 +59,7 @@ export const settingStoreState: SettingStoreState = {
   confirmedTips: {
     tweakableSliderByScroll: false,
     engineStartedOnAltPort: false,
-    notifyOnGenerateAudio: false,
+    notifyOnGenerate: false,
   },
   engineSettings: {},
 };

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -495,7 +495,7 @@ export type SplitterPosition = z.infer<typeof splitterPositionSchema>;
 export type ConfirmedTips = {
   tweakableSliderByScroll: boolean;
   engineStartedOnAltPort: boolean; // エンジンのポート変更の通知
-  notifyOnGenerateAudio: boolean; // 音声書き出し時の通知
+  notifyOnGenerate: boolean; // 音声書き出し時の通知
 };
 
 export const electronStoreSchema = z
@@ -586,7 +586,7 @@ export const electronStoreSchema = z
       .object({
         tweakableSliderByScroll: z.boolean().default(false),
         engineStartedOnAltPort: z.boolean().default(false),
-        notifyOnGenerateAudio: z.boolean().default(false),
+        notifyOnGenerate: z.boolean().default(false),
       })
       .passthrough()
       .default({}),

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -137,7 +137,7 @@ describe("store/vuex.js test", () => {
         confirmedTips: {
           tweakableSliderByScroll: false,
           engineStartedOnAltPort: false,
-          notifyOnGenerateAudio: false,
+          notifyOnGenerate: false,
         },
         progress: -1,
         isVuexReady: false,
@@ -256,6 +256,6 @@ describe("store/vuex.js test", () => {
     assert.propertyVal(store.state.splitterPosition, "portraitPaneWidth", 50);
     assert.equal(store.state.confirmedTips.tweakableSliderByScroll, false);
     assert.equal(store.state.confirmedTips.engineStartedOnAltPort, false);
-    assert.equal(store.state.confirmedTips.notifyOnGenerateAudio, false);
+    assert.equal(store.state.confirmedTips.notifyOnGenerate, false);
   });
 });


### PR DESCRIPTION
## 内容
`src/components/Dialog.ts` の処理をリファクタしました。

- 処理の共通化
  - 通知表示処理の関数切り出し
  - ダイアログ表示処理の関数切り出し
- `generateAndSaveAllAudioWithDialog` のリファクタ
  - 可読性向上のため `for` と `switch` の組み合わせの処理を `flatMap` に置き換えました

## 関連 Issue

close #1329 
close #1337 


## スクリーンショット・動画など

## その他
