### PR TITLE
fix #1349 （初回起動したエンジンが異常終了したときにエラーダイアログが表示されない）

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -207,10 +207,19 @@ if (!fs.existsSync(vvppEngineDir)) {
   fs.mkdirSync(vvppEngineDir);
 }
 
+const onEngineProcessError = (engineInfo: EngineInfo, error: Error) => {
+  const engineId = engineInfo.uuid;
+  log.error(`ENGINE ${engineId} ERROR: ${error}`);
+
+  ipcMainSend(win, "DETECTED_ENGINE_ERROR", { engineId });
+  dialog.showErrorBox("音声合成エンジンエラー", error.message);
+};
+
 const engineManager = new EngineManager({
   store,
   defaultEngineDir: appDirPath,
   vvppEngineDir,
+  onEngineProcessError,
 });
 const vvppManager = new VvppManager({ vvppEngineDir });
 
@@ -539,7 +548,7 @@ async function start() {
   }
   store.set("engineSettings", engineSettings);
 
-  await engineManager.runEngineAll(win);
+  await engineManager.runEngineAll();
   await createWindow();
 }
 
@@ -780,7 +789,7 @@ ipcMainHandle("ENGINE_INFOS", () => {
  * エンジンの起動が開始したらresolve、起動が失敗したらreject。
  */
 ipcMainHandle("RESTART_ENGINE", async (_, { engineId }) => {
-  await engineManager.restartEngine(engineId, win);
+  await engineManager.restartEngine(engineId);
 });
 
 ipcMainHandle("OPEN_ENGINE_DIRECTORY", async (_, { engineId }) => {

--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -320,7 +320,7 @@ export class EngineManager {
       log.error(`ENGINE ${engineId} STDERR: ${data.toString("utf-8")}`);
     });
 
-    // onErrorを一度だけ呼ぶためのフラグ。"error"と"close"がどちらも呼ばれることがある。
+    // onEngineProcessErrorを一度だけ呼ぶためのフラグ。"error"と"close"がどちらも呼ばれることがある。
     // 詳細 https://github.com/VOICEVOX/voicevox/pull/1053/files#r1051436950
     let errorNotified = false;
 
@@ -343,7 +343,10 @@ export class EngineManager {
           engineInfos.length === 1
             ? "音声合成エンジンが異常終了しました。エンジンを再起動してください。"
             : `${engineInfo.name}が異常終了しました。エンジンを再起動してください。`;
-        this.onEngineProcessError(engineInfo, new Error(errorMessage));
+        if (!errorNotified) {
+          errorNotified = true;
+          this.onEngineProcessError(engineInfo, new Error(errorMessage));
+        }
       }
     });
   }


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/1349

を解決します。

そもそもEngineMangerがwinを受け取っていたのがよくなかったので、エラーが発生した時にゴールバックを呼び出すように設計を変えました。
EngineMangerは他にもダイアログを使っているところがいくつかあるのですが、とりあえず今回はプロセス実行時のエラーだけをハンドリングするように書き換えてみました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #1349
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
