### PR TITLE
FIX: 追加エンジンのポートが切り替わらない問題を修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -529,6 +529,8 @@ async function createWindow() {
 
 // UI処理を開始。その他の準備が完了した後に呼ばれる。
 async function start() {
+  // エンジンの追加と削除を反映させるためEngineInfoとAltPortInfoを再生成する。
+  engineManager.initializeEngineInfosAndAltPortInfo();
   const engineInfos = engineManager.fetchEngineInfos();
   const engineSettings = store.get("engineSettings");
   for (const engineInfo of engineInfos) {
@@ -941,8 +943,6 @@ app.on("before-quit", async (event) => {
 
       appState.willRestart = false;
       appState.willQuit = false;
-      // エンジンの追加と削除を反映させるためEngineInfoを再生成する。
-      engineManager.resetEngineInfos();
 
       start();
     } else {

--- a/src/background.ts
+++ b/src/background.ts
@@ -941,6 +941,8 @@ app.on("before-quit", async (event) => {
 
       appState.willRestart = false;
       appState.willQuit = false;
+      // エンジンの追加と削除を反映させるためEngineInfoを再生成する。
+      engineManager.resetEngineInfos();
 
       start();
     } else {

--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -196,7 +196,7 @@ export class EngineManager {
   }
 
   /**
-   * EngineInfosを初期化する。
+   * EngineInfosとAltPortInfoを初期化する。
    */
   initializeEngineInfosAndAltPortInfo() {
     this.defaultEngineInfos = createDefaultEngineInfos(this.defaultEngineDir);

--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -197,9 +197,9 @@ export class EngineManager {
   }
 
   /**
-   * EngineInfosを再度初期化する。
+   * EngineInfosを初期化する。
    */
-  resetEngineInfos() {
+  initializeEngineInfosAndAltPortInfo() {
     this.defaultEngineInfos = createDefaultEngineInfos(this.defaultEngineDir);
     this.additionalEngineInfos = this.createAdditionalEngineInfos();
     this.altPortInfo = {};

--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -70,8 +70,8 @@ export class EngineManager {
   defaultEngineDir: string;
   vvppEngineDir: string;
 
-  defaultEngineInfos: EngineInfo[];
-  additionalEngineInfos: EngineInfo[];
+  defaultEngineInfos: EngineInfo[] = [];
+  additionalEngineInfos: EngineInfo[] = [];
   engineProcessContainers: Record<EngineId, EngineProcessContainer>;
 
   public altPortInfo: AltPortInfos = {};
@@ -89,8 +89,7 @@ export class EngineManager {
     this.defaultEngineDir = defaultEngineDir;
     this.vvppEngineDir = vvppEngineDir;
 
-    this.defaultEngineInfos = createDefaultEngineInfos(defaultEngineDir);
-    this.additionalEngineInfos = this.createAdditionalEngineInfos();
+    this.initializeEngineInfosAndAltPortInfo();
     this.engineProcessContainers = {};
   }
 

--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -71,6 +71,7 @@ export class EngineManager {
   vvppEngineDir: string;
 
   defaultEngineInfos: EngineInfo[];
+  additionalEngineInfos: EngineInfo[];
   engineProcessContainers: Record<EngineId, EngineProcessContainer>;
 
   public altPortInfo: AltPortInfos = {};
@@ -89,14 +90,15 @@ export class EngineManager {
     this.vvppEngineDir = vvppEngineDir;
 
     this.defaultEngineInfos = createDefaultEngineInfos(defaultEngineDir);
+    this.additionalEngineInfos = this.createAdditionalEngineInfos();
     this.engineProcessContainers = {};
   }
 
   /**
-   * 追加エンジンの一覧を取得する。
+   * 追加エンジンの一覧を作成する。
    * FIXME: store.get("registeredEngineDirs")への副作用をEngineManager外に移動する
    */
-  fetchAdditionalEngineInfos(): EngineInfo[] {
+  private createAdditionalEngineInfos(): EngineInfo[] {
     const engines: EngineInfo[] = [];
     const addEngine = (engineDir: string, type: "vvpp" | "path") => {
       const manifestPath = path.join(engineDir, "engine_manifest.json");
@@ -164,8 +166,7 @@ export class EngineManager {
    * 全てのエンジンの一覧を取得する。デフォルトエンジン＋追加エンジン。
    */
   fetchEngineInfos(): EngineInfo[] {
-    const additionalEngineInfos = this.fetchAdditionalEngineInfos();
-    return [...this.defaultEngineInfos, ...additionalEngineInfos];
+    return [...this.defaultEngineInfos, ...this.additionalEngineInfos];
   }
 
   /**
@@ -193,6 +194,15 @@ export class EngineManager {
     }
 
     return engineDirectory;
+  }
+
+  /**
+   * EngineInfosを再度初期化する。
+   */
+  resetEngineInfos() {
+    this.defaultEngineInfos = createDefaultEngineInfos(this.defaultEngineDir);
+    this.additionalEngineInfos = this.createAdditionalEngineInfos();
+    this.altPortInfo = {};
   }
 
   /**


### PR DESCRIPTION
## 内容

EngineManagerのadditionalEngineInfosをメンバ変数にするというアプローチで追加エンジンのポートが切り替わらない問題を修正します。

## 関連 Issue

- fix #1310

## その他

https://github.com/VOICEVOX/voicevox/issues/1310#issuecomment-1540752389
>また、エンジン再起動時は変更後のportが入ったengineInfoが参照されるので、元のポートに戻ろうとしない気がします。

この問題は解決していません。
