### PR TITLE
fix: 再起動ダイアログで断るとエンジンがアップデートされない問題を修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -972,7 +972,7 @@ app.on("before-quit", async (event) => {
 
   // エンジン終了後の処理を実行
   log.info(
-    "All ENGINE process kill operations done. running post engine kill process"
+    "All ENGINE process kill operations done. Running post engine kill process"
   );
   await vvppManager.handleMarkedEngineDirs();
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -924,27 +924,30 @@ app.on("before-quit", async (event) => {
 
   // すべてのエンジンプロセスが停止している
   if (numLivingEngineProcess === 0) {
-    log.info(
-      "All ENGINE processes are killed, running post engine kill process"
-    );
-    if (appState.willRestart) {
+    if (appState.willRestart || vvppManager.hasMarkedEngineDirs()) {
+      log.info(
+        "All ENGINE processes are killed, running post engine kill process"
+      );
       // awaitする前にevent.preventDefault()を呼び出さないとアプリがそのまま終了してしまう
       event.preventDefault();
-    }
 
-    // エンジン終了後の処理を実行
-    await vvppManager.handleMarkedEngineDirs();
+      // エンジン終了後の処理を実行
+      await vvppManager.handleMarkedEngineDirs();
 
-    if (appState.willRestart) {
-      // 再起動フラグが立っている場合はフラグを戻して再起動する
-      log.info(
-        "Post engine kill process done. Now restarting app because of willRestart flag"
-      );
+      if (appState.willRestart) {
+        // 再起動フラグが立っている場合はフラグを戻して再起動する
+        log.info(
+          "Post engine kill process done. Now restarting app because of willRestart flag"
+        );
 
-      appState.willRestart = false;
-      appState.willQuit = false;
+        appState.willRestart = false;
+        appState.willQuit = false;
 
-      start();
+        start();
+      } else {
+        // アプリケーションの終了をを再試行する
+        app.quit();
+      }
     } else {
       log.info("Post engine kill process done. Now quit app");
     }

--- a/src/background/vvppManager.ts
+++ b/src/background/vvppManager.ts
@@ -343,6 +343,12 @@ export class VvppManager {
     this.willReplaceEngineDirs = [];
   }
 
+  hasMarkedEngineDirs() {
+    return (
+      this.willReplaceEngineDirs.length > 0 || this.willDeleteEngineIds.size > 0
+    );
+  }
+
   private async detectFileFormat(
     filePath: string
   ): Promise<"zip" | "7z" | undefined> {


### PR DESCRIPTION
## 内容

再起動フラグが立っていないと`event.preventDefault()`を呼び出しません。
そのため非同期処理であるエンジンの削除が行われないままエディタが終了してしまいます。

VvppManagerに処理の予約がある場合`event.preventDefault()`を呼び出し処理をするように変更します。

## 関連 Issue

- fix #1319

