### PR TITLE
SAVE_PROJECT_FILEでエラー発生時にダイアログを出すようにする

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -197,15 +197,15 @@ const importTextFile = () => {
   }
 };
 
-const saveProject = () => {
+const saveProject = async () => {
   if (!uiLocked.value) {
-    store.dispatch("SAVE_PROJECT_FILE", { overwrite: true });
+    await store.dispatch("SAVE_PROJECT_FILE", { overwrite: true });
   }
 };
 
-const saveProjectAs = () => {
+const saveProjectAs = async () => {
   if (!uiLocked.value) {
-    store.dispatch("SAVE_PROJECT_FILE", {});
+    await store.dispatch("SAVE_PROJECT_FILE", {});
   }
 };
 
@@ -301,16 +301,16 @@ const menudata = ref<MenuItemData[]>([
       {
         type: "button",
         label: "プロジェクトを上書き保存",
-        onClick: () => {
-          saveProject();
+        onClick: async () => {
+          await saveProject();
         },
         disableWhenUiLocked: true,
       },
       {
         type: "button",
         label: "プロジェクトを名前を付けて保存",
-        onClick: () => {
-          saveProjectAs();
+        onClick: async () => {
+          await saveProjectAs();
         },
         disableWhenUiLocked: true,
       },

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -69,6 +69,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
   LOAD_PROJECT_FILE: {
     /**
      * プロジェクトファイルを読み込む。読み込めたかの成否が返る。
+     * エラー発生時はダイアログが表示される。
      */
     action: createUILockAction(
       async (
@@ -373,7 +374,9 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
 
   SAVE_PROJECT_FILE: {
     /**
-     * プロジェクトファイルを保存する。保存の成否が返る。
+     * プロジェクトファイルを保存する。
+     * 保存に成功した場合はtrueが、キャンセルされた場合はfalseが返る。
+     * 失敗した場合はエラーが投げられる。
      */
     action: createUILockAction(
       async (context, { overwrite }: { overwrite?: boolean }) => {
@@ -428,8 +431,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           buffer: buf,
         });
         if (writeFileResult) {
-          window.electron.logError(new Error(writeFileResult.message));
-          return false;
+          throw new Error(writeFileResult.message);
         }
         context.commit("SET_PROJECT_FILEPATH", { filePath });
         context.commit(
@@ -444,7 +446,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
   /**
    * プロジェクトファイルを保存するか破棄するかキャンセルするかのダイアログを出して、保存する場合は保存する。
    * 何を選択したかが返る。
-   * 保存に失敗した場合はキャンセル扱いになる。
+   * 保存に失敗した場合はエラーを投げる。
    */
   SAVE_OR_DISCARD_PROJECT_FILE: {
     action: createUILockAction(async ({ dispatch }, { additionalMessage }) => {

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -364,7 +364,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           await window.electron.showMessageDialog({
             type: "error",
             title: "エラー",
-            message,
+            message: `プロジェクトファイルの読み込みに失敗しました。\n${message}`,
           });
           return false;
         }
@@ -406,7 +406,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             context.state.projectFilePath &&
             context.state.projectFilePath != filePath
           ) {
-            window.electron.showMessageDialog({
+            await window.electron.showMessageDialog({
               type: "info",
               title: "保存",
               message: `編集中のプロジェクトが ${filePath} に切り替わりました。`,


### PR DESCRIPTION
## 内容

#1357 が先です。

`SAVE_PROJECT_FILE`でのエラーハンドリングがなかったので、`LOAD_PROJECT_FILE`に倣って内部でエラーダイアログを出すようにしました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

ref #1357 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
