### PR TITLE
Fix: vue-devtools が起動しない問題を修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -991,7 +991,7 @@ app.once("will-finish-launching", () => {
 });
 
 app.on("ready", async () => {
-  if (isDevelopment) {
+  if (isDevelopment && !isTest) {
     try {
       await installExtension(VUEJS_DEVTOOLS);
     } catch (e: unknown) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -12,7 +12,7 @@ import {
   shell,
   nativeTheme,
 } from "electron";
-import installExtension, { VUEJS3_DEVTOOLS } from "electron-devtools-installer";
+import installExtension, { VUEJS_DEVTOOLS } from "electron-devtools-installer";
 import Store, { Schema } from "electron-store";
 import dotenv from "dotenv";
 
@@ -993,7 +993,7 @@ app.once("will-finish-launching", () => {
 app.on("ready", async () => {
   if (isDevelopment) {
     try {
-      await installExtension(VUEJS3_DEVTOOLS);
+      await installExtension(VUEJS_DEVTOOLS);
     } catch (e: unknown) {
       if (e instanceof Error) {
         log.error("Vue Devtools failed to install:", e.toString());


### PR DESCRIPTION
## 内容

### 概要
`npm run electron:serve` 実行時に以下のようなエラーを吐いて vue-devtools が起動しなかったため修正しました。
` [error] Vue Devtools failed to install: Error: Invalid header: Does not start with Cr24`

### 原因
`electron-devtools-installer` で設定されていた `extension id` が古く参照できなくなっていたたため

参考：https://github.com/MarshallOfSound/electron-devtools-installer/pull/222#issuecomment-1295273667

### 修正内容
- `src/background.ts` の `VUEJS3_DEVTOOLS` を `VUEJS_DEVTOOLS` に変更

## スクリーンショット

### 修正前
![修正前](https://github.com/VOICEVOX/voicevox/assets/78523393/ae6c7d19-8cb0-4793-9a99-4d863519d5be)

### 修正後
![修正後](https://github.com/VOICEVOX/voicevox/assets/78523393/b83693ce-22e6-4f0e-b2ed-f80fc0997574)
