### PR TITLE
UPDATE: コンテキストメニューの内部処理の変更

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -735,8 +735,8 @@ ipcMainHandle("SHOW_IMPORT_FILE_DIALOG", (_, { title }) => {
   })?.[0];
 });
 
-ipcMainHandle("OPEN_CONTEXT_MENU", (_, { type }) => {
-  popupContextMenu(type, { window: win });
+ipcMainHandle("OPEN_CONTEXT_MENU", (_, { menuType }) => {
+  popupContextMenu(menuType, { window: win });
 });
 
 ipcMainHandle("IS_AVAILABLE_GPU_MODE", () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,7 +21,7 @@ import dayjs from "dayjs";
 import windowStateKeeper from "electron-window-state";
 import zodToJsonSchema from "zod-to-json-schema";
 import { hasSupportedGpu } from "./electron/device";
-import { textEditContextMenu } from "./electron/contextMenu";
+import { popupContextMenu } from "./electron/contextMenu";
 import {
   HotkeySetting,
   ThemeConf,
@@ -735,8 +735,8 @@ ipcMainHandle("SHOW_IMPORT_FILE_DIALOG", (_, { title }) => {
   })?.[0];
 });
 
-ipcMainHandle("OPEN_TEXT_EDIT_CONTEXT_MENU", () => {
-  textEditContextMenu.popup({ window: win });
+ipcMainHandle("OPEN_CONTEXT_MENU", (_, { type }) => {
+  popupContextMenu(type, { window: win });
 });
 
 ipcMainHandle("IS_AVAILABLE_GPU_MODE", () => {

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -259,7 +259,7 @@ const deleteButtonEnable = computed(() => {
 
 // テキスト編集エリアの右クリック
 const onRightClickTextField = async () => {
-  await store.dispatch("OPEN_CONTEXT_MENU", { type: "TEXT_EDIT" });
+  await store.dispatch("OPEN_CONTEXT_MENU", { menuType: "TEXT_EDIT" });
 };
 
 const blurCell = (event?: KeyboardEvent) => {

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -258,8 +258,8 @@ const deleteButtonEnable = computed(() => {
 });
 
 // テキスト編集エリアの右クリック
-const onRightClickTextField = () => {
-  store.dispatch("OPEN_TEXT_EDIT_CONTEXT_MENU");
+const onRightClickTextField = async () => {
+  await store.dispatch("OPEN_CONTEXT_MENU", { type: "TEXT_EDIT" });
 };
 
 const blurCell = (event?: KeyboardEvent) => {

--- a/src/electron/contextMenu.ts
+++ b/src/electron/contextMenu.ts
@@ -1,5 +1,5 @@
 import { Menu, MenuItem, MenuItemConstructorOptions } from "electron";
-import { ContextMenuType, TextEditContextMenuAction } from "@/type/contextMenu";
+import { ContextMenuActionRecord, ContextMenuType } from "@/type/contextMenu";
 
 type ContextMenuItemConstructorOptions<T> = MenuItemConstructorOptions & {
   label?: T;
@@ -29,29 +29,34 @@ const defaultMenuItemOptions: Record<
       label: "全選択",
       role: "selectAll",
     },
-  ] as ContextMenuItemConstructorOptions<TextEditContextMenuAction>[],
+  ] as ContextMenuItemConstructorOptions<
+    ContextMenuActionRecord["TEXT_EDIT"]
+  >[],
 };
 
 // 右クリックする場所(TEXT_EDITなど)ごとに動作を保持する仕様にしましたが、
 // 最後にクリックした場所だけを保存でも良いかもしれません
 const menus = new Map<ContextMenuType, Menu>();
 
-// 返り値の型は Electron.Menu | undefined ではなく Electron.Menu 確定のはずですがどうすればいいか分かりません
-const checkOrBuildContextMenu = (type: ContextMenuType) => {
-  if (menus.has(type)) return menus.get(type);
+const checkOrBuildContextMenu = (menuType: ContextMenuType) => {
+  if (menus.has(menuType)) {
+    const menu = menus.get(menuType);
+    if (menu === undefined) throw new Error("menu is undefined.");
+    return menu;
+  }
 
   const menu = Menu.buildFromTemplate(
-    defaultMenuItemOptions[type].map(
+    defaultMenuItemOptions[menuType].map(
       (menuItemOptions) => new MenuItem(menuItemOptions)
     )
   );
-  menus.set(type, menu);
+  menus.set(menuType, menu);
   return menu;
 };
 
 export const popupContextMenu = (
-  type: ContextMenuType,
+  menuType: ContextMenuType,
   options?: Electron.PopupOptions
 ) => {
-  checkOrBuildContextMenu(type)?.popup(options);
+  checkOrBuildContextMenu(menuType).popup(options);
 };

--- a/src/electron/contextMenu.ts
+++ b/src/electron/contextMenu.ts
@@ -1,9 +1,57 @@
-import { Menu } from "electron";
+import { Menu, MenuItem, MenuItemConstructorOptions } from "electron";
+import { ContextMenuType, TextEditContextMenuAction } from "@/type/contextMenu";
 
-export const textEditContextMenu = Menu.buildFromTemplate([
-  { label: "切り取り", role: "cut" },
-  { label: "コピー", role: "copy" },
-  { label: "貼り付け", role: "paste" },
-  { type: "separator" },
-  { label: "全選択", role: "selectAll" },
-]);
+type ContextMenuItemConstructorOptions<T> = MenuItemConstructorOptions & {
+  label?: T;
+};
+
+const defaultMenuItemOptions: Record<
+  ContextMenuType,
+  MenuItemConstructorOptions[]
+> = {
+  TEXT_EDIT: [
+    {
+      label: "切り取り",
+      role: "cut",
+    },
+    {
+      label: "コピー",
+      role: "copy",
+    },
+    {
+      label: "貼り付け",
+      role: "paste",
+    },
+    {
+      type: "separator",
+    },
+    {
+      label: "全選択",
+      role: "selectAll",
+    },
+  ] as ContextMenuItemConstructorOptions<TextEditContextMenuAction>[],
+};
+
+// 右クリックする場所(TEXT_EDITなど)ごとに動作を保持する仕様にしましたが、
+// 最後にクリックした場所だけを保存でも良いかもしれません
+const menus = new Map<ContextMenuType, Menu>();
+
+// 返り値の型は Electron.Menu | undefined ではなく Electron.Menu 確定のはずですがどうすればいいか分かりません
+const checkOrBuildContextMenu = (type: ContextMenuType) => {
+  if (menus.has(type)) return menus.get(type);
+
+  const menu = Menu.buildFromTemplate(
+    defaultMenuItemOptions[type].map(
+      (menuItemOptions) => new MenuItem(menuItemOptions)
+    )
+  );
+  menus.set(type, menu);
+  return menu;
+};
+
+export const popupContextMenu = (
+  type: ContextMenuType,
+  options?: Electron.PopupOptions
+) => {
+  checkOrBuildContextMenu(type)?.popup(options);
+};

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -134,8 +134,8 @@ const api: Sandbox = {
     return await ipcRendererInvoke("READ_FILE", { filePath });
   },
 
-  openContextMenu: async ({ type }) => {
-    await ipcRendererInvoke("OPEN_CONTEXT_MENU", { type });
+  openContextMenu: async ({ menuType }) => {
+    await ipcRendererInvoke("OPEN_CONTEXT_MENU", { menuType });
   },
 
   isAvailableGPUMode: () => {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -134,8 +134,8 @@ const api: Sandbox = {
     return await ipcRendererInvoke("READ_FILE", { filePath });
   },
 
-  openTextEditContextMenu: () => {
-    return ipcRendererInvoke("OPEN_TEXT_EDIT_CONTEXT_MENU");
+  openContextMenu: async ({ type }) => {
+    await ipcRendererInvoke("OPEN_CONTEXT_MENU", { type });
   },
 
   isAvailableGPUMode: () => {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1892,8 +1892,8 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   },
 
   OPEN_CONTEXT_MENU: {
-    action(_, { type }) {
-      window.electron.openContextMenu({ type });
+    action(_, { menuType }) {
+      window.electron.openContextMenu({ menuType });
     },
   },
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1891,9 +1891,9 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
-  OPEN_TEXT_EDIT_CONTEXT_MENU: {
-    action() {
-      window.electron.openTextEditContextMenu();
+  OPEN_CONTEXT_MENU: {
+    action(_, { type }) {
+      window.electron.openContextMenu({ type });
     },
   },
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -51,6 +51,7 @@ import {
   AudioKey,
   PresetKey,
 } from "@/type/preload";
+import { ContextMenuType } from "@/type/contextMenu";
 import { IEngineConnectorFactory } from "@/infrastructures/EngineConnector";
 
 /**
@@ -469,8 +470,8 @@ export type AudioStoreTypes = {
     action(): void;
   };
 
-  OPEN_TEXT_EDIT_CONTEXT_MENU: {
-    action(): void;
+  OPEN_CONTEXT_MENU: {
+    action(payload: { type: ContextMenuType }): void;
   };
 
   CHECK_FILE_EXISTS: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -471,7 +471,7 @@ export type AudioStoreTypes = {
   };
 
   OPEN_CONTEXT_MENU: {
-    action(payload: { type: ContextMenuType }): void;
+    action(payload: { menuType: ContextMenuType }): void;
   };
 
   CHECK_FILE_EXISTS: {

--- a/src/type/contextMenu.ts
+++ b/src/type/contextMenu.ts
@@ -1,23 +1,10 @@
-import { z } from "zod";
-
-export const textEditContextMenuActionSchema = z.enum([
-  "切り取り",
-  "コピー",
-  "貼り付け",
-  "全選択",
-]);
-export type TextEditContextMenuAction = z.infer<
-  typeof textEditContextMenuActionSchema
->;
+export type ContextMenuActionRecord = {
+  TEXT_EDIT: "切り取り" | "コピー" | "貼り付け" | "全選択";
+};
+export type ContextMenuType = keyof ContextMenuActionRecord;
 
 // 新たに追加したい場合はここに & で繋げる
-export type ContextMenuAction = TextEditContextMenuAction;
-
-export const ContextMenuTypeShema = z.object({
-  TEXT_EDIT: textEditContextMenuActionSchema,
-});
-const ContextMenuTypes = ContextMenuTypeShema.keyof();
-export type ContextMenuType = z.infer<typeof ContextMenuTypes>;
+export type ContextMenuAction = ContextMenuActionRecord["TEXT_EDIT"];
 
 // 現在未使用、将来クリック時の動作を変える機能を実装する際に必要になりそうな型
 // FIXME: electronからimportができないため、いくつかの型をunknownとしている

--- a/src/type/contextMenu.ts
+++ b/src/type/contextMenu.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+
+export const textEditContextMenuActionSchema = z.enum([
+  "切り取り",
+  "コピー",
+  "貼り付け",
+  "全選択",
+]);
+export type TextEditContextMenuAction = z.infer<
+  typeof textEditContextMenuActionSchema
+>;
+
+// 新たに追加したい場合はここに & で繋げる
+export type ContextMenuAction = TextEditContextMenuAction;
+
+export const ContextMenuTypeShema = z.object({
+  TEXT_EDIT: textEditContextMenuActionSchema,
+});
+const ContextMenuTypes = ContextMenuTypeShema.keyof();
+export type ContextMenuType = z.infer<typeof ContextMenuTypes>;
+
+// 現在未使用、将来クリック時の動作を変える機能を実装する際に必要になりそうな型
+// FIXME: electronからimportができないため、いくつかの型をunknownとしている
+export type ContextMenuClickCallback = (
+  // 本来はElectron.MenuItem
+  menuItem: unknown,
+  // 本来はElectron.BrowserWindow
+  browserWindow: unknown | undefined,
+  event: KeyboardEvent
+) => void;
+
+// 現在未使用、将来オプションを変える機能を実装する際に必要になりそうな型
+// FIXME: electronからimportができないため、いくつかの型をunknownとしている
+export type ContextMenuItemOptions<T extends ContextMenuAction> = {
+  id?: string;
+  label?: T;
+  click?: ContextMenuClickCallback;
+  // 本来はElectron.Menu
+  submenu?: unknown;
+  type?: "normal" | "separator" | "submenu" | "checkbox" | "radio";
+  role?:
+    | "undo"
+    | "redo"
+    | "cut"
+    | "copy"
+    | "paste"
+    | "pasteAndMatchStyle"
+    | "delete"
+    | "selectAll"
+    | "reload"
+    | "forceReload"
+    | "toggleDevTools"
+    | "resetZoom"
+    | "zoomIn"
+    | "zoomOut"
+    | "toggleSpellChecker"
+    | "togglefullscreen"
+    | "window"
+    | "minimize"
+    | "close"
+    | "help"
+    | "about"
+    | "services"
+    | "hide"
+    | "hideOthers"
+    | "unhide"
+    | "quit"
+    | "showSubstitutions"
+    | "toggleSmartQuotes"
+    | "toggleSmartDashes"
+    | "toggleTextReplacement"
+    | "startSpeaking"
+    | "stopSpeaking"
+    | "zoom"
+    | "front"
+    | "appMenu"
+    | "fileMenu"
+    | "editMenu"
+    | "viewMenu"
+    | "shareMenu"
+    | "recentDocuments"
+    | "toggleTabBar"
+    | "selectNextTab"
+    | "selectPreviousTab"
+    | "mergeAllWindows"
+    | "clearRecentDocuments"
+    | "moveTabToNewWindow"
+    | "windowMenu";
+  // https://www.electronjs.org/ja/docs/latest/api/accelerator を参照。
+  accelerator?: string;
+  // 本来はElectron.NativeImage
+  icon?: unknown | string;
+  sublabel?: string;
+  toolTip?: string;
+  enabled?: boolean;
+  visible?: boolean;
+  checked?: boolean;
+  registerAccelerator?: boolean;
+  // 本来はElectron.sharingItem
+  sharingItem?: {
+    filePaths?: string[];
+    texts?: string[];
+    urls?: string[];
+  };
+  commandId?: boolean;
+  menu?: boolean;
+};

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -13,6 +13,7 @@ import {
   EngineId,
   MessageBoxReturnValue,
 } from "@/type/preload";
+import { ContextMenuType } from "@/type/contextMenu";
 import { AltPortInfos } from "@/store/type";
 
 /**
@@ -149,8 +150,12 @@ export type IpcIHData = {
     return: MessageBoxReturnValue;
   };
 
-  OPEN_TEXT_EDIT_CONTEXT_MENU: {
-    args: [];
+  OPEN_CONTEXT_MENU: {
+    args: [
+      obj: {
+        type: ContextMenuType;
+      }
+    ];
     return: void;
   };
 

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -153,7 +153,7 @@ export type IpcIHData = {
   OPEN_CONTEXT_MENU: {
     args: [
       obj: {
-        type: ContextMenuType;
+        menuType: ContextMenuType;
       }
     ];
     return: void;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { IpcSOData } from "./ipc";
+import { ContextMenuType } from "./contextMenu";
 import { AltPortInfos } from "@/store/type";
 
 export const isMac =
@@ -186,7 +187,7 @@ export interface Sandbox {
     buffer: ArrayBuffer;
   }): Promise<WriteFileErrorResult | undefined>;
   readFile(obj: { filePath: string }): Promise<ArrayBuffer>;
-  openTextEditContextMenu(): Promise<void>;
+  openContextMenu(obj: { type: ContextMenuType }): Promise<void>;
   isAvailableGPUMode(): Promise<boolean>;
   isMaximizedWindow(): Promise<boolean>;
   onReceivedIPCMsg<T extends keyof IpcSOData>(

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -187,7 +187,7 @@ export interface Sandbox {
     buffer: ArrayBuffer;
   }): Promise<WriteFileErrorResult | undefined>;
   readFile(obj: { filePath: string }): Promise<ArrayBuffer>;
-  openContextMenu(obj: { type: ContextMenuType }): Promise<void>;
+  openContextMenu(obj: { menuType: ContextMenuType }): Promise<void>;
   isAvailableGPUMode(): Promise<boolean>;
   isMaximizedWindow(): Promise<boolean>;
   onReceivedIPCMsg<T extends keyof IpcSOData>(


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
今後の機能追加などをしやすいように、ユーザー視点の見た目・機能が変わらないように内部実装だけを変更しました。
また、AudioCell(テキスト欄)上での操作しか想定されていなかったため、他の場所での操作を追加したくなった時のために、拡張性を高めました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- ref #1353 
上記の機能をコンテキストメニューに追加した方が良いのではという意見が出たため、それのための部分実装です。

## その他
初PRのため、以下の点をどうするべきか分かりませんでした。実際の実装含め、酷い場合はPRをご却下ください…お手数をおかけします。
- コメントをどこに書くべきか分からず、ソースコード中に書いています。
PRを送る前に清書をしてgithub側のコメントに移す形をとるべきでしたでしょうか？
- `src/type/contextMenu.ts` 内に将来実装のために書いた部分がコメントアウトされていない状態で存在します。