### PR TITLE
engineVersionがダブルクォーテーションで囲まれなくなったので対応する

### DIFF
--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -426,12 +426,13 @@ watch(
           if (version.startsWith('"') && version.endsWith('"')) {
             return version.slice(1, -1);
           }
+          return version;
         })
         .catch(() => null);
       if (!version) continue;
       engineVersions.value = {
         ...engineVersions.value,
-        [id]: JSON.parse(version),
+        [id]: version,
       };
     }
   },

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -421,9 +421,14 @@ watch(
       const version = await store
         .dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId: id })
         .then((instance) => instance.invoke("versionVersionGet")({}))
+        .then((version) => {
+          // OpenAPIのバグで"latest"のようにダブルクォーテーションで囲まれていることがあるので外す
+          if (version.startsWith('"') && version.endsWith('"')) {
+            return version.slice(1, -1);
+          }
+        })
         .catch(() => null);
       if (!version) continue;
-      // "latest"のようにダブルクォーテーションで囲まれているので、JSON.parseで外す。
       engineVersions.value = {
         ...engineVersions.value,
         [id]: JSON.parse(version),


### PR DESCRIPTION
## 内容

OpenAPI周りが改善したため、いくつかあったOpenAPI周りのワークアラウンドが解消されました。

- https://github.com/VOICEVOX/voicevox/pull/1361

そのうちの１つの`versionVersionGet`が未対応だったので、対応してみました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

ref #1361 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

PRはこのときだったのですが、これがOpenAPIのバグっぽい挙動だったのかは特にメモが見当たりませんでした。

https://github.com/VOICEVOX/voicevox/pull/982/files#diff-1c1ce532e98b27633d850d2c08dd39481a59fa12a3311b77eaf2a53e1fe76763R305

ちなみにエラーはこんな感じです。

```log
SyntaxError: Unexpected non-whitespace character after JSON at position 4
    at JSON.parse (<anonymous>)
    at watch.immediate (http://localhost:5173/components/EngineManageDialog.vue:68:24)
```
