### PR TITLE
ESLintにvue3-recommendedを追加

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,11 +5,11 @@ module.exports = {
     node: true,
   },
   extends: [
-    "plugin:vue/vue3-essential",
+    "plugin:vue/vue3-recommended",
     "eslint:recommended",
     "@vue/typescript/recommended",
     "@vue/prettier",
-    "@vue/eslint-config-typescript",
+    "@vue/eslint-config-typescript/recommended",
     "@vue/eslint-config-prettier",
   ],
   plugins: ["import"],

--- a/src/components/AcceptRetrieveTelemetryDialog.vue
+++ b/src/components/AcceptRetrieveTelemetryDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="modelValueComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="accept-retrieve-telemetry-dialog transparent-backdrop"
-    v-model="modelValueComputed"
   >
     <q-layout container view="hHh Lpr lff" class="bg-background">
       <q-header class="q-py-sm">
@@ -54,6 +54,7 @@
             </q-card-section>
 
             <q-card-section class="text-body1">
+              <!-- eslint-disable-next-line vue/no-v-html -->
               <div v-html="privacyPolicy"></div>
             </q-card-section>
           </q-card>

--- a/src/components/AcceptTermsDialog.vue
+++ b/src/components/AcceptTermsDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="modelValueComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="accept-terms-dialog transparent-backdrop"
-    v-model="modelValueComputed"
   >
     <q-layout container view="hHh Lpr lff" class="bg-background">
       <q-header class="q-py-sm">
@@ -51,6 +51,7 @@
             </q-card-section>
 
             <q-card-section>
+              <!-- eslint-disable-next-line vue/no-v-html -->
               <div class="q-pa-md markdown markdown-body" v-html="terms" />
             </q-card-section>
           </q-card>

--- a/src/components/AudioAccent.vue
+++ b/src/components/AudioAccent.vue
@@ -13,7 +13,7 @@
           snap
           dense
           color="primary-light"
-          trackSize="2px"
+          track-size="2px"
           :min="previewAccentSlider.qSliderProps.min.value"
           :max="previewAccentSlider.qSliderProps.max.value"
           :step="previewAccentSlider.qSliderProps.step.value"
@@ -42,7 +42,6 @@
   </div>
   <template v-for="(mora, moraIndex) in accentPhrase.moras" :key="moraIndex">
     <div
-      @click="uiLocked || changeAccent(moraIndex + 1)"
       :class="[
         'accent-select-cell',
         {
@@ -51,6 +50,7 @@
         },
       ]"
       :style="{ 'grid-column': `${moraIndex * 2 + 1} / span 1` }"
+      @click="uiLocked || changeAccent(moraIndex + 1)"
     >
       <svg width="19" height="50" viewBox="0 0 19 50">
         <line x1="9" y1="0" x2="9" y2="50" stroke-width="1" />

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -8,18 +8,18 @@
       class="absolute active-arrow"
     />
     <div
+      v-if="showTextLineNumber"
       class="line-number"
       :class="{ active: isActiveAudioCell }"
-      v-if="showTextLineNumber"
     >
       {{ textLineNumberIndex }}
     </div>
     <character-button
+      v-model:selected-voice="selectedVoice"
       :character-infos="userOrderedCharacterInfos"
       :loading="isInitializingSpeaker"
       :show-engine-info="isMultipleEngine"
       :ui-locked="uiLocked"
-      v-model:selected-voice="selectedVoice"
     />
     <q-input
       ref="textfield"
@@ -31,6 +31,7 @@
       :disable="uiLocked"
       :error="audioTextBuffer.length >= 80"
       :model-value="audioTextBuffer"
+      :aria-label="`${textLineNumberIndex}行目`"
       @update:model-value="setAudioTextBuffer"
       @change="willRemove || pushAudioText()"
       @paste="pasteOnAudioCell"
@@ -38,21 +39,20 @@
       @keydown.prevent.up.exact="moveUpCell"
       @keydown.prevent.down.exact="moveDownCell"
       @mouseup.right="onRightClickTextField"
-      :aria-label="`${textLineNumberIndex}行目`"
     >
-      <template v-slot:error>
+      <template #error>
         文章が長いと正常に動作しない可能性があります。
         句読点の位置で文章を分割してください。
       </template>
-      <template #after v-if="deleteButtonEnable">
+      <template v-if="deleteButtonEnable" #after>
         <q-btn
           round
           flat
           icon="delete_outline"
           size="0.8rem"
           :disable="uiLocked"
-          @click="removeCell"
           :aria-label="`${textLineNumberIndex}行目を削除`"
+          @click="removeCell"
         />
       </template>
     </q-input>

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -3,7 +3,7 @@
     <div>
       <div class="side">
         <div class="detail-selector">
-          <q-tabs dense vertical class="text-display" v-model="selectedDetail">
+          <q-tabs v-model="selectedDetail" dense vertical class="text-display">
             <q-tab name="accent" label="ｱｸｾﾝﾄ" />
             <q-tab
               name="pitch"
@@ -37,17 +37,17 @@
               color="primary-light"
               text-color="display-on-primary"
               icon="stop"
-              @click="stop"
               :disable="nowGenerating"
+              @click="stop"
             ></q-btn>
           </template>
         </div>
       </div>
 
-      <div class="overflow-hidden-y accent-phrase-table" ref="audioDetail">
+      <div ref="audioDetail" class="overflow-hidden-y accent-phrase-table">
         <tool-tip
-          tip-key="tweakableSliderByScroll"
           v-if="selectedDetail === 'pitch'"
+          tip-key="tweakableSliderByScroll"
           class="tip-tweakable-slider-by-scroll"
         >
           <p>
@@ -61,21 +61,21 @@
         <div
           v-for="(accentPhrase, accentPhraseIndex) in accentPhrases"
           :key="accentPhraseIndex"
+          :ref="addAccentPhraseElem"
           class="mora-table"
           :class="[
             accentPhraseIndex === activePoint && 'mora-table-focus',
             uiLocked || 'mora-table-hover',
           ]"
           @click="setPlayAndStartPoint(accentPhraseIndex)"
-          :ref="addAccentPhraseElem"
         >
           <template v-if="selectedDetail === 'accent'">
             <audio-accent
-              :accentPhraseIndex="accentPhraseIndex"
-              :accentPhrase="accentPhrase"
-              :uiLocked="uiLocked"
-              :shiftKeyFlag="shiftKeyFlag"
-              :onChangeAccent="changeAccent"
+              :accent-phrase-index="accentPhraseIndex"
+              :accent-phrase="accentPhrase"
+              :ui-locked="uiLocked"
+              :shift-key-flag="shiftKeyFlag"
+              :on-change-accent="changeAccent"
             />
           </template>
           <template v-if="selectedDetail === 'pitch'">
@@ -87,17 +87,17 @@
             >
               <!-- div for input width -->
               <audio-parameter
-                :moraIndex="moraIndex"
-                :accentPhraseIndex="accentPhraseIndex"
+                :mora-index="moraIndex"
+                :accent-phrase-index="accentPhraseIndex"
                 :value="mora.pitch"
-                :uiLocked="uiLocked"
+                :ui-locked="uiLocked"
                 :min="minPitch"
                 :max="maxPitch"
                 :disable="mora.pitch == 0.0"
                 :type="'pitch'"
                 :clip="false"
-                :shiftKeyFlag="shiftKeyFlag"
-                @changeValue="changeMoraData"
+                :shift-key-flag="shiftKeyFlag"
+                @change-value="changeMoraData"
               />
             </div>
             <div v-if="accentPhrase.pauseMora" />
@@ -112,55 +112,55 @@
               <!-- consonant length -->
               <audio-parameter
                 v-if="mora.consonant && mora.consonantLength != undefined"
-                :moraIndex="moraIndex"
-                :accentPhraseIndex="accentPhraseIndex"
+                :mora-index="moraIndex"
+                :accent-phrase-index="accentPhraseIndex"
                 :value="mora.consonantLength"
-                :uiLocked="uiLocked"
+                :ui-locked="uiLocked"
                 :min="minMoraLength"
                 :max="maxMoraLength"
                 :step="0.001"
                 :type="'consonant'"
                 :clip="true"
-                :shiftKeyFlag="shiftKeyFlag"
-                @changeValue="changeMoraData"
-                @mouseOver="handleLengthHoverText"
+                :shift-key-flag="shiftKeyFlag"
+                @change-value="changeMoraData"
+                @mouse-over="handleLengthHoverText"
               />
               <!-- vowel length -->
               <audio-parameter
-                :moraIndex="moraIndex"
-                :accentPhraseIndex="accentPhraseIndex"
+                :mora-index="moraIndex"
+                :accent-phrase-index="accentPhraseIndex"
                 :value="mora.vowelLength"
-                :uiLocked="uiLocked"
+                :ui-locked="uiLocked"
                 :min="minMoraLength"
                 :max="maxMoraLength"
                 :step="0.001"
                 :type="'vowel'"
                 :clip="mora.consonant ? true : false"
-                :shiftKeyFlag="shiftKeyFlag"
-                @changeValue="changeMoraData"
-                @mouseOver="handleLengthHoverText"
+                :shift-key-flag="shiftKeyFlag"
+                @change-value="changeMoraData"
+                @mouse-over="handleLengthHoverText"
               />
             </div>
           </template>
           <div
-            class="q-mb-sm pitch-cell"
             v-if="accentPhrase.pauseMora && selectedDetail == 'length'"
+            class="q-mb-sm pitch-cell"
             :style="{
               'grid-column': `${accentPhrase.moras.length * 2 + 1} / span 1`,
             }"
           >
             <!-- pause length -->
             <audio-parameter
-              :moraIndex="accentPhrase.moras.length"
-              :accentPhraseIndex="accentPhraseIndex"
+              :mora-index="accentPhrase.moras.length"
+              :accent-phrase-index="accentPhraseIndex"
               :value="accentPhrase.pauseMora.vowelLength"
-              :uiLocked="uiLocked"
+              :ui-locked="uiLocked"
               :min="0"
               :max="1.0"
               :step="0.01"
               :type="'pause'"
-              :shiftKeyFlag="shiftKeyFlag"
-              @changeValue="changeMoraData"
+              :shift-key-flag="shiftKeyFlag"
+              @change-value="changeMoraData"
             />
           </div>
           <template
@@ -179,7 +179,7 @@
               :style="{
                 'grid-column': `${moraIndex * 2 + 1} / span 1`,
               }"
-              @mouseover="handleHoverText(true, accentPhraseIndex, moraIndex)"
+              @mouse-over="handleHoverText(true, accentPhraseIndex, moraIndex)"
               @mouseleave="handleHoverText(false, accentPhraseIndex, moraIndex)"
               @click.stop="
                 uiLocked ||
@@ -191,11 +191,11 @@
               </span>
               <q-popup-edit
                 v-if="selectedDetail == 'accent' && !uiLocked"
+                v-slot="scope"
                 :model-value="pronunciationByPhrase[accentPhraseIndex]"
                 auto-save
                 transition-show="none"
                 transition-hide="none"
-                v-slot="scope"
                 @save="handleChangePronounce($event, accentPhraseIndex)"
               >
                 <q-input
@@ -217,10 +217,6 @@
                 (accentPhraseIndex < accentPhrases.length - 1 ||
                   moraIndex < accentPhrase.moras.length - 1)
               "
-              @click.stop="
-                uiLocked ||
-                  toggleAccentPhraseSplit(accentPhraseIndex, false, moraIndex)
-              "
               :class="[
                 'splitter-cell',
                 {
@@ -231,6 +227,10 @@
                 },
               ]"
               :style="{ 'grid-column': `${moraIndex * 2 + 2} / span 1` }"
+              @click.stop="
+                uiLocked ||
+                  toggleAccentPhraseSplit(accentPhraseIndex, false, moraIndex)
+              "
             />
           </template>
           <template v-if="accentPhrase.pauseMora">
@@ -240,13 +240,13 @@
               </span>
             </div>
             <div
-              @click.stop="
-                uiLocked || toggleAccentPhraseSplit(accentPhraseIndex, true)
-              "
               class="
                 splitter-cell
                 splitter-cell-be-split
                 splitter-cell-be-split-pause
+              "
+              @click.stop="
+                uiLocked || toggleAccentPhraseSplit(accentPhraseIndex, true)
               "
             />
           </template>

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -179,7 +179,7 @@
               :style="{
                 'grid-column': `${moraIndex * 2 + 1} / span 1`,
               }"
-              @mouse-over="handleHoverText(true, accentPhraseIndex, moraIndex)"
+              @mouseover="handleHoverText(true, accentPhraseIndex, moraIndex)"
               @mouseleave="handleHoverText(false, accentPhraseIndex, moraIndex)"
               @click.stop="
                 uiLocked ||

--- a/src/components/AudioInfo.vue
+++ b/src/components/AudioInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="root full-height q-py-md" v-if="query">
+  <div v-if="query" class="root full-height q-py-md">
     <div v-if="enablePreset" class="q-px-md">
       <div class="row items-center no-wrap q-mb-xs">
         <div class="text-body1">プリセット</div>
@@ -7,8 +7,8 @@
           <q-menu transition-duration="100">
             <q-list>
               <q-item
-                clickable
                 v-close-popup
+                clickable
                 @click="registerPreset({ overwrite: false })"
               >
                 <q-item-section avatar>
@@ -23,8 +23,8 @@
                 </q-item-section>
               </q-item>
               <q-item
-                clickable
                 v-close-popup
+                clickable
                 @click="showsPresetEditDialog = true"
               >
                 <q-item-section avatar>
@@ -56,12 +56,12 @@
           transition-hide="none"
           :disable="uiLocked"
         >
-          <template v-slot:selected-item="scope">
+          <template #selected-item="scope">
             <div class="preset-select-label">
               {{ scope.opt.label }}
             </div>
           </template>
-          <template v-slot:no-option>
+          <template #no-option>
             <q-item>
               <q-item-section class="text-grey">
                 プリセットはありません
@@ -71,13 +71,13 @@
         </q-select>
 
         <q-btn
+          v-show="!isRegisteredPreset || isChangedPreset"
           dense
           outline
           class="col-auto q-ml-xs"
           size="sm"
           text-color="display"
           :label="isRegisteredPreset ? '再登録' : '登録'"
-          v-show="!isRegisteredPreset || isChangedPreset"
           @click="registerPreset({ overwrite: isRegisteredPreset })"
         />
       </div>
@@ -110,10 +110,10 @@
 
             <q-card-actions align="right">
               <q-btn
+                v-close-popup
                 flat
                 label="キャンセル"
                 @click="closeAllDialog"
-                v-close-popup
               />
               <q-btn flat type="submit" label="確定" />
             </q-card-actions>
@@ -147,10 +147,10 @@
                 <q-item-section> プリセットの再登録のみ行う </q-item-section>
               </q-item>
               <q-item
+                v-close-popup
                 clickable
                 class="no-margin"
                 @click="closeAllDialog"
-                v-close-popup
               >
                 <q-item-section avatar>
                   <q-avatar icon="arrow_forward" text-color="blue" />
@@ -182,7 +182,7 @@
           "
           @change="handleParameterChange(parameter, $event)"
         >
-          <template v-slot:before
+          <template #before
             ><span class="text-body1 text-display">{{
               parameter.label
             }}</span></template
@@ -192,7 +192,7 @@
           dense
           snap
           color="primary-light"
-          trackSize="2px"
+          track-size="2px"
           :min="parameter.slider.qSliderProps.min.value"
           :max="parameter.slider.qSliderProps.max.value"
           :step="parameter.slider.qSliderProps.step.value"
@@ -218,12 +218,12 @@
       <span class="text-body1 q-mb-xs">モーフィング</span>
       <div class="row no-wrap items-center">
         <character-button
+          v-model:selected-voice="morphingTargetVoice"
           class="q-my-xs"
           :character-infos="morphingTargetCharacters"
           :show-engine-info="morphingTargetEngines.length >= 2"
           :emptiable="true"
           :ui-locked="uiLocked"
-          v-model:selected-voice="morphingTargetVoice"
         />
         <div class="q-pl-xs row overflow-hidden">
           <div class="text-body2 ellipsis overflow-hidden">
@@ -275,7 +275,7 @@
           dense
           snap
           color="primary-light"
-          trackSize="2px"
+          track-size="2px"
           :min="morphingRateSlider.qSliderProps.min.value"
           :max="morphingRateSlider.qSliderProps.max.value"
           :step="morphingRateSlider.qSliderProps.step.value"

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -4,12 +4,12 @@
     @mouseleave="handleMouseHover(false)"
   >
     <q-badge
-      class="value-label"
-      color="primary-light"
-      text-color="display-on-primary"
       v-if="
         !disable && (valueLabel.visible || previewSlider.state.isPanning.value)
       "
+      class="value-label"
+      color="primary-light"
+      text-color="display-on-primary"
     >
       {{
         previewSlider.state.currentValue.value
@@ -22,7 +22,7 @@
       reverse
       snap
       color="primary-light"
-      trackSize="2.5px"
+      track-size="2.5px"
       :style="clipPathComputed"
       :min="previewSlider.qSliderProps.min.value"
       :max="previewSlider.qSliderProps.max.value"

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -71,7 +71,7 @@
               no-caps
               class="col-grow"
               @click="onSelectSpeaker(characterInfo.metas.speakerUuid)"
-              @mouse-over="reassignSubMenuOpen(-1)"
+              @mouseover="reassignSubMenuOpen(-1)"
               @mouseleave="reassignSubMenuOpen.cancel()"
             >
               <q-avatar rounded size="2rem" class="q-mr-md">
@@ -113,7 +113,7 @@
                 role="application"
                 :aria-label="`${characterInfo.metas.speakerName}のスタイル、マウスオーバーするか、右矢印キーを押してスタイル選択を表示できます`"
                 tabindex="0"
-                @mouse-over="reassignSubMenuOpen(characterIndex)"
+                @mouseover="reassignSubMenuOpen(characterIndex)"
                 @mouseleave="reassignSubMenuOpen.cancel()"
                 @keyup.right="reassignSubMenuOpen(characterIndex)"
               >

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -1,8 +1,8 @@
 <template>
   <q-btn
+    ref="buttonRef"
     flat
     class="q-pa-none character-button"
-    ref="buttonRef"
     :disable="uiLocked"
     :class="{ opaque: loading }"
     aria-haspopup="menu"
@@ -48,9 +48,9 @@
         </q-item>
         <q-item v-if="emptiable" class="to-unselect-item q-pa-none">
           <q-btn
+            v-close-popup
             flat
             no-caps
-            v-close-popup
             class="full-width"
             :class="selectedCharacter == undefined && 'selected-background'"
             @click="$emit('update:selectedVoice', undefined)"
@@ -66,12 +66,12 @@
         >
           <q-btn-group flat class="col full-width">
             <q-btn
+              v-close-popup
               flat
               no-caps
-              v-close-popup
               class="col-grow"
               @click="onSelectSpeaker(characterInfo.metas.speakerUuid)"
-              @mouseover="reassignSubMenuOpen(-1)"
+              @mouse-over="reassignSubMenuOpen(-1)"
               @mouseleave="reassignSubMenuOpen.cancel()"
             >
               <q-avatar rounded size="2rem" class="q-mr-md">
@@ -85,9 +85,9 @@
                   "
                 />
                 <q-avatar
+                  v-if="showEngineInfo && characterInfo.metas.styles.length < 2"
                   class="engine-icon"
                   rounded
-                  v-if="showEngineInfo && characterInfo.metas.styles.length < 2"
                 >
                   <img
                     :src="
@@ -110,29 +110,29 @@
                 :class="
                   subMenuOpenFlags[characterIndex] && 'selected-background'
                 "
-                @mouseover="reassignSubMenuOpen(characterIndex)"
-                @mouseleave="reassignSubMenuOpen.cancel()"
-                v-on:keyup.right="reassignSubMenuOpen(characterIndex)"
                 role="application"
                 :aria-label="`${characterInfo.metas.speakerName}のスタイル、マウスオーバーするか、右矢印キーを押してスタイル選択を表示できます`"
                 tabindex="0"
+                @mouse-over="reassignSubMenuOpen(characterIndex)"
+                @mouseleave="reassignSubMenuOpen.cancel()"
+                @keyup.right="reassignSubMenuOpen(characterIndex)"
               >
                 <q-icon name="keyboard_arrow_right" color="grey-6" size="sm" />
                 <q-menu
+                  v-model="subMenuOpenFlags[characterIndex]"
                   no-parent-event
                   anchor="top end"
                   self="top start"
                   transition-show="none"
                   transition-hide="none"
                   class="character-menu"
-                  v-model="subMenuOpenFlags[characterIndex]"
                 >
                   <q-list style="min-width: max-content">
                     <q-item
                       v-for="(style, styleIndex) in characterInfo.metas.styles"
                       :key="styleIndex"
-                      clickable
                       v-close-popup
+                      clickable
                       active-class="selected-style-item"
                       :active="
                         selectedVoice != undefined &&
@@ -159,9 +159,9 @@
                           :src="characterInfo.metas.styles[styleIndex].iconPath"
                         />
                         <q-avatar
+                          v-if="showEngineInfo"
                           rounded
                           class="engine-icon"
-                          v-if="showEngineInfo"
                         >
                           <img
                             :src="

--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="modelValueComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="transparent-backdrop"
-    v-model="modelValueComputed"
   >
     <q-layout container view="hHh Lpr lff" class="bg-background">
       <q-header class="q-py-sm">
@@ -55,8 +55,8 @@
               <q-item
                 v-for="speakerUuid of sampleCharacterOrder"
                 :key="speakerUuid"
-                clickable
                 v-ripple="isHoverableItem"
+                clickable
                 class="q-pa-none character-item"
                 :class="[
                   isHoverableItem && 'hoverable-character-item',
@@ -95,13 +95,13 @@
                       icon="chevron_left"
                       text-color="display"
                       class="style-select-button"
+                      aria-label="前のスタイル"
                       @mouseenter="isHoverableItem = false"
                       @mouseleave="isHoverableItem = true"
                       @click.stop="
                         selectCharacter(speakerUuid);
                         rollStyleIndex(speakerUuid, -1);
                       "
-                      aria-label="前のスタイル"
                     />
                     <span aria-live="polite">{{
                       selectedStyles[speakerUuid].styleName || "ノーマル"
@@ -112,13 +112,13 @@
                       icon="chevron_right"
                       text-color="display"
                       class="style-select-button"
+                      aria-label="次のスタイル"
                       @mouseenter="isHoverableItem = false"
                       @mouseleave="isHoverableItem = true"
                       @click.stop="
                         selectCharacter(speakerUuid);
                         rollStyleIndex(speakerUuid, 1);
                       "
-                      aria-label="次のスタイル"
                     />
                   </div>
                   <div class="voice-samples">
@@ -138,6 +138,7 @@
                       "
                       color="primary-light"
                       class="voice-sample-btn"
+                      :aria-label="`サンプルボイス${voiceSampleIndex + 1}`"
                       @mouseenter="isHoverableItem = false"
                       @mouseleave="isHoverableItem = true"
                       @click.stop="
@@ -148,7 +149,6 @@
                           voiceSampleIndex
                         );
                       "
-                      :aria-label="`サンプルボイス${voiceSampleIndex + 1}`"
                     />
                   </div>
                   <div
@@ -167,13 +167,13 @@
               キャラクター並び替え
             </div>
             <draggable
-              class="character-order q-px-sm"
               v-model="characterOrder"
+              class="character-order q-px-sm"
               :item-key="keyOfCharacterOrderItem"
               @start="characterOrderDragging = true"
               @end="characterOrderDragging = false"
             >
-              <template v-slot:item="{ element }">
+              <template #item="{ element }">
                 <div
                   class="character-order-item q-py-sm"
                   :class="[

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="character-portrait-wrapper">
     <span class="character-name">{{ characterName }}</span>
-    <span class="character-engine-name" v-if="isMultipleEngine">{{
+    <span v-if="isMultipleEngine" class="character-engine-name">{{
       engineName
     }}</span>
     <img :src="portraitPath" class="character-portrait" :alt="characterName" />

--- a/src/components/ContactInfo.vue
+++ b/src/components/ContactInfo.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="relative-absolute-wrapper scroller bg-background">
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div class="q-pa-md markdown markdown-body" v-html="contact"></div>
   </q-page>
 </template>

--- a/src/components/DefaultStyleListDialog.vue
+++ b/src/components/DefaultStyleListDialog.vue
@@ -12,11 +12,11 @@
     :character-info="selectedCharacterInfo"
   />
   <q-dialog
+    v-model="modelValueComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="transparent-backdrop"
-    v-model="modelValueComputed"
   >
     <q-layout container view="hHh Lpr lff" class="bg-background">
       <q-header class="q-py-sm">
@@ -49,8 +49,8 @@
               <q-item
                 v-for="speaker of speakerWithMultipleStyles"
                 :key="speaker.metas.speakerUuid"
-                clickable
                 v-ripple="isHoverableItem"
+                clickable
                 class="q-pa-none character-item"
                 :class="[isHoverableItem && 'hoverable-character-item']"
                 @click="openStyleSelectDialog(speaker)"

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -1,11 +1,11 @@
 <template>
   <q-dialog
+    v-model="isOpenComputed"
     maximized
     transition-show="none"
     transition-hide="none"
     transition-duration="100"
     class="default-style-select-dialog transparent-backdrop"
-    v-model="isOpenComputed"
   >
     <q-layout container view="hHh Lpr lff" class="bg-background">
       <q-header class="q-py-sm">
@@ -51,8 +51,8 @@
               <q-item
                 v-for="(style, styleIndex) of characterInfo.metas.styles"
                 :key="styleIndex"
-                clickable
                 v-ripple="isHoverableStyleItem"
+                clickable
                 class="q-pa-none style-item"
                 :class="[
                   selectedStyleIndexComputed === styleIndex &&

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="dictionaryManageDialogOpenedComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="setting-dialog transparent-backdrop"
-    v-model="dictionaryManageDialogOpenedComputed"
   >
     <q-layout container view="hHh Lpr fFf" class="bg-background">
       <q-page-container>
@@ -52,24 +52,24 @@
                   outline
                   text-color="warning"
                   class="text-no-wrap text-bold col-sm q-ma-sm"
-                  @click="deleteWord"
                   :disable="uiLocked || !isDeletable"
+                  @click="deleteWord"
                   >削除</q-btn
                 >
                 <q-btn
                   outline
                   text-color="display"
                   class="text-no-wrap text-bold col-sm q-ma-sm"
-                  @click="editWord"
                   :disable="uiLocked || !selectedId"
+                  @click="editWord"
                   >編集</q-btn
                 >
                 <q-btn
                   outline
                   text-color="display"
                   class="text-no-wrap text-bold col-sm q-ma-sm"
-                  @click="newWord"
                   :disable="uiLocked"
+                  @click="newWord"
                   >追加</q-btn
                 >
               </div>
@@ -78,13 +78,13 @@
               <q-item
                 v-for="(value, key) in userDict"
                 :key="key"
-                tag="label"
                 v-ripple
+                tag="label"
                 clickable
-                @click="selectWord(key)"
-                @dblclick="editWord"
                 :active="selectedId === key"
                 active-class="active-word"
+                @click="selectWord(key)"
+                @dblclick="editWord"
               >
                 <q-item-section>
                   <q-item-label class="text-display">{{
@@ -105,27 +105,27 @@
               <div class="text-h6">単語</div>
               <q-input
                 ref="surfaceInput"
-                class="word-input"
                 v-model="surface"
-                @blur="setSurface(surface)"
-                @keydown="yomiFocusWhenEnter"
+                class="word-input"
                 dense
                 :disable="uiLocked"
+                @blur="setSurface(surface)"
+                @keydown="yomiFocusWhenEnter"
               />
             </div>
             <div class="row q-pl-md q-pt-sm">
               <div class="text-h6">読み</div>
               <q-input
                 ref="yomiInput"
-                class="word-input q-pb-none"
                 v-model="yomi"
-                @blur="setYomi(yomi)"
-                @keydown="setYomiWhenEnter"
+                class="word-input q-pb-none"
                 dense
                 :error="!isOnlyHiraOrKana"
                 :disable="uiLocked"
+                @blur="setYomi(yomi)"
+                @keydown="setYomiWhenEnter"
               >
-                <template v-slot:error>
+                <template #error>
                   読みに使える文字はひらがなとカタカナのみです。
                 </template>
               </q-input>
@@ -150,8 +150,8 @@
                   color="primary-light"
                   text-color="display-on-primary"
                   icon="stop"
-                  @click="stop"
                   :disable="nowGenerating"
+                  @click="stop"
                 />
               </div>
               <div
@@ -163,7 +163,7 @@
                     :accent-phrase="accentPhrase"
                     :accent-phrase-index="0"
                     :ui-locked="uiLocked"
-                    :onChangeAccent="changeAccent"
+                    :on-change-accent="changeAccent"
                   />
                   <template
                     v-for="(mora, moraIndex) in accentPhrase.moras"
@@ -220,24 +220,24 @@
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="resetWord"
                 :disable="uiLocked || !isWordChanged"
+                @click="resetWord"
                 >リセット</q-btn
               >
               <q-btn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="discardOrNotDialog(cancel)"
                 :disable="uiLocked"
+                @click="discardOrNotDialog(cancel)"
                 >キャンセル</q-btn
               >
               <q-btn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="saveWord"
                 :disable="uiLocked || !isWordChanged"
+                @click="saveWord"
                 >保存</q-btn
               >
             </div>

--- a/src/components/EngineManageDialog.vue
+++ b/src/components/EngineManageDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="engineManageDialogOpenedComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="setting-dialog transparent-backdrop"
-    v-model="engineManageDialogOpenedComputed"
   >
     <q-layout container view="hHh Lpr fFf" class="bg-background">
       <q-page-container>
@@ -20,13 +20,13 @@
               flat
               icon="close"
               color="display"
-              @click="toDialogClosedState"
               :disabled="isAddingEngine || uiLocked"
+              @click="toDialogClosedState"
             />
           </q-toolbar>
         </q-header>
         <q-page class="row">
-          <div class="ui-lock-popup" v-if="uiLockedState">
+          <div v-if="uiLockedState" class="ui-lock-popup">
             <div class="q-pa-md">
               <q-spinner color="primary" size="2.5rem" />
               <div class="q-mt-xs">
@@ -48,8 +48,8 @@
                   outline
                   text-color="display"
                   class="text-no-wrap text-bold col-sm q-ma-sm"
-                  @click="toAddEngineState"
                   :disable="uiLocked"
+                  @click="toAddEngineState"
                   >追加</q-btn
                 >
               </div>
@@ -68,19 +68,19 @@
                 <q-item
                   v-for="id in engineIds"
                   :key="id"
-                  tag="label"
                   v-ripple
+                  tag="label"
                   clickable
-                  @click="selectEngine(id)"
                   :active="selectedId === id"
                   active-class="active-engine"
+                  @click="selectEngine(id)"
                 >
                   <q-item-section avatar>
                     <q-avatar rounded color="primary">
                       <img
+                        v-if="engineIcons[id]"
                         :src="engineIcons[id]"
                         :alt="engineInfos[id].name"
-                        v-if="engineIcons[id]"
                       />
                       <span v-else class="text-display-on-primary"> ? </span>
                     </q-avatar>
@@ -110,11 +110,11 @@
 
               <div class="q-ma-sm">
                 <q-btn-toggle
+                  v-model="engineLoaderType"
                   :options="[
                     { value: 'vvpp', label: 'VVPPファイル' },
                     { value: 'dir', label: '既存エンジン' },
                   ]"
-                  v-model="engineLoaderType"
                   color="surface"
                   unelevated
                   text-color="display"
@@ -124,7 +124,7 @@
               </div>
             </div>
 
-            <div class="no-wrap q-pl-md" v-if="engineLoaderType === 'vvpp'">
+            <div v-if="engineLoaderType === 'vvpp'" class="no-wrap q-pl-md">
               <div class="q-ma-sm">
                 VVPPファイルでエンジンをインストールします。
               </div>
@@ -137,7 +137,7 @@
                   placeholder="VVPPファイルの場所"
                   @click="selectVvppFile"
                 >
-                  <template v-slot:append>
+                  <template #append>
                     <q-btn
                       square
                       dense
@@ -151,7 +151,7 @@
                       </q-tooltip>
                     </q-btn>
                   </template>
-                  <template v-slot:error>
+                  <template #error>
                     {{
                       newEngineDirValidationState
                         ? getEngineDirValidationMessage(
@@ -163,7 +163,7 @@
                 </q-input>
               </div>
             </div>
-            <div class="no-wrap q-pl-md" v-if="engineLoaderType === 'dir'">
+            <div v-if="engineLoaderType === 'dir'" class="no-wrap q-pl-md">
               <div class="q-ma-sm">PC内にあるエンジンを追加します。</div>
               <div class="q-ma-sm">
                 <q-input
@@ -178,7 +178,7 @@
                   placeholder="エンジンフォルダの場所"
                   @click="selectEngineDir"
                 >
-                  <template v-slot:append>
+                  <template #append>
                     <q-btn
                       square
                       dense
@@ -192,7 +192,7 @@
                       </q-tooltip>
                     </q-btn>
                   </template>
-                  <template v-slot:error>
+                  <template #error>
                     {{
                       newEngineDirValidationState
                         ? getEngineDirValidationMessage(
@@ -218,8 +218,8 @@
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="addEngine"
                 :disabled="!canAddEngine"
+                @click="addEngine"
                 >追加</q-btn
               >
             </div>
@@ -235,7 +235,7 @@
                 :alt="engineInfos[selectedId].name"
                 class="engine-icon"
               />
-              <div class="q-mt-sm inline-block" v-else>
+              <div v-else class="q-mt-sm inline-block">
                 <q-avatar rounded color="primary" size="2rem">
                   <span class="text-display-on-primary"> ? </span>
                 </q-avatar>
@@ -311,27 +311,27 @@
                 outline
                 text-color="warning"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="deleteEngine"
                 :disable="
                   uiLocked ||
                   !['path', 'vvpp'].includes(engineInfos[selectedId].type)
                 "
+                @click="deleteEngine"
                 >削除</q-btn
               >
               <q-btn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="openSelectedEngineDirectory"
                 :disable="uiLocked || !engineInfos[selectedId].path"
+                @click="openSelectedEngineDirectory"
                 >フォルダを開く</q-btn
               >
               <q-btn
                 outline
                 text-color="display"
                 class="text-no-wrap text-bold q-mr-sm"
-                @click="restartSelectedEngine"
                 :disable="uiLocked || engineStates[selectedId] === 'STARTING'"
+                @click="restartSelectedEngine"
                 >再起動</q-btn
               >
             </div>

--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -15,6 +15,8 @@
         <div class="row full-width justify-between">
           <div class="col">
             <q-input
+              ref="patternInput"
+              v-model="currentFileNamePattern"
               dense
               outlined
               bg-color="background"
@@ -23,10 +25,8 @@
               :maxlength="maxLength"
               :error="hasError"
               :error-message="errorMessage"
-              v-model="currentFileNamePattern"
-              ref="patternInput"
             >
-              <template v-slot:after>
+              <template #after>
                 <q-btn
                   label="デフォルトにリセット"
                   outline

--- a/src/components/HeaderBarCustomDialog.vue
+++ b/src/components/HeaderBarCustomDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="headerBarCustomDialogOpenComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="header-bar-custom-dialog transparent-backdrop"
-    v-model="headerBarCustomDialogOpenComputed"
   >
     <q-layout container view="hHh Lpr fFf" class="bg-background">
       <q-page-container class="root">
@@ -19,8 +19,8 @@
               color="toolbar-button"
               text-color="toolbar-button-display"
               class="text-no-wrap text-bold q-mr-sm"
-              @click="applyDefaultSetting"
               :disable="isDefault"
+              @click="applyDefaultSetting"
               >デフォルトに戻す</q-btn
             >
             <q-btn
@@ -28,8 +28,8 @@
               color="toolbar-button"
               text-color="toolbar-button-display"
               class="text-no-wrap text-bold q-mr-sm"
-              @click="saveCustomToolbar"
               :disable="!isChanged"
+              @click="saveCustomToolbar"
               >保存</q-btn
             >
             <!-- close button -->
@@ -52,11 +52,7 @@
                 @end="toolbarButtonDragging = false"
               >
                 <template
-                  v-slot:item="{
-                    element: button,
-                  }: {
-                    element: ToolbarButtonTagType,
-                  }"
+                  #item="{ element: button }: { element: ToolbarButtonTagType }"
                 >
                   <q-btn
                     unelevated
@@ -95,8 +91,8 @@
                 <q-item
                   v-for="(desc, key) in usableButtonsDesc"
                   :key="key"
-                  tag="label"
                   v-ripple
+                  tag="label"
                 >
                   <q-item-section>
                     <q-item-label>{{ getToolbarButtonName(key) }}</q-item-label>

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="modelValueComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="help-dialog transparent-backdrop"
-    v-model="modelValueComputed"
   >
     <q-layout container view="hHh Lpr lff">
       <q-drawer
@@ -20,8 +20,8 @@
             <template v-for="(page, pageIndex) of pagedata" :key="pageIndex">
               <q-item
                 v-if="page.type === 'item'"
-                clickable
                 v-ripple
+                clickable
                 active-class="selected-item"
                 :active="selectedPageIndex === pageIndex"
                 @click="selectedPageIndex = pageIndex"
@@ -46,7 +46,7 @@
               :name="pageIndex"
               class="q-pa-none"
             >
-              <div class="root" v-if="page.type === 'item'">
+              <div v-if="page.type === 'item'" class="root">
                 <q-header class="q-pa-sm">
                   <q-toolbar>
                     <q-toolbar-title class="text-display">

--- a/src/components/HelpPolicy.vue
+++ b/src/components/HelpPolicy.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="relative-absolute-wrapper scroller bg-background">
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div class="q-pa-md markdown markdown-body" v-html="policyHtml"></div>
   </q-page>
 </template>

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="hotkeySettingDialogOpenComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="hotkey-setting-dialog transparent-backdrop"
-    v-model="hotkeySettingDialogOpenComputed"
   >
     <q-layout container view="hHh Lpr lff" class="bg-background">
       <q-header class="q-py-sm">
@@ -13,12 +13,12 @@
             >設定 / キー割り当て</q-toolbar-title
           >
           <q-input
+            v-model="hotkeyFilter"
             hide-bottom-space
             dense
             placeholder="検索"
             color="display"
             class="q-mr-sm search-box"
-            v-model="hotkeyFilter"
           >
             <template #prepend>
               <q-icon name="search" />
@@ -46,6 +46,7 @@
       <q-page-container>
         <q-page>
           <q-table
+            v-model:pagination="hotkeyPagination"
             flat
             dense
             hide-bottom
@@ -56,31 +57,45 @@
             :rows="hotkeySettings"
             :columns="hotkeyColumns"
             class="hotkey-table"
-            v-model:pagination="hotkeyPagination"
           >
-            <template #header="props">
-              <q-tr :props="props">
-                <q-th v-for="col of props.cols" :key="col.name" :props="props">
+            <template #header="tableProps">
+              <q-tr :props="tableProps">
+                <q-th
+                  v-for="col of tableProps.cols"
+                  :key="col.name"
+                  :props="tableProps"
+                >
                   {{ col.label }}
                 </q-th>
               </q-tr>
             </template>
 
-            <template #body="props">
-              <q-tr :props="props">
-                <q-td no-hover :key="props.cols[0].name" :props="props">
-                  {{ props.row.action }}
+            <template #body="tableProps">
+              <q-tr :props="tableProps">
+                <q-td
+                  :key="tableProps.cols[0].name"
+                  no-hover
+                  :props="tableProps"
+                >
+                  {{ tableProps.row.action }}
                 </q-td>
-                <q-td no-hover :key="props.cols[1].name" :props="props">
+                <q-td
+                  :key="tableProps.cols[1].name"
+                  no-hover
+                  :props="tableProps"
+                >
                   <q-btn
                     dense
                     text-color="display"
                     padding="none sm"
                     flat
-                    :disable="checkHotkeyReadonly(props.row.action)"
+                    :disable="checkHotkeyReadonly(tableProps.row.action)"
                     no-caps
                     :label="
-                      getHotkeyText(props.row.action, props.row.combination)
+                      getHotkeyText(
+                        tableProps.row.action,
+                        tableProps.row.combination
+                      )
                         .split(' ')
                         .map((hotkeyText) => {
                           // Mac の Meta キーは Cmd キーであるため、Meta の表示名を Cmd に置換する
@@ -89,7 +104,7 @@
                         })
                         .join(' + ')
                     "
-                    @click="openHotkeyDialog(props.row.action)"
+                    @click="openHotkeyDialog(tableProps.row.action)"
                   />
                   <q-btn
                     rounded
@@ -97,8 +112,8 @@
                     icon="settings_backup_restore"
                     padding="none sm"
                     size="1em"
-                    :disable="checkHotkeyReadonly(props.row.action)"
-                    @click="resetHotkey(props.row.action)"
+                    :disable="checkHotkeyReadonly(tableProps.row.action)"
+                    @click="resetHotkey(tableProps.row.action)"
                   >
                     <q-tooltip :delay="500">デフォルトに戻す</q-tooltip>
                   </q-btn>
@@ -174,12 +189,12 @@
           color="primary"
           text-color="display-on-primary"
           class="q-mt-sm"
+          :disabled="confirmBtnEnabled"
           @click="
             changeHotkeySettings(lastAction, lastRecord).then(() =>
               closeHotkeyDialog()
             )
           "
-          :disabled="confirmBtnEnabled"
         />
         <q-btn
           v-else
@@ -189,8 +204,8 @@
           color="primary"
           text-color="display-on-primary"
           class="q-mt-sm"
-          @click="solveDuplicated().then(() => closeHotkeyDialog())"
           :disabled="confirmBtnEnabled"
+          @click="solveDuplicated().then(() => closeHotkeyDialog())"
         />
       </q-card-actions>
     </q-card>

--- a/src/components/HowToUse.vue
+++ b/src/components/HowToUse.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="relative-absolute-wrapper scroller markdown-body">
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div class="q-pa-md markdown" v-html="howToUse"></div>
   </q-page>
 </template>

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -73,7 +73,7 @@ import { computed, ref } from "vue";
 import { useStore } from "@/store";
 import { useMarkdownIt } from "@/plugins/markdownItPlugin";
 import { EngineId, SpeakerId } from "@/type/preload";
-import { mapUndefinedPipe, undefinedToDefault } from "@/helpers/map";
+import { mapUndefinedPipe } from "@/helpers/map";
 
 type DetailKey = { engine: EngineId; character: SpeakerId };
 
@@ -114,7 +114,7 @@ const policy = computed<string | undefined>(() => {
   );
   if (characterInfo == undefined) return undefined;
 
-  return characterInfo.metas.policy;
+  return md.render(characterInfo.metas.policy);
 });
 
 const selectedInfo = ref<DetailKey | undefined>(undefined);

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -62,7 +62,7 @@
           }}
         </div>
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <div class="markdown" v-html="policy"></div>
+        <div v-if="policy" class="markdown" v-html="policy"></div>
       </div>
     </div>
   </q-page>
@@ -103,20 +103,19 @@ const engineInfos = computed(
     )
 );
 
-const policy = computed<string>(() =>
-  md.render(
-    undefinedToDefault(
-      "",
-      mapUndefinedPipe(
-        selectedInfo.value,
-        (v) => engineInfos.value.get(v.engine),
-        (v) => v.characterInfos,
-        (v) => mapUndefinedPipe(selectedInfo.value, (i) => v.get(i.character)),
-        (v) => v.metas.policy
-      )
-    )
-  )
-);
+const policy = computed<string | undefined>(() => {
+  if (selectedInfo.value == undefined) return undefined;
+
+  const engineInfo = engineInfos.value.get(selectedInfo.value.engine);
+  if (engineInfo == undefined) return undefined;
+
+  const characterInfo = engineInfo.characterInfos.get(
+    selectedInfo.value.character
+  );
+  if (characterInfo == undefined) return undefined;
+
+  return characterInfo.metas.policy;
+});
 
 const selectedInfo = ref<DetailKey | undefined>(undefined);
 

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -13,7 +13,7 @@
         >
           <!-- エンジンが一つだけの場合は名前を表示しない -->
           <template v-if="engineInfos.size > 1">
-            <q-separator spaced v-if="engineIndex > 0" />
+            <q-separator v-if="engineIndex > 0" spaced />
             <q-item-label header>{{
               mapUndefinedPipe(engineInfos.get(engineId), (v) => v.name)
             }}</q-item-label>
@@ -61,23 +61,8 @@
             )
           }}
         </div>
-        <div
-          class="markdown"
-          v-html="
-            convertMarkdown(
-              undefinedToDefault(
-                '',
-                mapUndefinedPipe(
-                  engineInfos.get(selectedInfo.engine),
-                  (v) => v.characterInfos,
-                  (v) =>
-                    mapUndefinedPipe(selectedInfo, (i) => v.get(i.character)),
-                  (v) => v.metas.policy
-                )
-              )
-            )
-          "
-        ></div>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <div class="markdown" v-html="policy"></div>
       </div>
     </div>
   </q-page>
@@ -118,9 +103,20 @@ const engineInfos = computed(
     )
 );
 
-const convertMarkdown = (text: string) => {
-  return md.render(text);
-};
+const policy = computed<string>(() =>
+  md.render(
+    undefinedToDefault(
+      "",
+      mapUndefinedPipe(
+        selectedInfo.value,
+        (v) => engineInfos.value.get(v.engine),
+        (v) => v.characterInfos,
+        (v) => mapUndefinedPipe(selectedInfo.value, (i) => v.get(i.character)),
+        (v) => v.metas.policy
+      )
+    )
+  )
+);
 
 const selectedInfo = ref<DetailKey | undefined>(undefined);
 

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -11,7 +11,7 @@
       v-model:selected="subMenuOpenFlags[index]"
       :menudata="root"
       :disable="menubarLocked"
-      @mouse-over="reassignSubMenuOpen(index)"
+      @mouseover="reassignSubMenuOpen(index)"
       @mouseleave="
         root.type === 'button' ? (subMenuOpenFlags[index] = false) : undefined
       "

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -8,10 +8,10 @@
     <menu-button
       v-for="(root, index) of menudata"
       :key="index"
-      :menudata="root"
       v-model:selected="subMenuOpenFlags[index]"
+      :menudata="root"
       :disable="menubarLocked"
-      @mouseover="reassignSubMenuOpen(index)"
+      @mouse-over="reassignSubMenuOpen(index)"
       @mouseleave="
         root.type === 'button' ? (subMenuOpenFlags[index] = false) : undefined
       "

--- a/src/components/MenuButton.vue
+++ b/src/components/MenuButton.vue
@@ -11,29 +11,29 @@
     "
     :class="selected ? 'active-menu' : 'bg-transparent'"
     :disable="disable"
+    aria-haspopup="menu"
     @click="
       (menudata.type === 'button' || menudata.type === 'root') &&
         menudata.onClick?.()
     "
-    aria-haspopup="menu"
   >
     {{ menudata.label }}
     <q-menu
       v-if="'subMenu' in menudata"
+      v-model="selectedComputed"
       transition-show="none"
       transition-hide="none"
       :fit="true"
-      v-model="selectedComputed"
     >
       <q-list dense>
         <menu-item
           v-for="(menu, index) of menudata.subMenu"
           :key="index"
+          v-model:selected="subMenuOpenFlags[index]"
           :menudata="menu"
           :disable="
             uiLocked && menu.type !== 'separator' && menu.disableWhenUiLocked
           "
-          v-model:selected="subMenuOpenFlags[index]"
           @mouseenter="reassignSubMenuOpen(index)"
           @mouseleave="reassignSubMenuOpen.cancel()"
         />

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -1,22 +1,22 @@
 <template>
-  <q-separator class="bg-surface" v-if="menudata.type === 'separator'" />
+  <q-separator v-if="menudata.type === 'separator'" class="bg-surface" />
   <q-item
-    class="bg-background"
     v-else-if="menudata.type === 'root'"
+    class="bg-background"
     clickable
     dense
     :disable="menudata.disabled"
     :class="selected && 'active-menu'"
     @click="menudata.onClick"
   >
-    <q-item-section side class="q-py-2" v-if="menudata.icon">
+    <q-item-section v-if="menudata.icon" side class="q-py-2">
       <img :src="menudata.icon" class="engine-icon" />
     </q-item-section>
 
     <q-item-section>{{ menudata.label }}</q-item-section>
     <q-item-section
-      side
       v-if="menudata.label != undefined && getMenuBarHotkey(menudata.label)"
+      side
     >
       {{ getMenuBarHotkey(menudata.label) }}
     </q-item-section>
@@ -26,34 +26,34 @@
     </q-item-section>
 
     <q-menu
+      v-model="selectedComputed"
       anchor="top end"
       transition-show="none"
       transition-hide="none"
-      v-model="selectedComputed"
       :target="!uiLocked"
     >
       <menu-item
         v-for="(menu, i) of menudata.subMenu"
         :key="i"
-        :menudata="menu"
         v-model:selected="subMenuOpenFlags[i]"
-        @mouseover="reassignSubMenuOpen(i)"
+        :menudata="menu"
+        @mouse-over="reassignSubMenuOpen(i)"
       />
     </q-menu>
   </q-item>
   <q-item
     v-else
-    dense
-    clickable
     v-ripple
     v-close-popup
+    dense
+    clickable
     class="bg-background"
     :disable="menudata.disabled"
     @click="menudata.onClick"
   >
     <q-item-section
-      avatar
       v-if="'icon' in menudata && menudata.icon != undefined"
+      avatar
     >
       <q-avatar>
         <img :src="menudata.icon" />
@@ -62,8 +62,8 @@
 
     <q-item-section>{{ menudata.label }}</q-item-section>
     <q-item-section
-      side
       v-if="menudata.label != undefined && getMenuBarHotkey(menudata.label)"
+      side
     >
       {{ getMenuBarHotkey(menudata.label) }}
     </q-item-section>

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -37,7 +37,7 @@
         :key="i"
         v-model:selected="subMenuOpenFlags[i]"
         :menudata="menu"
-        @mouse-over="reassignSubMenuOpen(i)"
+        @mouseover="reassignSubMenuOpen(i)"
       />
     </q-menu>
   </q-item>

--- a/src/components/MinMaxCloseButtons.vue
+++ b/src/components/MinMaxCloseButtons.vue
@@ -14,8 +14,8 @@
       size="8.5px"
       color="red"
       class="title-bar-buttons"
-      @click="closeWindow()"
       aria-label="閉じる"
+      @click="closeWindow()"
     ></q-btn>
     <q-btn
       dense
@@ -25,8 +25,8 @@
       size="8.5px"
       color="yellow"
       class="title-bar-buttons"
-      @click="minimizeWindow()"
       aria-label="最小化"
+      @click="minimizeWindow()"
     ></q-btn>
     <q-btn
       dense
@@ -36,8 +36,8 @@
       size="8.5px"
       color="green"
       class="title-bar-buttons"
-      @click="maximizeWindow()"
       aria-label="最大化"
+      @click="maximizeWindow()"
     ></q-btn>
   </q-badge>
   <q-badge
@@ -57,8 +57,8 @@
       flat
       icon="minimize"
       class="title-bar-buttons"
-      @click="minimizeWindow()"
       aria-label="最小化"
+      @click="minimizeWindow()"
     ></q-btn>
 
     <q-btn
@@ -67,8 +67,8 @@
       flat
       icon="crop_square"
       class="title-bar-buttons"
-      @click="maximizeWindow()"
       aria-label="最大化"
+      @click="maximizeWindow()"
     ></q-btn>
     <q-btn
       v-else
@@ -76,8 +76,8 @@
       flat
       :icon="mdiWindowRestore"
       class="title-bar-buttons"
-      @click="maximizeWindow()"
       aria-label="最大化"
+      @click="maximizeWindow()"
     >
     </q-btn>
 
@@ -86,8 +86,8 @@
       flat
       icon="close"
       class="title-bar-buttons close"
-      @click="closeWindow()"
       aria-label="閉じる"
+      @click="closeWindow()"
     ></q-btn>
   </q-badge>
 </template>

--- a/src/components/OssCommunityInfo.vue
+++ b/src/components/OssCommunityInfo.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="relative-absolute-wrapper scroller markdown-body">
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div class="q-pa-md markdown" v-html="ossCommunityInfos"></div>
   </q-page>
 </template>

--- a/src/components/PresetManageDialog.vue
+++ b/src/components/PresetManageDialog.vue
@@ -11,11 +11,11 @@
         <div class="full-width row wrap justify-between">
           <q-list bordered separator class="col-sm-grow">
             <draggable
-              :modelValue="previewPresetList"
-              @update:modelValue="reorderPreset"
+              :model-value="previewPresetList"
               item-key="key"
+              @update:model-value="reorderPreset"
             >
-              <template v-slot:item="{ element: item }">
+              <template #item="{ element: item }">
                 <q-item>
                   <q-item-section>{{ item.name }}</q-item-section>
                   <q-space />

--- a/src/components/QAndA.vue
+++ b/src/components/QAndA.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="relative-absolute-wrapper scroller bg-background">
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div class="q-pa-md markdown markdown-body" v-html="qAndA"></div>
   </q-page>
 </template>

--- a/src/components/SaveAllResultDialog.vue
+++ b/src/components/SaveAllResultDialog.vue
@@ -1,10 +1,10 @@
 <template>
-  <q-dialog persistent ref="dialogRef">
+  <q-dialog ref="dialogRef" persistent>
     <q-layout container class="q-dialog-plugin bg-background">
       <q-page-container>
         <q-page class="q-px-md">
           <h5 class="text-h5 q-my-md">音声書き出し結果</h5>
-          <q-list separator v-if="props.writeErrorArray.length > 0">
+          <q-list v-if="props.writeErrorArray.length > 0" separator>
             <div class="text-warning">失敗（書き込みエラー）:</div>
             <q-item
               v-for="(value, index) in props.writeErrorArray"
@@ -16,7 +16,7 @@
               </q-item-section>
             </q-item>
           </q-list>
-          <q-list separator v-if="props.engineErrorArray.length > 0">
+          <q-list v-if="props.engineErrorArray.length > 0" separator>
             <div class="text-warning">失敗（エンジンエラー）:</div>
             <q-item
               v-for="(value, index) in props.engineErrorArray"
@@ -30,7 +30,7 @@
               </q-item-section>
             </q-item>
           </q-list>
-          <q-list separator v-if="props.successArray.length > 0">
+          <q-list v-if="props.successArray.length > 0" separator>
             <div class="text-primary">成功:</div>
             <q-item v-for="(value, index) in props.successArray" :key="index">
               <q-item-section>
@@ -43,7 +43,7 @@
       <q-footer>
         <q-toolbar>
           <q-space />
-          <q-btn flat dense align="right" @click="close" label="閉じる" />
+          <q-btn flat dense align="right" label="閉じる" @click="close" />
         </q-toolbar>
       </q-footer>
     </q-layout>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <q-dialog
+    v-model="settingDialogOpenedComputed"
     maximized
     transition-show="jump-up"
     transition-hide="jump-down"
     class="setting-dialog transparent-backdrop"
-    v-model="settingDialogOpenedComputed"
   >
     <q-layout container view="hHh Lpr fFf" class="bg-background">
       <q-page-container class="root">
@@ -33,10 +33,10 @@
                 <template v-if="engineIds.length > 1">
                   <q-space />
                   <q-select
+                    v-model="selectedEngineId"
                     borderless
                     dense
                     name="engine"
-                    v-model="selectedEngineId"
                     :options="engineIds"
                     :option-label="renderEngineNameLabel"
                   />
@@ -60,9 +60,9 @@
                 </div>
                 <q-space />
                 <q-btn-toggle
+                  v-model="engineUseGpu"
                   padding="xs md"
                   unelevated
-                  v-model="engineUseGpu"
                   color="background"
                   text-color="display"
                   toggle-color="primary"
@@ -100,9 +100,9 @@
                 </div>
                 <q-space />
                 <q-select
+                  v-model="outputSamplingRate"
                   borderless
                   name="samplingRate"
-                  v-model="outputSamplingRate"
                   :options="samplingRateOptions"
                   :option-label="renderSamplingRateLabel"
                 >
@@ -205,7 +205,6 @@
                   padding="xs md"
                   unelevated
                   :model-value="splitTextWhenPaste"
-                  @update:model-value="changeSplitTextWhenPaste($event)"
                   color="background"
                   text-color="display"
                   toggle-color="primary"
@@ -223,8 +222,9 @@
                     },
                     { label: 'オフ', value: 'OFF', slot: 'splitTextOFF' },
                   ]"
+                  @update:model-value="changeSplitTextWhenPaste($event)"
                 >
-                  <template v-slot:splitTextPeriodAndNewLine>
+                  <template #splitTextPeriodAndNewLine>
                     <q-tooltip
                       :delay="500"
                       anchor="center right"
@@ -235,7 +235,7 @@
                       句点と改行を基にテキストを分割します。
                     </q-tooltip>
                   </template>
-                  <template v-slot:splitTextNewLine>
+                  <template #splitTextNewLine>
                     <q-tooltip
                       :delay="500"
                       anchor="center right"
@@ -246,7 +246,7 @@
                       改行のみを基にテキストを分割します。
                     </q-tooltip>
                   </template>
-                  <template v-slot:splitTextOFF>
+                  <template #splitTextOFF>
                     <q-tooltip
                       :delay="500"
                       anchor="center right"
@@ -277,11 +277,11 @@
                 <q-space />
                 <!-- ボタンクリックのフィードバックのためのチェックマーク -->
                 <q-icon
+                  v-if="isDefaultConfirmedTips && hasResetConfirmedTips"
                   name="check"
                   size="sm"
                   color="primary-light"
                   style="margin-right: 8px"
-                  v-if="isDefaultConfirmedTips && hasResetConfirmedTips"
                 >
                 </q-icon>
                 <q-btn
@@ -290,13 +290,13 @@
                   color="background"
                   text-color="display"
                   class="text-no-wrap q-mr-sm"
+                  :disable="isDefaultConfirmedTips"
                   @click="
                     () => {
                       store.dispatch('RESET_CONFIRMED_TIPS');
                       hasResetConfirmedTips = true;
                     }
                   "
-                  :disable="isDefaultConfirmedTips"
                 >
                 </q-btn>
               </q-card-actions>
@@ -326,9 +326,6 @@
                   padding="xs md"
                   unelevated
                   :model-value="savingSetting.fileEncoding"
-                  @update:model-value="
-                    handleSavingSettingChange('fileEncoding', $event)
-                  "
                   color="background"
                   text-color="display"
                   toggle-color="primary"
@@ -337,6 +334,9 @@
                     { label: 'UTF-8', value: 'UTF-8' },
                     { label: 'Shift_JIS', value: 'Shift_JIS' },
                   ]"
+                  @update:model-value="
+                    handleSavingSettingChange('fileEncoding', $event)
+                  "
                 />
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-surface">
@@ -356,8 +356,8 @@
                 </div>
                 <q-space />
                 <q-input
-                  dense
                   v-if="savingSetting.fixedExportEnabled"
+                  dense
                   maxheight="10px"
                   label="書き出し先のフォルダ"
                   hide-bottom-space
@@ -375,7 +375,7 @@
                     }
                   "
                 >
-                  <template v-slot:append>
+                  <template #append>
                     <q-btn
                       square
                       dense
@@ -526,13 +526,13 @@
                 </q-icon>
                 <q-space />
                 <q-btn-toggle
+                  v-model="currentThemeNameComputed"
                   unelevated
                   padding="xs md"
                   color="background"
                   text-color="display"
                   toggle-color="primary"
                   toggle-text-color="display-on-primary"
-                  v-model="currentThemeNameComputed"
                   :options="availableThemeNameComputed"
                 />
               </q-card-actions>
@@ -557,7 +557,6 @@
                   padding="xs md"
                   unelevated
                   :model-value="editorFont"
-                  @update:model-value="changeEditorFont($event)"
                   color="background"
                   text-color="display"
                   toggle-color="primary"
@@ -566,6 +565,7 @@
                     { label: 'デフォルト', value: 'default' },
                     { label: 'OS標準', value: 'os' },
                   ]"
+                  @update:model-value="changeEditorFont($event)"
                 />
               </q-card-actions>
               <q-card-actions class="q-px-md q-py-none bg-surface">
@@ -638,8 +638,8 @@
                 </div>
                 <q-space />
                 <q-select
-                  dense
                   v-model="currentAudioOutputDeviceComputed"
+                  dense
                   label="再生デバイス"
                   :options="availableAudioOutputDevices"
                   class="col-7"
@@ -694,13 +694,13 @@
                   :model-value="
                     experimentalSetting.shouldApplyDefaultPresetOnVoiceChanged
                   "
+                  :disable="!experimentalSetting.enablePreset"
                   @update:model-value="
                     changeExperimentalSetting(
                       'shouldApplyDefaultPresetOnVoiceChanged',
                       $event
                     )
                   "
-                  :disable="!experimentalSetting.enablePreset"
                 >
                 </q-toggle>
               </q-card-actions>

--- a/src/components/TitleBarButtons.vue
+++ b/src/components/TitleBarButtons.vue
@@ -8,15 +8,15 @@
   >
     <q-btn
       v-if="isPinned"
+      id="pinned-btn"
       dense
       flat
       round
       icon="push_pin"
       color="teal"
       class="title-bar-buttons"
-      id="pinned-btn"
-      @click="changePinWindow()"
       aria-label="最前面固定を解除"
+      @click="changePinWindow()"
     >
       <q-tooltip :delay="500" class="text-body2" :offset="[11, 11]">
         最前面固定を解除
@@ -24,15 +24,15 @@
     </q-btn>
     <q-btn
       v-else
+      id="pinned-btn"
       dense
       flat
       round
       icon="push_pin"
       color="display"
       class="title-bar-buttons rotate-45"
-      id="pinned-btn"
-      @click="changePinWindow()"
       aria-label="最前面に固定"
+      @click="changePinWindow()"
     >
       <q-tooltip :delay="500" class="text-body2" :offset="[11, 11]">
         最前面に固定
@@ -53,15 +53,15 @@
   >
     <q-btn
       v-if="isPinned"
+      id="pinned-btn"
       dense
       flat
       round
       icon="push_pin"
       color="teal"
       class="title-bar-buttons"
-      id="pinned-btn"
-      @click="changePinWindow()"
       aria-label="最前面固定を解除"
+      @click="changePinWindow()"
     >
       <q-tooltip :delay="500" class="text-body2" :offset="[11, 11]">
         最前面固定を解除
@@ -69,14 +69,14 @@
     </q-btn>
     <q-btn
       v-else
+      id="pinned-btn"
       dense
       flat
       round
       icon="push_pin"
       class="title-bar-buttons rotate-45"
-      id="pinned-btn"
-      @click="changePinWindow()"
       aria-label="最前面に固定"
+      @click="changePinWindow()"
     >
       <q-tooltip :delay="500" class="text-body2" :offset="[11, 11]">
         最前面に固定

--- a/src/components/ToolTip.vue
+++ b/src/components/ToolTip.vue
@@ -1,11 +1,11 @@
 <template>
   <div v-if="!tipConfirmed" style="z-index: 10">
     <q-banner class="bg-surface text-display" dense rounded inline-actions>
-      <template v-slot:avatar>
+      <template #avatar>
         <q-icon name="info" color="primary" />
       </template>
       <slot></slot>
-      <template v-slot:action>
+      <template #action>
         <q-btn
           color="primary"
           text-color="display-on-primary"

--- a/src/helpers/map.ts
+++ b/src/helpers/map.ts
@@ -13,13 +13,6 @@ export function mapUndefinedPipe<T, U1, U2, U3>(
   fn2: (_: NonNullable<U1>) => U2 | undefined,
   fn3: (_: NonNullable<U2>) => U3 | undefined
 ): U3 | undefined;
-export function mapUndefinedPipe<T, U1, U2, U3, U4>(
-  source: T | undefined,
-  fn1: (_: NonNullable<T>) => U1 | undefined,
-  fn2: (_: NonNullable<U1>) => U2 | undefined,
-  fn3: (_: NonNullable<U2>) => U3 | undefined,
-  fn4: (_: NonNullable<U3>) => U4 | undefined
-): U4 | undefined;
 /**
  * 一連の関数を実行する。途中でundefinedを返すとその後undefinedを返す。
  */

--- a/src/helpers/map.ts
+++ b/src/helpers/map.ts
@@ -13,6 +13,13 @@ export function mapUndefinedPipe<T, U1, U2, U3>(
   fn2: (_: NonNullable<U1>) => U2 | undefined,
   fn3: (_: NonNullable<U2>) => U3 | undefined
 ): U3 | undefined;
+export function mapUndefinedPipe<T, U1, U2, U3, U4>(
+  source: T | undefined,
+  fn1: (_: NonNullable<T>) => U1 | undefined,
+  fn2: (_: NonNullable<U1>) => U2 | undefined,
+  fn3: (_: NonNullable<U2>) => U3 | undefined,
+  fn4: (_: NonNullable<U3>) => U4 | undefined
+): U4 | undefined;
 /**
  * 一連の関数を実行する。途中でundefinedを返すとその後undefinedを返す。
  */

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -27,13 +27,13 @@
               <q-separator spaced />
               エンジン起動に時間がかかっています。<br />
               <q-btn
+                v-if="isMultipleEngine"
                 outline
                 @click="restartAppWithMultiEngineOffMode"
-                v-if="isMultipleEngine"
               >
                 マルチエンジンをオフにして再起動する</q-btn
               >
-              <q-btn outline @click="openFaq" v-else>FAQを見る</q-btn>
+              <q-btn v-else outline @click="openFaq">FAQを見る</q-btn>
             </template>
           </div>
         </div>
@@ -88,21 +88,21 @@
                       "
                     >
                       <draggable
-                        class="audio-cells"
                         ref="cellsRef"
-                        :modelValue="audioKeys"
-                        @update:modelValue="updateAudioKeys"
-                        :itemKey="itemKey"
+                        class="audio-cells"
+                        :model-value="audioKeys"
+                        :item-key="itemKey"
                         ghost-class="ghost"
                         filter="input"
-                        :preventOnFilter="false"
+                        :prevent-on-filter="false"
+                        @update:model-value="updateAudioKeys"
                       >
-                        <template v-slot:item="{ element }">
+                        <template #item="{ element }">
                           <audio-cell
-                            class="draggable-cursor"
-                            :audioKey="element"
                             :ref="addAudioCellRef"
-                            @focusCell="focusCell"
+                            class="draggable-cursor"
+                            :audio-key="element"
+                            @focus-cell="focusCell"
                           />
                         </template>
                       </draggable>
@@ -113,8 +113,8 @@
                           color="primary-light"
                           text-color="display-on-primary"
                           :disable="uiLocked"
-                          @click="addAudioItem"
                           aria-label="テキストを追加"
+                          @click="addAudioItem"
                         ></q-btn>
                       </div>
                     </div>
@@ -122,7 +122,7 @@
                   <template #after>
                     <audio-info
                       v-if="activeAudioKey != undefined"
-                      :activeAudioKey="activeAudioKey"
+                      :active-audio-key="activeAudioKey"
                     />
                   </template>
                 </q-splitter>
@@ -132,7 +132,7 @@
           <template #after>
             <audio-detail
               v-if="activeAudioKey != undefined"
-              :activeAudioKey="activeAudioKey"
+              :active-audio-key="activeAudioKey"
             />
           </template>
         </q-splitter>
@@ -150,13 +150,13 @@
   <header-bar-custom-dialog v-model="isToolbarSettingDialogOpenComputed" />
   <character-order-dialog
     v-if="orderedAllCharacterInfos.length > 0"
-    :characterInfos="orderedAllCharacterInfos"
     v-model="isCharacterOrderDialogOpenComputed"
+    :character-infos="orderedAllCharacterInfos"
   />
   <default-style-list-dialog
     v-if="orderedAllCharacterInfos.length > 0"
-    :characterInfos="orderedAllCharacterInfos"
     v-model="isDefaultStyleSelectDialogOpenComputed"
+    :character-infos="orderedAllCharacterInfos"
   />
   <dictionary-manage-dialog v-model="isDictionaryManageDialogOpenComputed" />
   <engine-manage-dialog v-model="isEngineManageDialogOpenComputed" />


### PR DESCRIPTION
## 内容

ESLintに適用するvueのルールを`vue3-essential`から`vue3-recommended`に変更します。ちなみにrecommendedはessentialを内包しています。
https://eslint.vuejs.org/user-guide/#bundle-configurations
引数の順序などがwarnになっていたので直しました。大半は`--fix`で修正可能でした。

ついで`@vue/eslint-config-typescript`も`@vue/eslint-config-typescript/recommended`に変更します。
こっちは特に変更は発生しませんでした（もう適用されてることになってるかも）
https://github.com/vuejs/eslint-config-typescript#usage

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

本当はtypescriptにあるより強力な[`recommended-requiring-type-checking`](https://typescript-eslint.io/linting/configs#recommended-requiring-type-checking)を導入したかったのですが、Vueに含めるためのあれこれの方法が用意されておらず、よくわからなかったので諦めました･･･。
