### PR TITLE
テキスト書き出しで無視する単語（テキスト）を設定できるようにする

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1678,6 +1678,12 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           }
         }
 
+        const ExportToText = (text: string): string => {
+          let resolvedText = text.replace(/\(.*?\)/g, "");
+          resolvedText = resolvedText.replace(/\[(.*?)\]/g, "$1");
+          return resolvedText;
+        };
+
         const texts: string[] = [];
         for (const audioKey of state.audioKeys) {
           const styleId = state.audioItems[audioKey].voice.styleId;
@@ -1690,7 +1696,8 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
               ? characters.get(`${engineId}:${styleId}`) + ","
               : "";
 
-          texts.push(speakerName + state.audioItems[audioKey].text);
+          const resolvedText = ExportToText(state.audioItems[audioKey].text);
+          texts.push(speakerName + resolvedText);
         }
 
         const textBlob = ((): Blob => {
@@ -1997,12 +2004,19 @@ export const audioCommandStore = transformCommandStore(
         const engineId = state.audioItems[audioKey].voice.engineId;
         const styleId = state.audioItems[audioKey].voice.styleId;
         const query = state.audioItems[audioKey].query;
+        const ExportToEngine = (targettext: string): string => {
+          let resolvedText = targettext.replace(/\[.*?\]/g, "");
+          resolvedText = resolvedText.replace(/\{(.*?)\}/g, "$1");
+          return resolvedText;
+        };
+        const resolvedText = ExportToEngine(text);
+
         try {
           if (query !== undefined) {
             const accentPhrases: AccentPhrase[] = await dispatch(
               "FETCH_ACCENT_PHRASES",
               {
-                text,
+                text: resolvedText,
                 engineId,
                 styleId,
               }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2006,7 +2006,7 @@ export const audioCommandStore = transformCommandStore(
         const query = state.audioItems[audioKey].query;
         const ExportToEngine = (targettext: string): string => {
           let resolvedText = targettext.replace(/\[.*?\]/g, "");
-          resolvedText = resolvedText.replace(/\{(.*?)\}/g, "$1");
+          resolvedText = resolvedText.replace(/\((.*?)\)/g, "$1");
           return resolvedText;
         };
         const resolvedText = ExportToEngine(text);


### PR DESCRIPTION
## 内容

テキスト書き出しで無視する単語（テキスト）を設定できるようにする #1355

## 関連 Issue

[#1355](https://github.com/VOICEVOX/voicevox/issues/1355)
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
エディタ　->　 書き出し
![image](https://github.com/VOICEVOX/voicevox/assets/100256521/2e4d40dc-68f6-41b5-9a36-c06a69ed576e)
エディタ　->　読み上げ
https://github.com/VOICEVOX/voicevox/assets/100256521/9b4578db-7fa7-46ff-ada0-37337313803c



## その他

とりあえず動くのでプッシュします。記法については、この後、()　-> {}に変更する予定です。