### PR TITLE
fix: 他のプロセスが使用中以外の理由でポートが使えない場合に起動できない問題を修正

### DIFF
--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -251,7 +251,9 @@ export class EngineManager {
       `ENGINE ${engineId}: Checking whether port ${engineHostInfo.port} is assignable...`
     );
 
-    if (!(await isAssignablePort(engineHostInfo))) {
+    if (
+      !(await isAssignablePort(engineHostInfo.port, engineHostInfo.hostname))
+    ) {
       // ポートを既に割り当てているプロセスidの取得
       const pid = await getPidFromPort(engineHostInfo);
       if (pid != undefined) {
@@ -267,7 +269,10 @@ export class EngineManager {
       }
 
       // 代替ポートの検索
-      const altPort = await findAltPort(engineHostInfo);
+      const altPort = await findAltPort(
+        engineHostInfo.port,
+        engineHostInfo.hostname
+      );
 
       // 代替ポートが見つからないとき
       if (altPort == undefined) {

--- a/src/background/portManager.ts
+++ b/src/background/portManager.ts
@@ -242,11 +242,5 @@ export async function findAltPort(
  * @param hostname 確認するホスト名
  */
 export async function isAssignablePort(port: number, hostname: string) {
-  const isAssignable = (await findOrCheckPort(port, hostname)) != undefined;
-  if (isAssignable) {
-    portLog(port, "Assignable");
-  } else {
-    portWarn(port, "Nonassignable");
-  }
-  return isAssignable;
+  return (await findOrCheckPort(port, hostname)) != undefined;
 }

--- a/src/background/portManager.ts
+++ b/src/background/portManager.ts
@@ -194,7 +194,7 @@ function findOrCheckPort(
       const address = server.address();
       server.close();
       if (address == undefined || typeof address === "string") {
-        reject(new Error("'address' is null or string"));
+        reject(new Error(`'address' is null or string: ${address}`));
         return;
       }
       resolve(address.port);

--- a/src/background/portManager.ts
+++ b/src/background/portManager.ts
@@ -203,18 +203,33 @@ function findOrCheckPort(
   });
 }
 
+type Address = Omit<HostInfo, "protocol">;
+
 /**
  * 割り当て可能な他のポートを探します
  *
- * @param hostInfo ホスト情報
+ * @param address ホスト情報
  * @returns 割り当て可能なポート番号 or `undefined` (割り当て可能なポートが見つからなかったとき)
  */
 export async function findAltPort(
-  hostInfo: HostInfo
+  address: Address
 ): Promise<number | undefined> {
-  const basePort = hostInfo.port;
-  portLog(basePort, "Find another assignable port");
-  const altPort = await findOrCheckPort(0, hostInfo.hostname);
+  const basePort = address.port;
+  portLog(basePort, `Find another assignable port from ${basePort}...`);
+
+  // エンジン指定のポート + 100番までを探索  エフェメラルポートの範囲の最大は超えないようにする
+  const altPortMax = Math.min(basePort + 100, 65535);
+
+  for (let altPort = basePort + 1; altPort <= altPortMax; altPort++) {
+    portLog(basePort, `Trying whether port ${altPort} is assignable...`);
+    if (await isAssignablePort({ port: altPort, hostname: address.hostname })) {
+      return altPort;
+    }
+  }
+
+  // 指定のポート + 100番まで見つからなかった場合ランダムなポートを使用する
+  portWarn(basePort, `No alternative port found! ${basePort}...${altPortMax}`);
+  const altPort = await findOrCheckPort(0, address.hostname);
   if (altPort == undefined) {
     portWarn(basePort, "No alternative port found!");
   } else {
@@ -225,15 +240,15 @@ export async function findAltPort(
 
 /**
  * ポートが割り当て可能か確認します
- * @param hostInfo ホスト情報
+ * @param address ホスト情報
  */
-export async function isAssignablePort(hostInfo: HostInfo) {
+export async function isAssignablePort(address: Address) {
   const isAssignable =
-    (await findOrCheckPort(hostInfo.port, hostInfo.hostname)) != undefined;
+    (await findOrCheckPort(address.port, address.hostname)) != undefined;
   if (isAssignable) {
-    portLog(hostInfo.port, "Assignable");
+    portLog(address.port, "Assignable");
   } else {
-    portWarn(hostInfo.port, "Nonassignable");
+    portWarn(address.port, "Nonassignable");
   }
   return isAssignable;
 }


### PR DESCRIPTION
## 内容

実際にlistenすることでポートが使用可能であるかの確認と代替ポートの取得を行うように変更します。
`[Errno 13] error while attempting to bind on address ('127.0.0.1', 50021): アクセス許可で禁じられた方法でソケットにアクセスしようとしました。`といったエラーでエンジンが起動できない問題を回避することができます。

## 関連 Issue

- fix #1330 

## その他

https://github.com/VOICEVOX/voicevox/issues/1330#issuecomment-1577077884 で提案された[get-port](https://www.npmjs.com/package/get-port)には取得したポートを一定時間再取得を防止する機能があるようです。
エンジンを起動直後に再起動するとポートが切り替わってしまうため使用しないことにしました。