### PR TITLE
Update: デフォルト出力ファイル名の"..."省略条件の見直し

### DIFF
--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -32,9 +32,9 @@ export function buildProjectFileName(state: State, extension?: string): string {
     state.audioItems[state.audioKeys[state.audioKeys.length - 1]].text;
 
   const headTailItemText =
-    headItemText !== tailItemText
-      ? headItemText + "..." + tailItemText
-      : headItemText;
+    state.audioKeys.length === 0
+      ? headItemText
+      : headItemText + "..." + tailItemText;
 
   let defaultFileNameStem = sanitizeFileName(headTailItemText);
 

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -32,7 +32,7 @@ export function buildProjectFileName(state: State, extension?: string): string {
     state.audioItems[state.audioKeys[state.audioKeys.length - 1]].text;
 
   const headTailItemText =
-    state.audioKeys.length === 0
+    state.audioKeys.length === 1
       ? headItemText
       : headItemText + "..." + tailItemText;
 


### PR DESCRIPTION
## 内容
デフォルト出力ファイル名が(「あああ...んんん.txt」などではなく)「あああ.txt」と省略される条件が、「最初と最後のテキストが同じ時」になってます。これはテキスト欄が以下のようなときにも省略されて「あああ.txt」となってしまいます。
例:
「あああ」
「いいい」
「あああ」
この省略条件を「AudioCellの数が1つの時」に変えることで、例の場合なら「あああ...あああ.txt」とします。

ちなみにデフォルト出力ファイル名は、[テキスト/音声を繋げて書き出し] や [プロジェクトを名前を付けて保存] した時に参照されます。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## スクリーンショット・動画など

![image](https://github.com/VOICEVOX/voicevox/assets/7900586/edff7291-ce78-457e-90d6-f2ac4c3b5b97)
![image](https://github.com/VOICEVOX/voicevox/assets/7900586/596b065a-700a-4e44-8d9d-0a4bc613fe90)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

[追記]
## 関連PR
- ref https://github.com/VOICEVOX/voicevox/pull/549#discussion_r762551049
これを見る限り、バグに近かったようです。