### PR TITLE
lsofがエラーを吐くことに対するエラーハンドリングを追加

### DIFF
--- a/src/background/portManager.ts
+++ b/src/background/portManager.ts
@@ -121,9 +121,17 @@ export async function getPidFromPort(
     isNested
   );
 
-  const stdout = execFileSync(exec.cmd, exec.args, {
-    shell: true,
-  }).toString();
+  // lsofは、ポートを使用しているプロセスが存在しない場合は
+  // エラーを返すので、エラーを無視して割り当て可能として扱う
+  let stdout: string;
+  try {
+    stdout = execFileSync(exec.cmd, exec.args, {
+      shell: true,
+    }).toString();
+  } catch (e) {
+    portLog(hostInfo.port, "Assignable; Nobody uses this port!", isNested);
+    return undefined;
+  }
 
   // Windows の場合は, lsof のように port と pid が 1to1 で取れないので, netstat の stdout をパース
   const pid = isWindows ? parse4windows(stdout) : stdout;

--- a/src/background/portManager.ts
+++ b/src/background/portManager.ts
@@ -123,6 +123,7 @@ export async function getPidFromPort(
 
   // lsofは、ポートを使用しているプロセスが存在しない場合は
   // エラーを返すので、エラーを無視して割り当て可能として扱う
+  // FIXME: lsof以外のエラーだった場合のエラーハンドリングを追加する
   let stdout: string;
   try {
     stdout = execFileSync(exec.cmd, exec.args, {


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題のとおりです。Mac/Linuxでひとまず起動を可能にします。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- ref #1360 (electronのバージョンアップまで含めてIssueの解決として扱いたいので、closeはしないようにします)
- ref #1368 

