### PR TITLE
キャラクターボイス試聴カードを単体コンポーネントに分離する

### DIFF
--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -301,10 +301,9 @@ const updatePortrait = (portraitPath: string) => {
   overflow-y: scroll;
 
   > div {
-    $character-item-size: 215px;
     display: grid;
-    grid-template-columns: repeat(auto-fit, $character-item-size);
-    grid-auto-rows: $character-item-size;
+    grid-template-columns: repeat(auto-fit, vars.$character-item-size);
+    grid-auto-rows: vars.$character-item-size;
     column-gap: 10px;
     row-gap: 10px;
     align-content: center;

--- a/src/components/CharacterTryListenCard.vue
+++ b/src/components/CharacterTryListenCard.vue
@@ -137,9 +137,7 @@ const updatePortrait = () => {
   emit("update:portrait", portraitPath);
 };
 
-// 変更される予定はないが、script setup内ではrefを使わないと
-// エラーを吐くので、refでラップしておく
-const speakerUuid = ref(props.characterInfo.metas.speakerUuid);
+const speakerUuid = computed(() => props.characterInfo.metas.speakerUuid);
 
 // 選択中のスタイル
 const selectedStyleIndex = ref<number>(0);

--- a/src/components/CharacterTryListenCard.vue
+++ b/src/components/CharacterTryListenCard.vue
@@ -1,0 +1,218 @@
+<template>
+  <q-item
+    v-ripple="isHoverableItem"
+    clickable
+    class="q-pa-none character-item"
+    :class="[
+      isHoverableItem && 'hoverable-character-item',
+      isSelected && 'selected-character-item',
+    ]"
+    @click="
+      selectCharacter(speakerUuid);
+      togglePlayOrStop(speakerUuid, selectedStyle, 0);
+    "
+  >
+    <div class="character-item-inner">
+      <img
+        :src="characterInfo.metas.styles[selectedStyleIndex || 0].iconPath"
+        :alt="characterInfo.metas.speakerName"
+        class="style-icon"
+      />
+      <span class="text-subtitle1 q-ma-sm">{{
+        characterInfo.metas.speakerName
+      }}</span>
+      <div
+        v-if="characterInfo.metas.styles.length > 1"
+        class="style-select-container"
+      >
+        <q-btn
+          flat
+          dense
+          icon="chevron_left"
+          text-color="display"
+          class="style-select-button"
+          aria-label="前のスタイル"
+          @mouseenter="isHoverableItem = false"
+          @mouseleave="isHoverableItem = true"
+          @click.stop="
+            selectCharacter(speakerUuid);
+            rollStyleIndex(speakerUuid, -1);
+          "
+        />
+        <span aria-live="polite">{{
+          selectedStyle.styleName || "ノーマル"
+        }}</span>
+        <q-btn
+          flat
+          dense
+          icon="chevron_right"
+          text-color="display"
+          class="style-select-button"
+          aria-label="次のスタイル"
+          @mouseenter="isHoverableItem = false"
+          @mouseleave="isHoverableItem = true"
+          @click.stop="
+            selectCharacter(speakerUuid);
+            rollStyleIndex(speakerUuid, 1);
+          "
+        />
+      </div>
+      <div class="voice-samples">
+        <q-btn
+          v-for="voiceSampleIndex of [...Array(3).keys()]"
+          :key="voiceSampleIndex"
+          round
+          outline
+          :icon="
+            playing != undefined &&
+            speakerUuid === playing.speakerUuid &&
+            selectedStyle.styleId === playing.styleId &&
+            voiceSampleIndex === playing.index
+              ? 'stop'
+              : 'play_arrow'
+          "
+          color="primary-light"
+          class="voice-sample-btn"
+          :aria-label="`サンプルボイス${voiceSampleIndex + 1}`"
+          @mouseenter="isHoverableItem = false"
+          @mouseleave="isHoverableItem = true"
+          @click.stop="
+            selectCharacter(speakerUuid);
+            togglePlayOrStop(speakerUuid, selectedStyle, voiceSampleIndex);
+          "
+        />
+      </div>
+      <div
+        v-if="isNewCharacter"
+        class="new-character-item q-pa-sm text-weight-bold"
+      >
+        NEW!
+      </div>
+    </div>
+  </q-item>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { CharacterInfo, SpeakerId, StyleId, StyleInfo } from "@/type/preload";
+
+const props =
+  defineProps<{
+    characterInfo: CharacterInfo;
+    isSelected: boolean;
+    isNewCharacter?: boolean;
+    playing?: {
+      speakerUuid: SpeakerId;
+      styleId: StyleId;
+      index: number;
+    };
+    togglePlayOrStop: (
+      speakerUuid: SpeakerId,
+      styleInfo: StyleInfo,
+      index: number
+    ) => void;
+  }>();
+
+const emit =
+  defineEmits<{
+    (event: "update:selectCharacter", speakerUuid: SpeakerId): void;
+    (event: "update:portrait", portrait: string): void;
+  }>();
+
+// キャラクター枠のホバー状態を表示するかどうか
+// 再生ボタンなどにカーソルがある場合はキャラクター枠のホバーUIを表示しないようにするため
+const isHoverableItem = ref(true);
+
+const selectCharacter = (speakerUuid: SpeakerId) => {
+  emit("update:selectCharacter", speakerUuid);
+  updatePortrait();
+};
+
+const updatePortrait = () => {
+  let portraitPath = props.characterInfo.portraitPath;
+  const stylePortraitPath = selectedStyle.value.portraitPath;
+  if (stylePortraitPath) {
+    portraitPath = stylePortraitPath;
+  }
+  emit("update:portrait", portraitPath);
+};
+
+// 変更される予定はないが、script setup内ではrefを使わないと
+// エラーを吐くので、refでラップしておく
+const speakerUuid = ref(props.characterInfo.metas.speakerUuid);
+
+// 選択中のスタイル
+const selectedStyleIndex = ref<number>(0);
+const selectedStyle = computed(
+  () => props.characterInfo.metas.styles[selectedStyleIndex.value]
+);
+
+// スタイル番号をずらす
+const rollStyleIndex = (speakerUuid: SpeakerId, diff: number) => {
+  // 0 <= index <= length に収める
+  const length = props.characterInfo.metas.styles.length;
+
+  let styleIndex = selectedStyleIndex.value + diff;
+  styleIndex = styleIndex < 0 ? length - 1 : styleIndex % length;
+  selectedStyleIndex.value = styleIndex;
+
+  // 音声を再生する。同じstyleIndexだったら停止する。
+  props.togglePlayOrStop(speakerUuid, selectedStyle.value, 0);
+  updatePortrait();
+};
+</script>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as vars;
+@use '@/styles/colors' as colors;
+
+$character-item-size: 215px;
+
+.character-item {
+  box-shadow: 0 0 0 1px rgba(colors.$primary-light-rgb, 0.5);
+  border-radius: 10px;
+  overflow: hidden;
+  &.selected-character-item {
+    box-shadow: 0 0 0 2px colors.$primary-light;
+  }
+  &:hover :deep(.q-focus-helper) {
+    opacity: 0 !important;
+  }
+  &.hoverable-character-item:hover :deep(.q-focus-helper) {
+    opacity: 0.15 !important;
+  }
+  .character-item-inner {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    .style-icon {
+      $icon-size: $character-item-size / 2;
+      width: $icon-size;
+      height: $icon-size;
+      border-radius: 5px;
+    }
+    .style-select-container {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      margin-top: -1rem;
+    }
+    .voice-samples {
+      display: flex;
+      column-gap: 5px;
+      align-items: center;
+      justify-content: center;
+    }
+    .new-character-item {
+      color: colors.$primary-light;
+      position: absolute;
+      left: 0px;
+      top: 0px;
+    }
+  }
+}
+</style>

--- a/src/components/CharacterTryListenCard.vue
+++ b/src/components/CharacterTryListenCard.vue
@@ -164,8 +164,6 @@ const rollStyleIndex = (speakerUuid: SpeakerId, diff: number) => {
 @use '@/styles/variables' as vars;
 @use '@/styles/colors' as colors;
 
-$character-item-size: 215px;
-
 .character-item {
   box-shadow: 0 0 0 1px rgba(colors.$primary-light-rgb, 0.5);
   border-radius: 10px;
@@ -187,7 +185,7 @@ $character-item-size: 215px;
     width: 100%;
     height: 100%;
     .style-icon {
-      $icon-size: $character-item-size / 2;
+      $icon-size: vars.$character-item-size / 2;
       width: $icon-size;
       height: $icon-size;
       border-radius: 5px;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -5,4 +5,4 @@ $menubar-height: 24px;
 
 $detail-view-splitter-cell-z-index: 2;
 
-$character-item-size: 215px;
+$character-item-size: 215px; // キャラクター並び替えダイアログなどでの１キャラ表示要素の横幅

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -4,3 +4,5 @@ $header-height: 66px;
 $menubar-height: 24px;
 
 $detail-view-splitter-cell-z-index: 2;
+
+$character-item-size: 215px;


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通りです
ライブラリ管理機能において使用するため、使い回せるようにコンポーネントを分離しました。
表示内容は大きく変わっていませんが、キャラクターのスタイルごとに立ち絵に対応するため、処理を少し追加しました。
このため、試聴ダイアログ内においても、スタイルを切り替えるとスタイルごとの立ち絵が存在する話者については、そちらが表示されるようになりました。

## その他

ライブラリ管理機能は規模が大きいのと、画面上のモックから実装していく(完全に動作しない)ため、ここからブランチを一旦分けています。