### PR TITLE
ブランド型をUUIDじゃなくする

### DIFF
--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -8,11 +8,11 @@ export const isMac =
     ? navigator.userAgent.includes("Mac")
     : process.platform === "darwin";
 
-export const engineIdSchema = z.string().uuid().brand<"EngineId">();
+export const engineIdSchema = z.string().brand<"EngineId">();
 export type EngineId = z.infer<typeof engineIdSchema>;
 export const EngineId = (id: string): EngineId => engineIdSchema.parse(id);
 
-export const speakerIdSchema = z.string().uuid().brand<"SpeakerId">();
+export const speakerIdSchema = z.string().brand<"SpeakerId">();
 export type SpeakerId = z.infer<typeof speakerIdSchema>;
 export const SpeakerId = (id: string): SpeakerId => speakerIdSchema.parse(id);
 
@@ -20,11 +20,11 @@ export const styleIdSchema = z.number().brand<"StyleId">();
 export type StyleId = z.infer<typeof styleIdSchema>;
 export const StyleId = (id: number): StyleId => styleIdSchema.parse(id);
 
-export const audioKeySchema = z.string().uuid().brand<"AudioKey">();
+export const audioKeySchema = z.string().brand<"AudioKey">();
 export type AudioKey = z.infer<typeof audioKeySchema>;
 export const AudioKey = (id: string): AudioKey => audioKeySchema.parse(id);
 
-export const presetKeySchema = z.string().uuid().brand<"PresetKey">();
+export const presetKeySchema = z.string().brand<"PresetKey">();
 export type PresetKey = z.infer<typeof presetKeySchema>;
 export const PresetKey = (id: string): PresetKey => presetKeySchema.parse(id);
 


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/1218

の解決PRです。

互換性の維持のために、以前はUUIDに限定していなかった型を、元のstring型に戻します。
４箇所あって重複しちゃうので、まあコメントはなくても良いかなと思いました。
ただのstringを持っているprojectファイルが読み込めるようなテストを書くのが良さそう。

マージ後のタスク

- [ ] 「engine/speaker/audiokey/presetにUUIDではないstringを持つprojectファイルが読み込めるようなテストを書く」というissueを作る


<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

fix #1218 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他


ちょっと確認してみたのですが、speakerUuidはもとからUUIDだった箇所がちょくちょくありました。[`defaultStyleIds`もuuid](https://github.com/VOICEVOX/voicevox/blob/release-0.14/src/type/preload.ts#L484)になっていました。

まあでも厳密にUUID4でなくても良いのは事実なので、緩めるのが良いと思います。
現在のコードでuuidとしてそうなのは以下４つです。（全体を`uuid(`で検索）

* engineIdSchema
* speakerIdSchema
* audioKeySchema
* presetKeySchema

このうち下２つはエディタが生成するものなので厳密にuuidでも良さそう･･･ですが、まあ[以前は`uuid()`にしてなかった](https://github.com/VOICEVOX/voicevox/blob/65a4465333e4c4963aa726d6cb8de7841ffedc13/src/store/project.ts#L424-L431)っぽいので、uuidにしないでおきます。