### PR TITLE
fix: #1309 で最初のAudioCellを変更しない条件を間違えていた問題を修正

### DIFF
--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -488,11 +488,8 @@ const userOrderedCharacterInfos = computed(
 const audioItems = computed(() => store.state.audioItems);
 // 並び替え後、テキスト欄が１つで空欄なら話者を更新
 // 経緯 https://github.com/VOICEVOX/voicevox/issues/1229
-watch(userOrderedCharacterInfos, (newValue, oldValue) => {
-  if (
-    newValue.length < 1 ||
-    (oldValue.length > 0 && newValue[0] === oldValue[0])
-  ) {
+watch(userOrderedCharacterInfos, (userOrderedCharacterInfos) => {
+  if (userOrderedCharacterInfos.length < 1) {
     return;
   }
 
@@ -503,7 +500,7 @@ watch(userOrderedCharacterInfos, (newValue, oldValue) => {
       return;
     }
 
-    const speakerId = newValue[0];
+    const speakerId = userOrderedCharacterInfos[0];
     const defaultStyleId = store.state.defaultStyleIds.find(
       (styleId) => styleId.speakerUuid === speakerId
     );


### PR DESCRIPTION
## 内容

https://github.com/sabonerune/voicevox/blob/5c9103ae557ea5fa6cca7e93b00ed62d1e0b0ad1/src/views/EditorHome.vue#L494
の判定により先頭のキャラクターを変更しない限りAudioCellが変更されないようになってしまっていた。

## 関連 Issue

- ref #1309
- ref #1229
