### PR TITLE
アプリケーション全体の拡大・縮小を可能に

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -51,6 +51,7 @@ import EngineManager from "./background/engineManager";
 import VvppManager, { isVvppFile } from "./background/vvppManager";
 import configMigration014 from "./background/configMigration014";
 import { failure, success } from "./type/result";
+import { generateMenuTemplate } from "./background/menu";
 import { ipcMainHandle, ipcMainSend } from "@/electron/ipc";
 
 type SingleInstanceLockData = {
@@ -546,29 +547,11 @@ async function start() {
   await createWindow();
 }
 
-const menuTemplateForMac: Electron.MenuItemConstructorOptions[] = [
-  {
-    label: "VOICEVOX",
-    submenu: [{ role: "quit" }],
-  },
-  {
-    label: "Edit",
-    submenu: [
-      { role: "cut" },
-      { role: "copy" },
-      { role: "paste" },
-      { role: "selectAll" },
-    ],
-  },
-];
-
-// For macOS, set the native menu to enable shortcut keys such as 'Cmd + V'.
-if (isMac) {
-  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplateForMac));
-} else {
-  if (!isDevelopment) {
-    Menu.setApplicationMenu(null);
-  }
+// メニュー
+if (!isDevelopment) {
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate(generateMenuTemplate({ isMac }))
+  );
 }
 
 // プロセス間通信

--- a/src/background/menu.ts
+++ b/src/background/menu.ts
@@ -19,7 +19,6 @@ const menuTemplateView: Electron.MenuItemConstructorOptions = {
   submenu: [
     { role: "zoomIn" },
     { role: "zoomOut" },
-    { role: "toggleDevTools" },
   ],
 };
 

--- a/src/background/menu.ts
+++ b/src/background/menu.ts
@@ -1,0 +1,34 @@
+const menuTemplateForMac: Electron.MenuItemConstructorOptions[] = [
+  {
+    label: "VOICEVOX",
+    submenu: [{ role: "quit" }],
+  },
+  {
+    label: "Edit",
+    submenu: [
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      { role: "selectAll" },
+    ],
+  },
+];
+
+const menuTemplateView: Electron.MenuItemConstructorOptions = {
+  label: "View",
+  submenu: [
+    { role: "zoomIn" },
+    { role: "zoomOut" },
+    { role: "toggleDevTools" },
+  ],
+};
+
+/**
+ * electron用のメニューのテンプレートを生成する
+ */
+export function generateMenuTemplate({ isMac }: { isMac: boolean }) {
+  const menuTemplate = isMac
+    ? [...menuTemplateForMac, menuTemplateView]
+    : [menuTemplateView];
+  return menuTemplate;
+}


### PR DESCRIPTION
## 内容

ビルド済みのアプリケーション内で、拡大・縮小<s>・DevTools</s>の表示を可能にします。

2023/07/13  2:03追記　DevToolsの表示はなくしました。

## 関連 Issue

fix #1391
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

<s>DevToolsが表示できるようになっちゃうので、偶然一般ユーザーの方がこのコマンドを発見しちゃった場合結構混乱される気がしますが、どちらかというと開発者である我々が使えた方が便利な時が結構あるのでオンにしようかなと！</s>

2023/07/13  2:03追記　DevToolsの表示はなくしました。
