### PR TITLE
keyCodeの使用をやめる

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -110,7 +110,7 @@
                 dense
                 :disable="uiLocked"
                 @blur="setSurface(surface)"
-                @keydown="yomiFocusWhenEnter"
+                @keydown.enter="yomiFocusWhenEnter"
               />
             </div>
             <div class="row q-pl-md q-pt-sm">
@@ -123,7 +123,7 @@
                 :error="!isOnlyHiraOrKana"
                 :disable="uiLocked"
                 @blur="setYomi(yomi)"
-                @keydown="setYomiWhenEnter"
+                @keydown.enter="setYomiWhenEnter"
               >
                 <template #error>
                   読みに使える文字はひらがなとカタカナのみです。
@@ -342,16 +342,12 @@ const wordEditing = ref(false);
 const surfaceInput = ref<QInput>();
 const yomiInput = ref<QInput>();
 const yomiFocusWhenEnter = (event: KeyboardEvent) => {
-  // keyCodeは非推奨で、keyが推奨だが、
-  // key === "Enter"はIMEのEnterも拾ってしまうので、keyCodeを用いている
-  if (event.keyCode === 13) {
+  if (!event.isComposing) {
     yomiInput.value?.focus();
   }
 };
 const setYomiWhenEnter = (event: KeyboardEvent) => {
-  // keyCodeは非推奨で、keyが推奨だが、
-  // key === "Enter"はIMEのEnterも拾ってしまうので、keyCodeを用いている
-  if (event.keyCode === 13) {
+  if (!event.isComposing) {
     setYomi(yomi.value);
   }
 };

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -110,7 +110,7 @@
                 dense
                 :disable="uiLocked"
                 @blur="setSurface(surface)"
-                @keydown.enter="yomiFocusWhenEnter"
+                @keydown.enter="yomiFocus"
               />
             </div>
             <div class="row q-pl-md q-pt-sm">
@@ -123,7 +123,7 @@
                 :error="!isOnlyHiraOrKana"
                 :disable="uiLocked"
                 @blur="setYomi(yomi)"
-                @keydown.enter="setYomiWhenEnter"
+                @keydown.enter="setYomi(yomi)"
               >
                 <template #error>
                   読みに使える文字はひらがなとカタカナのみです。
@@ -341,15 +341,8 @@ const wordEditing = ref(false);
 
 const surfaceInput = ref<QInput>();
 const yomiInput = ref<QInput>();
-const yomiFocusWhenEnter = (event: KeyboardEvent) => {
-  if (!event.isComposing) {
-    yomiInput.value?.focus();
-  }
-};
-const setYomiWhenEnter = (event: KeyboardEvent) => {
-  if (!event.isComposing) {
-    setYomi(yomi.value);
-  }
+const yomiFocus = () => {
+  yomiInput.value?.focus();
 };
 
 const selectedId = ref("");


### PR DESCRIPTION
## 内容
変更前のコメントアウトにある通り、keyCodeは非推奨となっています。
`@keydown`はIME確定時のEnterも捕捉しますが、`@keydown.enter`は捕捉しないみたいです。
[参考](https://r17n.page/2020/04/04/vue-submit-on-enter-japanese/)
(念のため実際に試して確認しました。)
これを使うことで、keyCodeの使用をやめます。
ユーザー視点での変更はありません。

<!--
プルリクエストの内容説明を端的に記載してください。
-->