### PR TITLE
fix: 「アップデート情報」内のダウンロードページリンクが機能しない問題を修正

### DIFF
--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -212,6 +212,7 @@ const pagedata = computed(() => {
       name: "アップデート情報",
       component: UpdateInfo,
       props: {
+        downloadLink: "https://voicevox.hiroshiba.jp/",
         updateInfos: updateInfos.value,
         isUpdateAvailable: isUpdateAvailable.value,
         latestVersion: latestVersion.value,

--- a/src/components/UpdateInfo.vue
+++ b/src/components/UpdateInfo.vue
@@ -6,9 +6,7 @@
     <div class="q-pa-md">
       <template v-if="props.isUpdateAvailable">
         <h3>最新バージョン {{ props.latestVersion }} が見つかりました</h3>
-        <a href="{{ props.downloadLink }}" target="_blank"
-          >ダウンロードページ</a
-        >
+        <a :href="props.downloadLink" target="_blank">ダウンロードページ</a>
         <hr />
       </template>
       <h3>アップデート履歴</h3>


### PR DESCRIPTION
## 内容

欠落していた`downloadLink`をとりあえずハードコードして修正します。
また、`UpdateInfo`の`href`部分の記法が間違っていたのでそこも修正しました。

## 関連 Issue

- fix #1294

## その他

`HelpDialog`でplopsが間違っていても型エラーにならない問題は解決していません。
https://github.com/VOICEVOX/voicevox/issues/1294#issuecomment-1517320008
