### PR TITLE
Fix: setSinkIdがないブラウザの処理を追加

### DIFF
--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -684,7 +684,7 @@
               </q-card-actions>
               <q-card-actions
                 class="q-px-md q-py-none bg-surface"
-                :class="{ disabled: !shouldEnableAudioOutputDeviceSetting }"
+                :class="{ disabled: !canSetAudioOutputDevice }"
               >
                 <div>再生デバイス</div>
                 <div aria-label="音声の再生デバイスを変更できます。">
@@ -697,7 +697,7 @@
                       transition-hide="jump-left"
                     >
                       音声の再生デバイスを変更できます。
-                      <template v-if="!shouldEnableAudioOutputDeviceSetting">
+                      <template v-if="!canSetAudioOutputDevice">
                         この機能はお使いの環境でサポートされていないため、使用できません。
                       </template>
                     </q-tooltip>
@@ -706,7 +706,7 @@
                 <q-space />
                 <q-select
                   v-model="currentAudioOutputDeviceComputed"
-                  :disable="!shouldEnableAudioOutputDeviceSetting"
+                  :disable="!canSetAudioOutputDevice"
                   dense
                   label="再生デバイス"
                   :options="availableAudioOutputDevices"
@@ -1035,7 +1035,7 @@ const changeShowAddAudioItemButton = (showAddAudioItemButton: boolean) => {
   }
 };
 
-const shouldEnableAudioOutputDeviceSetting = computed(() => {
+const canSetAudioOutputDevice = computed(() => {
   return !!HTMLAudioElement.prototype.setSinkId;
 });
 const currentAudioOutputDeviceComputed = computed<{

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -698,7 +698,7 @@
                     >
                       音声の再生デバイスを変更できます。
                       <template v-if="!shouldEnableAudioOutputDeviceSetting">
-                        この機能はブラウザがサポートしていないため、使用できません。
+                        この機能はお使いの環境でサポートされていないため、使用できません。
                       </template>
                     </q-tooltip>
                   </q-icon>

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -904,7 +904,6 @@ import {
   EditorFontType,
   EngineId,
 } from "@/type/preload";
-import { should } from "vitest";
 
 type SamplingRateOption = EngineSetting["outputSamplingRate"];
 

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -682,7 +682,10 @@
                 >
                 </q-toggle>
               </q-card-actions>
-              <q-card-actions class="q-px-md q-py-none bg-surface">
+              <q-card-actions
+                v-if="shouldShowAudioOutputDeviceSetting"
+                class="q-px-md q-py-none bg-surface"
+              >
                 <div>再生デバイス</div>
                 <div aria-label="音声の再生デバイスを変更できます。">
                   <q-icon name="help_outline" size="sm" class="help-hover-icon">
@@ -1028,6 +1031,9 @@ const changeShowAddAudioItemButton = (showAddAudioItemButton: boolean) => {
   }
 };
 
+const shouldShowAudioOutputDeviceSetting = computed(() => {
+  return !!HTMLAudioElement.prototype.setSinkId;
+});
 const currentAudioOutputDeviceComputed = computed<{
   key: string;
   label: string;

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -683,8 +683,8 @@
                 </q-toggle>
               </q-card-actions>
               <q-card-actions
-                v-if="shouldShowAudioOutputDeviceSetting"
                 class="q-px-md q-py-none bg-surface"
+                :class="{ disabled: !shouldEnableAudioOutputDeviceSetting }"
               >
                 <div>再生デバイス</div>
                 <div aria-label="音声の再生デバイスを変更できます。">
@@ -697,12 +697,16 @@
                       transition-hide="jump-left"
                     >
                       音声の再生デバイスを変更できます。
+                      <template v-if="!shouldEnableAudioOutputDeviceSetting">
+                        この機能はブラウザがサポートしていないため、使用できません。
+                      </template>
                     </q-tooltip>
                   </q-icon>
                 </div>
                 <q-space />
                 <q-select
                   v-model="currentAudioOutputDeviceComputed"
+                  :disable="!shouldEnableAudioOutputDeviceSetting"
                   dense
                   label="再生デバイス"
                   :options="availableAudioOutputDevices"
@@ -900,6 +904,7 @@ import {
   EditorFontType,
   EngineId,
 } from "@/type/preload";
+import { should } from "vitest";
 
 type SamplingRateOption = EngineSetting["outputSamplingRate"];
 
@@ -1031,7 +1036,7 @@ const changeShowAddAudioItemButton = (showAddAudioItemButton: boolean) => {
   }
 };
 
-const shouldShowAudioOutputDeviceSetting = computed(() => {
+const shouldEnableAudioOutputDeviceSetting = computed(() => {
   return !!HTMLAudioElement.prototype.setSinkId;
 });
 const currentAudioOutputDeviceComputed = computed<{

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1796,21 +1796,24 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           }
         }
 
-        audioElem
-          .setSinkId(state.savingSetting.audioOutputDevice)
-          .catch((err) => {
-            const stop = () => {
-              audioElem.pause();
-              audioElem.removeEventListener("canplay", stop);
-            };
-            audioElem.addEventListener("canplay", stop);
-            window.electron.showMessageDialog({
-              type: "error",
-              title: "エラー",
-              message: "再生デバイスが見つかりません",
+        // 一部ブラウザではsetSinkIdが実装されていないので、その環境では無視する
+        if (audioElem.setSinkId) {
+          audioElem
+            .setSinkId(state.savingSetting.audioOutputDevice)
+            .catch((err) => {
+              const stop = () => {
+                audioElem.pause();
+                audioElem.removeEventListener("canplay", stop);
+              };
+              audioElem.addEventListener("canplay", stop);
+              window.electron.showMessageDialog({
+                type: "error",
+                title: "エラー",
+                message: "再生デバイスが見つかりません",
+              });
+              throw new Error(err);
             });
-            throw new Error(err);
-          });
+        }
 
         // 再生終了時にresolveされるPromiseを返す
         const played = async () => {


### PR DESCRIPTION
## 内容

タイトル通り。

## 関連 Issue

- close: https://github.com/VOICEVOX/voicevox/issues/1405#issuecomment-1637507897

## スクリーンショット・動画など

Firefox / Chrome
![image](https://github.com/VOICEVOX/voicevox/assets/59691627/617c91f7-f988-486e-b226-233550b0f71e)

## その他

設定自体を隠しましたが、disabledにする+tooltipにサポートされてないことを書く実装でも良いかも