### PR TITLE
テキスト欄でもショートカットを発火させる

### DIFF
--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -576,14 +576,18 @@ onMounted(async () => {
   Mousetrap.prototype.stopCallback = (
     e: Mousetrap.ExtendedKeyboardEvent, // 未使用
     element: Element,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    combo: string // 未使用
+    combo: string
   ) => {
+    if (
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLSelectElement ||
+      element instanceof HTMLTextAreaElement ||
+      (element instanceof HTMLElement && element.contentEditable === "true")
+    ) {
+      // 2つ以上のキーの複合なら止めない(false) 単体なら止める(true)
+      return !combo.includes("+");
+    }
     return (
-      element.tagName === "INPUT" ||
-      element.tagName === "SELECT" ||
-      element.tagName === "TEXTAREA" ||
-      (element instanceof HTMLElement && element.contentEditable === "true") ||
       // メニュー項目ではショートカットキーを無効化
       element.classList.contains("q-item")
     );


### PR DESCRIPTION
## 内容
テキスト欄にフォーカスが当たっていてもショートカットキーが働くようにします。
ただし単体キーのショートカットは発火しないようにします。(デフォルトの [E] キー: 一つだけ書き出し など)
変換中は発火しないようです。
`<textarea>`と`<select>`でも発火するようになります。(調整可)

副作用の検証は全くしていないので、とりあえず Draft PR とさせていただきます。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
ref #507 の修正
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
[Mousetrap.prototype.stopCallback](https://craig.is/killing/mice#api.stopCallback) を使用。