### PR TITLE
Refactor: `indexOf()`と`-1`の比較を`includes()`へ統一

### DIFF
--- a/src/browser/fileImpl.ts
+++ b/src/browser/fileImpl.ts
@@ -113,7 +113,7 @@ export const writeFileImpl: typeof window[typeof SandboxKey]["writeFile"] =
   async (obj: { filePath: string; buffer: ArrayBuffer }) => {
     const path = obj.filePath;
 
-    if (path.indexOf(sep) === -1) {
+    if (!path.includes(sep)) {
       const aTag = document.createElement("a");
       const blob = URL.createObjectURL(new Blob([obj.buffer]));
       aTag.href = blob;
@@ -151,7 +151,7 @@ export const checkFileExistsImpl: typeof window[typeof SandboxKey]["checkFileExi
   async (file) => {
     const path = file;
 
-    if (path.indexOf(sep) === -1) {
+    if (!path.includes(sep)) {
       return Promise.resolve(false);
     }
 

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -732,7 +732,7 @@ const isHovered = (
       if (
         accentPhraseIndex === pitchHoveredInfo.accentPhraseIndex &&
         moraIndex === pitchHoveredInfo.moraIndex &&
-        unvoicableVowels.indexOf(vowel) > -1
+        unvoicableVowels.includes(vowel)
       ) {
         isHover = true;
       }
@@ -776,7 +776,7 @@ const handleChangeVoicing = (
 ) => {
   if (
     selectedDetail.value == "pitch" &&
-    unvoicableVowels.indexOf(mora.vowel) > -1
+    unvoicableVowels.includes(mora.vowel)
   ) {
     let data = 0;
     if (mora.pitch == 0) {

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -344,9 +344,9 @@ const solveDuplicated = () => {
 const confirmBtnEnabled = computed(() => {
   return (
     lastRecord.value == "" ||
-    ["Ctrl", "Shift", "Alt", "Meta"].indexOf(
+    ["Ctrl", "Shift", "Alt", "Meta"].includes(
       lastRecord.value.split(" ")[lastRecord.value.split(" ").length - 1]
-    ) > -1
+    )
   );
 });
 

--- a/src/electron/device.ts
+++ b/src/electron/device.ts
@@ -13,7 +13,7 @@ export function hasSupportedGpu(platform: string): Promise<boolean> {
         (datum) =>
           platform === "win32" ||
           (platform === "linux" &&
-            datum.vendor.toUpperCase().indexOf("NVIDIA") !== -1)
+            datum.vendor.toUpperCase().includes("NVIDIA"))
       )
     )
     .catch(() => false);

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2782,7 +2782,7 @@ export const audioCommandStore = transformCommandStore(
           let body = new TextDecoder("utf-8").decode(
             await window.electron.readFile({ filePath }).then(getValueOrThrow)
           );
-          if (body.indexOf("\ufffd") > -1) {
+          if (body.includes("\ufffd")) {
             body = new TextDecoder("shift-jis").decode(
               await window.electron.readFile({ filePath }).then(getValueOrThrow)
             );

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -526,11 +526,11 @@ export const parseCombo = (event: KeyboardEvent): string => {
   if (event.key === " ") {
     recordedCombo += "Space";
   } else {
-    if (["Control", "Shift", "Alt", "Meta"].indexOf(event.key) == -1) {
+    if (["Control", "Shift", "Alt", "Meta"].includes(event.key)) {
+      recordedCombo = recordedCombo.slice(0, -1);
+    } else {
       recordedCombo +=
         event.key.length > 1 ? event.key : event.key.toUpperCase();
-    } else {
-      recordedCombo = recordedCombo.slice(0, -1);
     }
   }
   return recordedCombo;


### PR DESCRIPTION
## 内容
全ての`array.indexOf(hoge)`・`string.indexOf(hoge)`と`-1`との比較(`>`,`!==`,`===`)を`array.includes(hoge)`と`string.includes(hoge)`に置き換えます。
参考:
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/includes
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf

<!--
プルリクエストの内容説明を端的に記載してください。
-->

ちなみに今回置き換えたものは関係ないですが、微妙に動作が違うようです
https://qiita.com/ryusaka/items/cbdb3ed1dcb8bcc46f2a