### PR TITLE
fix: 無視テキスト関連のバグ修正

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1600,10 +1600,9 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         if (state.savingSetting.exportText) {
           const textBlob = ((): Blob => {
             const text = texts.join("\n");
-            const skippedText = text;
             if (!encoding || encoding === "UTF-8") {
               const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
-              return new Blob([bom, skippedText], {
+              return new Blob([bom, text], {
                 type: "text/plain;charset=UTF-8",
               });
             }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -20,9 +20,8 @@ import {
   convertLongVowel,
   createKanaRegex,
   currentDateString,
-  skipMemoText,
-  skipReadingPart,
-  skipWritingPart,
+  extractExportText,
+  extractYomiText,
 } from "./utility";
 import { convertAudioQueryFromEditorToEngine } from "./proxy";
 import { createPartialStore } from "./vuex";
@@ -1555,7 +1554,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
             return { result: "WRITE_ERROR", path: filePath };
           }
           labs.push(lab);
-          texts.push(state.audioItems[audioKey].text);
+          texts.push(extractExportText(state.audioItems[audioKey].text));
           // 最終音素の終了時刻を取得する
           const splitLab = lab.split(" ");
           labOffset = Number(splitLab[splitLab.length - 2]);
@@ -1601,7 +1600,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         if (state.savingSetting.exportText) {
           const textBlob = ((): Blob => {
             const text = texts.join("\n");
-            const skippedText = skipReadingPart(skipMemoText(text));
+            const skippedText = text;
             if (!encoding || encoding === "UTF-8") {
               const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
               return new Blob([bom, skippedText], {
@@ -1694,8 +1693,8 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
               ? characters.get(`${engineId}:${styleId}`) + ","
               : "";
 
-          const skippedText = skipReadingPart(
-            skipMemoText(state.audioItems[audioKey].text)
+          const skippedText = extractExportText(
+            state.audioItems[audioKey].text
           );
           texts.push(speakerName + skippedText);
         }
@@ -2002,7 +2001,7 @@ export const audioCommandStore = transformCommandStore(
         const engineId = state.audioItems[audioKey].voice.engineId;
         const styleId = state.audioItems[audioKey].voice.styleId;
         const query = state.audioItems[audioKey].query;
-        const skippedText = skipWritingPart(skipMemoText(text));
+        const skippedText = extractYomiText(text);
 
         try {
           if (query !== undefined) {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1361,17 +1361,18 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           }
 
           if (state.savingSetting.exportText) {
+            const text = extractExportText(state.audioItems[audioKey].text);
             const textBlob = ((): Blob => {
               if (!encoding || encoding === "UTF-8") {
                 const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
-                return new Blob([bom, state.audioItems[audioKey].text], {
+                return new Blob([bom, text], {
                   type: "text/plain;charset=UTF-8",
                 });
               }
-              const sjisArray = Encoding.convert(
-                Encoding.stringToCode(state.audioItems[audioKey].text),
-                { to: "SJIS", type: "arraybuffer" }
-              );
+              const sjisArray = Encoding.convert(Encoding.stringToCode(text), {
+                to: "SJIS",
+                type: "arraybuffer",
+              });
               return new Blob([new Uint8Array(sjisArray)], {
                 type: "text/plain;charset=Shift_JIS",
               });

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -92,16 +92,21 @@ function replaceTag(
   return result;
 }
 
-export function skipReadingPart(text: string): string {
+export function extractExportText(text: string): string {
+  return skipReadingPart(skipMemoText(text));
+}
+export function extractYomiText(text: string): string {
+  return skipWritingPart(skipMemoText(text));
+}
+function skipReadingPart(text: string): string {
   // テキスト内の全ての{漢字|かんじ}パターンを探し、漢字部分だけを残す
   return text.replace(/\{([^|]*)\|([^}]*)\}/g, "$1");
 }
-
-export function skipWritingPart(text: string): string {
+function skipWritingPart(text: string): string {
   // テキスト内の全ての{漢字|かんじ}パターンを探し、かんじ部分だけを残す
   return text.replace(/\{([^|]*)\|([^}]*)\}/g, "$2");
 }
-export function skipMemoText(targettext: string): string {
+function skipMemoText(targettext: string): string {
   // []をスキップ
   const resolvedText = targettext.replace(/\[.*?\]/g, "");
   return resolvedText;


### PR DESCRIPTION
## 内容
txtファイル書き出しがONの時に無視するテキスト(読みとメモ)が一部無視されなかったのと無視されすぎたのを修正します。
- 一つだけ書き出し時に無視されない。
- Shift_JISで音声を繋げて書き出し時に無視されない。
- 音声を繋げて書き出し時に、以下が構文と認識されて無視されてしまう。
```
{字幕もどき|(改行)
読みもどき}
```
また、utilityから関数一つで呼べるようにします。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- #1355
メモ機能
- #1383
字幕/読み機能
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->