### PR TITLE
`new BrowserWindow`時に背景色を設定し、不具合#1425 を修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -477,6 +477,8 @@ async function createWindow() {
     trafficLightPosition: { x: 6, y: 4 },
     minWidth: 320,
     show: false,
+    backgroundColor:
+      store.get("currentTheme") === "Dark" ? "#3C3C3C" : "#DCDCDC",
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
       nodeIntegration: false,

--- a/src/browser/sandbox.ts
+++ b/src/browser/sandbox.ts
@@ -261,6 +261,8 @@ export const api: Sandbox = {
       await this.setSetting("currentTheme", newData);
       return;
     }
+    // NOTE: Electron版では起動時にテーマ情報が必要なので、
+    //       この実装とは違って起動時に読み込んだキャッシュを返すだけになっている。
     return Promise.all(
       // FIXME: themeファイルのいい感じのパスの設定
       ["/themes/default.json", "/themes/dark.json"].map((url) =>


### PR DESCRIPTION
## 内容
起動直後に一瞬真っ白な画面が表示される不具合(#1425)の修正PRです。
### 原因
`mainWindowState.manage(win);`の[内部処理](https://github.com/mawie81/electron-window-state/blob/2701d9a0f90a44dc8dbf81430538ceb16c9ff27a/index.js#L134)によって[自動的にshow状態になる](https://www.electronjs.org/ja/docs/latest/api/browser-window#winmaximize)のが原因でした。
(このため、前回最大化状態でウィンドウを閉じた場合にのみ起こる不具合でした)

### 解決策
new BrowserWindowのオプションに背景色(backgroundColor)を設定しました。

### 試したがダメそうだったもの
- `mainWindowState.manage(win);`の直後に`win.hide();`をしてもウィンドウが一瞬表示されました。
  - また、背景色を設定してかつこれを行うと、不具合がなぜか再発しました。
- on`ready-to-show`以降に最大化すると、変化前のサイズのウィンドウが一瞬表示されました。
- 初期ウィンドウを小さいサイズで開き、最大化してから裏でウィンドウサイズの変更する、という方法を試みましたが、最大化中はサイズ変更を受け付けないようでした。
- opacityでの制御はLinuxだと不可、かつ標準のウィンドウアニメーションが効きませんでした。

もっと厳密にするならopacityを併用してOSごとに処理を分けるべきだと思いますが、そもそも最大化状態でしか発生せず、また読み込み中のUIが見えてもそこまで酷い見た目にはならないので、このシンプルな実装が妥当かなと思いました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #1425
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くとmarge時に自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->




## スクリーンショット・動画など[
https://github.com/VOICEVOX/voicevox/assets/7900586/16537921-c3c5-4869-abe2-876d9bb34a87
<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

表示後にフォントが読み込まれているのと一瞬disableでないボタンが表示されるのが若干気になりますが、背景修正前も全画面で起動したときは表示されてたはずですし、真っ白な画面が表示されるよりはマシということで…
