### PR TITLE
Refactor: 文字コード系のwriteText関連処理を一箇所にまとめる

### DIFF
--- a/src/components/Dialog.ts
+++ b/src/components/Dialog.ts
@@ -1,9 +1,5 @@
 import { Dialog, DialogChainObject, Notify, Loading } from "quasar";
-import {
-  AudioKey,
-  ConfirmedTips,
-  Encoding as EncodingType,
-} from "@/type/preload";
+import { AudioKey, ConfirmedTips } from "@/type/preload";
 import {
   AllActions,
   SaveResultObject,
@@ -149,20 +145,17 @@ export async function generateAndSaveOneAudioWithDialog({
   audioKey,
   dispatch,
   filePath,
-  encoding,
   disableNotifyOnGenerate,
 }: {
   audioKey: AudioKey;
   dispatch: Dispatch<AllActions>;
   filePath?: string;
-  encoding?: EncodingType;
   disableNotifyOnGenerate: boolean;
 }): Promise<void> {
   const result: SaveResultObject = await withProgress(
     dispatch("GENERATE_AND_SAVE_AUDIO", {
       audioKey,
       filePath,
-      encoding,
     }),
     dispatch
   );
@@ -184,18 +177,15 @@ export async function generateAndSaveOneAudioWithDialog({
 export async function generateAndSaveAllAudioWithDialog({
   dispatch,
   dirPath,
-  encoding,
   disableNotifyOnGenerate,
 }: {
   dispatch: Dispatch<AllActions>;
   dirPath?: string;
-  encoding?: EncodingType;
   disableNotifyOnGenerate: boolean;
 }): Promise<void> {
   const result = await withProgress(
     dispatch("GENERATE_AND_SAVE_ALL_AUDIO", {
       dirPath,
-      encoding,
       callback: (finishedCount, totalCount) =>
         dispatch("SET_PROGRESS_FROM_COUNT", { finishedCount, totalCount }),
     }),
@@ -249,18 +239,15 @@ export async function generateAndSaveAllAudioWithDialog({
 export async function generateAndConnectAndSaveAudioWithDialog({
   dispatch,
   filePath,
-  encoding,
   disableNotifyOnGenerate,
 }: {
   dispatch: Dispatch<AllActions>;
   filePath?: string;
-  encoding?: EncodingType;
   disableNotifyOnGenerate: boolean;
 }): Promise<void> {
   const result = await withProgress(
     dispatch("GENERATE_AND_CONNECT_AND_SAVE_AUDIO", {
       filePath,
-      encoding,
       callback: (finishedCount, totalCount) =>
         dispatch("SET_PROGRESS_FROM_COUNT", { finishedCount, totalCount }),
     }),
@@ -283,17 +270,14 @@ export async function generateAndConnectAndSaveAudioWithDialog({
 export async function connectAndExportTextWithDialog({
   dispatch,
   filePath,
-  encoding,
   disableNotifyOnGenerate,
 }: {
   dispatch: Dispatch<AllActions>;
   filePath?: string;
-  encoding?: EncodingType;
   disableNotifyOnGenerate: boolean;
 }): Promise<void> {
   const result = await dispatch("CONNECT_AND_EXPORT_TEXT", {
     filePath,
-    encoding,
   });
 
   if (result === undefined || result.result === "CANCELED") return;

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -128,21 +128,18 @@ const generateAndSaveOneAudio = async () => {
   await generateAndSaveOneAudioWithDialog({
     audioKey: activeAudioKey.value,
     dispatch: store.dispatch,
-    encoding: store.state.savingSetting.fileEncoding,
     disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
   });
 };
 const generateAndSaveAllAudio = async () => {
   await generateAndSaveAllAudioWithDialog({
     dispatch: store.dispatch,
-    encoding: store.state.savingSetting.fileEncoding,
     disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
   });
 };
 const generateAndConnectAndSaveAudio = async () => {
   await generateAndConnectAndSaveAudioWithDialog({
     dispatch: store.dispatch,
-    encoding: store.state.savingSetting.fileEncoding,
     disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
   });
 };

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -131,7 +131,6 @@ const createNewProject = async () => {
 const generateAndSaveAllAudio = async () => {
   if (!uiLocked.value) {
     await generateAndSaveAllAudioWithDialog({
-      encoding: store.state.savingSetting.fileEncoding,
       disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
       dispatch: store.dispatch,
     });
@@ -142,7 +141,6 @@ const generateAndConnectAndSaveAllAudio = async () => {
   if (!uiLocked.value) {
     await generateAndConnectAndSaveAudioWithDialog({
       dispatch: store.dispatch,
-      encoding: store.state.savingSetting.fileEncoding,
       disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
     });
   }
@@ -162,7 +160,6 @@ const generateAndSaveOneAudio = async () => {
 
   await generateAndSaveOneAudioWithDialog({
     audioKey: activeAudioKey,
-    encoding: store.state.savingSetting.fileEncoding,
     disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
     dispatch: store.dispatch,
   });
@@ -172,7 +169,6 @@ const connectAndExportText = async () => {
   if (!uiLocked.value) {
     await connectAndExportTextWithDialog({
       dispatch: store.dispatch,
-      encoding: store.state.savingSetting.fileEncoding,
       disableNotifyOnGenerate: store.state.confirmedTips.notifyOnGenerate,
     });
   }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -128,6 +128,37 @@ function parseTextFile(
   return audioItems;
 }
 
+export async function writeTextFile(obj: {
+  filePath: string;
+  text: string;
+  encoding?: EncodingType;
+}) {
+  obj.encoding ??= "UTF-8";
+
+  const textBlob = {
+    "UTF-8": (text: string) => {
+      const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+      return new Blob([bom, text], {
+        type: "text/plain;charset=UTF-8",
+      });
+    },
+    Shift_JIS: (text: string) => {
+      const sjisArray = Encoding.convert(Encoding.stringToCode(text), {
+        to: "SJIS",
+        type: "arraybuffer",
+      });
+      return new Blob([new Uint8Array(sjisArray)], {
+        type: "text/plain;charset=Shift_JIS",
+      });
+    },
+  }[obj.encoding](obj.text);
+
+  return window.electron.writeFile({
+    filePath: obj.filePath,
+    buffer: await textBlob.arrayBuffer(),
+  });
+}
+
 // TODO: GETTERに移動する
 function buildFileName(state: State, audioKey: AudioKey) {
   const fileNamePattern = state.savingSetting.fileNamePattern;
@@ -1278,11 +1309,9 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         {
           audioKey,
           filePath,
-          encoding,
         }: {
           audioKey: AudioKey;
           filePath?: string;
-          encoding?: EncodingType;
         }
       ): Promise<SaveResultObject> => {
         if (state.savingSetting.fixedExportEnabled) {
@@ -1347,43 +1376,18 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
                 errorMessage: "labの生成に失敗しました。",
               };
 
-            const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
-            const labBlob = new Blob([bom, labString], {
-              type: "text/plain;charset=UTF-8",
-            });
-
-            await window.electron
-              .writeFile({
-                filePath: filePath.replace(/\.wav$/, ".lab"),
-                buffer: await labBlob.arrayBuffer(),
-              })
-              .then(getValueOrThrow);
+            await writeTextFile({
+              text: labString,
+              filePath: filePath.replace(/\.wav$/, ".lab"),
+            }).then(getValueOrThrow);
           }
 
           if (state.savingSetting.exportText) {
-            const text = extractExportText(state.audioItems[audioKey].text);
-            const textBlob = ((): Blob => {
-              if (!encoding || encoding === "UTF-8") {
-                const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
-                return new Blob([bom, text], {
-                  type: "text/plain;charset=UTF-8",
-                });
-              }
-              const sjisArray = Encoding.convert(Encoding.stringToCode(text), {
-                to: "SJIS",
-                type: "arraybuffer",
-              });
-              return new Blob([new Uint8Array(sjisArray)], {
-                type: "text/plain;charset=Shift_JIS",
-              });
-            })();
-
-            await window.electron
-              .writeFile({
-                filePath: filePath.replace(/\.wav$/, ".txt"),
-                buffer: await textBlob.arrayBuffer(),
-              })
-              .then(getValueOrThrow);
+            await writeTextFile({
+              text: extractExportText(state.audioItems[audioKey].text),
+              filePath: filePath.replace(/\.wav$/, ".txt"),
+              encoding: state.savingSetting.fileEncoding,
+            }).then(getValueOrThrow);
           }
 
           return { result: "SUCCESS", path: filePath };
@@ -1414,11 +1418,9 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         { state, dispatch },
         {
           dirPath,
-          encoding,
           callback,
         }: {
           dirPath?: string;
-          encoding?: EncodingType;
           callback?: (finishedCount: number, totalCount: number) => void;
         }
       ) => {
@@ -1440,7 +1442,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
             return dispatch("GENERATE_AND_SAVE_AUDIO", {
               audioKey,
               filePath: path.join(_dirPath, name),
-              encoding,
             }).then((value) => {
               callback?.(++finishedCount, totalCount);
               return value;
@@ -1458,11 +1459,9 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         { state, dispatch },
         {
           filePath,
-          encoding,
           callback,
         }: {
           filePath?: string;
-          encoding?: EncodingType;
           callback?: (finishedCount: number, totalCount: number) => void;
         }
       ): Promise<SaveResultObject> => {
@@ -1578,54 +1577,27 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         }
 
         if (state.savingSetting.exportLab) {
-          // GENERATE_LABで生成される文字列はすべて改行で終わるので、改行なしに結合する
-          const labString = labs.join("");
-
-          const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
-          const labBlob = new Blob([bom, labString], {
-            type: "text/plain;charset=UTF-8",
+          const labResult = await writeTextFile({
+            // GENERATE_LABで生成される文字列はすべて改行で終わるので、追加で改行を挟む必要はない
+            text: labs.join(""),
+            filePath: filePath.replace(/\.wav$/, ".lab"),
           });
-
-          await window.electron
-            .writeFile({
-              filePath: filePath.replace(/\.wav$/, ".lab"),
-              buffer: await labBlob.arrayBuffer(),
-            })
-            .then((result) => {
-              if (result.ok) return;
-              window.electron.logError(result.error);
-              return { result: "WRITE_ERROR", path: filePath };
-            });
+          if (!labResult.ok) {
+            window.electron.logError(labResult.error);
+            return { result: "WRITE_ERROR", path: filePath };
+          }
         }
 
         if (state.savingSetting.exportText) {
-          const textBlob = ((): Blob => {
-            const text = texts.join("\n");
-            if (!encoding || encoding === "UTF-8") {
-              const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
-              return new Blob([bom, text], {
-                type: "text/plain;charset=UTF-8",
-              });
-            }
-            const sjisArray = Encoding.convert(Encoding.stringToCode(text), {
-              to: "SJIS",
-              type: "arraybuffer",
-            });
-            return new Blob([new Uint8Array(sjisArray)], {
-              type: "text/plain;charset=Shift_JIS",
-            });
-          })();
-
-          await window.electron
-            .writeFile({
-              filePath: filePath.replace(/\.wav$/, ".txt"),
-              buffer: await textBlob.arrayBuffer(),
-            })
-            .then((result) => {
-              if (result.ok) return;
-              window.electron.logError(result.error);
-              return { result: "WRITE_ERROR", path: filePath };
-            });
+          const textResult = await writeTextFile({
+            text: texts.join("\n"),
+            filePath: filePath.replace(/\.wav$/, ".txt"),
+            encoding: state.savingSetting.fileEncoding,
+          });
+          if (!textResult.ok) {
+            window.electron.logError(textResult.error);
+            return { result: "WRITE_ERROR", path: filePath };
+          }
         }
 
         return { result: "SUCCESS", path: filePath };
@@ -1637,7 +1609,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     action: createUILockAction(
       async (
         { state, dispatch, getters },
-        { filePath, encoding }: { filePath?: string; encoding?: EncodingType }
+        { filePath }: { filePath?: string }
       ): Promise<SaveResultObject> => {
         const defaultFileName = buildProjectFileName(state, "txt");
         if (state.savingSetting.fixedExportEnabled) {
@@ -1699,33 +1671,15 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           texts.push(speakerName + skippedText);
         }
 
-        const textBlob = ((): Blob => {
-          const text = texts.join("\n");
-          if (!encoding || encoding === "UTF-8") {
-            const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
-            return new Blob([bom, text], {
-              type: "text/plain;charset=UTF-8",
-            });
-          }
-          const sjisArray = Encoding.convert(Encoding.stringToCode(text), {
-            to: "SJIS",
-            type: "arraybuffer",
-          });
-          return new Blob([new Uint8Array(sjisArray)], {
-            type: "text/plain;charset=Shift_JIS",
-          });
-        })();
-
-        await window.electron
-          .writeFile({
-            filePath,
-            buffer: await textBlob.arrayBuffer(),
-          })
-          .then((result) => {
-            if (result.ok) return;
-            window.electron.logError(result.error);
-            return { result: "WRITE_ERROR", path: filePath };
-          });
+        const result = await writeTextFile({
+          text: texts.join("\n"),
+          encoding: state.savingSetting.fileEncoding,
+          filePath,
+        });
+        if (!result.ok) {
+          window.electron.logError(result.error);
+          return { result: "WRITE_ERROR", path: filePath };
+        }
 
         return { result: "SUCCESS", path: filePath };
       }

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -19,7 +19,6 @@ import {
 import {
   CharacterInfo,
   DefaultStyleId,
-  Encoding as EncodingType,
   AcceptRetrieveTelemetryStatus,
   AcceptTermsStatus,
   HotkeySetting,
@@ -415,14 +414,12 @@ export type AudioStoreTypes = {
     action(payload: {
       audioKey: AudioKey;
       filePath?: string;
-      encoding?: EncodingType;
     }): SaveResultObject;
   };
 
   GENERATE_AND_SAVE_ALL_AUDIO: {
     action(payload: {
       dirPath?: string;
-      encoding?: EncodingType;
       callback?: (finishedCount: number, totalCount: number) => void;
     }): SaveResultObject[] | undefined;
   };
@@ -430,16 +427,12 @@ export type AudioStoreTypes = {
   GENERATE_AND_CONNECT_AND_SAVE_AUDIO: {
     action(payload: {
       filePath?: string;
-      encoding?: EncodingType;
       callback?: (finishedCount: number, totalCount: number) => void;
     }): SaveResultObject | undefined;
   };
 
   CONNECT_AND_EXPORT_TEXT: {
-    action(payload: {
-      filePath?: string;
-      encoding?: EncodingType;
-    }): SaveResultObject | undefined;
+    action(payload: { filePath?: string }): SaveResultObject | undefined;
   };
 
   PLAY_AUDIO: {


### PR DESCRIPTION
## 内容
labファイル・テキストファイルのファイル出力がコピペコードになっているのをaudio.ts先頭にまとめます。
また、encodeをaction内でstateから取得するようにします。
さらに、いくつかエラーハンドリングが上手くいってなさそうだった箇所も修正します。
ユーザー視点での変更はエラーハンドリングの改善以外はありません。
<!--
プルリクエストの内容説明を端的に記載してください。
-->
