### PR TITLE
[docs] mac版のログ保存ディレクトリの案内が間違っていたので訂正する

### DIFF
--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -137,7 +137,7 @@ VOICEVOX Twitter アカウント [@voicevox_pj](https://twitter.com/voicevox_pj)
 
 #### Mac 版
 
-`/Users/(ユーザー名)/Library/Application Support/voicevox/logs`
+`/Users/(ユーザー名)/Library/Logs/voicevox-cpu`
 
 ### Q. Ubuntu 22.04 で動きません
 


### PR DESCRIPTION
## 内容

タイトルの通りです。こちらのissueの解決です。

- https://github.com/VOICEVOX/voicevox/issues/1452

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

fix #1452

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->


## その他

electronが使うパスでビルド時のアプリの名称（voicevox-cpu）が入りそうなところはlogsとuserDataくらいっぽいです。なのでエラーログの案内さえ変えればとりあえず解決かなと。
https://www.electronjs.org/ja/docs/latest/api/app#appgetpathname

それはそれとして、CPU版とGPU版で変えているアプリ名称の影響を抑えたいので、background.ts内でsetAppNameしちゃうのも良いかなと思いました。
issueを作ってみようと思います。