### PR TITLE
[docs] 全体構成.mdの画像配置がおかしいのを修正

### DIFF
--- a/docs/全体構成.md
+++ b/docs/全体構成.md
@@ -12,8 +12,9 @@
 [The Open Source Definition](https://opensource.org/osd)
 
 そのため VOICEVOX では、キャラクターの要素（声や見た目）を含まない OSS 版と、OSS 版をもとに構築してキャラクターの要素を含めた製品版を分けて開発・配布しています。
+
 <img src="./res/全体構成_OSS版と製品版の違い.svg" width="320">
-<!-- 修正時はエディタ側のドキュメントも要修正 -->
+<!-- 修正時は全体向け側のドキュメントも要修正 -->
 <!-- https://github.com/VOICEVOX/.github/blob/main/profile/README.md -->
 
 ## 構成


### PR DESCRIPTION
## 内容

テキストと画像が同じ行になってしまって、横幅の短い画面では変に表示されていたので修正します。

[org内の説明](https://github.com/VOICEVOX/.github/blob/main/profile/README.md)の方はすでに正しくなってました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->
