### PR TITLE
エンジンのエラーが早かった場合にwin存在しない問題を迂回する

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -236,6 +236,8 @@ const onEngineProcessError = (engineInfo: EngineInfo, error: Error) => {
   // FIXME: winが作られた後にエンジンを起動させる
   if (win != undefined) {
     ipcMainSend(win, "DETECTED_ENGINE_ERROR", { engineId });
+  } else {
+    log.error(`onEngineProcessError: win is undefined`);
   }
 
   dialog.showErrorBox("音声合成エンジンエラー", error.message);

--- a/src/background.ts
+++ b/src/background.ts
@@ -232,7 +232,12 @@ const onEngineProcessError = (engineInfo: EngineInfo, error: Error) => {
   const engineId = engineInfo.uuid;
   log.error(`ENGINE ${engineId} ERROR: ${error}`);
 
-  ipcMainSend(win, "DETECTED_ENGINE_ERROR", { engineId });
+  // winが作られる前にエラーが発生した場合はwinへの通知を諦める
+  // FIXME: winが作られた後にエンジンを起動させる
+  if (win != undefined) {
+    ipcMainSend(win, "DETECTED_ENGINE_ERROR", { engineId });
+  }
+
   dialog.showErrorBox("音声合成エンジンエラー", error.message);
 };
 


### PR DESCRIPTION
## 内容

エンジンのエラー発生がめちゃくちゃ早かった場合（そもそもexeファイルがなかった時とか）、ウィンドウが表示される前にエンジンエラーが発生します。
この場合に画面に通知を送ろうとして失敗し、その後のダイアログ表示ができていなかったので、とりあえずダイアログ表示だけでもできるようにとりあえず問題を迂回します。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1460
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

一番いいのはそもそもUIが表示される前にエンジンを起動しようとしないことだと思います。
なぜそうしないかというと、ポートの自動変更が実装される前まではそうなっていたのですが、エンジンを起動してみようとしない限りそのポートが使えるかどうかわからないという関係上、現状の起動シーケンスだと、必ずエンジンの起動の方が早くないといけない感じになっているためです。

- https://github.com/VOICEVOX/voicevox/pull/1317#pullrequestreview-1434765325

これはもうどうしようもないので、UIを表示した後にエンジンを起動しようとするのではなく、Vuex側からエンジンを起動するようにするのが一番いいのかなと思いました。
そのためのissueがこちらです

- https://github.com/VOICEVOX/voicevox/issues/1460

それはそれとして、UI側が`DETECTED_ENGINE_ERROR`を受け付けられるようになるまで待機してからメッセージを飛ばすという方法もあるのですが、色々考えてちょっとすぐに実装できなさそうだったのと、↑のissueが解決したらそもそも不要になるのと、ユーザー向けにはダイアログが表示されてかつVOICEVOXがまともに動かないので、まあ一旦これでいいかなと。。。
