### PR TITLE
テキスト読み飛ばし関数の一部のコード量の削減

### DIFF
--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -103,8 +103,7 @@ export function extractYomiText(text: string): string {
 }
 function skipMemoText(targettext: string): string {
   // []をスキップ
-  const resolvedText = targettext.replace(/\[.*?\]/g, "");
-  return resolvedText;
+  return targettext.replace(/\[.*?\]/g, "");
 }
 
 /**

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -94,18 +94,12 @@ function replaceTag(
 }
 
 export function extractExportText(text: string): string {
-  return skipReadingPart(skipMemoText(text));
+  // []をスキップし "テキスト内の全ての{漢字|かんじ}" パターンを探し、漢字部分だけを残す
+  return skipMemoText(text.replace(/\{([^|]*)\|([^}]*)\}/g, "$1"));
 }
 export function extractYomiText(text: string): string {
-  return skipWritingPart(skipMemoText(text));
-}
-function skipReadingPart(text: string): string {
-  // テキスト内の全ての{漢字|かんじ}パターンを探し、漢字部分だけを残す
-  return text.replace(/\{([^|]*)\|([^}]*)\}/g, "$1");
-}
-function skipWritingPart(text: string): string {
-  // テキスト内の全ての{漢字|かんじ}パターンを探し、かんじ部分だけを残す
-  return text.replace(/\{([^|]*)\|([^}]*)\}/g, "$2");
+  // []をスキップし、"テキスト内の全ての{漢字|かんじ}" パターンを探し、かんじ部分だけを残す
+  return skipMemoText(text.replace(/\{([^|]*)\|([^}]*)\}/g, "$2"));
 }
 function skipMemoText(targettext: string): string {
   // []をスキップ


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

skipReadingPart
skipWritingPartという関数がありましたが、一行で済む処理なので関数化する必要がないと考えました。extractExportTextとextractYomiTextの方がわかりやすそうなので、そちらの関数に組み込む形にしています。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

ref #1355

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
