### PR TITLE
リリース時にHomebrew caskのリポジトリに自動でPRを出すGitHub Actions

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -8,7 +8,7 @@ jobs:
   bump-casks:
     runs-on: macos-latest
     steps:
-      - uses: macauley/action-homebrew-bump-cask@v1
+      - uses: macauley/action-homebrew-bump-cask@v1.0.0
         with:
           # Required, custom GitHub access token with only the 'public_repo' scope enabled
           token: ${{ secrets.BUMP_CASK_TOKEN }}

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,0 +1,18 @@
+name: Bump the Homebrew cask on release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  bump-casks:
+    runs-on: macos-latest
+    steps:
+      - uses: macauley/action-homebrew-bump-cask@v1
+        with:
+          # Required, custom GitHub access token with only the 'public_repo' scope enabled
+          token: ${{ secrets.BUMP_CASK_TOKEN }}
+          tap: VOICEVOX/voicevox
+          cask: voicevox
+          livecheck: true
+          dryrun: false


### PR DESCRIPTION
## 内容

#1451 で話している、HomebrewのFormula (`*.rb`) をリリース時に自動更新するためのGitHub Actionsです。
Formula (`*.rb`) が `VOICEVOX/homebrew-voicevox` リポジトリにあるとき、リリース毎に自動でPRが作成されます。

## 関連 Issue

#1451 

## その他

リポジトリのsecretsに[public_repoを有効にしたパーソナルアクセストークン](https://github.com/settings/tokens/new?scopes=public_repo,workflow)をセットする必要があります。