### PR TITLE
長さパラメーターを0にしたときに、ラベルに値が表示されるように修正しました

### DIFF
--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -12,7 +12,7 @@
       text-color="display-on-primary"
     >
       {{
-        previewSlider.state.currentValue.value
+        previewSlider.state.currentValue.value !== undefined
           ? previewSlider.state.currentValue.value.toFixed(precisionComputed)
           : undefined
       }}


### PR DESCRIPTION
## 内容

長さパラメーターが0になった時に、ラベルに値が何も表示されなくなるバグを修正しました。
currentValueがundefinedではない場合、valueをラベルに表示するようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

close #1439

## スクリーンショット・動画など

[![Image from Gyazo](https://i.gyazo.com/e46699714ac1f5e7b697b2bb8f1c33f5.gif)](https://gyazo.com/e46699714ac1f5e7b697b2bb8f1c33f5)

## その他
