### PR TITLE
キャラクター並び替えダイアログでの並べ替えカードホバー時の挙動を修正

### DIFF
--- a/src/components/CharacterOrderDialog.vue
+++ b/src/components/CharacterOrderDialog.vue
@@ -88,7 +88,9 @@
                   @mouseenter="
                     // ドラッグ中はバグるので無視
                     characterOrderDragging ||
-                      selectCharacter(element.metas.speakerUuid)
+                      selectCharacterWithChangePortrait(
+                        element.metas.speakerUuid
+                      )
                   "
                 >
                   {{ element.metas.speakerName }}
@@ -146,6 +148,10 @@ const sampleCharacterOrder = ref<SpeakerId[]>([]);
 const selectedCharacter = ref(props.characterInfos[0].metas.speakerUuid);
 const selectCharacter = (speakerUuid: SpeakerId) => {
   selectedCharacter.value = speakerUuid;
+};
+const selectCharacterWithChangePortrait = (speakerUuid: SpeakerId) => {
+  selectCharacter(speakerUuid);
+  portrait.value = characterInfosMap.value[speakerUuid].portraitPath;
 };
 
 // キャラクター表示順序


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題のとおりです。
#1385 をやったときに、少し挙動が変わっていたので修正しました。
具体的には、並び替えダイアログキャラ名ホバー時、キャラ名に併せて立ち絵も変化していましたが、キャラクター音声試聴カードを分離したことによって、立ち絵を変更する機能がそちら側に移ったため、ホバー時の挙動がキャラを選択した状態にはなってたものの、立ち絵が変化しないといった挙動になっていました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
#1385 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

https://github.com/VOICEVOX/voicevox/assets/34832037/4ed01640-ebd5-441b-8887-06ea30f77d9b


## その他
