### PR TITLE
`DEFAULT_FILE_NAME_TEMPLATE`の拡張子無し版を定義

### DIFF
--- a/src/components/FileNamePatternDialog.vue
+++ b/src/components/FileNamePatternDialog.vue
@@ -105,10 +105,10 @@ const tagStrings = Object.values(replaceTagIdToTagString);
 
 const savingSetting = computed(() => store.state.savingSetting);
 
-const savedFileBaseNamePattern = computed(() => {
+const savedBaseNamePattern = computed(() => {
   return savingSetting.value.fileNamePattern.replace(/\.wav$/, "");
 });
-const currentBaseNamePattern = ref(savedFileBaseNamePattern.value);
+const currentBaseNamePattern = ref(savedBaseNamePattern.value);
 const currentNamePattern = computed(
   () => `${currentBaseNamePattern.value}.wav`
 );
@@ -145,7 +145,7 @@ const previewFileName = computed(() =>
 );
 
 const initializeInput = () => {
-  currentBaseNamePattern.value = savedFileBaseNamePattern.value;
+  currentBaseNamePattern.value = savedBaseNamePattern.value;
 
   if (currentBaseNamePattern.value === "") {
     currentBaseNamePattern.value = DEFAULT_AUDIO_FILE_BASE_NAME_TEMPLATE;

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -14,7 +14,7 @@ import {
   transformCommandStore,
 } from "./type";
 import {
-  buildFileNameFromRawData,
+  buildAudioFileNameFromRawData,
   buildProjectFileName,
   isAccentPhrasesTextDifferent,
   convertHiraToKana,
@@ -192,7 +192,7 @@ function buildFileName(state: State, audioKey: AudioKey) {
   if (style === undefined) throw new Error("assert style !== undefined");
 
   const styleName = style.styleName || "ノーマル";
-  return buildFileNameFromRawData(fileNamePattern, {
+  return buildAudioFileNameFromRawData(fileNamePattern, {
     characterName: character.metas.speakerName,
     index,
     styleName,

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -59,9 +59,10 @@ const replaceTagStringToTagId: { [tagString: string]: string } = Object.entries(
   replaceTagIdToTagString
 ).reduce((prev, [k, v]) => ({ ...prev, [v]: k }), {});
 
-export const DEFAULT_FILE_NAME_TEMPLATE =
-  "$連番$_$キャラ$（$スタイル$）_$テキスト$.wav";
-const DEFAULT_FILE_NAME_VARIABLES = {
+export const DEFAULT_AUDIO_FILE_BASE_NAME_TEMPLATE =
+  "$連番$_$キャラ$（$スタイル$）_$テキスト$";
+export const DEFAULT_AUDIO_FILE_NAME_TEMPLATE = `${DEFAULT_AUDIO_FILE_BASE_NAME_TEMPLATE}.wav`;
+const DEFAULT_AUDIO_FILE_NAME_VARIABLES = {
   index: 0,
   characterName: "四国めたん",
   text: "テキストテキストテキスト",
@@ -147,14 +148,14 @@ export function isAccentPhrasesTextDifferent(
   return false;
 }
 
-export function buildFileNameFromRawData(
-  fileNamePattern = DEFAULT_FILE_NAME_TEMPLATE,
-  vars = DEFAULT_FILE_NAME_VARIABLES
+export function buildAudioFileNameFromRawData(
+  fileNamePattern = DEFAULT_AUDIO_FILE_NAME_TEMPLATE,
+  vars = DEFAULT_AUDIO_FILE_NAME_VARIABLES
 ): string {
   let pattern = fileNamePattern;
   if (pattern === "") {
     // ファイル名指定のオプションが初期値("")ならデフォルトテンプレートを使う
-    pattern = DEFAULT_FILE_NAME_TEMPLATE;
+    pattern = DEFAULT_AUDIO_FILE_NAME_TEMPLATE;
   }
 
   let text = sanitizeFileName(vars.text);
@@ -171,10 +172,10 @@ export function buildFileNameFromRawData(
   const date = currentDateString();
 
   return replaceTag(pattern, {
-    index,
-    characterName,
-    styleName: styleName,
     text,
+    characterName,
+    index,
+    styleName,
     date,
   });
 }


### PR DESCRIPTION
## 内容
DEFAULT_FILE_NAME_TEMPLATEから`.wav`を取り除いた定数を新たに定義します。
さらに、PROJECT_NAMEと混ざらないようにAUDIOを名前に付け足します。
また、それによって処理を簡略化できる`src\components\FileNamePatternDialog.vue`もリファクタリングします。
ユーザー視点での変更はありません。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
ref #1475
上記の一環です。
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
