### PR TITLE
厳密には`undefined`ではなく`null`だったのを修正

### DIFF
--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -12,7 +12,7 @@
       text-color="display-on-primary"
     >
       {{
-        previewSlider.state.currentValue.value !== undefined
+        previewSlider.state.currentValue.value != undefined
           ? previewSlider.state.currentValue.value.toFixed(precisionComputed)
           : undefined
       }}


### PR DESCRIPTION
## 内容
VSCode上で「nullの可能性があります」と警告が出ていたので比較を厳密でなくしました(`!==`から`!=`へ)。
バグ自体は直ったままなのを確認しました。挙動に変更はありません。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue/PR
- #1469
- #1035
(個人的には厳密演算子派で、なんならif文の条件式にはboolean以外含めるべきではないとすら思っています。が、nullOrUndefinedに限っては、例えば`{ text: string | undefined } | null`を返す外部の関数hogeがあった場合に`if ((hoge()?.text ?? undefined) === undefined)`みたいな記述は微妙なのでif (hoge()?.text)という記述になり、falsyな`""`(空文字列)をスルーしてしまう可能性があるのを懸念しています。それを見越してかeslintの[eqeqeq](https://eslint.org/docs/latest/rules/eqeqeq)ではnullとの比較だけは厳密でなくても良いオプションがあるみたいです)
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
![image](https://github.com/VOICEVOX/voicevox/assets/7900586/9b294619-2791-4aa8-be34-6f2acf891cd5)
<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
