### PR TITLE
Refactor: デフォルトファイル名取得関数2つをgetterへ移動

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -15,7 +15,6 @@ import {
 } from "./type";
 import {
   buildAudioFileNameFromRawData,
-  buildProjectFileName,
   isAccentPhrasesTextDifferent,
   convertHiraToKana,
   convertLongVowel,
@@ -23,6 +22,7 @@ import {
   currentDateString,
   extractExportText,
   extractYomiText,
+  sanitizeFileName,
 } from "./utility";
 import { convertAudioQueryFromEditorToEngine } from "./proxy";
 import { createPartialStore } from "./vuex";
@@ -171,36 +171,6 @@ export async function writeTextFile(obj: {
   });
 }
 
-// TODO: GETTERに移動する
-function buildFileName(state: State, audioKey: AudioKey) {
-  const fileNamePattern = state.savingSetting.fileNamePattern;
-
-  const index = state.audioKeys.indexOf(audioKey);
-  const audioItem = state.audioItems[audioKey];
-
-  const character = getCharacterInfo(
-    state,
-    audioItem.voice.engineId,
-    audioItem.voice.styleId
-  );
-  if (character === undefined)
-    throw new Error("assert character !== undefined");
-
-  const style = character.metas.styles.find(
-    (style) => style.styleId === audioItem.voice.styleId
-  );
-  if (style === undefined) throw new Error("assert style !== undefined");
-
-  const styleName = style.styleName || "ノーマル";
-  return buildAudioFileNameFromRawData(fileNamePattern, {
-    characterName: character.metas.speakerName,
-    index,
-    styleName,
-    text: audioItem.text,
-    date: currentDateString(),
-  });
-}
-
 function generateWriteErrorMessage(writeFileResult: ResultError) {
   if (writeFileResult.code) {
     const code = writeFileResult.code.toUpperCase();
@@ -221,7 +191,7 @@ function generateWriteErrorMessage(writeFileResult: ResultError) {
   return `何らかの理由で失敗しました。${writeFileResult.message}`;
 }
 
-// TODO: GETTERに移動する。buildFileNameから参照されているので、そちらも一緒に移動する。
+// TODO: GETTERに移動する。
 export function getCharacterInfo(
   state: State,
   engineId: EngineId,
@@ -1137,6 +1107,55 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
+  DEFAULT_PROJECT_FILE_BASE_NAME: {
+    getter: (state) => {
+      const headItemText = state.audioItems[state.audioKeys[0]].text;
+
+      const tailItemText =
+        state.audioItems[state.audioKeys[state.audioKeys.length - 1]].text;
+
+      const headTailItemText =
+        state.audioKeys.length === 1
+          ? headItemText
+          : headItemText + "..." + tailItemText;
+
+      const defaultFileBaseName = sanitizeFileName(headTailItemText);
+
+      return defaultFileBaseName === "" ? "Untitled" : defaultFileBaseName;
+    },
+  },
+
+  DEFAULT_AUDIO_FILE_NAME: {
+    getter: (state) => (audioKey) => {
+      const fileNamePattern = state.savingSetting.fileNamePattern;
+
+      const index = state.audioKeys.indexOf(audioKey);
+      const audioItem = state.audioItems[audioKey];
+
+      const character = getCharacterInfo(
+        state,
+        audioItem.voice.engineId,
+        audioItem.voice.styleId
+      );
+      if (character === undefined)
+        throw new Error("assert character !== undefined");
+
+      const style = character.metas.styles.find(
+        (style) => style.styleId === audioItem.voice.styleId
+      );
+      if (style === undefined) throw new Error("assert style !== undefined");
+
+      const styleName = style.styleName || "ノーマル";
+      return buildAudioFileNameFromRawData(fileNamePattern, {
+        characterName: character.metas.speakerName,
+        index,
+        styleName,
+        text: audioItem.text,
+        date: currentDateString(),
+      });
+    },
+  },
+
   GENERATE_LAB: {
     action: createUILockAction(
       async (
@@ -1321,7 +1340,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   GENERATE_AND_SAVE_AUDIO: {
     action: createUILockAction(
       async (
-        { state, dispatch },
+        { state, getters, dispatch },
         {
           audioKey,
           filePath,
@@ -1330,15 +1349,16 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           filePath?: string;
         }
       ): Promise<SaveResultObject> => {
+        const defaultAudioFileName = getters.DEFAULT_AUDIO_FILE_NAME(audioKey);
         if (state.savingSetting.fixedExportEnabled) {
           filePath = path.join(
             state.savingSetting.fixedExportDir,
-            buildFileName(state, audioKey)
+            defaultAudioFileName
           );
         } else {
           filePath ??= await window.electron.showAudioSaveDialog({
             title: "音声を保存",
-            defaultPath: buildFileName(state, audioKey),
+            defaultPath: defaultAudioFileName,
           });
         }
 
@@ -1426,7 +1446,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   GENERATE_AND_SAVE_ALL_AUDIO: {
     action: createUILockAction(
       async (
-        { state, dispatch },
+        { state, getters, dispatch },
         {
           dirPath,
           callback,
@@ -1449,7 +1469,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           let finishedCount = 0;
 
           const promises = state.audioKeys.map((audioKey) => {
-            const name = buildFileName(state, audioKey);
+            const name = getters.DEFAULT_AUDIO_FILE_NAME(audioKey);
             return dispatch("GENERATE_AND_SAVE_AUDIO", {
               audioKey,
               filePath: path.join(_dirPath, name),
@@ -1467,7 +1487,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   GENERATE_AND_CONNECT_AND_SAVE_AUDIO: {
     action: createUILockAction(
       async (
-        { state, dispatch },
+        { state, getters, dispatch },
         {
           filePath,
           callback,
@@ -1476,7 +1496,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           callback?: (finishedCount: number, totalCount: number) => void;
         }
       ): Promise<SaveResultObject> => {
-        const defaultFileName = buildProjectFileName(state, "wav");
+        const defaultFileName = `${getters.DEFAULT_PROJECT_FILE_BASE_NAME}.wav`;
 
         if (state.savingSetting.fixedExportEnabled) {
           filePath = path.join(
@@ -1617,7 +1637,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         { state, getters },
         { filePath }: { filePath?: string }
       ): Promise<SaveResultObject> => {
-        const defaultFileName = buildProjectFileName(state, "txt");
+        const defaultFileName = `${getters.DEFAULT_PROJECT_FILE_BASE_NAME}.txt`;
         if (state.savingSetting.fixedExportEnabled) {
           filePath = path.join(
             state.savingSetting.fixedExportDir,

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,6 +1,6 @@
 import semver from "semver";
 import { z } from "zod";
-import { buildProjectFileName, getBaseName } from "./utility";
+import { getBaseName } from "./utility";
 import { createPartialStore } from "./vuex";
 import { createUILockAction } from "@/store/ui";
 import { AudioItem, ProjectStoreState, ProjectStoreTypes } from "@/store/type";
@@ -393,7 +393,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
 
             if (!filePath) {
               // if new project: use generated name
-              defaultPath = buildProjectFileName(context.state, "vvproj");
+              defaultPath = `${context.getters.DEFAULT_PROJECT_FILE_BASE_NAME}.vvproj`;
             } else {
               // if saveAs for existing project: use current project path
               defaultPath = filePath;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -387,6 +387,14 @@ export type AudioStoreTypes = {
     }): Promise<AccentPhrase[]>;
   };
 
+  DEFAULT_PROJECT_FILE_BASE_NAME: {
+    getter: string;
+  };
+
+  DEFAULT_AUDIO_FILE_NAME: {
+    getter(audioKey: AudioKey): string;
+  };
+
   GENERATE_LAB: {
     action(payload: {
       audioKey: AudioKey;

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import { Platform } from "quasar";
-import { State } from "@/store/type";
 import { ToolbarButtonTagType, isMac } from "@/type/preload";
 import { AccentPhrase } from "@/openapi";
 
@@ -24,28 +23,6 @@ export function sanitizeFileName(fileName: string): string {
   const sanitizer = /[\x00-\x1f\x22\x2a\x2f\x3a\x3c\x3e\x3f\x5c\x7c\x7f]/g;
 
   return fileName.replace(sanitizer, "");
-}
-
-export function buildProjectFileName(state: State, extension?: string): string {
-  const headItemText = state.audioItems[state.audioKeys[0]].text;
-
-  const tailItemText =
-    state.audioItems[state.audioKeys[state.audioKeys.length - 1]].text;
-
-  const headTailItemText =
-    state.audioKeys.length === 1
-      ? headItemText
-      : headItemText + "..." + tailItemText;
-
-  let defaultFileNameStem = sanitizeFileName(headTailItemText);
-
-  if (defaultFileNameStem === "") {
-    defaultFileNameStem = "Untitled";
-  }
-
-  return extension
-    ? `${defaultFileNameStem}.${extension}`
-    : defaultFileNameStem;
 }
 
 export const replaceTagIdToTagString = {


### PR DESCRIPTION
## 内容
デフォルトのプロジェクト名と音声ファイル名を返す関数をstore.getterに移動しました。
ユーザー視点での変更はありません。

## 関連 Issue
ref #1475
上記の一環です。

## スクリーンショット・動画など


## その他
プロジェクト名取得(`DEFAULT_PROJECT_FILE_BASE_NAME`)は、名前的には`project.ts`が妥当なんですが、`audio.ts`の繋げて書き出し2種の時にも参照されているのと、内部処理的にもaudioItemを参照しているのでどちらに置くべきか微妙なところかもです。とりあえず`audio.ts`のほうに置いてみました。