### PR TITLE
ブラウザ版のmacOS判定がおかしいのを直す

### DIFF
--- a/src/type/globals.d.ts
+++ b/src/type/globals.d.ts
@@ -12,4 +12,10 @@ declare global {
   interface Window {
     readonly [SandboxKey]: import("./preload").Sandbox;
   }
+
+  interface Navigator {
+    userAgentData: {
+      readonly platform: string;
+    };
+  }
 }

--- a/src/type/globals.d.ts
+++ b/src/type/globals.d.ts
@@ -14,6 +14,7 @@ declare global {
   }
 
   interface Navigator {
+    // navigator.userAgentDataを認識してくれないため
     userAgentData: {
       readonly platform: string;
     };

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -10,10 +10,10 @@ export const isBrowser = import.meta.env.VITE_TARGET === "browser";
 function checkIsMac(): boolean {
   let isMac: boolean | undefined = undefined;
   if (process?.platform) {
-    // electron用
+    // electronのメインプロセス用
     isMac = process.platform === "darwin";
   } else if (navigator?.userAgentData) {
-    // ブラウザ用、実験的機能
+    // electronのレンダラープロセス用、Chrome系統が実装する実験的機能
     isMac = navigator.userAgentData.platform.toLowerCase().includes("mac");
   } else if (navigator?.platform) {
     // ブラウザ用、非推奨機能

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -5,10 +5,24 @@ import { Result } from "@/type/result";
 
 export const isElectron = import.meta.env.VITE_TARGET === "electron";
 export const isBrowser = import.meta.env.VITE_TARGET === "browser";
-export const isMac =
-  typeof process === "undefined"
-    ? navigator.userAgent.includes("Mac")
-    : process.platform === "darwin";
+
+// Electronのメイン・レンダラープロセス内、ブラウザ内どこでも使用可能なmacOS判定
+function checkIsMac() {
+  let isMac: boolean | undefined = undefined;
+
+  if (process?.platform) {
+    isMac = process.platform === "darwin";
+  } else if (navigator?.userAgentData) {
+    isMac = navigator.userAgentData.platform.toLowerCase().includes("mac");
+  } else if (navigator?.platform) {
+    isMac = navigator.platform.toLowerCase().includes("mac");
+  } else {
+    isMac = navigator.userAgent.toLowerCase().includes("mac");
+  }
+
+  return isMac;
+}
+export const isMac = checkIsMac();
 
 export const engineIdSchema = z.string().brand<"EngineId">();
 export type EngineId = z.infer<typeof engineIdSchema>;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -6,16 +6,20 @@ import { Result } from "@/type/result";
 export const isElectron = import.meta.env.VITE_TARGET === "electron";
 export const isBrowser = import.meta.env.VITE_TARGET === "browser";
 
-// Electronのメイン・レンダラープロセス内、ブラウザ内どこでも使用可能なmacOS判定
+// electronのメイン・レンダラープロセス内、ブラウザ内どこでも使用可能なmacOS判定
 function checkIsMac(): boolean {
   let isMac: boolean | undefined = undefined;
   if (process?.platform) {
+    // electron用
     isMac = process.platform === "darwin";
   } else if (navigator?.userAgentData) {
+    // ブラウザ用、実験的機能
     isMac = navigator.userAgentData.platform.toLowerCase().includes("mac");
   } else if (navigator?.platform) {
+    // ブラウザ用、非推奨機能
     isMac = navigator.platform.toLowerCase().includes("mac");
   } else {
+    // ブラウザ用、不正確
     isMac = navigator.userAgent.toLowerCase().includes("mac");
   }
   return isMac;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -7,9 +7,8 @@ export const isElectron = import.meta.env.VITE_TARGET === "electron";
 export const isBrowser = import.meta.env.VITE_TARGET === "browser";
 
 // Electronのメイン・レンダラープロセス内、ブラウザ内どこでも使用可能なmacOS判定
-function checkIsMac() {
+function checkIsMac(): boolean {
   let isMac: boolean | undefined = undefined;
-
   if (process?.platform) {
     isMac = process.platform === "darwin";
   } else if (navigator?.userAgentData) {
@@ -19,7 +18,6 @@ function checkIsMac() {
   } else {
     isMac = navigator.userAgent.toLowerCase().includes("mac");
   }
-
   return isMac;
 }
 export const isMac = checkIsMac();


### PR DESCRIPTION
## 内容

ブラウザ版のmacOS判定がおかしかったっぽいので直します。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/1470

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->


## その他

electronだとprocessが必ず存在しているけど、`process.platform`はレンダラー側にはなさそう。
ここが以前の判定だと間違ってた。

chrome系は実験的機能だけど`navigator.userAgentData`が便利そう。
`navigator.platform`は非推奨機能だけどどのブラウザも実装しっぱなしなので一番これが利便性高そう。
ユーザーエージェントで判断するところまではだいたいのブラウザで来ない気がするけど、スマホをブラウザとかだと違うかもなので必ず値を返すように置いてます。

もし将来的にユーザーエージェントをしっかりと判定に使うようにするのであれば`UAParser.js`とかのライブラリを使うと良さそう。