### PR TITLE
fn is not a function エラーを修正

### DIFF
--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -140,7 +140,7 @@ const precisionComputed = computed(() => {
 
 // クリックでアクセント句が選択されないように@click.stopに渡す
 const stopPropagation = () => {
-  //
+  // fn is not a function エラーを回避するために何もしない関数を渡す
 };
 </script>
 

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -139,7 +139,9 @@ const precisionComputed = computed(() => {
 });
 
 // クリックでアクセント句が選択されないように@click.stopに渡す
-const stopPropagation = undefined;
+const stopPropagation = () => {
+  //
+};
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## 内容
イントネーション項目の無声化されたスライダーをクリックした際に開発者ツール上で`fn is not a function`とエラーが表示されるのを修正します。
特に動作に変更はありません。 
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## スクリーンショット・動画など
(修正前)
![image](https://github.com/VOICEVOX/voicevox/assets/7900586/7f797b2f-930d-45c0-906f-b84da48d9410)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
