### PR TITLE
テキスト追加後に待つ処理を追加

### DIFF
--- a/tests/e2e/browser/オプション/書き出しファイル名パターン.spec.ts
+++ b/tests/e2e/browser/オプション/書き出しファイル名パターン.spec.ts
@@ -74,7 +74,7 @@ test("「オプション」から「書き出しファイル名パターン」�
 
   // 確定するとダイアログが閉じて設定した内容が反映されている
   await doneButton.click();
-  await page.waitForTimeout(500);
+  await page.waitForTimeout(700);
   await expect(optionDialog.getByText("test$連番$.wav")).toBeVisible();
 
   // 再度開くと設定した内容が反映されている

--- a/tests/e2e/browser/テキスト追加・削除.spec.ts
+++ b/tests/e2e/browser/テキスト追加・削除.spec.ts
@@ -19,6 +19,7 @@ test("+ボタンを押したら行が追加され、ゴミ箱のボタンを押�
   await page.getByRole("button").filter({ hasText: "add" }).click();
   await page.getByRole("button").filter({ hasText: "add" }).click();
   await page.getByRole("button").filter({ hasText: "add" }).click();
+  await page.waitForTimeout(100);
   expect(await page.locator(".audio-cell").count()).toBe(4);
   await (await page.locator(".audio-cell").all())[0].hover();
   await (


### PR DESCRIPTION
## 内容
e2eテストで、追加ボタンを押した直後のアサーションで落ちていたので、waitForTimeoutを追加しました
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
