### PR TITLE
Refactor: `audioElements`をRecordから単体にする

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -510,7 +510,7 @@ const play = async () => {
 };
 
 const stop = () => {
-  store.dispatch("STOP_AUDIO", { audioKey: props.activeAudioKey });
+  store.dispatch("STOP_AUDIO");
 };
 
 const nowPlaying = computed(

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -432,9 +432,6 @@ const changeAccent = async (_: number, accent: number) => {
   }
 };
 
-const audioElem = new Audio();
-audioElem.pause();
-
 const play = async () => {
   if (!accentPhrase.value) return;
 

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -471,7 +471,7 @@ const play = async () => {
   }
   nowGenerating.value = false;
   nowPlaying.value = true;
-  await store.dispatch("PLAY_AUDIO_BLOB", { audioElem, audioBlob: blob });
+  await store.dispatch("PLAY_AUDIO_BLOB", { audioBlob: blob });
   nowPlaying.value = false;
 };
 const stop = () => {

--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -475,7 +475,7 @@ const play = async () => {
   nowPlaying.value = false;
 };
 const stop = () => {
-  audioElem.pause();
+  store.dispatch("STOP_AUDIO");
 };
 
 // accent phraseにあるaccentと実際に登録するアクセントには差が生まれる

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -238,7 +238,7 @@ export function applyAudioPresetToAudioItem(
 }
 
 const audioBlobCache: Record<string, Blob> = {};
-const audioElement = new Audio();
+let audioElement: HTMLAudioElement;
 
 export const audioStoreState: AudioStoreState = {
   characterInfos: {},
@@ -455,6 +455,12 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
               state.userCharacterOrder.indexOf(b.metas.speakerUuid)
           )
         : undefined;
+    },
+  },
+
+  INITIALIZE_AUDIO_ELEMENT: {
+    action() {
+      audioElement = new Audio();
     },
   },
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -238,7 +238,7 @@ export function applyAudioPresetToAudioItem(
 }
 
 const audioBlobCache: Record<string, Blob> = {};
-const audioElements: Record<AudioKey, HTMLAudioElement> = {};
+const audioElement = new Audio();
 
 export const audioStoreState: AudioStoreState = {
   characterInfos: {},
@@ -276,7 +276,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   ACTIVE_AUDIO_ELEM_CURRENT_TIME: {
     getter: (state) => {
       return state._activeAudioKey !== undefined
-        ? audioElements[state._activeAudioKey]?.currentTime
+        ? audioElement.currentTime
         : undefined;
     },
   },
@@ -461,7 +461,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   GENERATE_AUDIO_KEY: {
     action() {
       const audioKey = AudioKey(uuidv4());
-      audioElements[audioKey] = new Audio();
       return audioKey;
     },
   },
@@ -1713,7 +1712,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   PLAY_AUDIO: {
     action: createUILockAction(
       async ({ commit, dispatch }, { audioKey }: { audioKey: AudioKey }) => {
-        const audioElem = audioElements[audioKey];
+        const audioElem = audioElement;
         audioElem.pause();
 
         // 音声用意
@@ -1823,7 +1822,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   STOP_AUDIO: {
     action(_, { audioKey }: { audioKey: AudioKey }) {
-      const audioElem = audioElements[audioKey];
+      const audioElem = audioElement;
       audioElem.pause();
     },
   },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1747,10 +1747,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     action: createUILockAction(
       async (
         { state, commit, dispatch },
-        {
-          audioBlob,
-          audioKey,
-        }: { audioBlob: Blob; audioKey?: AudioKey }
+        { audioBlob, audioKey }: { audioBlob: Blob; audioKey?: AudioKey }
       ) => {
         audioElement.src = URL.createObjectURL(audioBlob);
         // 途中再生用の処理

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1737,7 +1737,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
         return dispatch("PLAY_AUDIO_BLOB", {
           audioBlob: blob,
-          audioElem,
           audioKey,
         });
       }
@@ -1750,9 +1749,8 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         { state, commit, dispatch },
         {
           audioBlob,
-          audioElem,
           audioKey,
-        }: { audioBlob: Blob; audioElem: HTMLAudioElement; audioKey?: AudioKey }
+        }: { audioBlob: Blob; audioKey?: AudioKey }
       ) => {
         audioElement.src = URL.createObjectURL(audioBlob);
         // 途中再生用の処理

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1754,34 +1754,34 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           audioKey,
         }: { audioBlob: Blob; audioElem: HTMLAudioElement; audioKey?: AudioKey }
       ) => {
-        audioElem.src = URL.createObjectURL(audioBlob);
+        audioElement.src = URL.createObjectURL(audioBlob);
         // 途中再生用の処理
         if (audioKey) {
           const accentPhraseOffsets = await dispatch("GET_AUDIO_PLAY_OFFSETS", {
             audioKey,
           });
           if (accentPhraseOffsets.length === 0) {
-            audioElem.currentTime = 0;
+            audioElement.currentTime = 0;
           } else {
             const startTime =
               accentPhraseOffsets[state.audioPlayStartPoint ?? 0];
             if (startTime === undefined) throw Error("startTime === undefined");
             // 小さい値が切り捨てられることでフォーカスされるアクセントフレーズが一瞬元に戻るので、
             // 再生に影響のない程度かつ切り捨てられない値を加算する
-            audioElem.currentTime = startTime + 10e-6;
+            audioElement.currentTime = startTime + 10e-6;
           }
         }
 
         // 一部ブラウザではsetSinkIdが実装されていないので、その環境では無視する
-        if (audioElem.setSinkId) {
-          audioElem
+        if (audioElement.setSinkId) {
+          audioElement
             .setSinkId(state.savingSetting.audioOutputDevice)
             .catch((err) => {
               const stop = () => {
-                audioElem.pause();
-                audioElem.removeEventListener("canplay", stop);
+                audioElement.pause();
+                audioElement.removeEventListener("canplay", stop);
               };
-              audioElem.addEventListener("canplay", stop);
+              audioElement.addEventListener("canplay", stop);
               window.electron.showMessageDialog({
                 type: "error",
                 title: "エラー",
@@ -1797,23 +1797,23 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
             commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: true });
           }
         };
-        audioElem.addEventListener("play", played);
+        audioElement.addEventListener("play", played);
 
         let paused: () => void;
         const audioPlayPromise = new Promise<boolean>((resolve) => {
           paused = () => {
-            resolve(audioElem.ended);
+            resolve(audioElement.ended);
           };
-          audioElem.addEventListener("pause", paused);
+          audioElement.addEventListener("pause", paused);
         }).finally(async () => {
-          audioElem.removeEventListener("play", played);
-          audioElem.removeEventListener("pause", paused);
+          audioElement.removeEventListener("play", played);
+          audioElement.removeEventListener("pause", paused);
           if (audioKey) {
             commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: false });
           }
         });
 
-        audioElem.play();
+        audioElement.play();
 
         return audioPlayPromise;
       }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1821,9 +1821,8 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   },
 
   STOP_AUDIO: {
-    action(_, { audioKey }: { audioKey: AudioKey }) {
-      const audioElem = audioElement;
-      audioElem.pause();
+    action() {
+      audioElement.pause();
     },
   },
 
@@ -1877,7 +1876,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     action({ state, dispatch }) {
       for (const audioKey of state.audioKeys) {
         if (state.audioStates[audioKey].nowPlaying) {
-          dispatch("STOP_AUDIO", { audioKey });
+          dispatch("STOP_AUDIO");
         }
       }
     },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1712,8 +1712,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   PLAY_AUDIO: {
     action: createUILockAction(
       async ({ commit, dispatch }, { audioKey }: { audioKey: AudioKey }) => {
-        const audioElem = audioElement;
-        audioElem.pause();
+        audioElement.pause();
 
         // 音声用意
         let blob = await dispatch("GET_AUDIO_CACHE", { audioKey });

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -171,6 +171,10 @@ export type AudioStoreTypes = {
     getter: CharacterInfo[] | undefined;
   };
 
+  INITIALIZE_AUDIO_ELEMENT: {
+    action(): void;
+  };
+
   GENERATE_AUDIO_KEY: {
     action(): AudioKey;
   };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -456,7 +456,7 @@ export type AudioStoreTypes = {
   };
 
   STOP_AUDIO: {
-    action(payload: { audioKey: AudioKey }): void;
+    action(): void;
   };
 
   SET_AUDIO_PRESET_KEY: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -450,7 +450,6 @@ export type AudioStoreTypes = {
   PLAY_AUDIO_BLOB: {
     action(payload: {
       audioBlob: Blob;
-      audioElem: HTMLAudioElement;
       audioKey?: AudioKey;
     }): boolean;
   };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -448,10 +448,7 @@ export type AudioStoreTypes = {
   };
 
   PLAY_AUDIO_BLOB: {
-    action(payload: {
-      audioBlob: Blob;
-      audioKey?: AudioKey;
-    }): boolean;
+    action(payload: { audioBlob: Blob; audioKey?: AudioKey }): boolean;
   };
 
   STOP_AUDIO: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -171,10 +171,6 @@ export type AudioStoreTypes = {
     getter: CharacterInfo[] | undefined;
   };
 
-  INITIALIZE_AUDIO_ELEMENT: {
-    action(): void;
-  };
-
   GENERATE_AUDIO_KEY: {
     action(): AudioKey;
   };

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -605,9 +605,6 @@ onMounted(async () => {
     store.state.acceptTerms !== "Accepted";
 
   isCompletedInitialStartup.value = true;
-
-  // audioElementの初期化
-  store.dispatch("INITIALIZE_AUDIO_ELEMENT");
 });
 
 // エンジン待機

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -605,6 +605,9 @@ onMounted(async () => {
     store.state.acceptTerms !== "Accepted";
 
   isCompletedInitialStartup.value = true;
+
+  // audioElementの初期化
+  store.dispatch("INITIALIZE_AUDIO_ELEMENT");
 });
 
 // エンジン待機


### PR DESCRIPTION
## 内容
`store/audio.ts`の
```ts
const audioElements: Record<AudioKey, HTMLAudioElement> = {};
```
を
```ts
const audioElement = new Audio();
```
とします。
以前の実装は複数の同時再生をしたい場合は便利ですが、少なくとも現在は使われておらず、また将来的にも使われる可能性が低そうなため、変更しても大丈夫そうです。
ユーザー視点での変更はありません。
（かなり厳密に言うと、辞書登録で長い文章を読ませている最中に［キャンセル］>［閉じるボタン］後に詳細調整欄の再生ボタンを押すと辞書の読みが停止されるようになりますが、実質影響なしだと思います）

----
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- ref #1475
上記の一環です。
- ref ##1492
上記で話題に出ました。(具体的な該当コメントは「その他」を参照)
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
### 該当コメント

（前略）将来をひとまず考えないなら、現状同時に複数再生する必要はないはずなので、
```ts
const audioElements: Record<AudioKey, HTMLAudioElement> = {};
```
を
```ts
const audioElement = new Audio();
```
としてしまうことで何か所か単純化できる気がしました。再生中の音声が高々一つになるので、そこら辺の実装を省けそうかなと。結構レビューしていただいた範囲も変更が必要そうなので、そこはアレなんですが…。
今のところは音声を複数再生できた方が良いissueは無いはず…？

_Originally posted by @thiramisu in https://github.com/VOICEVOX/voicevox/issues/1492#issuecomment-1693090800_

----

> 現状同時に複数再生する必要はない

こちらに関しても賛成です。
仮に同時再生する機能があっても聞き比べ程度しか需要がなさそうで、もしその機能を実装する場合も任意の個数でなく2つあれば良さそうですし。
あとはCeVIOみたいにタイムライン編集できると嬉しいかもですが、これも別の実装になりそうなので、１つだけにするので良いのかなと思いました！
_Originally posted by @Hiroshiba in https://github.com/VOICEVOX/voicevox/issues/1492#issuecomment-1694146904_
