### PR TITLE
Refactor: 再生中のアクセント句の見た目を強調する処理を改善

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -574,7 +574,6 @@ const scrollToActivePoint = () => {
   }
 };
 
-// NodeJS.Timeout型が直接指定できないので、typeofとReturnTypeで取ってきている
 let requestId: number | undefined;
 watch(nowPlaying, async (newState) => {
   if (newState) {

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -593,9 +593,12 @@ watch(nowPlaying, async (newState) => {
           (currentOffset) => currentTime < currentOffset
         ) - 1;
       if (playingAccentPhraseIndex === -1) {
+        // accentPhraseOffsets[0] は必ず 0 なので到達しないはず
         throw new Error("playingAccentPhraseIndex === -1");
       }
       if (playingAccentPhraseIndex === -2) {
+        // データと音声ファイルの長さに誤差があるため許容
+        // see https://github.com/VOICEVOX/voicevox/issues/785
         return;
       }
       activePoint.value = playingAccentPhraseIndex;

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -588,16 +588,19 @@ watch(nowPlaying, async (newState) => {
       if (currentTime === undefined) {
         throw new Error("currentTime === undefined)");
       }
-      for (let i = 1; i < accentPhraseOffsets.length; i++) {
-        if (
-          accentPhraseOffsets[i - 1] <= currentTime &&
-          currentTime < accentPhraseOffsets[i]
-        ) {
-          activePoint.value = i - 1;
-          scrollToActivePoint();
-          requestId = window.requestAnimationFrame(focusAccentPhrase);
-        }
+      const playingAccentPhraseIndex =
+        accentPhraseOffsets.findIndex(
+          (currentOffset) => currentTime < currentOffset
+        ) - 1;
+      if (playingAccentPhraseIndex === -1) {
+        throw new Error("playingAccentPhraseIndex === -1");
       }
+      if (playingAccentPhraseIndex === -2) {
+        return;
+      }
+      activePoint.value = playingAccentPhraseIndex;
+      scrollToActivePoint();
+      requestId = window.requestAnimationFrame(focusAccentPhrase);
     };
     requestId = window.requestAnimationFrame(focusAccentPhrase);
   } else if (requestId !== undefined) {

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -585,9 +585,11 @@ watch(nowPlaying, async (newState) => {
     // それに合わせてフォーカスするアクセント句を変えていく
     const focusAccentPhrase = () => {
       const currentTime = store.getters.ACTIVE_AUDIO_ELEM_CURRENT_TIME;
+      if (currentTime === undefined) {
+        throw new Error("currentTime === undefined)");
+      }
       for (let i = 1; i < accentPhraseOffsets.length; i++) {
         if (
-          currentTime !== undefined &&
           accentPhraseOffsets[i - 1] <= currentTime &&
           currentTime < accentPhraseOffsets[i]
         ) {

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -600,8 +600,10 @@ watch(nowPlaying, async (newState) => {
         // see https://github.com/VOICEVOX/voicevox/issues/785
         return;
       }
-      activePoint.value = playingAccentPhraseIndex;
-      scrollToActivePoint();
+      if (activePoint.value !== playingAccentPhraseIndex) {
+        activePoint.value = playingAccentPhraseIndex;
+        scrollToActivePoint();
+      }
       requestId = window.requestAnimationFrame(focusAccentPhrase);
     };
     requestId = window.requestAnimationFrame(focusAccentPhrase);


### PR DESCRIPTION
## 内容
具体的には以下の点を変更しました。
- `setInterval`を`requestAnimationFrame`に変更
- `currentTime !== undefine`の判定を`for`ループの外に出す
- `for`ループを`findIndex`へ変更
- エラー分岐を詳細にする
- [追記]  必要時(`activePoint.value`変更時)のみ`scrollToActivePoint`が実行されるように変更

ユーザー視点での変更はありません。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- #785
エラー分岐の理由に関係
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
[Window.requestAnimationFrame() - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/window/requestAnimationFrame)
次フレームの直前に実行される処理を指定できるメソッドです。