### PR TITLE
テキストをつなげて保存を二回押したときの処理を変更

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -132,12 +132,14 @@ function parseTextFile(
   return audioItems;
 }
 
-async function changeFileTailToNonExistent(filePath: string) {
-  const EXTENSION = "wav";
+async function changeFileTailToNonExistent(
+  filePath: string,
+  extension: string
+) {
   let tail = 1;
-  const name = filePath.slice(0, filePath.length - 1 - EXTENSION.length);
+  const name = filePath.slice(0, filePath.length - 1 - extension.length);
   while (await window.electron.checkFileExists(filePath)) {
-    filePath = `${name}[${tail}].${EXTENSION}`;
+    filePath = `${name}[${tail}].${extension}`;
     tail += 1;
   }
   return filePath;
@@ -1370,7 +1372,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         }
 
         if (state.savingSetting.avoidOverwrite) {
-          filePath = await changeFileTailToNonExistent(filePath);
+          filePath = await changeFileTailToNonExistent(filePath, "wav");
         }
 
         let blob = await dispatch("GET_AUDIO_CACHE", { audioKey });
@@ -1518,7 +1520,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         }
 
         if (state.savingSetting.avoidOverwrite) {
-          filePath = await changeFileTailToNonExistent(filePath);
+          filePath = await changeFileTailToNonExistent(filePath, "wav");
         }
 
         const encodedBlobs: string[] = [];
@@ -1658,7 +1660,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         }
 
         if (state.savingSetting.avoidOverwrite) {
-          filePath = await changeFileTailToNonExistent(filePath);
+          filePath = await changeFileTailToNonExistent(filePath, "txt");
         }
 
         const characters = new Map<string, string>();


### PR DESCRIPTION
## 内容
上書き防止をしてさらにテキスト防止を２回押した際に２回めに保存したファイルの拡張子がwavになっていたので、txtになるようにしました。

関数の引数で拡張子をいじれるようにしました
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #1521 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
