### PR TITLE
Refactor: `audioStates`から`nowPlayingAudioKey`を独立させる

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -514,7 +514,7 @@ const stop = () => {
 };
 
 const nowPlaying = computed(
-  () => store.state.audioStates[props.activeAudioKey]?.nowPlaying
+  () => props.activeAudioKey === store.state.nowPlayingAudioKey
 );
 const nowGenerating = computed(
   () => store.state.audioStates[props.activeAudioKey]?.nowGenerating

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -120,7 +120,7 @@ const playContinuously = async () => {
   }
 };
 const stopContinuously = () => {
-  store.dispatch("STOP_CONTINUOUSLY_AUDIO");
+  store.dispatch("STOP_AUDIO");
 };
 const generateAndSaveOneAudio = async () => {
   if (activeAudioKey.value == undefined)

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1877,16 +1877,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       }
     }),
   },
-
-  STOP_CONTINUOUSLY_AUDIO: {
-    action({ state, dispatch }) {
-      for (const audioKey of state.audioKeys) {
-        if (state.nowPlayingAudioKey === audioKey) {
-          dispatch("STOP_AUDIO");
-        }
-      }
-    },
-  },
 });
 
 export const audioCommandStoreState: AudioCommandStoreState = {};

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -261,6 +261,7 @@ export const audioStoreState: AudioStoreState = {
   audioStates: {},
   // audio elementの再生オフセット
   audioPlayStartPoint: undefined,
+  nowPlayingAudioKey: undefined,
   nowPlayingContinuously: false,
 };
 
@@ -535,7 +536,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       state,
       { audioKey, nowPlaying }: { audioKey: AudioKey; nowPlaying: boolean }
     ) {
-      state.audioStates[audioKey].nowPlaying = nowPlaying;
+      state.nowPlayingAudioKey = nowPlaying ? audioKey : undefined;
     },
   },
 
@@ -687,7 +688,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       state.audioKeys.splice(index, 0, audioKey);
       state.audioItems[audioKey] = audioItem;
       state.audioStates[audioKey] = {
-        nowPlaying: false,
         nowGenerating: false,
       };
     },
@@ -713,7 +713,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       for (const { audioKey, audioItem } of audioKeyItemPairs) {
         state.audioItems[audioKey] = audioItem;
         state.audioStates[audioKey] = {
-          nowPlaying: false,
           nowGenerating: false,
         };
       }
@@ -1882,7 +1881,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   STOP_CONTINUOUSLY_AUDIO: {
     action({ state, dispatch }) {
       for (const audioKey of state.audioKeys) {
-        if (state.audioStates[audioKey].nowPlaying) {
+        if (state.nowPlayingAudioKey === audioKey) {
           dispatch("STOP_AUDIO");
         }
       }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1828,6 +1828,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   STOP_AUDIO: {
     action() {
+      // PLAY_ でonpause時の処理が設定されているため、pauseするだけで良い
       getAudioElement().pause();
     },
   },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -465,10 +465,6 @@ export type AudioStoreTypes = {
   PLAY_CONTINUOUSLY_AUDIO: {
     action(): void;
   };
-
-  STOP_CONTINUOUSLY_AUDIO: {
-    action(): void;
-  };
 };
 
 /*

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -73,7 +73,6 @@ export type AudioItem = {
 };
 
 export type AudioState = {
-  nowPlaying: boolean;
   nowGenerating: boolean;
 };
 
@@ -131,6 +130,7 @@ export type AudioStoreState = {
   audioStates: Record<AudioKey, AudioState>;
   _activeAudioKey?: AudioKey;
   audioPlayStartPoint?: number;
+  nowPlayingAudioKey?: AudioKey;
   nowPlayingContinuously: boolean;
 };
 


### PR DESCRIPTION
## 内容
#1525 により、再生中の`audioKey`が高々1つになりました。
そのため、`nowPlaying`を`audioKey`ごとに管理する必要がなくなります。
これを反映し、`store.state.audioStates[audioKey].nowPlaying`から`store.state.nowPlayingAudioKey`に独立させます。
また、それにより`STOP_CONTINUOUSLY_AUDIO`が不要になったので、削除します。
- その際、`STOP_AUDIO`内で諸々の処理が行われていない（ように見える）理由が分かりにくいと感じたので、説明コメントを追加しました。

ユーザー視点の変更はありません。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- ref #1475 
上記の一環です。
- ref #1525 
上記を受けての変更です。
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
