### PR TITLE
fix: 連続再生の停止がキーでは出来ないバグを修正

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -305,7 +305,7 @@ const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
   [
     "再生/停止",
     () => {
-      if (!nowPlaying.value && !nowGenerating.value && !uiLocked.value) {
+      if (!nowPlaying.value && !uiLocked.value) {
         play();
       } else {
         stop();

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -83,12 +83,10 @@ const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
   [
     "連続再生/停止",
     () => {
-      if (!uiLocked.value) {
-        if (nowPlayingContinuously.value) {
-          stopContinuously();
-        } else {
-          playContinuously();
-        }
+      if (nowPlayingContinuously.value) {
+        stopContinuously();
+      } else if (!uiLocked.value) {
+        playContinuously();
       }
     },
   ],

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -83,10 +83,10 @@ const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
   [
     "連続再生/停止",
     () => {
-      if (nowPlayingContinuously.value) {
-        stopContinuously();
-      } else if (!uiLocked.value) {
+      if (!nowPlayingContinuously.value && !uiLocked.value) {
         playContinuously();
+      } else {
+        stopContinuously();
       }
     },
   ],


### PR DESCRIPTION
## 内容
キー割り当て［連続再生/停止］（デフォルト: Shift + Space）のうち、停止がキーでは出来ないのを修正します。
また、［再生/停止］と統一されてなかったのも見逃していた一因と思われるので、条件の見た目を統一します。
`uiLock`中も`STOP_AUDIO`は呼ばれますが、`audioDetail.vue`は元からその実装になっていることと、`STOP_AUDIO`では`audioElement.pause()`が呼ばれるだけということを考えると問題ないと思います。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## その他
条件の対応の参考表です。
![image](https://github.com/VOICEVOX/voicevox/assets/7900586/70071dac-bd71-439d-853f-3a8dd83b0ae8)
