### PR TITLE
feat: 停止ボタンを連続再生中と通常再生中で共用にする

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -22,25 +22,23 @@
           </q-tabs>
         </div>
         <div class="play-button-wrapper">
-          <template v-if="!nowPlayingContinuously">
-            <q-btn
-              v-if="!nowPlaying && !nowGenerating"
-              fab
-              color="primary"
-              text-color="display-on-primary"
-              icon="play_arrow"
-              @click="play"
-            ></q-btn>
-            <q-btn
-              v-else
-              fab
-              color="primary"
-              text-color="display-on-primary"
-              icon="stop"
-              :disable="nowGenerating"
-              @click="stop"
-            ></q-btn>
-          </template>
+          <q-btn
+            v-if="!nowPlaying && !nowGenerating"
+            fab
+            color="primary"
+            text-color="display-on-primary"
+            icon="play_arrow"
+            @click="play"
+          ></q-btn>
+          <q-btn
+            v-else
+            fab
+            color="primary"
+            text-color="display-on-primary"
+            icon="stop"
+            :disable="nowGenerating"
+            @click="stop"
+          ></q-btn>
         </div>
       </div>
 
@@ -518,11 +516,6 @@ const nowPlaying = computed(
 );
 const nowGenerating = computed(
   () => store.state.audioStates[props.activeAudioKey]?.nowGenerating
-);
-
-// continuously play
-const nowPlayingContinuously = computed(
-  () => store.state.nowPlayingContinuously
 );
 
 const audioDetail = ref<HTMLElement>();

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -511,7 +511,7 @@ const stop = () => {
   store.dispatch("STOP_AUDIO");
 };
 
-const nowPlaying = computed(() => store.getters.IS_PLAYING);
+const nowPlaying = computed(() => store.getters.NOW_PLAYING);
 const nowGenerating = computed(
   () => store.state.audioStates[props.activeAudioKey]?.nowGenerating
 );

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -511,9 +511,7 @@ const stop = () => {
   store.dispatch("STOP_AUDIO");
 };
 
-const nowPlaying = computed(
-  () => props.activeAudioKey === store.state.nowPlayingAudioKey
-);
+const nowPlaying = computed(() => store.getters.IS_PLAYING);
 const nowGenerating = computed(
   () => store.state.audioStates[props.activeAudioKey]?.nowGenerating
 );

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -85,7 +85,7 @@ const hotkeyMap = new Map<HotkeyAction, () => HotkeyReturnType>([
     () => {
       if (!uiLocked.value) {
         if (nowPlayingContinuously.value) {
-          stopContinuously();
+          stop();
         } else {
           playContinuously();
         }
@@ -119,7 +119,7 @@ const playContinuously = async () => {
     });
   }
 };
-const stopContinuously = () => {
+const stop = () => {
   store.dispatch("STOP_AUDIO");
 };
 const generateAndSaveOneAudio = async () => {
@@ -159,7 +159,7 @@ const usableButtons: Record<
     disable: uiLocked,
   },
   STOP: {
-    click: stopContinuously,
+    click: stop,
     disable: computed(
       () =>
         activeAudioKey.value === undefined ||

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -160,7 +160,11 @@ const usableButtons: Record<
   },
   STOP: {
     click: stopContinuously,
-    disable: computed(() => !nowPlayingContinuously.value),
+    disable: computed(
+      () =>
+        activeAudioKey.value === undefined ||
+        activeAudioKey.value !== store.state.nowPlayingAudioKey
+    ),
   },
   EXPORT_AUDIO_ONE: {
     click: generateAndSaveOneAudio,

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -160,7 +160,7 @@ const usableButtons: Record<
   },
   STOP: {
     click: stop,
-    disable: computed(() => !store.getters.IS_PLAYING),
+    disable: computed(() => !store.getters.NOW_PLAYING),
   },
   EXPORT_AUDIO_ONE: {
     click: generateAndSaveOneAudio,

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -160,11 +160,7 @@ const usableButtons: Record<
   },
   STOP: {
     click: stop,
-    disable: computed(
-      () =>
-        activeAudioKey.value === undefined ||
-        activeAudioKey.value !== store.state.nowPlayingAudioKey
-    ),
+    disable: computed(() => !store.getters.IS_PLAYING),
   },
   EXPORT_AUDIO_ONE: {
     click: generateAndSaveOneAudio,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -298,6 +298,16 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
+  IS_PLAYING: {
+    getter(state, getters) {
+      const activeAudioKey = getters.ACTIVE_AUDIO_KEY;
+      return (
+        activeAudioKey != undefined &&
+        activeAudioKey === state.nowPlayingAudioKey
+      );
+    },
+  },
+
   ACTIVE_AUDIO_ELEM_CURRENT_TIME: {
     getter: (state) => {
       return state._activeAudioKey !== undefined

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -298,7 +298,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
-  IS_PLAYING: {
+  NOW_PLAYING: {
     getter(state, getters) {
       const activeAudioKey = getters.ACTIVE_AUDIO_KEY;
       return (

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -152,6 +152,10 @@ export type AudioStoreTypes = {
     getter(audioKey: AudioKey): boolean;
   };
 
+  IS_PLAYING: {
+    getter: boolean;
+  };
+
   ACTIVE_AUDIO_ELEM_CURRENT_TIME: {
     getter: number | undefined;
   };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -152,7 +152,7 @@ export type AudioStoreTypes = {
     getter(audioKey: AudioKey): boolean;
   };
 
-  IS_PLAYING: {
+  NOW_PLAYING: {
     getter: boolean;
   };
 


### PR DESCRIPTION
## 内容
#1530 で、`STOP_CONTINUOUSLY_AUDIO`が`STOP_AUDIO`に統一されました。
これにより、停止ボタンでの処理が通常再生時と連続再生時で共通化され、簡単に共用ができるようになったので、ボタンを統一します。
具体的には以下の2点を実施します。
- これまで連続再生中専用だったツールバーの［停止］ボタンを通常再生中でも使えるようにします。
- これまで通常再生中専用だった［再生ボタン］での停止を連続再生中でも使えるようにします。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- #1530
上記で提案をいただきました。（当該コメントは「その他」を参照）
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
両方使用できます。
![image](https://github.com/VOICEVOX/voicevox/assets/7900586/8e3848bf-c7e5-4892-bb6e-fe9468c90e06)
<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
該当コメント：

`STOP_COUNTINIOUSLY`が削除可能なのが意外でした。
実は連続再生を開始すると、詳細調整欄に表示されてある方の停止ボタンがhiddenになる実装になってるんですよね。
これは連続再生用と通常再生用で停止させるべき関数が異なるからこういう実装にしていたのですが、停止ボタンを共通化できるのであれば話が変わってきそうに感じました！！

_Originally posted by @Hiroshiba in https://github.com/VOICEVOX/voicevox/pull/1530#pullrequestreview-1601711006_