### PR TITLE
Improve: ブラウザ版e2eテストを改善

### DIFF
--- a/src/background/engineManager.ts
+++ b/src/background/engineManager.ts
@@ -8,7 +8,6 @@ import shlex from "shlex";
 import { app, dialog } from "electron"; // FIXME: ここでelectronをimportするのは良くない
 
 import log from "electron-log";
-import { z } from "zod";
 import {
   findAltPort,
   getPidFromPort,
@@ -23,8 +22,8 @@ import {
   EngineDirValidationResult,
   MinimumEngineManifest,
   EngineId,
-  engineIdSchema,
   minimumEngineManifestSchema,
+  envEngineInfoSchema,
 } from "@/type/preload";
 import { AltPortInfos } from "@/store/type";
 
@@ -41,17 +40,7 @@ function createDefaultEngineInfos(defaultEngineDir: string): EngineInfo[] {
   const defaultEngineInfosEnv =
     import.meta.env.VITE_DEFAULT_ENGINE_INFOS ?? "[]";
 
-  const envSchema = z
-    .object({
-      uuid: engineIdSchema,
-      host: z.string(),
-      name: z.string(),
-      executionEnabled: z.boolean(),
-      executionFilePath: z.string(),
-      executionArgs: z.array(z.string()),
-      path: z.string().optional(),
-    })
-    .array();
+  const envSchema = envEngineInfoSchema.array();
   const engines = envSchema.parse(JSON.parse(defaultEngineInfosEnv));
 
   return engines.map((engineInfo) => {

--- a/src/browser/contract.ts
+++ b/src/browser/contract.ts
@@ -1,14 +1,11 @@
-import { EngineInfo, EngineId } from "@/type/preload";
+import { EngineInfo, envEngineInfoSchema } from "@/type/preload";
 
-export const defaultEngine: EngineInfo = {
-  uuid: EngineId("074fc39e-678b-4c13-8916-ffca8d505d1d"),
-  host: "http://127.0.0.1:50021",
-  name: "VOICEVOX Engine",
-  path: undefined,
-  executionEnabled: false,
-  executionFilePath: "",
-  executionArgs: [],
-  type: "default",
-};
+export const engineInfos: EngineInfo[] = envEngineInfoSchema
+  .array()
+  .parse(JSON.parse(import.meta.env.VITE_DEFAULT_ENGINE_INFOS))
+  .map((v) => ({
+    ...v,
+    type: "default",
+  }));
 
 export const directoryHandleStoreKey = "directoryHandle";

--- a/src/browser/sandbox.ts
+++ b/src/browser/sandbox.ts
@@ -1,4 +1,4 @@
-import { defaultEngine } from "./contract";
+import { engineInfos } from "./contract";
 import {
   checkFileExistsImpl,
   showOpenDirectoryDialogImpl,
@@ -214,7 +214,7 @@ export const api: Sandbox = {
   },
   /* eslint-enable no-console */
   engineInfos() {
-    return Promise.resolve([defaultEngine]);
+    return Promise.resolve(engineInfos);
   },
   restartEngine(/* engineId: EngineId */) {
     throw new Error(`Not supported on Browser version: restartEngine`);

--- a/src/browser/storeImpl.ts
+++ b/src/browser/storeImpl.ts
@@ -1,9 +1,9 @@
-import { defaultEngine, directoryHandleStoreKey } from "./contract";
+import { engineInfos, directoryHandleStoreKey } from "./contract";
 
 import {
   electronStoreSchema,
   ElectronStoreType,
-  EngineId,
+  EngineSetting,
   engineSettingSchema,
 } from "@/type/preload";
 
@@ -31,10 +31,10 @@ export const openDB = () =>
         const db = request.result;
         const baseSchema = electronStoreSchema.parse({});
 
-        const defaultVoicevoxEngineId = EngineId(defaultEngine.uuid);
-        baseSchema.engineSettings = {
-          [defaultVoicevoxEngineId]: engineSettingSchema.parse({}),
-        };
+        baseSchema.engineSettings = engineInfos.reduce((acc, v) => {
+          acc[v.uuid] = engineSettingSchema.parse({});
+          return acc;
+        }, {} as Record<string, EngineSetting>);
         db.createObjectStore(settingStoreKey).add(baseSchema, entryKey);
 
         // NOTE: fixedExportDirectoryを使用してファイルの書き出しをする際、

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -347,6 +347,18 @@ export const minimumEngineManifestSchema = z
 
 export type MinimumEngineManifest = z.infer<typeof minimumEngineManifestSchema>;
 
+export const envEngineInfoSchema = z.object({
+  uuid: engineIdSchema,
+  host: z.string(),
+  name: z.string(),
+  executionEnabled: z.boolean(),
+  executionFilePath: z.string(),
+  executionArgs: z.array(z.string()),
+  path: z.string().optional(),
+});
+
+export type EnvEngineInfo = z.infer<typeof envEngineInfoSchema>;
+
 export type EngineInfo = {
   uuid: EngineId;
   host: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": ["vitest/globals"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ import checker from "vite-plugin-checker";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { BuildOptions, defineConfig, loadEnv, Plugin } from "vite";
 import { quasar } from "@quasar/vite-plugin";
+import { name as packageName } from "./package.json";
 
 rmSync(path.resolve(__dirname, "dist"), { recursive: true, force: true });
 
@@ -17,11 +18,10 @@ const isElectron = process.env.VITE_TARGET === "electron";
 const isBrowser = process.env.VITE_TARGET === "browser";
 
 export default defineConfig((options) => {
-  const package_name = process.env.npm_package_name;
   const env = loadEnv(options.mode, __dirname);
-  if (!package_name.startsWith(env.VITE_APP_NAME)) {
+  if (!packageName.startsWith(env.VITE_APP_NAME)) {
     throw new Error(
-      `"package.json"の"name":"${package_name}"は"VITE_APP_NAME":"${env.VITE_APP_NAME}"から始まっている必要があります`
+      `"package.json"の"name":"${packageName}"は"VITE_APP_NAME":"${env.VITE_APP_NAME}"から始まっている必要があります`
     );
   }
   const shouldEmitSourcemap = ["development", "test"].includes(options.mode);


### PR DESCRIPTION
## 内容

- ブラウザ版のengineInfoを.envのものにするようにしまう。
- vite.config.tsのpackage.jsonからnameを持ってくるところをjson importで行うようにします。
- test-resultsをgitignoreします。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）