### PR TITLE
エンジンが起動していないときはエラーメッセージが表示されるようにする

### DIFF
--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -9,15 +9,7 @@
         <progress-dialog />
 
         <!-- TODO: 複数エンジン対応 -->
-        <div v-if="allEngineState === 'ERROR'" class="waiting-engine">
-          <div>
-            エンジンのエラーによって失敗しました。エンジンの再起動をお試しください。
-          </div>
-        </div>
-        <div
-          v-else-if="allEngineState === 'FAILED_STARTING'"
-          class="waiting-engine"
-        >
+        <div v-if="allEngineState === 'FAILED_STARTING'" class="waiting-engine">
           <div>
             エンジンの起動に失敗しました。エンジンの再起動をお試しください。
           </div>

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -9,6 +9,7 @@
         <progress-dialog />
 
         <!-- TODO: 複数エンジン対応 -->
+        <!-- TODO: allEngineStateが "ERROR" のときエラーになったエンジンを探してトーストで案内 -->
         <div v-if="allEngineState === 'FAILED_STARTING'" class="waiting-engine">
           <div>
             エンジンの起動に失敗しました。エンジンの再起動をお試しください。

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -9,7 +9,15 @@
         <progress-dialog />
 
         <!-- TODO: 複数エンジン対応 -->
-        <div v-if="allEngineState === 'FAILED_STARTING'" class="waiting-engine">
+        <div v-if="allEngineState === 'ERROR'" class="waiting-engine">
+          <div>
+            エンジンのエラーによって失敗しました。エンジンの再起動をお試しください。
+          </div>
+        </div>
+        <div
+          v-else-if="allEngineState === 'FAILED_STARTING'"
+          class="waiting-engine"
+        >
           <div>
             エンジンの起動に失敗しました。エンジンの再起動をお試しください。
           </div>

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -9,8 +9,15 @@
         <progress-dialog />
 
         <!-- TODO: 複数エンジン対応 -->
+        <div v-if="allEngineState === 'FAILED_STARTING'" class="waiting-engine">
+          <div>
+            エンジンの起動に失敗しました。エンジンの再起動をお試しください。
+          </div>
+        </div>
         <div
-          v-if="!isCompletedInitialStartup || allEngineState === 'STARTING'"
+          v-else-if="
+            !isCompletedInitialStartup || allEngineState === 'STARTING'
+          "
           class="waiting-engine"
         >
           <div>


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

エンジンが起動していないときに渡される `FAILED_STARTING` ステートをハンドリングしてエラーメッセージを表示するようにしました。
~ついでに `ERROR` ステートのハンドリングも追加しました。~

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

close #1538 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

![VOICEVOX-Ver-999-999-999](https://github.com/VOICEVOX/voicevox/assets/98309680/570f362e-7a82-4b20-8741-c7672713ebbd)

## その他
