### PR TITLE
`GENERATE_AUDIO_KEY`をストアの外に出す

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2838,15 +2838,13 @@ export const audioCommandStore = transformCommandStore(
               })
             );
           }
-          const audioKeys = audioItems.map(() => generateAudioKey());
-          const audioKeyItemPairs = audioItems.map((audioItem, index) => ({
+          const audioKeyItemPairs = audioItems.map((audioItem) => ({
             audioItem,
-            audioKey: audioKeys[index],
+            audioKey: generateAudioKey(),
           }));
           commit("COMMAND_IMPORT_FROM_FILE", {
             audioKeyItemPairs,
           });
-          return audioKeys;
         }
       ),
     },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2838,9 +2838,7 @@ export const audioCommandStore = transformCommandStore(
               })
             );
           }
-          const audioKeys = await Promise.all(
-            audioItems.map(() => generateAudioKey())
-          );
+          const audioKeys = audioItems.map(() => generateAudioKey());
           const audioKeyItemPairs = audioItems.map((audioItem, index) => ({
             audioItem,
             audioKey: audioKeys[index],

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -48,6 +48,10 @@ import { AudioQuery, AccentPhrase, Speaker, SpeakerInfo } from "@/openapi";
 import { base64ImageToUri } from "@/helpers/imageHelper";
 import { getValueOrThrow, ResultError } from "@/type/result";
 
+function generateAudioKey() {
+  return AudioKey(uuidv4());
+}
+
 async function generateUniqueIdAndQuery(
   state: State,
   audioItem: AudioItem
@@ -496,13 +500,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     },
   },
 
-  GENERATE_AUDIO_KEY: {
-    action() {
-      const audioKey = AudioKey(uuidv4());
-      return audioKey;
-    },
-  },
-
   SETUP_SPEAKER: {
     /**
      * AudioItemに設定される話者（スタイルID）に対してエンジン側の初期化を行い、即座に音声合成ができるようにする。
@@ -701,13 +698,13 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   REGISTER_AUDIO_ITEM: {
     async action(
-      { dispatch, commit },
+      { commit },
       {
         audioItem,
         prevAudioKey,
       }: { audioItem: AudioItem; prevAudioKey?: AudioKey }
     ) {
-      const audioKey = await dispatch("GENERATE_AUDIO_KEY");
+      const audioKey = generateAudioKey();
       commit("INSERT_AUDIO_ITEM", { audioItem, audioKey, prevAudioKey });
       return audioKey;
     },
@@ -1941,7 +1938,7 @@ export const audioCommandStore = transformCommandStore(
         audioStore.mutations.INSERT_AUDIO_ITEM(draft, payload);
       },
       async action(
-        { dispatch, commit },
+        { commit },
         {
           audioItem,
           prevAudioKey,
@@ -1950,7 +1947,7 @@ export const audioCommandStore = transformCommandStore(
           prevAudioKey: AudioKey | undefined;
         }
       ) {
-        const audioKey = await dispatch("GENERATE_AUDIO_KEY");
+        const audioKey = generateAudioKey();
         commit("COMMAND_REGISTER_AUDIO_ITEM", {
           audioItem,
           audioKey,
@@ -2841,8 +2838,8 @@ export const audioCommandStore = transformCommandStore(
               })
             );
           }
-          const audioKeys: AudioKey[] = await Promise.all(
-            audioItems.map(() => dispatch("GENERATE_AUDIO_KEY"))
+          const audioKeys = await Promise.all(
+            audioItems.map(() => generateAudioKey())
           );
           const audioKeyItemPairs = audioItems.map((audioItem, index) => ({
             audioItem,
@@ -2895,7 +2892,7 @@ export const audioCommandStore = transformCommandStore(
           }
 
           for (const text of texts.filter((value) => value != "")) {
-            const audioKey: AudioKey = await dispatch("GENERATE_AUDIO_KEY");
+            const audioKey = generateAudioKey();
             const audioItem = await dispatch("GENERATE_AUDIO_ITEM", {
               text,
               voice,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -180,10 +180,6 @@ export type AudioStoreTypes = {
     getter: CharacterInfo[] | undefined;
   };
 
-  GENERATE_AUDIO_KEY: {
-    action(): AudioKey;
-  };
-
   SETUP_SPEAKER: {
     action(payload: {
       audioKey: AudioKey;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -673,7 +673,7 @@ export type AudioCommandStoreTypes = {
     mutation: {
       audioKeyItemPairs: { audioItem: AudioItem; audioKey: AudioKey }[];
     };
-    action(payload: { filePath?: string }): string[] | void;
+    action(payload: { filePath?: string }): void;
   };
 
   COMMAND_PUT_TEXTS: {


### PR DESCRIPTION
## 内容
#1525 により`GENERATE_AUDIO_KEY`内でstateを参照する必要がなくなったため、独立した関数として定義します。
また、その周辺で未使用の戻り値のために複雑になっている実装があったので、解消します。
ユーザー視点での変更はありません。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- #1475
上記の一環です。
- #1525
上記により実現しました。
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
