### PR TITLE
refactor: `audioElement`関連の処理を分離

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1815,20 +1815,22 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           offset = startTime + 10e-6;
         }
 
+        const audioElement = getAudioElement();
+
         if (offset !== undefined) {
-          getAudioElement().currentTime = offset;
+          audioElement.currentTime = offset;
         }
 
         // 一部ブラウザではsetSinkIdが実装されていないので、その環境では無視する
-        if (getAudioElement().setSinkId) {
-          getAudioElement()
+        if (audioElement.setSinkId) {
+          audioElement
             .setSinkId(state.savingSetting.audioOutputDevice)
             .catch((err) => {
               const stop = () => {
-                getAudioElement().pause();
-                getAudioElement().removeEventListener("canplay", stop);
+                audioElement.pause();
+                audioElement.removeEventListener("canplay", stop);
               };
-              getAudioElement().addEventListener("canplay", stop);
+              audioElement.addEventListener("canplay", stop);
               window.electron.showMessageDialog({
                 type: "error",
                 title: "エラー",
@@ -1844,23 +1846,23 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
             commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: true });
           }
         };
-        getAudioElement().addEventListener("play", played);
+        audioElement.addEventListener("play", played);
 
         let paused: () => void;
         const audioPlayPromise = new Promise<boolean>((resolve) => {
           paused = () => {
-            resolve(getAudioElement().ended);
+            resolve(audioElement.ended);
           };
-          getAudioElement().addEventListener("pause", paused);
+          audioElement.addEventListener("pause", paused);
         }).finally(async () => {
-          getAudioElement().removeEventListener("play", played);
-          getAudioElement().removeEventListener("pause", paused);
+          audioElement.removeEventListener("play", played);
+          audioElement.removeEventListener("pause", paused);
           if (audioKey) {
             commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: false });
           }
         });
 
-        getAudioElement().play();
+        audioElement.play();
 
         return audioPlayPromise;
       }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1806,15 +1806,14 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
             audioKey,
           });
           if (accentPhraseOffsets.length === 0) {
-            getAudioElement().currentTime = 0;
-          } else {
+            throw new Error("accentPhraseOffsets.length === 0");
+          }
             const startTime =
               accentPhraseOffsets[state.audioPlayStartPoint ?? 0];
             if (startTime === undefined) throw Error("startTime === undefined");
             // 小さい値が切り捨てられることでフォーカスされるアクセントフレーズが一瞬元に戻るので、
             // 再生に影響のない程度かつ切り捨てられない値を加算する
             getAudioElement().currentTime = startTime + 10e-6;
-          }
         }
 
         // 一部ブラウザではsetSinkIdが実装されていないので、その環境では無視する

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1787,13 +1787,19 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     ),
   },
 
+  SET_AUDIO_SOURCE: {
+    mutation(_, { audioBlob }: { audioBlob: Blob }) {
+      getAudioElement().src = URL.createObjectURL(audioBlob);
+    },
+  },
+
   PLAY_AUDIO_BLOB: {
     action: createUILockAction(
       async (
         { state, commit, dispatch },
         { audioBlob, audioKey }: { audioBlob: Blob; audioKey?: AudioKey }
       ) => {
-        getAudioElement().src = URL.createObjectURL(audioBlob);
+        commit("SET_AUDIO_SOURCE", { audioBlob });
         // 途中再生用の処理
         if (audioKey) {
           const accentPhraseOffsets = await dispatch("GET_AUDIO_PLAY_OFFSETS", {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1787,6 +1787,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     ),
   },
 
+  // NOTE: リファクタリング中、別ファイルに移動予定
   SET_AUDIO_SOURCE: {
     mutation(_, { audioBlob }: { audioBlob: Blob }) {
       getAudioElement().src = URL.createObjectURL(audioBlob);
@@ -1820,6 +1821,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     ),
   },
 
+  // NOTE: リファクタリング中、別ファイルに移動予定
   PLAY_AUDIO_PLAYER: {
     async action(
       { state, commit },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1869,6 +1869,15 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     ),
   },
 
+  PLAY_AUDIO_PLAYER: {
+    async action(
+      { state, commit },
+      { offset, audioKey }: { offset?: number; audioKey?: AudioKey }
+    ) {
+      //
+    },
+  },
+
   STOP_AUDIO: {
     action() {
       // PLAY_ でonpause時の処理が設定されているため、pauseするだけで良い

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1815,55 +1815,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           offset = startTime + 10e-6;
         }
 
-        const audioElement = getAudioElement();
-
-        if (offset !== undefined) {
-          audioElement.currentTime = offset;
-        }
-
-        // 一部ブラウザではsetSinkIdが実装されていないので、その環境では無視する
-        if (audioElement.setSinkId) {
-          audioElement
-            .setSinkId(state.savingSetting.audioOutputDevice)
-            .catch((err) => {
-              const stop = () => {
-                audioElement.pause();
-                audioElement.removeEventListener("canplay", stop);
-              };
-              audioElement.addEventListener("canplay", stop);
-              window.electron.showMessageDialog({
-                type: "error",
-                title: "エラー",
-                message: "再生デバイスが見つかりません",
-              });
-              throw new Error(err);
-            });
-        }
-
-        // 再生終了時にresolveされるPromiseを返す
-        const played = async () => {
-          if (audioKey) {
-            commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: true });
-          }
-        };
-        audioElement.addEventListener("play", played);
-
-        let paused: () => void;
-        const audioPlayPromise = new Promise<boolean>((resolve) => {
-          paused = () => {
-            resolve(audioElement.ended);
-          };
-          audioElement.addEventListener("pause", paused);
-        }).finally(async () => {
-          audioElement.removeEventListener("play", played);
-          audioElement.removeEventListener("pause", paused);
-          if (audioKey) {
-            commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: false });
-          }
-        });
-
-        audioElement.play();
-
         return dispatch("PLAY_AUDIO_PLAYER", { offset, audioKey });
       }
     ),

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1805,15 +1805,13 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           const accentPhraseOffsets = await dispatch("GET_AUDIO_PLAY_OFFSETS", {
             audioKey,
           });
-          if (accentPhraseOffsets.length === 0) {
+          if (accentPhraseOffsets.length === 0)
             throw new Error("accentPhraseOffsets.length === 0");
-          }
-            const startTime =
-              accentPhraseOffsets[state.audioPlayStartPoint ?? 0];
-            if (startTime === undefined) throw Error("startTime === undefined");
-            // 小さい値が切り捨てられることでフォーカスされるアクセントフレーズが一瞬元に戻るので、
-            // 再生に影響のない程度かつ切り捨てられない値を加算する
-            getAudioElement().currentTime = startTime + 10e-6;
+          const startTime = accentPhraseOffsets[state.audioPlayStartPoint ?? 0];
+          if (startTime === undefined) throw Error("startTime === undefined");
+          // 小さい値が切り捨てられることでフォーカスされるアクセントフレーズが一瞬元に戻るので、
+          // 再生に影響のない程度かつ切り捨てられない値を加算する
+          getAudioElement().currentTime = startTime + 10e-6;
         }
 
         // 一部ブラウザではsetSinkIdが実装されていないので、その環境では無視する

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1879,6 +1879,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   },
 
   STOP_AUDIO: {
+    // 停止中でも呼び出して問題ない
     action() {
       // PLAY_ でonpause時の処理が設定されているため、pauseするだけで良い
       getAudioElement().pause();

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1864,7 +1864,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
         audioElement.play();
 
-        return audioPlayPromise;
+        return dispatch("PLAY_AUDIO_PLAYER", { offset, audioKey });
       }
     ),
   },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1874,7 +1874,56 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       { state, commit },
       { offset, audioKey }: { offset?: number; audioKey?: AudioKey }
     ) {
-      //
+      const audioElement = getAudioElement();
+
+      if (offset !== undefined) {
+        audioElement.currentTime = offset;
+      }
+
+      // 一部ブラウザではsetSinkIdが実装されていないので、その環境では無視する
+      if (audioElement.setSinkId) {
+        audioElement
+          .setSinkId(state.savingSetting.audioOutputDevice)
+          .catch((err) => {
+            const stop = () => {
+              audioElement.pause();
+              audioElement.removeEventListener("canplay", stop);
+            };
+            audioElement.addEventListener("canplay", stop);
+            window.electron.showMessageDialog({
+              type: "error",
+              title: "エラー",
+              message: "再生デバイスが見つかりません",
+            });
+            throw new Error(err);
+          });
+      }
+
+      // 再生終了時にresolveされるPromiseを返す
+      const played = async () => {
+        if (audioKey) {
+          commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: true });
+        }
+      };
+      audioElement.addEventListener("play", played);
+
+      let paused: () => void;
+      const audioPlayPromise = new Promise<boolean>((resolve) => {
+        paused = () => {
+          resolve(audioElement.ended);
+        };
+        audioElement.addEventListener("pause", paused);
+      }).finally(async () => {
+        audioElement.removeEventListener("play", played);
+        audioElement.removeEventListener("pause", paused);
+        if (audioKey) {
+          commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: false });
+        }
+      });
+
+      audioElement.play();
+
+      return audioPlayPromise;
     },
   },
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1800,6 +1800,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         { audioBlob, audioKey }: { audioBlob: Blob; audioKey?: AudioKey }
       ) => {
         commit("SET_AUDIO_SOURCE", { audioBlob });
+        let offset: number | undefined;
         // 途中再生用の処理
         if (audioKey) {
           const accentPhraseOffsets = await dispatch("GET_AUDIO_PLAY_OFFSETS", {
@@ -1811,7 +1812,11 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           if (startTime === undefined) throw Error("startTime === undefined");
           // 小さい値が切り捨てられることでフォーカスされるアクセントフレーズが一瞬元に戻るので、
           // 再生に影響のない程度かつ切り捨てられない値を加算する
-          getAudioElement().currentTime = startTime + 10e-6;
+          offset = startTime + 10e-6;
+        }
+
+        if (offset !== undefined) {
+          getAudioElement().currentTime = offset;
         }
 
         // 一部ブラウザではsetSinkIdが実装されていないので、その環境では無視する

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1757,7 +1757,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   PLAY_AUDIO: {
     action: createUILockAction(
       async ({ commit, dispatch }, { audioKey }: { audioKey: AudioKey }) => {
-        getAudioElement().pause();
+        await dispatch("STOP_AUDIO");
 
         // 音声用意
         let blob = await dispatch("GET_AUDIO_CACHE", { audioKey });

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -466,7 +466,7 @@ export type AudioStoreTypes = {
   };
 
   PLAY_AUDIO_PLAYER: {
-    action(payload: { offset?: number; audioKey?: AudioKey }): Promise<void>;
+    action(payload: { offset?: number; audioKey?: AudioKey }): Promise<boolean>;
   };
 
   STOP_AUDIO: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -457,6 +457,10 @@ export type AudioStoreTypes = {
     action(payload: { audioKey: AudioKey }): boolean;
   };
 
+  SET_AUDIO_SOURCE: {
+    mutation: { audioBlob: Blob };
+  };
+
   PLAY_AUDIO_BLOB: {
     action(payload: { audioBlob: Blob; audioKey?: AudioKey }): boolean;
   };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -465,6 +465,10 @@ export type AudioStoreTypes = {
     action(payload: { audioBlob: Blob; audioKey?: AudioKey }): boolean;
   };
 
+  PLAY_AUDIO_PLAYER: {
+    action(payload: { offset?: number; audioKey?: AudioKey }): Promise<void>;
+  };
+
   STOP_AUDIO: {
     action(): void;
   };


### PR DESCRIPTION
## 内容
audioElementに割と密接に関係している処理を`audioPlayer.ts`へ分離する準備として、別ファイルに分ける前に一旦ファイル内で分離しました。
ユーザー視点での変更はありません。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- #1475
上記の一環です。
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
