### PR TITLE
デフォルトスタイルページのデザイン変更

### DIFF
--- a/src/components/DefaultStyleListDialog.vue
+++ b/src/components/DefaultStyleListDialog.vue
@@ -64,10 +64,13 @@
                     "
                     class="style-icon"
                   />
-                  <span class="text-subtitle1 q-my-md text-weight-bold">{{
-                    characterInfosMap[speaker.metas.speakerUuid].metas
-                      .speakerName
-                  }}</span>
+                  <span
+                    class="text-subtitle1 q-mt-sm q-mb-xs text-weight-bold"
+                    >{{
+                      characterInfosMap[speaker.metas.speakerUuid].metas
+                        .speakerName
+                    }}</span
+                  >
                   <div
                     v-if="
                       characterInfosMap[speaker.metas.speakerUuid].metas.styles
@@ -288,7 +291,6 @@ const openStyleSelectDialog = (characterInfo: CharacterInfo) => {
           flex-direction: column;
           justify-content: center;
           align-items: center;
-          margin-top: -1rem;
         }
       }
     }

--- a/src/components/DefaultStyleListDialog.vue
+++ b/src/components/DefaultStyleListDialog.vue
@@ -64,10 +64,14 @@
                     "
                     class="style-icon"
                   />
-                  <span class="text-subtitle1 q-ma-sm">{{
-                    characterInfosMap[speaker.metas.speakerUuid].metas
-                      .speakerName
-                  }}</span>
+                  <span
+                    class="text-subtitle1 q-ma-sm"
+                    style="font-weight: bold; margin-bottom: 20px"
+                    >{{
+                      characterInfosMap[speaker.metas.speakerUuid].metas
+                        .speakerName
+                    }}</span
+                  >
                   <div
                     v-if="
                       characterInfosMap[speaker.metas.speakerUuid].metas.styles
@@ -75,15 +79,16 @@
                     "
                     class="style-select-container"
                   >
-                    <span
-                      >{{
-                        selectedStyles[speaker.metas.speakerUuid]
-                          ? selectedStyles[speaker.metas.speakerUuid].styleName
-                          : DEFAULT_STYLE_NAME
-                      }}（{{
+                    <span>{{
+                      selectedStyles[speaker.metas.speakerUuid]
+                        ? selectedStyles[speaker.metas.speakerUuid].styleName
+                        : DEFAULT_STYLE_NAME
+                    }}</span
+                    ><span style="font-size: 0.8rem"
+                      >全{{
                         characterInfosMap[speaker.metas.speakerUuid].metas
                           .styles.length
-                      }}スタイル）</span
+                      }}スタイル</span
                     >
                   </div>
                 </div>
@@ -284,7 +289,7 @@ const openStyleSelectDialog = (characterInfo: CharacterInfo) => {
         }
         .style-select-container {
           display: flex;
-          flex-direction: row;
+          flex-direction: column;
           justify-content: center;
           align-items: center;
           margin-top: -1rem;

--- a/src/components/DefaultStyleListDialog.vue
+++ b/src/components/DefaultStyleListDialog.vue
@@ -64,14 +64,10 @@
                     "
                     class="style-icon"
                   />
-                  <span
-                    class="text-subtitle1 q-ma-sm"
-                    style="font-weight: bold; margin-bottom: 20px"
-                    >{{
-                      characterInfosMap[speaker.metas.speakerUuid].metas
-                        .speakerName
-                    }}</span
-                  >
+                  <span class="text-subtitle1 q-my-md text-weight-bold">{{
+                    characterInfosMap[speaker.metas.speakerUuid].metas
+                      .speakerName
+                  }}</span>
                   <div
                     v-if="
                       characterInfosMap[speaker.metas.speakerUuid].metas.styles
@@ -84,7 +80,7 @@
                         ? selectedStyles[speaker.metas.speakerUuid].styleName
                         : DEFAULT_STYLE_NAME
                     }}</span
-                    ><span style="font-size: 0.8rem"
+                    ><span class="text-caption"
                       >全{{
                         characterInfosMap[speaker.metas.speakerUuid].metas
                           .styles.length


### PR DESCRIPTION
## 内容
デフォルトスタイルの変更ページのレイアウトを

- 名前太字
- スタイルそのまま
- 全スタイル数縮小

で変更。

## 関連 Issue
ref #1512

## スクリーンショット・動画など
![image](https://github.com/VOICEVOX/voicevox/assets/36288369/c2333245-a656-47c7-879d-4c0f58d0aacd)

## その他
