### PR TITLE
[project-library-manage] 音声ライブラリの最新バージョン判定の誤りを修正

### DIFF
--- a/src/components/LibraryManageDialog.vue
+++ b/src/components/LibraryManageDialog.vue
@@ -225,7 +225,8 @@ const isLatest = (engineId: EngineId, library: BrandedDownloadableLibrary) => {
   if (!installedLibrary) {
     return false;
   }
-  return semver.gte(library.version, installedLibrary.version);
+  // installedLibrary.versionがlibrary.versionと等しいか、それより大きい場合はlatest
+  return semver.gte(installedLibrary.version, library.version);
 };
 
 const isUninstallable = (


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題のとおりです。頭が混乱していたのか、判定を誤っていたので修正しました。
ついでに、頭がこんがらがらないようにコメントを追記しました。

## その他

#1560 を適用しないと、sharevox engineによるUIでの確認ができません。
