### PR TITLE
Fix: Insecure ContextでSettingDialogが開かないのを修正

### DIFF
--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -1089,7 +1089,7 @@ const updateAudioOutputDevices = async () => {
       return { label: device.label, key: device.deviceId };
     });
 };
-navigator.mediaDevices.addEventListener(
+navigator.mediaDevices?.addEventListener(
   "devicechange",
   updateAudioOutputDevices
 );


### PR DESCRIPTION
## 内容
Insecure Context（`localhost`以外の`http://`）でSettingDialogが動かないのを修正します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）