### PR TITLE
feat: モーラが編集不可な理由を表示する

### DIFF
--- a/src/components/AccentPhrase.vue
+++ b/src/components/AccentPhrase.vue
@@ -366,6 +366,8 @@ const handleChangeVoicing = (mora: Mora, moraIndex: number) => {
   white-space: nowrap;
   color: colors.$display;
   position: relative;
+  // デフォルトは編集不可
+  cursor: not-allowed;
 }
 .text-cell-inner {
   position: absolute;

--- a/src/components/AccentPhrase.vue
+++ b/src/components/AccentPhrase.vue
@@ -108,6 +108,16 @@
       @mouseleave="handleHoverText(false, moraIndex)"
       @click.stop="uiLocked || handleChangeVoicing(mora, moraIndex)"
     >
+      <q-tooltip
+        v-if="
+          selectedDetail === 'pitch' && !unvoicableVowels.includes(mora.vowel)
+        "
+        :delay="500"
+        >この音は無声化できません。</q-tooltip
+      >
+      <q-tooltip v-if="selectedDetail === 'length'" :delay="500"
+        >長さ項目では編集できません。</q-tooltip
+      >
       <span class="text-cell-inner">
         {{ getHoveredText(mora, moraIndex) }}
       </span>


### PR DESCRIPTION
## 内容
#1572 の解決PRです。
編集不可なモーラにhoverした時、その理由を`<q-tooltip>`で表示します。
ｲﾝﾄﾈｰｼｮﾝ項目のモーラのうち無声化が不可能なものは以下のように表示されます。
![image](https://github.com/VOICEVOX/voicevox/assets/7900586/b1e5f0d6-bdcd-48cc-9eef-46571aa4fb04)
長さ項目ではモーラの編集が不可能なので、以下のように表示されます。
![image](https://github.com/VOICEVOX/voicevox/assets/7900586/b5cf0702-b0bd-4ec7-a501-9b2ef99874ec)

意図しないhover時には邪魔にならないようにdelay: 500をつけました。

また上記の対象モーラでは`cursor: not-allowed`が適用されます。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- #1572
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
https://github.com/VOICEVOX/voicevox/assets/7900586/2248f86e-3924-44c2-8b48-7cf88acb55e9
<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

