### PR TITLE
feat: 詳細調整欄でのアクセント区間単位の読み変更時に読点が含まれる場合の挙動を改善

### DIFF
--- a/src/components/AccentPhrase.vue
+++ b/src/components/AccentPhrase.vue
@@ -130,6 +130,7 @@
             width: `${scope.value.length + 1}em`,
             minWidth: '50px',
           }"
+          :aria-label="`${index + 1}番目のアクセント区間の読み`"
           autofocus
           outlined
           @keyup.enter="scope.set"

--- a/src/components/AccentPhrase.vue
+++ b/src/components/AccentPhrase.vue
@@ -200,11 +200,19 @@ const pronunciation = computed(() => {
 
 const handleChangePronounce = (newPronunciation: string) => {
   let popUntilPause = false;
-  newPronunciation = newPronunciation.replace(",", "、");
-  if (newPronunciation.slice(-1) == "、" && !props.isLast) {
-    // 生成エラー回避
-    newPronunciation += "ア";
-    popUntilPause = true;
+  newPronunciation = newPronunciation
+    .replace(/,/g, "、")
+    // 連続する読点をまとめる
+    .replace(/、{2,}/g, "、");
+  if (newPronunciation.endsWith("、")) {
+    if (props.isLast) {
+      // 末尾の読点を削除
+      newPronunciation = newPronunciation.slice(0, -1);
+    } else {
+      // 生成エラー回避
+      newPronunciation += "ア";
+      popUntilPause = true;
+    }
   }
   store.dispatch("COMMAND_CHANGE_SINGLE_ACCENT_PHRASE", {
     audioKey: props.audioKey,

--- a/tests/e2e/browser/音声詳細.spec.ts
+++ b/tests/e2e/browser/音声詳細.spec.ts
@@ -25,14 +25,17 @@ test("単体アクセント句の読み変更", async ({ page }) => {
     getNthAccentPhraseInput({ page, n: i })
   );
 
+  // 最後のアクセント区間に読点をつけても無視される
   await page.getByText("ヨ", { exact: true }).click();
   await inputs[3].fill("ヨン,、,、");
   await inputs[3].press("Enter");
 
+  // 連続する読点を追加すると１つに集約される
   await page.getByText("ジュ", { exact: true }).click();
   await inputs[2].fill("サンジュウ,、,、");
   await inputs[2].press("Enter");
 
+  // 読点を追加
   await page.getByText("ヒャ", { exact: true }).click();
   await inputs[1].fill("ニヒャク、");
   await inputs[1].press("Enter");

--- a/tests/e2e/browser/音声詳細.spec.ts
+++ b/tests/e2e/browser/音声詳細.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 
 import { navigateToMain } from "../navigators";
 
@@ -6,6 +6,45 @@ test.beforeEach(async ({ page }) => {
   const BASE_URL = "http://localhost:5173/#/home";
   await page.setViewportSize({ width: 800, height: 600 });
   await page.goto(BASE_URL);
+});
+
+function getNthAccentPhraseInput({ page, n }: { page: Page; n: number }) {
+  return page.getByLabel(`${n + 1}番目のアクセント区間の読み`);
+}
+
+test("単体アクセント句の読み変更", async ({ page }) => {
+  await navigateToMain(page);
+  await page.waitForTimeout(100);
+
+  const textField = page.getByRole("textbox", { name: "1行目" });
+  await textField.click();
+  await textField.fill("1234");
+  await textField.press("Enter");
+
+  const inputs = Array.from(new Array(4), (_, i) =>
+    getNthAccentPhraseInput({ page, n: i })
+  );
+
+  await page.getByText("ヨ", { exact: true }).click();
+  await inputs[3].fill("ヨン,、,、");
+  await inputs[3].press("Enter");
+
+  await page.getByText("ジュ", { exact: true }).click();
+  await inputs[2].fill("サンジュウ,、,、");
+  await inputs[2].press("Enter");
+
+  await page.getByText("ヒャ", { exact: true }).click();
+  await inputs[1].fill("ニヒャク、");
+  await inputs[1].press("Enter");
+
+  await page.getByText("セ", { exact: true }).click();
+  await inputs[0].fill("セン,");
+  await inputs[0].press("Enter");
+
+  await expect(page.getByText("セン、")).toBeVisible();
+  await expect(page.getByText("ニヒャク、")).toBeVisible();
+  await expect(page.getByText("サンジュウ、")).toBeVisible();
+  await expect(page.getByText("ヨン、")).not.toBeVisible();
 });
 
 test("詳細調整欄のコンテキストメニュー", async ({ page }) => {

--- a/tests/e2e/browser/音声詳細.spec.ts
+++ b/tests/e2e/browser/音声詳細.spec.ts
@@ -21,7 +21,7 @@ test("単体アクセント句の読み変更", async ({ page }) => {
   await textField.fill("1234");
   await textField.press("Enter");
 
-  const inputs = Array.from(new Array(4), (_, i) =>
+  const inputs = Array.from({ length: 4 }, (_, i) =>
     getNthAccentPhraseInput({ page, n: i })
   );
 

--- a/tests/e2e/browser/音声詳細.spec.ts
+++ b/tests/e2e/browser/音声詳細.spec.ts
@@ -32,6 +32,7 @@ test("単体アクセント句の読み変更", async ({ page }) => {
   await page.waitForTimeout(100);
   await expect(page.getByText("セン、")).toBeVisible();
 
+  // 「,」が読点に変換される
   await page.getByText("ヒャ", { exact: true }).click();
   await inputs[1].fill("ニヒャク,");
   await inputs[1].press("Enter");

--- a/tests/e2e/browser/音声詳細.spec.ts
+++ b/tests/e2e/browser/音声詳細.spec.ts
@@ -25,28 +25,31 @@ test("単体アクセント句の読み変更", async ({ page }) => {
     getNthAccentPhraseInput({ page, n: i })
   );
 
-  // 最後のアクセント区間に読点をつけても無視される
-  await page.getByText("ヨ", { exact: true }).click();
-  await inputs[3].fill("ヨン,、,、");
-  await inputs[3].press("Enter");
+  // 読点を追加
+  await page.getByText("セ", { exact: true }).click();
+  await inputs[0].fill("セン、");
+  await inputs[0].press("Enter");
+  await page.waitForTimeout(100);
+  await expect(page.getByText("セン、")).toBeVisible();
+
+  await page.getByText("ヒャ", { exact: true }).click();
+  await inputs[1].fill("ニヒャク,");
+  await inputs[1].press("Enter");
+  await page.waitForTimeout(100);
+  await expect(page.getByText("ニヒャク、")).toBeVisible();
 
   // 連続する読点を追加すると１つに集約される
   await page.getByText("ジュ", { exact: true }).click();
   await inputs[2].fill("サンジュウ,、,、");
   await inputs[2].press("Enter");
-
-  // 読点を追加
-  await page.getByText("ヒャ", { exact: true }).click();
-  await inputs[1].fill("ニヒャク、");
-  await inputs[1].press("Enter");
-
-  await page.getByText("セ", { exact: true }).click();
-  await inputs[0].fill("セン,");
-  await inputs[0].press("Enter");
-
-  await expect(page.getByText("セン、")).toBeVisible();
-  await expect(page.getByText("ニヒャク、")).toBeVisible();
+  await page.waitForTimeout(100);
   await expect(page.getByText("サンジュウ、")).toBeVisible();
+
+  // 最後のアクセント区間に読点をつけても無視される
+  await page.getByText("ヨ", { exact: true }).click();
+  await inputs[3].fill("ヨン,、,、");
+  await inputs[3].press("Enter");
+  await page.waitForTimeout(100);
   await expect(page.getByText("ヨン、")).not.toBeVisible();
 });
 


### PR DESCRIPTION
## 内容
以下の挙動を改善し、fallbackしないようにします。
- 読みに読点の連続が含まれる場合にfallbackしていた
- 最後のアクセント区間の変更時かつ読みに読点が含まれる場合にfallbackしていた

（「fallbackする」は、以下の行が実行されることを指します。この場合は読みが解析されるため、例えば「ハ」「ヘ」が「ワ」「エ」に変換されたりがありそうです。）
https://github.com/VOICEVOX/voicevox/blob/7a4242cf9ebad27f3ee0c4d5ce1a97128c2fc161/src/store/audio.ts#L2289-L2294

また、これに関連するe2eテストを追加しました。
さらに、その際に書きにくかったのでついでにaria-labelを追加しました。
ただし、現状キーボード操作では各モーラにフォーカスできないため、アクセシビリティ的にはほぼ無意味です。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
- https://github.com/VOICEVOX/voicevox/issues/766#issuecomment-1722661052

[追記ここから]
- #796
isKana: trueになるようになっているはずなので、図らずも上記のバグの一部が修正されているかもです
（分割位置が変わるのは修正されるはず。ただ、アクセント位置が変わるのはそのままです。）

[追記ここまで]
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
