### PR TITLE
詳細調整欄でのアクセント句全体のパラメータ調整（alt＋ｲﾝﾄﾈｰｼｮﾝ・長さ変更）中に値をプレビュー表示する

### DIFF
--- a/src/components/AccentPhrase.vue
+++ b/src/components/AccentPhrase.vue
@@ -29,7 +29,9 @@
         :type="'pitch'"
         :clip="false"
         :shift-key-flag="shiftKeyFlag"
+        :force-value-visible="forceValueVisible"
         @change-value="changeMoraData"
+        @change-self-value-visible="handleValueVisible"
       />
     </div>
     <div v-if="accentPhrase.pauseMora" />
@@ -54,8 +56,10 @@
         :type="'consonant'"
         :clip="true"
         :shift-key-flag="shiftKeyFlag"
+        :force-value-visible="forceValueVisible"
         @change-value="changeMoraData"
         @mouse-over="handleLengthHoverText"
+        @change-self-value-visible="handleValueVisible"
       />
       <!-- vowel length -->
       <audio-parameter
@@ -68,8 +72,10 @@
         :type="'vowel'"
         :clip="mora.consonant ? true : false"
         :shift-key-flag="shiftKeyFlag"
+        :force-value-visible="forceValueVisible"
         @change-value="changeMoraData"
         @mouse-over="handleLengthHoverText"
+        @change-self-value-visible="handleValueVisible"
       />
     </div>
     <div
@@ -89,7 +95,9 @@
         :step="0.01"
         :type="'pause'"
         :shift-key-flag="shiftKeyFlag"
+        :force-value-visible="forceValueVisible"
         @change-value="changeMoraData"
+        @change-self-value-visible="handleValueVisible"
       />
     </div>
   </template>
@@ -301,6 +309,15 @@ const toggleAccentPhraseSplit = (isPause: boolean, moraIndex?: number) => {
 
 const lastPitches = computed(() =>
   props.accentPhrase.moras.map((mora) => mora.pitch)
+);
+
+// alt押下中の全モーラのスライダーの数値表示
+const isAnySingleValueVisible = ref(false);
+const handleValueVisible = (isVisible: boolean) => {
+  isAnySingleValueVisible.value = isVisible;
+};
+const forceValueVisible = computed(
+  () => props.altKeyFlag && isAnySingleValueVisible.value
 );
 
 const maxPitch = 6.5;

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -7,6 +7,7 @@
       v-if="isSelfBadgeVisible || (!props.disable && props.forceValueVisible)"
       class="value-label"
       :class="{
+        'value-label-translucent': !isSelfBadgeVisible,
         'value-label-consonant': props.clip && props.type === 'consonant',
         'value-label-vowel': props.clip && props.type === 'vowel',
       }"
@@ -170,6 +171,10 @@ div {
     height: $value-label-height;
     padding: 0px 8px;
     transform: translateX(-50%) translateX(15px);
+  }
+
+  .value-label-translucent {
+    opacity: 0.8;
   }
 
   .value-label-consonant {

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -4,9 +4,7 @@
     @mouseleave="handleMouseHover(false)"
   >
     <q-badge
-      v-if="
-        !disable && (valueLabel.visible || previewSlider.state.isPanning.value)
-      "
+      v-if="isSelfBadgeVisible || (!props.disable && props.forceValueVisible)"
       class="value-label"
       :class="{
         'value-label-consonant': props.clip && props.type === 'consonant',
@@ -43,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from "vue";
+import { computed, reactive, watch } from "vue";
 import { previewSliderHelper } from "@/helpers/previewSliderHelper";
 import { MoraDataType } from "@/type/preload";
 
@@ -59,6 +57,7 @@ const props = withDefaults(
     type?: MoraDataType;
     clip?: boolean;
     shiftKeyFlag?: boolean;
+    forceValueVisible?: boolean;
   }>(),
   {
     min: 0.0,
@@ -68,6 +67,7 @@ const props = withDefaults(
     type: "vowel",
     clip: false,
     shiftKeyFlag: false,
+    forceValueVisible: false,
   }
 );
 
@@ -85,6 +85,7 @@ const emit =
       type: MoraDataType,
       moraIndex: number
     ): void;
+    (e: "changeSelfValueVisible", isVisible: boolean): void;
   }>();
 
 const changeValue = (newValue: number, type: MoraDataType = props.type) =>
@@ -131,6 +132,16 @@ const precisionComputed = computed(() => {
   } else {
     return 3;
   }
+});
+
+const isSelfBadgeVisible = computed(
+  () =>
+    !props.disable &&
+    (valueLabel.visible || previewSlider.state.isPanning.value)
+);
+
+watch(isSelfBadgeVisible, (newValue) => {
+  emit("changeSelfValueVisible", newValue);
 });
 
 // クリックでアクセント句が選択されないように@click.stopに渡す

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -8,6 +8,10 @@
         !disable && (valueLabel.visible || previewSlider.state.isPanning.value)
       "
       class="value-label"
+      :class="{
+        'value-label-consonant': props.clip && props.type === 'consonant',
+        'value-label-vowel': props.clip && props.type === 'vowel',
+      }"
       color="primary"
       text-color="display-on-primary"
     >
@@ -155,6 +159,14 @@ div {
     height: $value-label-height;
     padding: 0px 8px;
     transform: translateX(-50%) translateX(15px);
+  }
+
+  .value-label-consonant {
+    transform: translateX(-50%) translateX(14px) translateY(-60%);
+  }
+
+  .value-label-vowel {
+    transform: translateX(-50%) translateX(16px) translateY(60%);
   }
 }
 </style>


### PR DESCRIPTION
## 内容
#646 の解決PRです。
タイトル通り、詳細調整欄でのアクセント句全体のパラメータ調整（alt＋ｲﾝﾄﾈｰｼｮﾝ・長さ変更）中に値をプレビュー表示するようにします。
また位置が被るのを避けるため、副作用として、長さ項目の母音と子音に分かれているものは表示される高さが変わります。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #646
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

https://github.com/VOICEVOX/voicevox/assets/7900586/3a7009e3-ec7f-44b5-bbcb-007b1f51abfd


<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
