### PR TITLE
[project-library-manage] ライブラリ管理画面のデータの持ち方などをリファクタリング

### DIFF
--- a/src/components/LibraryManageDialog.vue
+++ b/src/components/LibraryManageDialog.vue
@@ -486,10 +486,7 @@ const togglePlayOrStop = (
   }
 };
 
-const installLibrary = async (
-  engineId: EngineId,
-  library: DownloadableLibrary
-) => {
+const installLibrary = async (engineId: EngineId, library: LibraryType) => {
   selectLibraryAndSpeaker(
     LibraryId(library.uuid),
     SpeakerId(library.speakers[0].metas.speakerUuid)
@@ -498,10 +495,7 @@ const installLibrary = async (
   // TODO: インストール処理を追加する
 };
 
-const uninstallLibrary = async (
-  engineId: EngineId,
-  library: DownloadableLibrary
-) => {
+const uninstallLibrary = async (engineId: EngineId, library: LibraryType) => {
   selectLibraryAndSpeaker(
     LibraryId(library.uuid),
     SpeakerId(library.speakers[0].metas.speakerUuid)

--- a/src/components/LibraryManageDialog.vue
+++ b/src/components/LibraryManageDialog.vue
@@ -369,6 +369,8 @@ watch(modelValueComputed, async (newValue) => {
       const [convertedDownloadableLibraries, convertedInstalledLibraries] =
         fetchResult;
 
+      installedLibraries.value[engineId] = convertedInstalledLibraries;
+      // ダウンロード可能なライブラリはソートしてから代入する
       const toPrimaryOrder = (library: DownloadableLibrary) => {
         const localLibrary = installedLibraries.value[engineId].find(
           (l) => l.uuid === library.uuid
@@ -391,7 +393,6 @@ watch(modelValueComputed, async (newValue) => {
         downloadableLibraries.value[engineId][downloadableLibrary.uuid] =
           downloadableLibrary;
       }
-      installedLibraries.value[engineId] = convertedInstalledLibraries;
     })
   );
 });


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題のとおりです、 https://github.com/VOICEVOX/voicevox/pull/1568#pullrequestreview-1635929557 でのコメントをもとにリファクタリングを行いました。
各リファクタを分けてもいいかなとも考えたのですが、それぞれのリファクタリングが密結合な感じだったので、一気にやってしまいました。

1. エンジンから受け取ったデータを、エディタ側で変換した型・変数において`Brand(ed)`というユビキタス言語を使わないようにし、逆にエンジン側からのデータに対して`Engine`とつけるようにしました。
2. `DownloadableLibrary`と`InstalledLibrary`や、エンジンにはあるが`DownloadableLibrary`にはないライブラリ(`カスタムライブラリ`)などを考える際に関数を通すと言ったことを意識しなくていいよう、これらを結合した`LibraryType`を作り、管理画面内ではそれのみをいじるようにしました。(これに合わせて、`installedLibraries`変数が消えました。)
3. `downloadableLibraries`(#1568 では`allLibraries`にあたるもの)を重複禁止のためRecordで管理するようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #1568 

## その他

リファクタと新たな変更は分けたほうがいいと思うので分けました。