### PR TITLE
test: 「書き出しファイル名パターン」のe2eテストが落ちるのを修正

### DIFF
--- a/tests/e2e/browser/オプション/書き出しファイル名パターン.spec.ts
+++ b/tests/e2e/browser/オプション/書き出しファイル名パターン.spec.ts
@@ -71,6 +71,7 @@ test("「オプション」から「書き出しファイル名パターン」�
   await page.getByRole("button", { name: "$連番$" }).click();
   await expect(textbox).toHaveValue("test$連番$");
   await expect(doneButton).toBeEnabled();
+  await page.waitForTimeout(100);
 
   // 確定するとダイアログが閉じて設定した内容が反映されている
   await doneButton.click();

--- a/tests/e2e/locators.ts
+++ b/tests/e2e/locators.ts
@@ -1,7 +1,7 @@
 import { Page } from "@playwright/test";
 
 /**
- * 最新のquasarダイアログのlocaltorを取得する
+ * 最新のquasarダイアログのlocatorを取得する
  */
 export function getNewestQuasarDialog(page: Page) {
   const locator = page.locator('[id^="q-portal--dialog"]');
@@ -9,7 +9,7 @@ export function getNewestQuasarDialog(page: Page) {
 }
 
 /**
- * quasarのメニューのlocaltorを取得する
+ * quasarのメニューのlocatorを取得する
  */
 export function getQuasarMenu(page: Page, menuName: string) {
   return page.getByRole("listitem").filter({ hasText: menuName });


### PR DESCRIPTION
## 内容
#1488 で実装された、書き出しファイル名パターンのテストが結構な確率で落ちます。
狙って再現できないので正確な原因はよく分からないんですが、playwrightの動画を見る限りだとボタンを押すのが早すぎて値の変更が保存できていないように見えます。そこで、少しの間waitForTimeoutで（#1515の一つ前の処理で）待つようにしました。
GitHub Action上でubuntu, mac, windowsを各3回ずつ回して落ちなかったので多分修正できているはず…。

ついでに以下のコメントアウトの誤字も修正しました。
https://github.com/VOICEVOX/voicevox/pull/1488#discussion_r1292810546
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 PR
- #1488 
- #1515
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
修正出来ているかを簡単に判別できる方法がもしあれば教えていただきたいです…。