### PR TITLE
fix: fn is not a function エラーを修正

### DIFF
--- a/src/components/AudioAccent.vue
+++ b/src/components/AudioAccent.vue
@@ -105,6 +105,7 @@ const accentLine = computed(() => {
     .toString();
 });
 
+// クリックでアクセント句が選択されないように、@click.stopに渡す
 const stopPropagation = () => {
   // fn is not a function エラーを回避するために何もしない関数を渡す
 };

--- a/src/components/AudioAccent.vue
+++ b/src/components/AudioAccent.vue
@@ -105,8 +105,9 @@ const accentLine = computed(() => {
     .toString();
 });
 
-// クリックでアクセント句が選択されないように、@click.stopに渡す
-const stopPropagation = undefined;
+const stopPropagation = () => {
+  // fn is not a function エラーを回避するために何もしない関数を渡す
+};
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## 内容
アクセント位置の変更スライダーのクリック時に`fn is not a function`エラーが出るのを修正します。

#1509 と同じ実装が別のファイルにもありましたが、修正が漏れていました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 PR
- #1509
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

https://github.com/VOICEVOX/voicevox/assets/7900586/421961b6-b648-4734-8204-ac0657c05986

(Discordより、posted by @Hiroshiba )
<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
