### PR TITLE
[project-s] 出力する音声が0dBを超えないようにする

### DIFF
--- a/src/infrastructures/AudioRenderer.ts
+++ b/src/infrastructures/AudioRenderer.ts
@@ -944,11 +944,14 @@ export class Limiter {
     this.correctionGainNode = new GainNode(audioContext);
     this.outputGainNode = new GainNode(audioContext);
 
-    this.compNode.threshold.value = -5;
-    this.compNode.ratio.value = 20;
-    this.compNode.knee.value = 8;
-    this.compNode.attack.value = 0;
-    this.compNode.release.value = options.release;
+    // TODO: 伴奏を再生する機能を実装したら、パラメーターを再調整する
+    this.compNode.threshold.value = -5; // 0dBを超えそうになったら（-5dBを超えたら）圧縮する
+    this.compNode.ratio.value = 20; // クリッピングが起こらないように、高いレシオ（1/20）で圧縮する
+    this.compNode.knee.value = 8; // 自然にかかってほしいという気持ちで8に設定（リミッターなので0でも良いかも）
+    this.compNode.attack.value = 0; // クリッピングが起こらないように、すぐに圧縮を開始する
+    this.compNode.release.value = options.release; // 歪まないように少し遅めに設定
+
+    // メイクアップゲインで上がった分を下げる（圧縮していないときは元の音量で出力）
     this.correctionGainNode.gain.value = 0.85;
 
     this.setGainInDecibels(options.inputGain, this.inputGainNode);
@@ -979,7 +982,7 @@ export class Limiter {
 
   private setGainInDecibels(value: number, gainNode: GainNode) {
     if (!Number.isFinite(value)) {
-      throw new Error("The value is an infinite number.");
+      throw new Error("Not a finite number.");
     }
     gainNode.gain.value = this.decibelToLinear(value);
   }

--- a/src/infrastructures/AudioRenderer.ts
+++ b/src/infrastructures/AudioRenderer.ts
@@ -99,7 +99,6 @@ export class Transport {
     }
     return this._time;
   }
-
   set time(value: number) {
     if (this._state === "started") {
       this.stop();
@@ -542,7 +541,7 @@ class AudioPlayerVoice {
   }
 
   constructor(audioContext: BaseAudioContext, buffer: AudioBuffer) {
-    this.audioBufferSourceNode = audioContext.createBufferSource();
+    this.audioBufferSourceNode = new AudioBufferSourceNode(audioContext);
     this.audioBufferSourceNode.buffer = buffer;
     this.audioBufferSourceNode.onended = () => {
       this._isStopped = true;
@@ -606,7 +605,7 @@ export class AudioPlayer {
   ) {
     this.audioContext = audioContext;
 
-    this.gainNode = this.audioContext.createGain();
+    this.gainNode = new GainNode(audioContext);
     this.gainNode.gain.value = options.volume;
   }
 
@@ -682,11 +681,11 @@ class SynthVoice {
     this.midi = params.midi;
     this.envelope = params.envelope;
 
-    this.oscillatorNode = audioContext.createOscillator();
+    this.oscillatorNode = new OscillatorNode(audioContext);
     this.oscillatorNode.onended = () => {
       this._isStopped = true;
     };
-    this.gainNode = audioContext.createGain();
+    this.gainNode = new GainNode(audioContext);
     this.oscillatorNode.type = params.oscillatorType;
     this.oscillatorNode.connect(this.gainNode);
   }
@@ -790,7 +789,7 @@ export class PolySynth implements Instrument {
 
     this.oscillatorType = options.oscillatorType;
     this.envelope = options.envelope;
-    this.gainNode = this.audioContext.createGain();
+    this.gainNode = new GainNode(this.audioContext);
     this.gainNode.gain.value = options.volume;
   }
 
@@ -869,7 +868,6 @@ export class ChannelStrip {
   get volume() {
     return this.gainNode.gain.value;
   }
-
   set volume(value: number) {
     this.gainNode.gain.value = value;
   }
@@ -878,7 +876,131 @@ export class ChannelStrip {
     audioContext: BaseAudioContext,
     options: ChannelStripOptions = { volume: 0.1 }
   ) {
-    this.gainNode = audioContext.createGain();
+    this.gainNode = new GainNode(audioContext);
     this.gainNode.gain.value = options.volume;
+  }
+}
+
+export type LimiterOptions = {
+  readonly inputGain: number;
+  readonly outputGain: number;
+  readonly release: number;
+};
+
+/**
+ * リミッターです。大きい音を抑えます。
+ */
+export class Limiter {
+  private readonly inputGainNode: GainNode;
+  private readonly compNode: DynamicsCompressorNode;
+  private readonly correctionGainNode: GainNode;
+  private readonly outputGainNode: GainNode;
+
+  get input(): AudioNode {
+    return this.inputGainNode;
+  }
+
+  get output(): AudioNode {
+    return this.outputGainNode;
+  }
+
+  /**
+   * 入力ゲイン（dB）
+   */
+  get inputGain() {
+    return this.getGainInDecibels(this.inputGainNode);
+  }
+  set inputGain(value: number) {
+    this.setGainInDecibels(value, this.inputGainNode);
+  }
+
+  /**
+   * 出力ゲイン（dB）
+   */
+  get outputGain() {
+    return this.getGainInDecibels(this.outputGainNode);
+  }
+  set outputGain(value: number) {
+    this.setGainInDecibels(value, this.outputGainNode);
+  }
+
+  get release() {
+    return this.compNode.release.value;
+  }
+  set release(value: number) {
+    this.compNode.release.value = value;
+  }
+
+  get reduction() {
+    return this.compNode.reduction;
+  }
+
+  constructor(
+    audioContext: BaseAudioContext,
+    options: LimiterOptions = { inputGain: 0, outputGain: 0, release: 0.25 }
+  ) {
+    this.inputGainNode = new GainNode(audioContext);
+    this.compNode = new DynamicsCompressorNode(audioContext);
+    this.correctionGainNode = new GainNode(audioContext);
+    this.outputGainNode = new GainNode(audioContext);
+
+    this.compNode.threshold.value = -5;
+    this.compNode.ratio.value = 20;
+    this.compNode.knee.value = 8;
+    this.compNode.attack.value = 0;
+    this.compNode.release.value = options.release;
+    this.correctionGainNode.gain.value = 0.85;
+
+    this.setGainInDecibels(options.inputGain, this.inputGainNode);
+    this.setGainInDecibels(options.outputGain, this.outputGainNode);
+
+    this.inputGainNode.connect(this.compNode);
+    this.compNode.connect(this.correctionGainNode);
+    this.correctionGainNode.connect(this.outputGainNode);
+  }
+
+  private linearToDecibel(linearValue: number) {
+    if (linearValue === 0) {
+      return -1000;
+    }
+    return 20 * Math.log10(linearValue);
+  }
+
+  private decibelToLinear(decibelValue: number) {
+    if (decibelValue <= -1000) {
+      return 0;
+    }
+    return Math.pow(10, decibelValue / 20);
+  }
+
+  private getGainInDecibels(gainNode: GainNode) {
+    return this.linearToDecibel(gainNode.gain.value);
+  }
+
+  private setGainInDecibels(value: number, gainNode: GainNode) {
+    if (!Number.isFinite(value)) {
+      throw new Error("The value is an infinite number.");
+    }
+    gainNode.gain.value = this.decibelToLinear(value);
+  }
+}
+
+/**
+ * 音声が0dB（-1～1の範囲）を超えないようにクリップします。
+ */
+export class Clipper {
+  private readonly waveShaperNode: WaveShaperNode;
+
+  get input(): AudioNode {
+    return this.waveShaperNode;
+  }
+
+  get output(): AudioNode {
+    return this.waveShaperNode;
+  }
+
+  constructor(audioContext: BaseAudioContext) {
+    this.waveShaperNode = new WaveShaperNode(audioContext);
+    this.waveShaperNode.curve = new Float32Array([-1, 0, 1]);
   }
 }

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1766,7 +1766,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         }
 
         const sampleRate = 48000; // TODO: 設定できるようにする
-        const useLimiter = false; // TODO: 設定できるようにする
+        const withLimiter = false; // TODO: 設定できるようにする
 
         const offlineAudioContext = new OfflineAudioContext(
           2,
@@ -1775,7 +1775,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         );
         const offlineTransport = new OfflineTransport();
         const channelStrip = new ChannelStrip(offlineAudioContext);
-        const limiter = useLimiter
+        const limiter = withLimiter
           ? new Limiter(offlineAudioContext)
           : undefined;
         const clipper = new Clipper(offlineAudioContext);


### PR DESCRIPTION
## 内容
出力する音声が0dBを超えないようにします。
`Limiter`で大きい音を抑え、抑えきれなかった音を`Clipper`で-1～1の範囲にクリップします。

`Limiter`は内部で`DynamicsCompressorNode`を使用していて、パラメーターは以下のように設定しています。
``` ts
compNode.threshold.value = -5;
compNode.ratio.value = 20; // 最大に設定しています
compNode.knee.value = 8; // 0でも良いかも
compNode.attack.value = 0;
compNode.release.value = 0.25;
```
`DynamicsCompressorNode`ではメイクアップゲインが自動で設定されますが、音圧を上げることが目的ではないので、`GainNode`を繋いでメイクアップゲインで上がった分を下げています。
``` ts
correctionGainNode.gain.value = 0.85;
```
コンプレッションカーブは以下のようになります。
![Figure_1](https://github.com/VOICEVOX/voicevox/assets/62321214/22a00d8d-ef38-440f-9bde-5cb547a0cb92)
`Limiter`、`Clipper`は以下のページを参考に実装しています。
- [15.コンプレッサーの使い方（Web Audio API 解説）](https://www.g200kg.com/jp/docs/webaudio/compressor.html)
- [1.19. DynamicsCompressorNode インターフェース（Web Audio API 日本語訳）](https://g200kg.github.io/web-audio-api-ja/#DynamicsCompressorNode)
- [14.ウェイブシェイパーの使い方（Web Audio API 解説）](https://www.g200kg.com/jp/docs/webaudio/waveshaper.html)
- [1.31. WaveShaperNode インターフェース（Web Audio API 日本語訳）](https://g200kg.github.io/web-audio-api-ja/#WaveShaperNode)

コンプレッサーやリミッターについては、以下のYouTubeの動画がわかりやすいです。
- [コンプレッサーとは何か？: ミックス初級講座（iZotope Asia）](https://www.youtube.com/watch?v=sDVrEE2kb3c)
- [Limiter（リミッター）DTM用語集（Sleepfreaks DTMスクール）](https://www.youtube.com/watch?v=mMnlSLHGUlE)
## 関連 Issue
ref #1578
## その他
