### PR TITLE
[project-s] シーケンサーの計算の整理と修正

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -14,8 +14,8 @@
       <!-- グリッド -->
       <!-- NOTE: 現状小節+オクターブごとの罫線なし -->
       <svg
-        :width="`${gridColumnWidth * gridColumnNum}`"
-        :height="`${gridRowHeight * keyInfos.length}`"
+        :width="`${gridCellWidth * gridColumnNum}`"
+        :height="`${gridCellHeight * keyInfos.length}`"
         xmlns="http://www.w3.org/2000/svg"
         class="sequencer-grid"
       >
@@ -23,24 +23,24 @@
         <defs>
           <pattern
             id="sequencer-grid-column"
-            :width="`${gridColumnWidth}px`"
-            :height="`${gridRowHeight * 12}px`"
+            :width="`${gridCellWidth}px`"
+            :height="`${gridCellHeight * 12}px`"
             patternUnits="userSpaceOnUse"
           >
             <rect
               v-for="(keyInfo, index) in keyInfos"
               :key="index"
               x="0"
-              :y="`${gridRowHeight * index}`"
-              :width="`${gridColumnWidth}`"
-              :height="`${gridRowHeight}`"
+              :y="`${gridCellHeight * index}`"
+              :width="`${gridCellWidth}`"
+              :height="`${gridCellHeight}`"
               :class="`sequencer-grid-cell sequencer-grid-cell-${keyInfo.color}`"
             />
           </pattern>
           <pattern
             id="sequencer-grid-measure"
-            :width="`${gridColumnWidth * gridColumnNumPerMeasure}`"
-            :height="`${gridRowHeight * 12}`"
+            :width="`${gridCellWidth * gridColumnNumPerMeasure}`"
+            :height="`${gridCellHeight * 12}`"
             patternUnits="userSpaceOnUse"
           >
             <rect
@@ -188,21 +188,21 @@ export default defineComponent({
       return snapBaseWidth.value * zoomX.value;
     });
     // シーケンサグリッド
-    const gridColumnTicks = snapTicks;
-    const gridColumnBaseWidth = snapBaseWidth;
-    const gridColumnWidth = computed(() => {
-      return gridColumnBaseWidth.value * zoomX.value;
+    const gridCellTicks = snapTicks; // ひとまずスナップ幅＝グリッドセル幅
+    const gridCellBaseWidth = snapBaseWidth;
+    const gridCellWidth = computed(() => {
+      return gridCellBaseWidth.value * zoomX.value;
     });
-    const gridRowBaseHeight = getKeyBaseHeight();
-    const gridRowHeight = computed(() => {
-      return gridRowBaseHeight * zoomY.value;
+    const gridCellBaseHeight = getKeyBaseHeight();
+    const gridCellHeight = computed(() => {
+      return gridCellBaseHeight * zoomY.value;
     });
     const measureDuration = computed(() => {
       return getMeasureDuration(timeSignature.value, tpqn.value);
     });
     const gridColumnNumPerMeasure = computed(() => {
       // TODO: スナップが3連符のときにおかしくなるので修正する
-      return Math.round(measureDuration.value / gridColumnTicks.value);
+      return Math.round(measureDuration.value / gridCellTicks.value);
     });
     const gridColumnNum = computed(() => {
       // NOTE: 最低長: 仮32小節...スコア長(曲長さ)が決まっていないため、無限スクロール化する or 最後尾に足した場合は伸びるようにするなど？
@@ -224,8 +224,8 @@ export default defineComponent({
       const eventOffsetBaseX = event.offsetX / zoomX.value;
       const eventOffsetBaseY = event.offsetY / zoomY.value;
       const positionBaseX =
-        gridColumnBaseWidth.value *
-        Math.floor(eventOffsetBaseX / gridColumnBaseWidth.value);
+        gridCellBaseWidth.value *
+        Math.floor(eventOffsetBaseX / gridCellBaseWidth.value);
       const position = baseXToTick(positionBaseX, tpqn.value);
       const noteNumber = baseYToNoteNumber(eventOffsetBaseY);
       if (noteNumber < 0) {
@@ -289,21 +289,19 @@ export default defineComponent({
 
       // カーソル位置に応じてノート移動量を計算
       let amountPositionX = 0;
-      if (gridColumnWidth.value <= Math.abs(distanceX)) {
+      if (gridCellWidth.value <= Math.abs(distanceX)) {
         amountPositionX = 0 < distanceX ? snapTicks.value : -snapTicks.value;
         const dragMoveCurrentXNext =
           dragMoveCurrentX.value +
-          (0 < amountPositionX
-            ? gridColumnWidth.value
-            : -gridColumnWidth.value);
+          (0 < amountPositionX ? gridCellWidth.value : -gridCellWidth.value);
         dragMoveCurrentX.value = dragMoveCurrentXNext;
       }
       let amountPositionY = 0;
-      if (gridRowHeight.value <= Math.abs(distanceY)) {
+      if (gridCellHeight.value <= Math.abs(distanceY)) {
         amountPositionY = 0 < distanceY ? -1 : 1;
         const dragMoveCurrentYNext =
           dragMoveCurrentY.value +
-          (0 > amountPositionY ? gridRowHeight.value : -gridRowHeight.value);
+          (0 > amountPositionY ? gridCellHeight.value : -gridCellHeight.value);
         dragMoveCurrentY.value = dragMoveCurrentYNext;
       }
 
@@ -601,8 +599,8 @@ export default defineComponent({
     });
 
     return {
-      gridColumnWidth,
-      gridRowHeight,
+      gridCellWidth,
+      gridCellHeight,
       gridColumnNumPerMeasure,
       gridColumnNum,
       keyInfos,

--- a/src/components/Sing/SequencerKeys.vue
+++ b/src/components/Sing/SequencerKeys.vue
@@ -1,37 +1,37 @@
 <template>
   <svg
     width="48"
-    :height="`${sizeY * zoomY * 128}`"
+    :height="`${keyHeight * keyInfos.length}`"
     xmlns="http://www.w3.org/2000/svg"
     class="sequencer-keys"
   >
-    <g v-for="(y, index) in gridY" :key="index">
+    <g v-for="(keyInfo, index) in keyInfos" :key="index">
       <rect
         x="0"
-        :y="`${sizeY * zoomY * index}`"
-        :width="`${y.color === 'black' ? 30 : 48}`"
-        :height="`${sizeY * zoomY}`"
-        :class="`sequencer-keys-item-${y.color}`"
-        :title="y.name"
+        :y="`${keyHeight * index}`"
+        :width="`${keyInfo.color === 'black' ? 30 : 48}`"
+        :height="`${keyHeight}`"
+        :class="`sequencer-keys-item-${keyInfo.color}`"
+        :title="keyInfo.name"
       />
       <line
-        v-if="y.pitch === 'C' || y.pitch === 'F'"
+        v-if="keyInfo.pitch === 'C' || keyInfo.pitch === 'F'"
         x1="0"
         x2="48"
-        :y1="`${(index + 1) * sizeY * zoomY}`"
-        :y2="`${(index + 1) * sizeY * zoomY}`"
+        :y1="`${(index + 1) * keyHeight}`"
+        :y2="`${(index + 1) * keyHeight}`"
         :class="`sequencer-keys-item-separator ${
-          y.pitch === 'C' && 'sequencer-keys-item-separator-octave'
-        } ${y.pitch === 'F' && 'sequencer-keys-item-separator-f'}`"
+          keyInfo.pitch === 'C' && 'sequencer-keys-item-separator-octave'
+        } ${keyInfo.pitch === 'F' && 'sequencer-keys-item-separator-f'}`"
       />
       <text
-        v-if="y.pitch === 'C'"
+        v-if="keyInfo.pitch === 'C'"
         font-size="10"
         x="32"
-        :y="`${sizeY * zoomY * (index + 1) - 4}`"
+        :y="`${keyHeight * (index + 1) - 4}`"
         class="sequencer-keys-item-pitchname"
       >
-        {{ y.name }}
+        {{ keyInfo.name }}
       </text>
     </g>
   </svg>
@@ -40,25 +40,21 @@
 <script lang="ts">
 import { defineComponent, computed } from "vue";
 import { useStore } from "@/store";
-import {
-  midiKeys,
-  BASE_GRID_SIZE_X as sizeX,
-  BASE_GRID_SIZE_Y as sizeY,
-} from "@/helpers/singHelper";
+import { keyInfos, getKeyBaseHeight } from "@/helpers/singHelper";
 
 export default defineComponent({
   name: "SingSequencerKeys",
   setup() {
     const store = useStore();
-    const gridY = midiKeys;
     const zoomX = computed(() => store.state.sequencerZoomX);
     const zoomY = computed(() => store.state.sequencerZoomY);
+    const keyBaseHeight = getKeyBaseHeight();
+    const keyHeight = computed(() => keyBaseHeight * zoomY.value);
     return {
-      gridY,
-      sizeX,
-      sizeY,
+      keyInfos,
       zoomX,
       zoomY,
+      keyHeight,
     };
   },
 });

--- a/src/helpers/singHelper.ts
+++ b/src/helpers/singHelper.ts
@@ -15,13 +15,13 @@ export function getMeasureDuration(timeSignature: TimeSignature, tpqn: number) {
   return tpqn * quarterNotesPerMeasure;
 }
 
-export function getMeasureNum(notes: Note[], ticksPerMeasure: number) {
+export function getMeasureNum(notes: Note[], measureDuration: number) {
   if (notes.length === 0) {
     return 0;
   }
   const lastNote = notes[notes.length - 1];
   const maxTicks = lastNote.position + lastNote.duration;
-  return Math.ceil(maxTicks / ticksPerMeasure);
+  return Math.ceil(maxTicks / measureDuration);
 }
 
 // NOTE: 戻り値の単位はtick

--- a/src/helpers/singHelper.ts
+++ b/src/helpers/singHelper.ts
@@ -1,5 +1,61 @@
-export function getPitchFromMidi(midi: number): string {
-  const mapPitches: Array<string> = [
+import { Note, TimeSignature } from "@/store/type";
+
+const BASE_X_PER_QUARTER_NOTE = 120;
+const BASE_Y_PER_NOTE_NUMBER = 30;
+
+export function noteNumberToFrequency(noteNumber: number) {
+  return 440 * 2 ** ((noteNumber - 69) / 12);
+}
+
+// NOTE: 戻り値の単位はtick
+export function getMeasureDuration(timeSignature: TimeSignature, tpqn: number) {
+  const beats = timeSignature.beats;
+  const beatType = timeSignature.beatType;
+  const quarterNotesPerMeasure = (4 / beatType) * beats;
+  return tpqn * quarterNotesPerMeasure;
+}
+
+export function getMeasureNum(notes: Note[], ticksPerMeasure: number) {
+  if (notes.length === 0) {
+    return 0;
+  }
+  const lastNote = notes[notes.length - 1];
+  const maxTicks = lastNote.position + lastNote.duration;
+  return Math.ceil(maxTicks / ticksPerMeasure);
+}
+
+// NOTE: 戻り値の単位はtick
+export function getNoteDuration(noteType: number, tpqn: number) {
+  return (tpqn * 4) / noteType;
+}
+
+export function getKeyBaseHeight() {
+  return BASE_Y_PER_NOTE_NUMBER;
+}
+
+export function tickToBaseX(ticks: number, tpqn: number) {
+  return (ticks / tpqn) * BASE_X_PER_QUARTER_NOTE;
+}
+
+export function baseXToTick(baseX: number, tpqn: number) {
+  return (baseX / BASE_X_PER_QUARTER_NOTE) * tpqn;
+}
+
+// NOTE: ノート番号が整数のときに、そのノート番号のキーの中央の位置を返します
+export function noteNumberToBaseY(noteNumber: number) {
+  return (127.5 - noteNumber) * BASE_Y_PER_NOTE_NUMBER;
+}
+
+// NOTE: integerがfalseの場合は、ノート番号のキーの中央の位置が
+//       ちょうどそのノート番号となるように計算します
+export function baseYToNoteNumber(baseY: number, integer = true) {
+  return integer
+    ? 127 - Math.floor(baseY / BASE_Y_PER_NOTE_NUMBER)
+    : 127.5 - baseY / BASE_Y_PER_NOTE_NUMBER;
+}
+
+export function getPitchFromNoteNumber(noteNumber: number) {
+  const mapPitches = [
     "C",
     "C#",
     "D",
@@ -13,12 +69,12 @@ export function getPitchFromMidi(midi: number): string {
     "A#",
     "B",
   ];
-  const pitchPos = midi % 12;
+  const pitchPos = noteNumber % 12;
   return mapPitches[pitchPos];
 }
 
-export function getDoremiFromMidi(midi: number): string {
-  const mapPitches: Array<string> = [
+export function getDoremiFromNoteNumber(noteNumber: number) {
+  const mapPitches = [
     "ド",
     "ド",
     "レ",
@@ -32,28 +88,28 @@ export function getDoremiFromMidi(midi: number): string {
     "ラ",
     "シ",
   ];
-  const pitchPos = midi % 12;
+  const pitchPos = noteNumber % 12;
   return mapPitches[pitchPos];
 }
 
-export function getOctaveFromMidi(midi: number): number {
-  return Math.floor(midi / 12) - 1;
+export function getOctaveFromNoteNumber(noteNumber: number) {
+  return Math.floor(noteNumber / 12) - 1;
 }
 
-export function getKeyColorFromMidi(midi: number): string {
-  const mapWhiteKeys: Array<string> = ["C", "D", "E", "F", "G", "A", "B"];
-  const pitch = getPitchFromMidi(midi);
+export function getKeyColorFromNoteNumber(noteNumber: number) {
+  const mapWhiteKeys = ["C", "D", "E", "F", "G", "A", "B"];
+  const pitch = getPitchFromNoteNumber(noteNumber);
   return mapWhiteKeys.includes(pitch) ? "white" : "black";
 }
 
-export const midiKeys = [...Array(128)]
-  .map((_, midi) => {
-    const pitch = getPitchFromMidi(midi);
-    const octave = getOctaveFromMidi(midi);
+export const keyInfos = [...Array(128)]
+  .map((_, noteNumber) => {
+    const pitch = getPitchFromNoteNumber(noteNumber);
+    const octave = getOctaveFromNoteNumber(noteNumber);
     const name = `${pitch}${octave}`;
-    const color = getKeyColorFromMidi(midi);
+    const color = getKeyColorFromNoteNumber(noteNumber);
     return {
-      midi,
+      noteNumber,
       pitch,
       octave,
       name,
@@ -62,14 +118,7 @@ export const midiKeys = [...Array(128)]
   })
   .reverse();
 
-export const BASE_GRID_SIZE_X = 30;
-export const BASE_GRID_SIZE_Y = 30;
-
 export function round(value: number, digits: number) {
   const powerOf10 = 10 ** digits;
   return Math.round(value * powerOf10) / powerOf10;
-}
-
-export function midiToFrequency(midi: number) {
-  return 440 * 2 ** ((midi - 69) / 12);
 }

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -29,8 +29,8 @@ import {
 } from "@/infrastructures/AudioRenderer";
 import { EngineId, StyleId } from "@/type/preload";
 import {
-  getDoremiFromMidi,
-  midiToFrequency,
+  getDoremiFromNoteNumber,
+  noteNumberToFrequency,
   round,
 } from "@/helpers/singHelper";
 import { AudioQuery, Mora } from "@/openapi";
@@ -275,9 +275,9 @@ export const singingStoreState: SingingStoreState = {
   isShowSinger: true,
   sequencerZoomX: 0.5,
   sequencerZoomY: 0.75,
-  sequencerScrollY: 60, // Y軸 midi number
-  sequencerScrollX: 0, // X軸 midi duration(仮)
-  sequencerSnapSize: 120, // スナップサイズ 試行用で1/18(ppq=480)のmidi durationで固定
+  sequencerScrollY: 60, // Y軸 note number
+  sequencerScrollX: 0, // X軸 tick(仮)
+  sequencerSnapType: 16, // スナップタイプ 試行用で1/16で固定
   selectedNoteIds: [], // 選択中のノート
   nowPlaying: false,
   volume: 0,
@@ -1006,7 +1006,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             }
 
             // 音高を編集
-            const freq = midiToFrequency(note.midi);
+            const freq = noteNumberToFrequency(note.midi);
             mora.pitch = Math.log(freq);
 
             // 無声化を解除
@@ -1312,7 +1312,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               note.durationTicks
             ),
             midi: note.midi,
-            lyric: getDoremiFromMidi(note.midi),
+            lyric: getDoremiFromNoteNumber(note.midi),
           }))
           .sort((a, b) => a.position - b.position)
           .forEach((note) => {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -751,7 +751,7 @@ export type SingingStoreState = {
   sequencerZoomY: number;
   sequencerScrollX: number;
   sequencerScrollY: number;
-  sequencerSnapSize: number;
+  sequencerSnapType: number;
   selectedNoteIds: string[];
   nowPlaying: boolean;
   volume: number;

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -153,7 +153,7 @@ describe("store/vuex.js test", () => {
         sequencerZoomY: 1,
         sequencerScrollX: 0,
         sequencerScrollY: 60,
-        sequencerSnapSize: 120,
+        sequencerSnapType: 16,
         selectedNoteIds: [],
         nowPlaying: false,
         volume: 0,


### PR DESCRIPTION
## 内容
以下を行います。
- 計算の整理・修正
  - マジックナンバーを無くし、変換処理などを関数化する
- 変数やクラスの名前をわかりやすいものに変更
  - なるべく単位をつけるように
  - `midi`から`noteNumber`に変更
  - `resolution`から`tpqn`に変更
- 拍子やスナップが変わっても、グリッドが適切に描画されるようにする

### 値の変換
以下のように行っています。
``` mermaid
flowchart LR;
    Ticks <-->|TPQN| QuarterNotes
    QuarterNotes <-->|BaseXPerQuarterNote| BaseX
    BaseX <-->|ZoomX| ViewX
    NoteNumber <-->|BaseYPerNoteNumber| BaseY
    BaseY <-->|ZoomY| ViewY
    style Hidden1 fill-opacity:0, stroke-opacity:0;
    Hidden1[" "] ~~~ NoteNumber
    style Hidden2 fill-opacity:0, stroke-opacity:0;
    ViewX ~~~~ Hidden2[" "]
```

`TPQN`＝4分音符あたりのティック数（Ticks Per Quarter Note）です。

`QuarterNote`＝4分音符です。4分音符の長さは拍子（小節の長さ）に依存しません。

`BaseX`、`BaseY`はズーム適用前の値、`ViewX`、`ViewY`はズーム適用後の値です。
（ズーム適用前の値を保持する変数は、`Base`をつけています）
## 関連 Issue
VOICEVOX/voicevox_project#15
## その他
- `singing.ts`の方も後で修正したいと思います

