### PR TITLE
build: エンジンの配置ディレクトリを変更

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -4,7 +4,7 @@ VITE_DEFAULT_ENGINE_INFOS=`[
         "uuid": "074fc39e-678b-4c13-8916-ffca8d505d1d",
         "name": "VOICEVOX Engine",
         "executionEnabled": true,
-        "executionFilePath": "run.exe",
+        "executionFilePath": "engine/run.exe",
         "executionArgs": [],
         "host": "http://127.0.0.1:50021"
     }

--- a/.env.production
+++ b/.env.production
@@ -4,7 +4,7 @@ VITE_DEFAULT_ENGINE_INFOS=`[
         "uuid": "074fc39e-678b-4c13-8916-ffca8d505d1d",
         "name": "VOICEVOX Engine",
         "executionEnabled": true,
-        "executionFilePath": "engine/run.exe",
+        "executionFilePath": "vv-engine/run.exe",
         "executionArgs": [],
         "host": "http://127.0.0.1:50021"
     }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,26 +278,24 @@ jobs:
       - name: Merge VOICEVOX ENGINE into prepackage/
         if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'linux-')
         run: |
-          mv voicevox_engine/* prepackage/
-          rm -rf voicevox_engine
+          mv voicevox_engine/ prepackage/engine/
 
       - name: Merge VOICEVOX ENGINE into prepackage/VOICEVOX.app/Contents/MacOS/
         if: startsWith(matrix.artifact_name, 'macos-')
         run: |
-          mv voicevox_engine/* prepackage/VOICEVOX.app/Contents/MacOS/
-          rm -rf voicevox_engine
+          mv voicevox_engine/ prepackage/VOICEVOX.app/Contents/MacOS/engine/
 
       - name: Recover file permissions
         if: startsWith(matrix.artifact_name, 'linux-') # linux
         run: |
           chmod +x "prepackage/${{ matrix.linux_executable_name }}"
-          chmod +x "prepackage/run"
+          chmod +x "prepackage/engine/run"
 
       - name: Recover file permissions for macOS build
         if: startsWith(matrix.artifact_name, 'macos-') # macOS
         run: |
           chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/${{ matrix.macos_executable_name }}"
-          chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/run"
+          chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/engine/run"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (GPU).app/Contents/MacOS/VOICEVOX Helper (GPU)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Plugin).app/Contents/MacOS/VOICEVOX Helper (Plugin)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Renderer).app/Contents/MacOS/VOICEVOX Helper (Renderer)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,24 +278,24 @@ jobs:
       - name: Merge VOICEVOX ENGINE into prepackage/
         if: startsWith(matrix.artifact_name, 'windows-') || startsWith(matrix.artifact_name, 'linux-')
         run: |
-          mv voicevox_engine/ prepackage/engine/
+          mv voicevox_engine/ prepackage/vv-engine/
 
       - name: Merge VOICEVOX ENGINE into prepackage/VOICEVOX.app/Contents/MacOS/
         if: startsWith(matrix.artifact_name, 'macos-')
         run: |
-          mv voicevox_engine/ prepackage/VOICEVOX.app/Contents/MacOS/engine/
+          mv voicevox_engine/ prepackage/VOICEVOX.app/Contents/MacOS/vv-engine/
 
       - name: Recover file permissions
         if: startsWith(matrix.artifact_name, 'linux-') # linux
         run: |
           chmod +x "prepackage/${{ matrix.linux_executable_name }}"
-          chmod +x "prepackage/engine/run"
+          chmod +x "prepackage/vv-engine/run"
 
       - name: Recover file permissions for macOS build
         if: startsWith(matrix.artifact_name, 'macos-') # macOS
         run: |
           chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/${{ matrix.macos_executable_name }}"
-          chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/engine/run"
+          chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/vv-engine/run"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (GPU).app/Contents/MacOS/VOICEVOX Helper (GPU)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Plugin).app/Contents/MacOS/VOICEVOX Helper (Plugin)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Renderer).app/Contents/MacOS/VOICEVOX Helper (Renderer)"

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -7,7 +7,7 @@ const dotenvPath = path.join(process.cwd(), ".env.production");
 dotenv.config({ path: dotenvPath });
 
 const VOICEVOX_ENGINE_DIR =
-  process.env.VOICEVOX_ENGINE_DIR ?? "../voicevox_engine/run.dist/";
+  process.env.VOICEVOX_ENGINE_DIR ?? "../voicevox_engine/dist/run/";
 
 // ${productName} Web Setup ${version}.${ext}
 const NSIS_WEB_ARTIFACT_NAME = process.env.NSIS_WEB_ARTIFACT_NAME;
@@ -90,7 +90,7 @@ const builderOptions = {
     },
     {
       from: VOICEVOX_ENGINE_DIR,
-      to: extraFilePrefix,
+      to: path.join(extraFilePrefix, "engine"),
     },
     {
       from: path.resolve(__dirname, "build", "vendored", "7z", sevenZipFile),

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -90,7 +90,7 @@ const builderOptions = {
     },
     {
       from: VOICEVOX_ENGINE_DIR,
-      to: path.join(extraFilePrefix, "engine"),
+      to: path.join(extraFilePrefix, "vv-engine"),
     },
     {
       from: path.resolve(__dirname, "build", "vendored", "7z", sevenZipFile),


### PR DESCRIPTION
## 内容

今までエンジンをエディタの実行ファイルと同じディレクトリに展開していました。
これを別の別のディレクトリに移動することで問題を回避します。

## 関連 Issue

- fix #1237
- close #1603

## その他

とりあえずディレクトリ名は`engine`にしました。

個人のリポジトリでリリースビルドはできました。

WindowsとLinuxは動作テストをしましたがMacは所有していないためテストできていません。