### PR TITLE
ショートカットキーを初期値に戻す際に、衝突チェックを行うようにしました

### DIFF
--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -361,9 +361,20 @@ const resetHotkey = async (action: string) => {
       .getDefaultHotkeySettings()
       .then((defaultSettings: HotkeySetting[]) => {
         const setting = defaultSettings.find((value) => value.action == action);
-        if (setting) {
-          changeHotkeySettings(action, setting.combination);
+        if (setting === undefined) {
+          return;
         }
+        // デフォルトが未設定でない場合は、衝突チェックを行う
+        if (setting.combination) {
+          const duplicated = hotkeySettings.value.find((item) =>
+              item.combination == setting.combination && item.action != action);
+          if (duplicated !== undefined) {
+            openHotkeyDialog(action);
+            lastRecord.value = duplicated.combination;
+            return;
+          }
+        }
+        changeHotkeySettings(action, setting.combination);
       });
   }
 };

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -366,8 +366,10 @@ const resetHotkey = async (action: string) => {
         }
         // デフォルトが未設定でない場合は、衝突チェックを行う
         if (setting.combination) {
-          const duplicated = hotkeySettings.value.find((item) =>
-              item.combination == setting.combination && item.action != action);
+          const duplicated = hotkeySettings.value.find(
+            (item) =>
+              item.combination == setting.combination && item.action != action
+          );
           if (duplicated !== undefined) {
             openHotkeyDialog(action);
             lastRecord.value = duplicated.combination;


### PR DESCRIPTION
## 内容

ショートカットキーを「初期値に戻す」とした時、他の action と衝突する場合はショートカットキー設定のダイアログを出すようにしました。
```setting``` が undefined の場合は、従来通り何の処理も行わないようにしています。

## 関連 Issue

ref #566 

## スクリーンショット・動画など

特になし

## その他

特になし
