### PR TITLE
Improve: e2eを改善

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,8 +84,8 @@ const config: PlaywrightTestConfig = {
 
   webServer: [
     {
-      command: "vite --mode test",
-      port: 5173,
+      command: "vite --mode test --port 7357",
+      port: 7357,
       reuseExistingServer: !process.env.CI,
     },
     ...additionalWebServer,

--- a/tests/e2e/browser/アクセント.spec.ts
+++ b/tests/e2e/browser/アクセント.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect } from "@playwright/test";
 
-import { navigateToMain } from "../navigators";
+import { gotoHome, navigateToMain } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 test("アクセント分割したらアクセント区間が増える", async ({ page }) => {
   await navigateToMain(page);

--- a/tests/e2e/browser/オプション/書き出しファイル名パターン.spec.ts
+++ b/tests/e2e/browser/オプション/書き出しファイル名パターン.spec.ts
@@ -1,13 +1,9 @@
 import { test, expect, Page, Locator } from "@playwright/test";
 
-import { navigateToOptionDialog } from "../../navigators";
+import { gotoHome, navigateToOptionDialog } from "../../navigators";
 import { getNewestQuasarDialog } from "../../locators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 /**
  * 書き出しファイル名パターンダイアログまで移動

--- a/tests/e2e/browser/キャラクター並び替えダイアログ.spec.ts
+++ b/tests/e2e/browser/キャラクター並び替えダイアログ.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect } from "@playwright/test";
 
-import { navigateToMain } from "../navigators";
+import { gotoHome, navigateToMain } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 test("「設定」→「キャラクター並び替え・視聴」で「設定 / キャラクター並び替え・視聴」ページが表示される", async ({
   page,

--- a/tests/e2e/browser/ツールバーカスタマイズダイアログ.spec.ts
+++ b/tests/e2e/browser/ツールバーカスタマイズダイアログ.spec.ts
@@ -1,13 +1,9 @@
 import { test, expect } from "@playwright/test";
 
-import { navigateToMain } from "../navigators";
+import { gotoHome, navigateToMain } from "../navigators";
 import { getNewestQuasarDialog, getQuasarMenu } from "../locators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 test("ツールバーのカスタマイズでボタンを追加でき、デフォルトに戻すこともできる", async ({
   page,

--- a/tests/e2e/browser/テキスト追加・削除・入れ替え.spec.ts
+++ b/tests/e2e/browser/テキスト追加・削除・入れ替え.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect, Locator, Page } from "@playwright/test";
 
-import { navigateToMain } from "../navigators";
+import { gotoHome, navigateToMain } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 async function fillInput(page: Page, locator: Locator, text: string) {
   await locator.fill(text);

--- a/tests/e2e/browser/デフォルトスタイルダイアログ.spec.ts
+++ b/tests/e2e/browser/デフォルトスタイルダイアログ.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect } from "@playwright/test";
 
-import { navigateToMain } from "../navigators";
+import { gotoHome, navigateToMain } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 test("「設定」→「デフォルトスタイル」で「設定 / デフォルトスタイル・試聴」ダイアログが表示される", async ({
   page,

--- a/tests/e2e/browser/ヘルプ.spec.ts
+++ b/tests/e2e/browser/ヘルプ.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect } from "@playwright/test";
 
-import { navigateToHelpDialog } from "../navigators";
+import { gotoHome, navigateToHelpDialog } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 test("「ヘルプ」メニューから各項目をクリックすると、その項目の内容が表示される", async ({
   page,

--- a/tests/e2e/browser/初回起動時.spec.ts
+++ b/tests/e2e/browser/初回起動時.spec.ts
@@ -5,6 +5,6 @@ test.beforeEach(gotoHome);
 
 test("起動したら「利用規約に関するお知らせ」が表示される", async ({ page }) => {
   await expect(page.getByText("利用規約に関するお知らせ")).toBeVisible({
-    timeout: 60 * 1000,
+    timeout: 90 * 1000,
   });
 });

--- a/tests/e2e/browser/初回起動時.spec.ts
+++ b/tests/e2e/browser/初回起動時.spec.ts
@@ -1,11 +1,10 @@
 import { test, expect } from "@playwright/test";
+import { gotoHome } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 test("起動したら「利用規約に関するお知らせ」が表示される", async ({ page }) => {
-  await expect(page.getByText("利用規約に関するお知らせ")).toBeVisible();
+  await expect(page.getByText("利用規約に関するお知らせ")).toBeVisible({
+    timeout: 60 * 1000,
+  });
 });

--- a/tests/e2e/browser/複数選択/値変更.spec.ts
+++ b/tests/e2e/browser/複数選択/値変更.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
-import { toggleSetting, navigateToMain } from "../../navigators";
+import { toggleSetting, navigateToMain, gotoHome } from "../../navigators";
 import { addAudioCells } from "./utils";
 
 /*
@@ -68,9 +68,7 @@ async function getAudioInfoParameters(
 }
 
 test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
+  await gotoHome({ page });
 
   await navigateToMain(page);
   await page.waitForTimeout(100);

--- a/tests/e2e/browser/複数選択/選択.spec.ts
+++ b/tests/e2e/browser/複数選択/選択.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect, Page } from "@playwright/test";
-import { toggleSetting, navigateToMain } from "../../navigators";
+import { toggleSetting, navigateToMain, gotoHome } from "../../navigators";
 import { ctrlLike, addAudioCells } from "./utils";
 
 test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
+  await gotoHome({ page });
 
   await navigateToMain(page);
   await page.waitForTimeout(100);
@@ -36,7 +34,7 @@ async function getSelectedStatus(page: Page): Promise<SelectedStatus> {
         selected.push(i + 1);
       }
     }
-    if (active === undefined) {
+    if (active == undefined) {
       throw new Error("No active audio cell");
     }
 

--- a/tests/e2e/browser/調整結果.spec.ts
+++ b/tests/e2e/browser/調整結果.spec.ts
@@ -1,11 +1,8 @@
 import { test, expect, Page } from "@playwright/test";
-import { toggleSetting, navigateToMain } from "../navigators";
+import { toggleSetting, navigateToMain, gotoHome } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
+
 /**
  * イントネーションのスライダーの値をnumber[][]として取得する
  * @param page

--- a/tests/e2e/browser/辞書ダイアログ.spec.ts
+++ b/tests/e2e/browser/辞書ダイアログ.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect, Page, Locator } from "@playwright/test";
-import { navigateToMain } from "../navigators";
+import { gotoHome, navigateToMain } from "../navigators";
 import { getNewestQuasarDialog } from "../locators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 // 「abs」を入力して読み方を確認する
 async function validateAbsYomi(
@@ -16,7 +12,7 @@ async function validateAbsYomi(
   await page.locator(".audio-cell input").last().fill("abs");
   await page.waitForTimeout(100);
   await page.locator(".audio-cell input").last().press("Enter");
-  await page.waitForTimeout(100);
+  await page.waitForTimeout(500);
   const text = (await page.locator(".text-cell").allInnerTexts()).join("");
   expect(text).toBe(expectedText);
 }

--- a/tests/e2e/browser/音声.spec.ts
+++ b/tests/e2e/browser/音声.spec.ts
@@ -1,12 +1,8 @@
 import { test } from "@playwright/test";
 
-import { navigateToMain } from "../navigators";
+import { gotoHome, navigateToMain } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 test("テキストを入力→アクセントを変更→音声合成→再生ができる", async ({
   page,

--- a/tests/e2e/browser/音声パラメータ.spec.ts
+++ b/tests/e2e/browser/音声パラメータ.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect, Locator } from "@playwright/test";
 
-import { navigateToMain, toggleSetting } from "../navigators";
+import { gotoHome, navigateToMain, toggleSetting } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 async function validateValue(locator: Locator, expectedValue: string) {
   const value = await locator.evaluate((e: HTMLInputElement) => e.value);

--- a/tests/e2e/browser/音声詳細.spec.ts
+++ b/tests/e2e/browser/音声詳細.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect, Page } from "@playwright/test";
 
-import { navigateToMain } from "../navigators";
+import { gotoHome, navigateToMain } from "../navigators";
 
-test.beforeEach(async ({ page }) => {
-  const BASE_URL = "http://localhost:5173/#/home";
-  await page.setViewportSize({ width: 800, height: 600 });
-  await page.goto(BASE_URL);
-});
+test.beforeEach(gotoHome);
 
 function getNthAccentPhraseInput({ page, n }: { page: Page; n: number }) {
   return page.getByLabel(`${n + 1}番目のアクセント区間の読み`);

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -47,7 +47,7 @@ test("起動したら「利用規約に関するお知らせ」が表示され�
     timeout: process.env.CI ? 0 : 60000,
     env: {
       ...process.env,
-      VITE_DEV_SERVER_URL: "http://localhost:5173",
+      VITE_DEV_SERVER_URL: "http://localhost:7357",
     },
   });
 

--- a/tests/e2e/navigators.ts
+++ b/tests/e2e/navigators.ts
@@ -15,7 +15,7 @@ export async function gotoHome({ page }: { page: Page }) {
  */
 export async function navigateToMain(page: Page) {
   await expect(page.getByText("利用規約に関するお知らせ")).toBeVisible({
-    timeout: 60 * 1000,
+    timeout: 90 * 1000,
   });
   await page.waitForTimeout(100);
   await page.getByRole("button", { name: "同意して使用開始" }).click();
@@ -23,6 +23,7 @@ export async function navigateToMain(page: Page) {
   await page.getByRole("button", { name: "完了" }).click();
   await page.waitForTimeout(100);
   await page.getByRole("button", { name: "許可" }).click();
+  await page.waitForTimeout(100);
 }
 
 /**

--- a/tests/e2e/navigators.ts
+++ b/tests/e2e/navigators.ts
@@ -2,6 +2,15 @@ import { expect, Page } from "@playwright/test";
 import { getNewestQuasarDialog, getQuasarMenu } from "./locators";
 
 /**
+ * /#/homeに移動
+ */
+export async function gotoHome({ page }: { page: Page }) {
+  const BASE_URL = "http://localhost:7357/#/home";
+  await page.setViewportSize({ width: 800, height: 600 });
+  await page.goto(BASE_URL);
+}
+
+/**
  * 初回起動時の確認を完了してメイン画面に移動
  */
 export async function navigateToMain(page: Page) {
@@ -34,7 +43,7 @@ export async function toggleSetting(page: Page, settingName: string) {
     .click();
   await page.waitForTimeout(100);
   await page.getByRole("button", { name: "設定を閉じる" }).click();
-  await page.waitForTimeout(100);
+  await page.waitForTimeout(500);
 }
 
 /**


### PR DESCRIPTION
## 内容

e2eテストを改善します。
- テストサーバーをポート7357で開くようにします。
	- 開発サーバーが既に起動してると競合して別のポートにテストサーバーが起動し、それでe2eが落ちることがあったので
	- 7357はTESTのleet表記です（5173がSITEのleetなので）
- test.beforeEachを共通化します。
	- navigateToMainをbeforeEachにいれてもいいかも

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）