### PR TITLE
fix: config読み込みに失敗したときのフォールバックを復活させる

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -987,7 +987,7 @@ app.on("ready", async () => {
         }
       })
       .finally(async () => {
-        await configManager?.ensureSaved();
+        await configManager.ensureSaved();
         app.exit(1);
       });
   });

--- a/src/background.ts
+++ b/src/background.ts
@@ -964,7 +964,33 @@ app.once("will-finish-launching", () => {
 });
 
 app.on("ready", async () => {
-  await configManager.initialize();
+  await configManager.initialize().catch(async (e) => {
+    log.error(e);
+    await dialog
+      .showMessageBox({
+        type: "error",
+        title: "設定ファイルの読み込みエラー",
+        message: `設定ファイルの読み込みに失敗しました。${app.getPath(
+          "userData"
+        )} にある config.json の名前を変えることで解決することがあります（ただし設定がすべてリセットされます）。設定ファイルがあるフォルダを開きますか？`,
+        buttons: ["いいえ", "はい"],
+        noLink: true,
+        cancelId: 0,
+      })
+      .then(async ({ response }) => {
+        if (response === 1) {
+          await shell.openPath(app.getPath("userData"));
+          // 直後にexitするとフォルダが開かないため
+          await new Promise((resolve) => {
+            setTimeout(resolve, 500);
+          });
+        }
+      })
+      .finally(async () => {
+        await configManager?.ensureSaved();
+        app.exit(1);
+      });
+  });
 
   if (isDevelopment && !isTest) {
     try {

--- a/src/background/electronConfig.ts
+++ b/src/background/electronConfig.ts
@@ -1,7 +1,6 @@
 import { join } from "path";
 import fs from "fs";
-import { app, dialog, shell } from "electron";
-import log from "electron-log/main";
+import { app } from "electron";
 import { BaseConfigManager, Metadata } from "@/shared/ConfigManager";
 import { ConfigType } from "@/type/preload";
 
@@ -36,39 +35,8 @@ export class ElectronConfigManager extends BaseConfigManager {
 let configManager: ElectronConfigManager | undefined;
 
 export function getConfigManager(): ElectronConfigManager {
-  try {
-    if (!configManager) {
-      configManager = new ElectronConfigManager();
-    }
-    return configManager;
-  } catch (e) {
-    log.error(e);
-    app.whenReady().then(() => {
-      dialog
-        .showMessageBox({
-          type: "error",
-          title: "設定ファイルの読み込みエラー",
-          message: `設定ファイルの読み込みに失敗しました。${app.getPath(
-            "userData"
-          )} にある config.json の名前を変えることで解決することがあります（ただし設定がすべてリセットされます）。設定ファイルがあるフォルダを開きますか？`,
-          buttons: ["いいえ", "はい"],
-          noLink: true,
-          cancelId: 0,
-        })
-        .then(async ({ response }) => {
-          if (response === 1) {
-            await shell.openPath(app.getPath("userData"));
-            // 直後にexitするとフォルダが開かないため
-            await new Promise((resolve) => {
-              setTimeout(resolve, 500);
-            });
-          }
-        })
-        .finally(async () => {
-          await configManager?.ensureSaved();
-          app.exit(1);
-        });
-    });
-    throw e;
+  if (!configManager) {
+    configManager = new ElectronConfigManager();
   }
+  return configManager;
 }

--- a/tests/e2e/browser/辞書ダイアログ.spec.ts
+++ b/tests/e2e/browser/辞書ダイアログ.spec.ts
@@ -21,7 +21,7 @@ async function openDictDialog(page: Page): Promise<void> {
   await page.getByRole("button", { name: "設定" }).click();
   await page.waitForTimeout(100);
   await page.getByText("読み方＆アクセント辞書").click();
-  await page.waitForTimeout(100);
+  await page.waitForTimeout(500);
   await expect(page.getByText("読み方＆アクセント辞書")).toBeVisible();
   await expect(page.getByText("単語一覧")).toBeVisible();
 }


### PR DESCRIPTION
## 内容

electron-storeから離脱したあたりで、config.jsonの読み込みに失敗した時のフォールバックが発動しなくなっていたので、修正してみました。

具体的には以前はConfigインスタンス作成時にスキーマエラーが発生していたのが、initalize時にエラー発生するように変わったタイミングでコード移動できてなかったのが原因でした。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1156

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

この後↓やろうかなと思います

- https://github.com/VOICEVOX/voicevox/issues/1626

ついでにelectronのメインプロセスでダイアログを開く周りのテストを書こうかなと思ったのですが、モックを指す方法がパッとなさそうだったので諦めました。
たぶんplaywright+electrongでモックを刺せない気がしているので（実はさせるかも･････？）

多分テスト時だけ何かしらの関数を呼ぶようにコードの方直接書き換えないといけない気がします。
（書き換えた先の関数が呼ばれたかどうかの獲得方法が分からない･･････。ログを吐くようにして、ログを参照する･･･？）