### PR TITLE
[project-s] シーケンサー周りの調整

### DIFF
--- a/src/components/Sing/ScorePosition.vue
+++ b/src/components/Sing/ScorePosition.vue
@@ -7,7 +7,9 @@ import { defineComponent } from "vue";
 
 export default defineComponent({
   name: "SingScorePosition",
-
+  props: {
+    offset: { type: Number, default: 0 },
+  },
   setup() {
     return {};
   },
@@ -22,6 +24,5 @@ export default defineComponent({
   background: colors.$background;
   border-bottom: 1px solid #ccc;
   height: 32px;
-  width: 100%;
 }
 </style>

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -1,21 +1,24 @@
 <template>
   <div
-    id="score-sequencer"
     class="score-sequencer"
     @mousedown="handleMouseDown"
     @mousemove="handleMouseMove"
     @mouseup="handleMouseUp"
     @dblclick="addNote"
   >
+    <!-- 左上の角 -->
+    <div class="corner"></div>
+    <!-- スコア位置を表示するエリア -->
+    <score-position :offset="scrollX" />
     <!-- 鍵盤 -->
-    <sequencer-keys />
+    <sequencer-keys :offset="scrollY" />
     <!-- シーケンサ -->
-    <div class="sequencer-body">
+    <div id="sequencer-body" class="sequencer-body" @scroll="onScroll">
       <!-- グリッド -->
       <!-- NOTE: 現状小節+オクターブごとの罫線なし -->
       <svg
-        :width="`${gridCellWidth * numOfGridColumns}`"
-        :height="`${gridCellHeight * keyInfos.length}`"
+        :width="gridCellWidth * numOfGridColumns"
+        :height="gridCellHeight * keyInfos.length"
         xmlns="http://www.w3.org/2000/svg"
         class="sequencer-grid"
       >
@@ -24,42 +27,42 @@
           <pattern
             id="sequencer-grid-octave-cells"
             patternUnits="userSpaceOnUse"
-            :width="`${gridCellWidth}`"
-            :height="`${gridCellHeight * 12}`"
+            :width="gridCellWidth"
+            :height="gridCellHeight * 12"
           >
             <rect
               v-for="(keyInfo, index) in keyInfos"
               :key="index"
               x="0"
-              :y="`${gridCellHeight * index}`"
-              :width="`${gridCellWidth}`"
-              :height="`${gridCellHeight}`"
+              :y="gridCellHeight * index"
+              :width="gridCellWidth"
+              :height="gridCellHeight"
               :class="`sequencer-grid-cell sequencer-grid-cell-${keyInfo.color}`"
             />
           </pattern>
           <pattern
             id="sequencer-grid-measure"
             patternUnits="userSpaceOnUse"
-            :width="`${beatWidth * beatsPerMeasure}`"
-            :height="`${gridCellHeight * keyInfos.length}`"
+            :width="beatWidth * beatsPerMeasure"
+            :height="gridCellHeight * keyInfos.length"
           >
             <line
               v-for="n in beatsPerMeasure"
               :key="n"
-              :x1="`${beatWidth * (n - 1)}`"
-              :x2="`${beatWidth * (n - 1)}`"
+              :x1="beatWidth * (n - 1)"
+              :x2="beatWidth * (n - 1)"
               y1="0"
               y2="100%"
               stroke-width="1"
               :class="`sequencer-grid-${n === 1 ? 'measure' : 'beat'}-line`"
             />
             <line
-              :x1="`${beatWidth * beatsPerMeasure}`"
-              :x2="`${beatWidth * beatsPerMeasure}`"
+              :x1="beatWidth * beatsPerMeasure"
+              :x2="beatWidth * beatsPerMeasure"
               y1="0"
               y2="100%"
               stroke-width="1"
-              :class="`sequencer-grid-measure-line`"
+              class="sequencer-grid-measure-line"
             />
           </pattern>
         </defs>
@@ -101,8 +104,8 @@
       :style="{
         position: 'fixed',
         zIndex: 10000,
-        bottom: '8px',
-        right: '16px',
+        bottom: '20px',
+        right: '36px',
         width: '80px',
       }"
       @input="setZoomX"
@@ -116,8 +119,8 @@
       :style="{
         position: 'fixed',
         zIndex: 10000,
-        bottom: '64px',
-        right: '-8px',
+        bottom: '68px',
+        right: '-12px',
         transform: 'rotate(-90deg)',
         width: '80px',
       }"
@@ -130,6 +133,7 @@
 import { defineComponent, computed, ref, onMounted } from "vue";
 import { v4 as uuidv4 } from "uuid";
 import { useStore } from "@/store";
+import ScorePosition from "@/components/Sing/ScorePosition.vue";
 import SequencerKeys from "@/components/Sing/SequencerKeys.vue";
 import SequencerNote from "@/components/Sing/SequencerNote.vue";
 import {
@@ -148,6 +152,7 @@ import {
 export default defineComponent({
   name: "SingScoreSequencer",
   components: {
+    ScorePosition,
     SequencerKeys,
     SequencerNote,
   },
@@ -233,8 +238,8 @@ export default defineComponent({
       return tickToBaseX(beatTicks, tpqn.value) * zoomX.value;
     });
     // スクロール位置
-    // const scrollX = computed(() => state.sequencerScrollX);
-    // const scrollY = computed(() => state.sequencerScrollY);
+    const scrollX = ref(0);
+    const scrollY = ref(0);
     const selectedNoteIds = computed(() => state.selectedNoteIds);
 
     // ノートの追加
@@ -585,14 +590,21 @@ export default defineComponent({
       }
     };
 
+    const onScroll = (event: Event) => {
+      if (event.target instanceof HTMLDivElement) {
+        scrollX.value = event.target.scrollLeft;
+        scrollY.value = event.target.scrollTop;
+      }
+    };
+
     onMounted(() => {
-      const el = document.querySelector("#score-sequencer");
+      const el = document.querySelector("#sequencer-body");
       // 上から2/3の位置がC4になるようにスクロールする
       if (el) {
         const c4BaseY = noteNumberToBaseY(60);
         const clientBaseHeight = el.clientHeight / zoomY.value;
         const scrollBaseY = c4BaseY - clientBaseHeight * (2 / 3);
-        el.scrollTop = scrollBaseY * zoomY.value;
+        el.scrollTo(0, scrollBaseY * zoomY.value);
       }
     });
 
@@ -608,6 +620,8 @@ export default defineComponent({
       zoomY,
       cursorX,
       cursorY,
+      scrollX,
+      scrollY,
       setZoomX,
       setZoomY,
       addNote,
@@ -618,6 +632,7 @@ export default defineComponent({
       handleDragMoveStart,
       handleDragRightStart,
       handleDragLeftStart,
+      onScroll,
     };
   },
 });
@@ -629,27 +644,25 @@ export default defineComponent({
 
 .score-sequencer {
   backface-visibility: hidden;
-  display: block;
-  height: 100%;
-  overflow: auto;
-  padding-bottom: 164px;
-  position: relative;
-  width: 100%;
+  display: grid;
+  grid-template-rows: 32px 1fr;
+  grid-template-columns: 48px 1fr;
 
   &.move {
     cursor: move;
   }
 }
 
+.corner {
+  background: #fff;
+  border-bottom: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+}
+
 .sequencer-body {
   backface-visibility: hidden;
-  display: block;
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0;
-  left: 48px;
-  padding-bottom: 164px;
+  overflow: auto;
+  position: relative;
 }
 
 .sequencer-grid {

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -591,7 +591,7 @@ export default defineComponent({
     };
 
     const onScroll = (event: Event) => {
-      if (event.target instanceof HTMLDivElement) {
+      if (event.target instanceof HTMLElement) {
         scrollX.value = event.target.scrollLeft;
         scrollY.value = event.target.scrollTop;
       }

--- a/src/components/Sing/SequencerKeys.vue
+++ b/src/components/Sing/SequencerKeys.vue
@@ -1,40 +1,51 @@
 <template>
-  <svg
-    width="48"
-    :height="`${keyHeight * keyInfos.length}`"
-    xmlns="http://www.w3.org/2000/svg"
-    class="sequencer-keys"
-  >
-    <g v-for="(keyInfo, index) in keyInfos" :key="index">
-      <rect
-        x="0"
-        :y="`${keyHeight * index}`"
-        :width="`${keyInfo.color === 'black' ? 30 : 48}`"
-        :height="`${keyHeight}`"
-        :class="`sequencer-keys-item-${keyInfo.color}`"
-        :title="keyInfo.name"
-      />
-      <line
-        v-if="keyInfo.pitch === 'C' || keyInfo.pitch === 'F'"
-        x1="0"
-        x2="48"
-        :y1="`${(index + 1) * keyHeight}`"
-        :y2="`${(index + 1) * keyHeight}`"
-        :class="`sequencer-keys-item-separator ${
-          keyInfo.pitch === 'C' && 'sequencer-keys-item-separator-octave'
-        } ${keyInfo.pitch === 'F' && 'sequencer-keys-item-separator-f'}`"
-      />
-      <text
-        v-if="keyInfo.pitch === 'C'"
-        font-size="10"
-        x="32"
-        :y="`${keyHeight * (index + 1) - 4}`"
-        class="sequencer-keys-item-pitchname"
-      >
-        {{ keyInfo.name }}
-      </text>
-    </g>
-  </svg>
+  <div class="sequencer-keys">
+    <svg
+      width="48"
+      :height="keyHeight * keyInfos.length + 1"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <symbol id="white-keys">
+          <g v-for="(whiteKeyInfo, index) in whiteKeyInfos" :key="index">
+            <rect
+              :x="whiteKeyRects[index].x"
+              :y="whiteKeyRects[index].y"
+              :width="whiteKeyRects[index].width"
+              :height="whiteKeyRects[index].height"
+              class="sequencer-keys-item-white"
+              :title="whiteKeyInfo.name"
+            />
+            <text
+              v-if="whiteKeyInfo.pitch === 'C'"
+              font-size="10"
+              x="32"
+              :y="keyHeight * (128 - whiteKeyInfo.noteNumber) - 4"
+              class="sequencer-keys-item-pitchname"
+            >
+              {{ whiteKeyInfo.name }}
+            </text>
+          </g>
+        </symbol>
+        <symbol id="black-keys">
+          <rect
+            v-for="(blackKeyInfo, index) in blackKeyInfos"
+            :key="index"
+            :x="blackKeyRects[index].x"
+            :y="blackKeyRects[index].y"
+            :width="blackKeyRects[index].width"
+            :height="blackKeyRects[index].height"
+            rx="2"
+            ry="2"
+            class="sequencer-keys-item-black"
+            :title="blackKeyInfo.name"
+          />
+        </symbol>
+      </defs>
+      <use href="#white-keys" :y="-offset" />
+      <use href="#black-keys" :y="-offset" />
+    </svg>
+  </div>
 </template>
 
 <script lang="ts">
@@ -44,17 +55,64 @@ import { keyInfos, getKeyBaseHeight } from "@/helpers/singHelper";
 
 export default defineComponent({
   name: "SingSequencerKeys",
+  props: {
+    offset: { type: Number, default: 0 },
+  },
   setup() {
     const store = useStore();
     const zoomX = computed(() => store.state.sequencerZoomX);
     const zoomY = computed(() => store.state.sequencerZoomY);
     const keyBaseHeight = getKeyBaseHeight();
+    const whiteKeyInfos = keyInfos.filter((value) => value.color === "white");
+    const blackKeyInfos = keyInfos.filter((value) => value.color === "black");
+    const whiteKeyBasePositions = whiteKeyInfos.map((value) => {
+      const noteNumber = value.noteNumber;
+      const n = noteNumber % 12;
+      const o = Math.floor(noteNumber / 12);
+      if (n < 5) {
+        return keyBaseHeight * (128 - 12 * o - (5 / 3) * (n / 2 + 1));
+      } else {
+        return keyBaseHeight * (128 - 12 * o - 5 - (7 / 4) * ((n - 5) / 2 + 1));
+      }
+    });
+    const blackKeyBasePositions = blackKeyInfos.map((value) => {
+      return keyBaseHeight * (127 - value.noteNumber);
+    });
     const keyHeight = computed(() => keyBaseHeight * zoomY.value);
+    const whiteKeyRects = computed(() => {
+      return whiteKeyBasePositions.map((value, index, array) => {
+        const isLast = index === array.length - 1;
+        const nextValue = isLast ? keyBaseHeight * 128 : array[index + 1];
+        return {
+          x: -2.5,
+          y: Math.floor(value * zoomY.value) + 0.5,
+          width: 50,
+          height:
+            Math.floor(nextValue * zoomY.value) -
+            Math.floor(value * zoomY.value),
+        };
+      });
+    });
+    const blackKeyRects = computed(() => {
+      return blackKeyBasePositions.map((value) => {
+        return {
+          x: -2.5,
+          y: Math.floor(value * zoomY.value) + 0.5,
+          width: 32,
+          height: Math.floor(keyBaseHeight * zoomY.value),
+        };
+      });
+    });
+
     return {
       keyInfos,
       zoomX,
       zoomY,
       keyHeight,
+      whiteKeyInfos,
+      blackKeyInfos,
+      whiteKeyRects,
+      blackKeyRects,
     };
   },
 });
@@ -67,29 +125,16 @@ export default defineComponent({
 .sequencer-keys {
   backface-visibility: hidden;
   background: #fff;
-  display: block;
-  position: sticky;
-  left: 0;
-  z-index: 100;
-}
-
-.sequencer-keys-item-separator {
-  stroke-width: 1;
-}
-.sequencer-keys-item-separator-octave {
-  stroke: #bbb;
-}
-
-.sequencer-keys-item-separator-f {
-  stroke: #ddd;
+  overflow: hidden;
 }
 
 .sequencer-keys-item-white {
   fill: #fff;
+  stroke: #ccc;
 }
 
 .sequencer-keys-item-black {
-  fill: #555;
+  fill: #5a5a5a;
 }
 
 .sequencer-keys-item-pitchname {

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -13,8 +13,8 @@
       @input="setLyric"
     />
     <svg
-      :height="`${barHeight}`"
-      :width="`${barWidth}`"
+      :height="barHeight"
+      :width="barWidth"
       xmlns="http://www.w3.org/2000/svg"
       class="sequencer-note-bar"
       focusable="true"
@@ -43,7 +43,7 @@
         />
         <rect
           y="-25%"
-          :x="`${barWidth - 4}`"
+          :x="barWidth - 4"
           width="12"
           height="150%"
           fill-opacity="0"

--- a/src/components/Sing/SingerPanel.vue
+++ b/src/components/Sing/SingerPanel.vue
@@ -84,7 +84,6 @@ export default defineComponent({
 .sing-singer-panel {
   background: colors.$background;
   border-right: 1px solid #ccc;
-  height: 100%;
   width: 200px;
 
   &.hide {

--- a/src/views/SingerHome.vue
+++ b/src/views/SingerHome.vue
@@ -4,10 +4,7 @@
   <tool-bar />
   <div class="sing-main">
     <singer-panel />
-    <div class="sing-editor">
-      <score-position />
-      <score-sequencer />
-    </div>
+    <score-sequencer />
   </div>
 </template>
 
@@ -29,7 +26,6 @@ import MenuBar from "@/components/Sing/MenuBar.vue";
 import ToolBar from "@/components/Sing/ToolBar.vue";
 import SingerPanel from "@/components/Sing/SingerPanel.vue";
 import ScoreSequencer from "@/components/Sing/ScoreSequencer.vue";
-import ScorePosition from "@/components/Sing/ScorePosition.vue";
 import {
   DEFAULT_BEATS,
   DEFAULT_BEAT_TYPE,
@@ -45,7 +41,6 @@ export default defineComponent({
     ToolBar,
     SingerPanel,
     ScoreSequencer,
-    ScorePosition,
   },
 
   setup() {
@@ -99,11 +94,6 @@ export default defineComponent({
 }
 .sing-main {
   display: flex;
-  height: 100vh;
-  width: 100vw;
-}
-
-.sing-editor {
-  width: 100%;
+  overflow: hidden;
 }
 </style>


### PR DESCRIPTION
## 内容
以下を行います。
- シーケンサーのコンポーネントのレイアウトをCSS Gridで行うように変更
  - スクロール判定はひとまず`sequencer-body`エリアのみ（鍵盤はスクロール判定なし）
- 横スクロールバーが表示されるように修正
- 鍵盤の描画処理の変更
  - 白鍵のアウトラインが描画されるようにする
- リファクタリング
## 関連 Issue
VOICEVOX/voicevox_project#15
## スクリーンショット・動画など
https://github.com/VOICEVOX/voicevox/assets/62321214/49f06650-5f2d-4964-b134-8ea4bd4c96bc
## その他