### PR TITLE
[fix] リソースを0.15に、jqが何も見つけられなかった場合はエラーに

### DIFF
--- a/.github/actions/download-engine/action.yml
+++ b/.github/actions/download-engine/action.yml
@@ -97,5 +97,4 @@ runs:
         else
           echo "run_path=$DEST/run" >> $GITHUB_OUTPUT
         fi
-        echo "version=$(jq -r '.tag_name' $TEMPDIR/target.json)" >> $GITHUB_OUTPUT
-
+        echo "version=$(jq -er '.tag_name' $TEMPDIR/target.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ on:
 env:
   VOICEVOX_ENGINE_REPO_URL: "https://github.com/VOICEVOX/voicevox_engine"
   VOICEVOX_ENGINE_VERSION: 0.14.6
-  VOICEVOX_RESOURCE_VERSION: 0.14.4
+  VOICEVOX_RESOURCE_VERSION: 0.15.0-preview.3
   VOICEVOX_EDITOR_VERSION:
     |- # releaseタグ名か、workflow_dispatchでのバージョン名か、999.999.999-developが入る
     ${{ github.event.release.tag_name || github.event.inputs.version || '999.999.999-develop' }}
@@ -202,7 +202,7 @@ jobs:
       - name: Replace .env.production infomations
         run: |
           # GTM ID
-          gtm_id=$(jq -r '.gtm_container_id' resource/editor/metas.json)
+          gtm_id=$(jq -er '.gtm_container_id' resource/editor/metas.json)
           $sed -i 's/VITE_GTM_CONTAINER_ID=.*/VITE_GTM_CONTAINER_ID='"$gtm_id"'/' .env.production
 
       - name: Generate public/licenses.json


### PR DESCRIPTION

## 内容

リソースのバージョンが0.15じゃないと実行時に問題が生じるようになっていたので、修正しました。
ついでにjqは-eをつけないとキーが見つからなかった時にエラーにならないので、そこも修正しました。

- https://github.com/VOICEVOX/voicevox/issues/1637

の解決プルリクエストです。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue


fix #1637
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など


## その他


