### PR TITLE
[project-s] ズーム周りの調整

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -652,15 +652,16 @@ export default defineComponent({
     };
 
     onMounted(() => {
-      // 上から2/3の位置がC4になるようにスクロールする
       const sequencerBodyElement = sequencerBody.value;
-      if (sequencerBodyElement) {
-        const clientHeight = sequencerBodyElement.clientHeight;
-        const c4BaseY = noteNumberToBaseY(60);
-        const clientBaseHeight = clientHeight / zoomY.value;
-        const scrollBaseY = c4BaseY - clientBaseHeight * (2 / 3);
-        sequencerBodyElement.scrollTo(0, scrollBaseY * zoomY.value);
+      if (!sequencerBodyElement) {
+        throw new Error("sequencerBodyElement is null.");
       }
+      // 上から2/3の位置がC4になるようにスクロールする
+      const clientHeight = sequencerBodyElement.clientHeight;
+      const c4BaseY = noteNumberToBaseY(60);
+      const clientBaseHeight = clientHeight / zoomY.value;
+      const scrollBaseY = c4BaseY - clientBaseHeight * (2 / 3);
+      sequencerBodyElement.scrollTo(0, scrollBaseY * zoomY.value);
     });
 
     return {

--- a/src/components/Sing/SequencerKeys.vue
+++ b/src/components/Sing/SequencerKeys.vue
@@ -109,20 +109,21 @@ export default defineComponent({
 
     onMounted(() => {
       const sequencerKeysElement = sequencerKeys.value;
-      if (sequencerKeysElement) {
-        resizeObserver = new ResizeObserver((entries) => {
-          let inlineSize = 0;
-          for (const entry of entries) {
-            for (const borderBoxSize of entry.borderBoxSize) {
-              inlineSize = borderBoxSize.inlineSize;
-            }
-          }
-          if (inlineSize > 0 && inlineSize !== width.value) {
-            width.value = inlineSize;
-          }
-        });
-        resizeObserver.observe(sequencerKeysElement);
+      if (!sequencerKeysElement) {
+        throw new Error("sequencerKeysElement is null.");
       }
+      resizeObserver = new ResizeObserver((entries) => {
+        let inlineSize = 0;
+        for (const entry of entries) {
+          for (const borderBoxSize of entry.borderBoxSize) {
+            inlineSize = borderBoxSize.inlineSize;
+          }
+        }
+        if (inlineSize > 0 && inlineSize !== width.value) {
+          width.value = inlineSize;
+        }
+      });
+      resizeObserver.observe(sequencerKeysElement);
     });
 
     onUnmounted(() => {

--- a/src/components/Sing/SequencerKeys.vue
+++ b/src/components/Sing/SequencerKeys.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sequencer-keys">
+  <div ref="sequencerKeys" class="sequencer-keys">
     <svg xmlns="http://www.w3.org/2000/svg" :width="width" :height="height">
       <defs>
         <symbol id="white-keys">
@@ -45,7 +45,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent, computed, ref, onMounted, onUnmounted } from "vue";
 import { useStore } from "@/store";
 import { keyInfos, getKeyBaseHeight } from "@/helpers/singHelper";
 
@@ -53,11 +53,11 @@ export default defineComponent({
   name: "SingSequencerKeys",
   props: {
     offset: { type: Number, default: 0 },
-    width: { type: Number, default: 48 },
     blackKeyWidth: { type: Number, default: 30 },
   },
   setup(props) {
     const store = useStore();
+    const width = ref(48);
     const zoomX = computed(() => store.state.sequencerZoomX);
     const zoomY = computed(() => store.state.sequencerZoomY);
     const keyBaseHeight = getKeyBaseHeight();
@@ -86,7 +86,7 @@ export default defineComponent({
         return {
           x: -2,
           y: Math.floor(value * zoomY.value),
-          width: props.width + 2,
+          width: width.value + 2,
           height:
             Math.floor(nextValue * zoomY.value) -
             Math.floor(value * zoomY.value),
@@ -104,15 +104,44 @@ export default defineComponent({
       });
     });
 
+    const sequencerKeys = ref<HTMLElement | null>(null);
+    let resizeObserver: ResizeObserver | undefined;
+
+    onMounted(() => {
+      const sequencerKeysElement = sequencerKeys.value;
+      if (sequencerKeysElement) {
+        resizeObserver = new ResizeObserver((entries) => {
+          let inlineSize = 0;
+          for (const entry of entries) {
+            for (const borderBoxSize of entry.borderBoxSize) {
+              inlineSize = borderBoxSize.inlineSize;
+            }
+          }
+          if (inlineSize > 0 && inlineSize !== width.value) {
+            width.value = inlineSize;
+          }
+        });
+        resizeObserver.observe(sequencerKeysElement);
+      }
+    });
+
+    onUnmounted(() => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    });
+
     return {
       keyInfos,
       zoomX,
       zoomY,
+      width,
       height,
       whiteKeyInfos,
       blackKeyInfos,
       whiteKeyRects,
       blackKeyRects,
+      sequencerKeys,
     };
   },
 });
@@ -124,7 +153,8 @@ export default defineComponent({
 
 .sequencer-keys {
   backface-visibility: hidden;
-  background: #ccc;
+  background: colors.$background;
+  border-right: 1px solid #ccc;
   overflow: hidden;
 }
 

--- a/src/components/Sing/SequencerRuler.vue
+++ b/src/components/Sing/SequencerRuler.vue
@@ -130,20 +130,21 @@ export default defineComponent({
 
     onMounted(() => {
       const sequencerRulerElement = sequencerRuler.value;
-      if (sequencerRulerElement) {
-        resizeObserver = new ResizeObserver((entries) => {
-          let blockSize = 0;
-          for (const entry of entries) {
-            for (const borderBoxSize of entry.borderBoxSize) {
-              blockSize = borderBoxSize.blockSize;
-            }
-          }
-          if (blockSize > 0 && blockSize !== height.value) {
-            height.value = blockSize;
-          }
-        });
-        resizeObserver.observe(sequencerRulerElement);
+      if (!sequencerRulerElement) {
+        throw new Error("sequencerRulerElement is null.");
       }
+      resizeObserver = new ResizeObserver((entries) => {
+        let blockSize = 0;
+        for (const entry of entries) {
+          for (const borderBoxSize of entry.borderBoxSize) {
+            blockSize = borderBoxSize.blockSize;
+          }
+        }
+        if (blockSize > 0 && blockSize !== height.value) {
+          height.value = blockSize;
+        }
+      });
+      resizeObserver.observe(sequencerRulerElement);
     });
 
     onUnmounted(() => {

--- a/src/components/Sing/SequencerRuler.vue
+++ b/src/components/Sing/SequencerRuler.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sequencer-ruler">
+  <div ref="sequencerRuler" class="sequencer-ruler">
     <svg xmlns="http://www.w3.org/2000/svg" :width="width" :height="height">
       <defs>
         <pattern
@@ -50,7 +50,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent, computed, ref, onMounted, onUnmounted } from "vue";
 import { useStore } from "@/store";
 import {
   getMeasureDuration,
@@ -62,12 +62,12 @@ export default defineComponent({
   name: "SingSequencerRuler",
   props: {
     offset: { type: Number, default: 0 },
-    height: { type: Number, default: 32 },
     numOfMeasures: { type: Number, default: 32 },
   },
   setup(props) {
     const store = useStore();
     const state = store.state;
+    const height = ref(32);
     const tpqn = computed(() => state.score.tpqn);
     const timeSignatures = computed(() => state.score.timeSignatures);
     const zoomX = computed(() => state.sequencerZoomX);
@@ -125,10 +125,39 @@ export default defineComponent({
       return measureInfos;
     });
 
+    const sequencerRuler = ref<HTMLElement | null>(null);
+    let resizeObserver: ResizeObserver | undefined;
+
+    onMounted(() => {
+      const sequencerRulerElement = sequencerRuler.value;
+      if (sequencerRulerElement) {
+        resizeObserver = new ResizeObserver((entries) => {
+          let blockSize = 0;
+          for (const entry of entries) {
+            for (const borderBoxSize of entry.borderBoxSize) {
+              blockSize = borderBoxSize.blockSize;
+            }
+          }
+          if (blockSize > 0 && blockSize !== height.value) {
+            height.value = blockSize;
+          }
+        });
+        resizeObserver.observe(sequencerRulerElement);
+      }
+    });
+
+    onUnmounted(() => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    });
+
     return {
       measureWidth,
       width,
+      height,
       measureInfos,
+      sequencerRuler,
     };
   },
 });


### PR DESCRIPTION
## 内容
スライダーを操作したときは画面の中央を基準にズーム、
Ctrlキーを押しながらホイールを回したときはマウスカーソル位置を基準にズーム（水平方向）するようにします。
また、`SequencerKeys`の幅と`SequencerRuler`の高さを`ResizeObserver`で取得するようにします。
## 関連 Issue
VOICEVOX/voicevox_project#15
## スクリーンショット・動画など
https://github.com/VOICEVOX/voicevox/assets/62321214/0d435cad-8b9b-4be1-bc16-a42c16bdafdf
## その他