### PR TITLE
Hotfix: 初回起動と0.13からの更新が出来ないのを修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -162,15 +162,14 @@ const store = new Store<ElectronStoreType>({
     },
     ">=0.14.9": (store) => {
       // マルチエンジン機能を実験的機能から通常機能に
-      if (!store.has("experimentalSetting.enableMultiEngine")) {
-        return;
-      }
-      const enableMultiEngine: boolean =
+      if (store.has("experimentalSetting.enableMultiEngine")) {
+        const enableMultiEngine: boolean =
+          // @ts-expect-error 削除されたパラメータ。
+          store.get("experimentalSetting").enableMultiEngine;
+        store.set("enableMultiEngine", enableMultiEngine);
         // @ts-expect-error 削除されたパラメータ。
-        store.get("experimentalSetting").enableMultiEngine;
-      store.set("enableMultiEngine", enableMultiEngine);
-      // @ts-expect-error 削除されたパラメータ。
-      store.delete("experimentalSetting.enableMultiEngine");
+        store.delete("experimentalSetting.enableMultiEngine");
+      }
     },
   },
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -162,6 +162,9 @@ const store = new Store<ElectronStoreType>({
     },
     ">=0.14.9": (store) => {
       // マルチエンジン機能を実験的機能から通常機能に
+      if (!store.has("experimentalSetting.enableMultiEngine")) {
+        return;
+      }
       const enableMultiEngine: boolean =
         // @ts-expect-error 削除されたパラメータ。
         store.get("experimentalSetting").enableMultiEngine;


### PR DESCRIPTION
## 内容

初回起動だと`experimentalSetting.enableMultiEngine`が存在しないため、`store.set("enableMultiEngine", enableMultiEngine);`にundefinedが渡され型違反 -> 死亡という感じで死んでたのを直します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）