### PR TITLE
[project-s] 再生ヘッドの位置を設定する機能を追加

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -655,11 +655,13 @@ export default defineComponent({
         throw new Error("sequencerBodyElement is null.");
       }
       if (event.ctrlKey) {
-        // カーソル位置を基準に水平方向のズームを行う
+        // マウスカーソル位置を基準に水平方向のズームを行う
         const oldZoomX = zoomX.value;
         const scrollLeft = sequencerBodyElement.scrollLeft;
         const scrollTop = sequencerBodyElement.scrollTop;
-        const cursorX = event.offsetX - scrollLeft;
+        const clientRect = sequencerBodyElement.getBoundingClientRect();
+        // sequencerBody要素のborderとpaddingが0であることを前提にマウスカーソル位置を算出
+        const cursorX = event.clientX - clientRect.left;
 
         let newZoomX = zoomX.value;
         newZoomX -= event.deltaY * (ZOOM_X_STEP * 0.01);

--- a/src/components/Sing/SequencerRuler.vue
+++ b/src/components/Sing/SequencerRuler.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="sequencerRuler" class="sequencer-ruler">
+  <div ref="sequencerRuler" class="sequencer-ruler" @click="onClick">
     <svg xmlns="http://www.w3.org/2000/svg" :width="width" :height="height">
       <defs>
         <pattern
@@ -60,6 +60,7 @@
 import { defineComponent, computed, ref, onMounted, onUnmounted } from "vue";
 import { useStore } from "@/store";
 import {
+  baseXToTick,
   getMeasureDuration,
   getTimeSignaturePositions,
   tickToBaseX,
@@ -137,6 +138,16 @@ export default defineComponent({
       return Math.floor(baseX * zoomX.value);
     });
 
+    const onClick = (event: MouseEvent) => {
+      const sequencerRulerElement = sequencerRuler.value;
+      if (!sequencerRulerElement) {
+        throw new Error("sequencerRulerElement is null.");
+      }
+      const baseX = (props.offset + event.offsetX) / zoomX.value;
+      const ticks = baseXToTick(baseX, tpqn.value);
+      store.dispatch("SET_PLAYHEAD_POSITION", { position: ticks });
+    };
+
     const sequencerRuler = ref<HTMLElement | null>(null);
     let resizeObserver: ResizeObserver | undefined;
 
@@ -182,6 +193,7 @@ export default defineComponent({
       measureInfos,
       playheadX,
       sequencerRuler,
+      onClick,
     };
   },
 });


### PR DESCRIPTION
## 内容
ルーラーをクリックで再生ヘッドの位置を設定できるようにします。
また、マウスカーソルの位置が正しく取得できていなかったので、その修正も行います。
## 関連 Issue
VOICEVOX/voicevox_project#15
## スクリーンショット・動画など
https://github.com/VOICEVOX/voicevox/assets/62321214/fa7ceb5b-b730-4c04-9b4e-47e2a5d2541a
## その他