### PR TITLE
[docs] 依存ライブラリのライセンス情報の生成は自動であることを案内

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ npm run test-watch:electron-e2e # 監視モード
 
 ## 依存ライブラリのライセンス情報の生成
 
+依存ライブラリのライセンス情報は Github Workflow でのビルド時に自動生成されます。以下のコマンドで生成できます。
+
 ```bash
 # get licenses.json from voicevox_engine as engine_licenses.json
 


### PR DESCRIPTION
## 内容

ライセンス情報の手動更新は必要ないことを伝えたいので、自動で作られていることを案内するようにしてみました。


## その他
