### PR TITLE
useFetchNewUpdateInfosのテストを追加

### DIFF
--- a/src/components/help/HelpDialog.vue
+++ b/src/components/help/HelpDialog.vue
@@ -137,13 +137,10 @@ if (!import.meta.env.VITE_LATEST_UPDATE_INFOS_URL) {
     "環境変数VITE_LATEST_UPDATE_INFOS_URLが設定されていません。.envに記載してください。"
   );
 }
-const { isCheckingFinished, latestVersion } = useFetchNewUpdateInfos(
+const newUpdateResult = useFetchNewUpdateInfos(
+  () => window.electron.getAppInfos().then((obj) => obj.version), // アプリのバージョン
   import.meta.env.VITE_LATEST_UPDATE_INFOS_URL
 );
-
-const isUpdateAvailable = computed(() => {
-  return isCheckingFinished.value && latestVersion.value !== "";
-});
 
 // エディタのOSSライセンス取得
 const licenses = ref<Record<string, string>[]>();
@@ -192,8 +189,14 @@ const pagedata = computed(() => {
       props: {
         downloadLink: import.meta.env.VITE_OFFICIAL_WEBSITE_URL,
         updateInfos: updateInfos.value,
-        isUpdateAvailable: isUpdateAvailable.value,
-        latestVersion: latestVersion.value,
+        ...(newUpdateResult.value.status == "updateAvailable"
+          ? {
+              isUpdateAvailable: true,
+              latestVersion: newUpdateResult.value.latestVersion,
+            }
+          : {
+              isUpdateAvailable: false,
+            }),
       },
     },
     {

--- a/src/components/help/HelpDialog.vue
+++ b/src/components/help/HelpDialog.vue
@@ -196,6 +196,7 @@ const pagedata = computed(() => {
             }
           : {
               isUpdateAvailable: false,
+              latestVersion: undefined,
             }),
       },
     },

--- a/src/components/help/HelpDialog.vue
+++ b/src/components/help/HelpDialog.vue
@@ -85,7 +85,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, type Component } from "vue";
+import { computed, ref } from "vue";
+import type { Component } from "vue";
 import HelpPolicy from "./HelpPolicy.vue";
 import LibraryPolicy from "./LibraryPolicy.vue";
 import HowToUse from "./HowToUse.vue";
@@ -131,7 +132,14 @@ const store = useStore();
 const updateInfos = ref<UpdateInfoObject[]>();
 store.dispatch("GET_UPDATE_INFOS").then((obj) => (updateInfos.value = obj));
 
-const { isCheckingFinished, latestVersion } = useFetchNewUpdateInfos();
+if (!import.meta.env.VITE_LATEST_UPDATE_INFOS_URL) {
+  throw new Error(
+    "環境変数VITE_LATEST_UPDATE_INFOS_URLが設定されていません。.envに記載してください。"
+  );
+}
+const { isCheckingFinished, latestVersion } = useFetchNewUpdateInfos(
+  import.meta.env.VITE_LATEST_UPDATE_INFOS_URL
+);
 
 const isUpdateAvailable = computed(() => {
   return isCheckingFinished.value && latestVersion.value !== "";

--- a/src/components/help/UpdateInfo.vue
+++ b/src/components/help/UpdateInfo.vue
@@ -42,7 +42,7 @@ import { UpdateInfo } from "@/type/preload";
 
 const props =
   defineProps<{
-    latestVersion: string;
+    latestVersion: string | undefined;
     downloadLink: string;
     updateInfos: UpdateInfo[];
     isUpdateAvailable: boolean;

--- a/src/composables/useFetchNewUpdateInfos.ts
+++ b/src/composables/useFetchNewUpdateInfos.ts
@@ -13,7 +13,7 @@ export const useFetchNewUpdateInfos = (
 ) => {
   const result = ref<
     | {
-        status: "upadteChecking";
+        status: "updateChecking";
       }
     | {
         status: "updateAvailable";
@@ -24,7 +24,7 @@ export const useFetchNewUpdateInfos = (
         status: "updateNotAvailable";
       }
   >({
-    status: "upadteChecking",
+    status: "updateChecking",
   });
 
   (async () => {

--- a/src/composables/useFetchNewUpdateInfos.ts
+++ b/src/composables/useFetchNewUpdateInfos.ts
@@ -13,7 +13,7 @@ export const useFetchNewUpdateInfos = (
 ) => {
   const result = ref<
     | {
-        status: "checking";
+        status: "upadteChecking";
       }
     | {
         status: "updateAvailable";
@@ -24,7 +24,7 @@ export const useFetchNewUpdateInfos = (
         status: "updateNotAvailable";
       }
   >({
-    status: "checking",
+    status: "upadteChecking",
   });
 
   (async () => {

--- a/src/composables/useFetchNewUpdateInfos.ts
+++ b/src/composables/useFetchNewUpdateInfos.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { UpdateInfo, updateInfoSchema } from "@/type/preload";
 
 /**
- * 現在のバージョンより新しい最新バージョンがリリースされているか調べる。
+ * 現在のバージョンより新しいバージョンがリリースされているか調べる。
  * あれば最新バージョンと、現在より新しいバージョンの情報を返す。
  */
 export const useFetchNewUpdateInfos = (

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -270,11 +270,12 @@ export type CharacterInfo = {
   };
 };
 
-export type UpdateInfo = {
-  version: string;
-  descriptions: string[];
-  contributors: string[];
-};
+export const updateInfoSchema = z.object({
+  version: z.string(),
+  descriptions: z.array(z.string()),
+  contributors: z.array(z.string()),
+});
+export type UpdateInfo = z.infer<typeof updateInfoSchema>;
 
 export type Voice = {
   engineId: EngineId;

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -550,8 +550,13 @@ watch(userOrderedCharacterInfos, (userOrderedCharacterInfos) => {
 });
 
 // エディタのアップデート確認
+if (!import.meta.env.VITE_LATEST_UPDATE_INFOS_URL) {
+  throw new Error(
+    "環境変数VITE_LATEST_UPDATE_INFOS_URLが設定されていません。.envに記載してください。"
+  );
+}
 const { isCheckingFinished, latestVersion, newUpdateInfos } =
-  useFetchNewUpdateInfos();
+  useFetchNewUpdateInfos(import.meta.env.VITE_LATEST_UPDATE_INFOS_URL);
 const isUpdateAvailable = computed(() => {
   return isCheckingFinished.value && latestVersion.value !== "";
 });

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -178,9 +178,10 @@
   />
   <accept-terms-dialog v-model="isAcceptTermsDialogOpenComputed" />
   <update-notification-dialog
+    v-if="newUpdateResult.status == 'updateAvailable'"
     v-model="isUpdateNotificationDialogOpenComputed"
-    :latest-version="latestVersion"
-    :new-update-infos="newUpdateInfos"
+    :latest-version="newUpdateResult.latestVersion"
+    :new-update-infos="newUpdateResult.newUpdateInfos"
   />
 </template>
 
@@ -555,11 +556,10 @@ if (!import.meta.env.VITE_LATEST_UPDATE_INFOS_URL) {
     "環境変数VITE_LATEST_UPDATE_INFOS_URLが設定されていません。.envに記載してください。"
   );
 }
-const { isCheckingFinished, latestVersion, newUpdateInfos } =
-  useFetchNewUpdateInfos(import.meta.env.VITE_LATEST_UPDATE_INFOS_URL);
-const isUpdateAvailable = computed(() => {
-  return isCheckingFinished.value && latestVersion.value !== "";
-});
+const newUpdateResult = useFetchNewUpdateInfos(
+  () => window.electron.getAppInfos().then((obj) => obj.version), // アプリのバージョン
+  import.meta.env.VITE_LATEST_UPDATE_INFOS_URL
+);
 
 // ソフトウェアを初期化
 const isCompletedInitialStartup = ref(false);
@@ -643,7 +643,8 @@ onMounted(async () => {
     import.meta.env.MODE !== "development" &&
     store.state.acceptTerms !== "Accepted";
 
-  isUpdateNotificationDialogOpenComputed.value = isUpdateAvailable.value;
+  isUpdateNotificationDialogOpenComputed.value =
+    newUpdateResult.value.status == "updateAvailable";
 
   isCompletedInitialStartup.value = true;
 });

--- a/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
+++ b/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
@@ -1,0 +1,62 @@
+import { Ref } from "vue";
+import { UpdateInfo } from "@/type/preload";
+import { useFetchNewUpdateInfos } from "@/composables/useFetchNewUpdateInfos";
+
+// 現バージョンや新バージョンの情報を返すモックを作成する
+const setupMock = ({
+  currentVersion,
+  latestVersion,
+}: {
+  currentVersion: string;
+  latestVersion: string;
+}) => {
+  // window.electron.getAppInfosのモックを作成
+  vi.stubGlobal("window", {
+    electron: {
+      getAppInfos: async () => {
+        return { version: currentVersion };
+      },
+    },
+  });
+
+  // fetchのモックを作成
+  const updateInfos: UpdateInfo[] = [
+    {
+      version: latestVersion,
+      descriptions: [],
+      contributors: [],
+    },
+  ];
+  vi.stubGlobal("fetch", async () => {
+    return new Response(JSON.stringify(updateInfos), { status: 200 });
+  });
+};
+
+// 準備完了まで待機
+const waitFinished = async (isCheckingFinished: Ref<boolean>) => {
+  await vi.waitFor(() => {
+    if (!isCheckingFinished.value) throw new Error();
+  });
+};
+
+it("新バージョンがある場合、latestVersionに最新バージョンが代入される", async () => {
+  setupMock({ currentVersion: "1.0.0", latestVersion: "2.0.0" });
+
+  const { isCheckingFinished, latestVersion, newUpdateInfos } =
+    useFetchNewUpdateInfos("http://example.com");
+
+  await waitFinished(isCheckingFinished);
+  expect(latestVersion.value).toBe("2.0.0");
+  expect(newUpdateInfos.value).toHaveLength(1);
+});
+
+it("新バージョンがない場合、latestVersionは空", async () => {
+  setupMock({ currentVersion: "1.0.0", latestVersion: "1.0.0" });
+
+  const { isCheckingFinished, latestVersion, newUpdateInfos } =
+    useFetchNewUpdateInfos("http://example.com");
+
+  await waitFinished(isCheckingFinished);
+  expect(latestVersion.value).toBe("");
+  expect(newUpdateInfos.value).toHaveLength(0);
+});

--- a/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
+++ b/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
@@ -20,7 +20,7 @@ const setupFetchMock = (latestVersion: string) => {
 // 準備完了まで待機
 const waitFinished = async (result: Ref<{ status: string }>) => {
   await vi.waitFor(() => {
-    if (result.value.status === "upadteChecking") throw new Error();
+    if (result.value.status === "updateChecking") throw new Error();
   });
 };
 

--- a/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
+++ b/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
@@ -18,9 +18,9 @@ const setupFetchMock = (latestVersion: string) => {
 };
 
 // 準備完了まで待機
-const waitFinished = async (result: Ref<{ status: "checking" | string }>) => {
+const waitFinished = async (result: Ref<{ status: string }>) => {
   await vi.waitFor(() => {
-    if (result.value.status == "checking") throw new Error();
+    if (result.value.status === "upadteChecking") throw new Error();
   });
 };
 
@@ -41,7 +41,7 @@ it("新バージョンがある場合、latestVersionに最新バージョンが
   });
 });
 
-it("新バージョンがない場合、latestVersionはundefined", async () => {
+it("新バージョンがない場合は状態が変わるだけ", async () => {
   const currentVersion = "1.0.0";
   const latestVersion = "1.0.0";
   setupFetchMock(latestVersion);

--- a/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
+++ b/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
@@ -2,23 +2,8 @@ import { Ref } from "vue";
 import { UpdateInfo } from "@/type/preload";
 import { useFetchNewUpdateInfos } from "@/composables/useFetchNewUpdateInfos";
 
-// 現バージョンや新バージョンの情報を返すモックを作成する
-const setupMock = ({
-  currentVersion,
-  latestVersion,
-}: {
-  currentVersion: string;
-  latestVersion: string;
-}) => {
-  // window.electron.getAppInfosのモックを作成
-  vi.stubGlobal("window", {
-    electron: {
-      getAppInfos: async () => {
-        return { version: currentVersion };
-      },
-    },
-  });
-
+// 最新バージョンの情報をfetchするモックを作成する
+const setupFetchMock = (latestVersion: string) => {
   // fetchのモックを作成
   const updateInfos: UpdateInfo[] = [
     {
@@ -33,30 +18,39 @@ const setupMock = ({
 };
 
 // 準備完了まで待機
-const waitFinished = async (isCheckingFinished: Ref<boolean>) => {
+const waitFinished = async (result: Ref<{ status: "checking" | string }>) => {
   await vi.waitFor(() => {
-    if (!isCheckingFinished.value) throw new Error();
+    if (result.value.status == "checking") throw new Error();
   });
 };
 
 it("新バージョンがある場合、latestVersionに最新バージョンが代入される", async () => {
-  setupMock({ currentVersion: "1.0.0", latestVersion: "2.0.0" });
+  const currentVersion = "1.0.0";
+  const latestVersion = "2.0.0";
+  setupFetchMock(latestVersion);
 
-  const { isCheckingFinished, latestVersion, newUpdateInfos } =
-    useFetchNewUpdateInfos("http://example.com");
+  const result = useFetchNewUpdateInfos(
+    async () => currentVersion,
+    "Dummy Url"
+  );
 
-  await waitFinished(isCheckingFinished);
-  expect(latestVersion.value).toBe("2.0.0");
-  expect(newUpdateInfos.value).toHaveLength(1);
+  await waitFinished(result);
+  expect(result.value).toMatchObject({
+    status: "updateAvailable",
+    latestVersion,
+  });
 });
 
-it("新バージョンがない場合、latestVersionは空", async () => {
-  setupMock({ currentVersion: "1.0.0", latestVersion: "1.0.0" });
+it("新バージョンがない場合、latestVersionはundefined", async () => {
+  const currentVersion = "1.0.0";
+  const latestVersion = "1.0.0";
+  setupFetchMock(latestVersion);
 
-  const { isCheckingFinished, latestVersion, newUpdateInfos } =
-    useFetchNewUpdateInfos("http://example.com");
+  const result = useFetchNewUpdateInfos(
+    async () => currentVersion,
+    "Dummy Url"
+  );
 
-  await waitFinished(isCheckingFinished);
-  expect(latestVersion.value).toBe("");
-  expect(newUpdateInfos.value).toHaveLength(0);
+  await waitFinished(result);
+  expect(result.value).toMatchObject({ status: "updateNotAvailable" });
 });


### PR DESCRIPTION
## 内容

アップデート情報を取ってくる`useFetchNewUpdateInfos`コンポーザブルのテストを書きました。

[バージョンごとにアップデート通知を切れるようにするタスク](https://github.com/VOICEVOX/voicevox/issues/1633)をテスト可能にしたくて、その前に既存の関数のテストを書いてみた感じです。

## その他

fetchのモックを刺してみています。こんな感じ。
```ts
// fetchのモックを作成
vi.stubGlobal("fetch", async () => {
  return new Response(JSON.stringify(updateInfos), { status: 200 });
});
```

refの値の待機は`vi.waitFor`が便利でした。
```ts
await vi.waitFor(() => {
  if (!isCheckingFinished.value) throw new Error();
});
```
