### PR TITLE
[project-s] 歌詞入力周りの実装

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -104,7 +104,6 @@
         :key="note.id"
         :note="note"
         is-selected
-        :is-preview="nowPreviewing"
         @body-mousedown="startPreview($event, 'MOVE', note)"
         @right-edge-mousedown="startPreview($event, 'RESIZE_RIGHT', note)"
         @left-edge-mousedown="startPreview($event, 'RESIZE_LEFT', note)"

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -631,7 +631,7 @@ export default defineComponent({
       if (event.detail === 1) {
         clickedNoteInfos = [];
       }
-      if (mouseDownNoteId === undefined) {
+      if (mouseDownNoteId == undefined) {
         clickedNoteInfos.push(undefined);
       } else {
         clickedNoteInfos.push({
@@ -671,7 +671,7 @@ export default defineComponent({
       if (clickedNoteInfos.some((value) => value?.edited ?? false)) {
         return;
       }
-      if (clickedNoteInfos[0] === undefined) {
+      if (clickedNoteInfos[0] == undefined) {
         return;
       }
       for (let i = 1; i < clickedNoteInfos.length; i++) {

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -547,10 +547,6 @@ export default defineComponent({
           lyric: getDoremiFromNoteNumber(cursorNoteNumber),
         };
         store.dispatch("DESELECT_ALL_NOTES");
-        store.dispatch("PLAY_PREVIEW_SOUND", {
-          noteNumber: note.noteNumber,
-          duration: PREVIEW_SOUND_DURATION,
-        });
         copiedNotes.push(note);
       } else {
         if (!note) {
@@ -602,12 +598,14 @@ export default defineComponent({
     };
 
     const onNoteLyricMouseDown = (note: Note) => {
-      store.dispatch("DESELECT_ALL_NOTES");
-      store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
-      store.dispatch("PLAY_PREVIEW_SOUND", {
-        noteNumber: note.noteNumber,
-        duration: PREVIEW_SOUND_DURATION,
-      });
+      if (!state.selectedNoteIds.has(note.id)) {
+        store.dispatch("DESELECT_ALL_NOTES");
+        store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
+        store.dispatch("PLAY_PREVIEW_SOUND", {
+          noteNumber: note.noteNumber,
+          duration: PREVIEW_SOUND_DURATION,
+        });
+      }
       mouseDownNoteId = note.id;
     };
 
@@ -679,9 +677,11 @@ export default defineComponent({
           return;
         }
       }
-      store.dispatch("SET_EDITING_LYRIC_NOTE_ID", {
-        noteId: clickedNoteInfos[0].id,
-      });
+
+      const noteId = clickedNoteInfos[0].id;
+      if (state.editingLyricNoteId !== noteId) {
+        store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId });
+      }
     };
 
     // キーボードイベント

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -22,7 +22,6 @@
       v-if="showLyricInput"
       v-model.lazy.trim="lyric"
       v-focus
-      type="text"
       class="note-lyric-input"
       @mousedown.stop
       @dblclick.stop
@@ -42,7 +41,7 @@ import {
   noteNumberToBaseY,
 } from "@/helpers/singHelper";
 
-type NoteState = "NONE" | "SELECTED" | "OVERLAPPING";
+type NoteState = "NORMAL" | "SELECTED" | "OVERLAPPING";
 
 export default defineComponent({
   name: "SingSequencerNote",
@@ -88,7 +87,7 @@ export default defineComponent({
       if (state.overlappingNoteIds.has(props.note.id)) {
         return "OVERLAPPING";
       }
-      return "NONE";
+      return "NORMAL";
     });
     const lyric = computed({
       get() {
@@ -205,8 +204,7 @@ export default defineComponent({
   position: absolute;
   left: 0;
   bottom: calc(100% - 3px);
-  min-width: min(22px, 100%);
-  max-width: 100%;
+  min-width: 20px;
   padding: 0 1px 2px;
   background: white;
   color: colors.$display;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -776,6 +776,7 @@ export type SingingStoreState = {
   sequencerSnapType: number;
   selectedNoteIds: Set<string>;
   overlappingNoteIds: Set<string>;
+  editingLyricNoteId?: string;
   nowPlaying: boolean;
   volume: number;
   leftLocatorPosition: number;
@@ -850,6 +851,11 @@ export type SingingStoreTypes = {
 
   REMOVE_SELECTED_NOTES: {
     action(): void;
+  };
+
+  SET_EDITING_LYRIC_NOTE_ID: {
+    mutation: { noteId?: string };
+    action(payload: { noteId?: string }): void;
   };
 
   SET_PHRASE: {


### PR DESCRIPTION
## 内容
以下を行います。
- 歌詞編集時にのみ`input`を表示するように変更
  - ノートをダブルクリックで歌詞編集モードに移行
  - Tabキーで次のノートに、Shiftキーで前のノートに移動する機能を追加
  - Enterキーで歌詞編集を終了
  - `change`イベント発生時に歌詞の変更を適用するように変更
- ノートの描画をSVGからDOMに変更
- カーソル周りの処理を一旦元に戻す（カーソルのちらつきを防げていなかったので）
- 修正とリファクタリング
## 関連 Issue
VOICEVOX/voicevox_project#15
## その他