### PR TITLE
[project-s] ノートが追加される位置を表示する機能を追加

### DIFF
--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -208,7 +208,7 @@ export default defineComponent({
   padding: 0 1px 2px;
   background: white;
   color: colors.$display;
-  border: 1px solid hsl(130, 0%, 90%);
+  border: 1px solid hsl(130, 0%, 91%);
   border-radius: 3px;
   font-size: 12px;
   font-weight: bold;
@@ -230,8 +230,8 @@ export default defineComponent({
 .note-left-edge {
   position: absolute;
   top: 0;
-  left: -2px;
-  width: 6px;
+  left: 0px;
+  width: 4px;
   height: 100%;
   cursor: ew-resize;
 }
@@ -239,8 +239,8 @@ export default defineComponent({
 .note-right-edge {
   position: absolute;
   top: 0;
-  right: -2px;
-  width: 6px;
+  right: 0px;
+  width: 4px;
   height: 100%;
   cursor: ew-resize;
 }

--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -332,7 +332,7 @@ export default defineComponent({
 }
 
 .singer-panel-toggler {
-  border: 2px solid #aaa;
+  border: 2px solid #bbb;
   border-radius: 50%;
   display: block;
   height: 48px;


### PR DESCRIPTION
## 内容
以下を行います。
- ノートが追加される位置を表示する機能を追加
  - 縦線で表示
  - プレビュー中（移動中・リサイズ中）も判定が分かるように表示
- ノート追加位置の判定を「スナップ幅の1/4」右にずらす
  - グリッドの線とグリッドセル、どちらを狙っても意図した位置にノートが追加されるように
- 移動・リサイズを行ったあとにノートの選択をすべて解除するようにする
  - 複数ノートを選択して編集後に単一ノートの編集ができるように
    - 今のところ選択を解除する手段がルーラークリックかノート追加しかないので
- ノートの端の判定を調整
- 色を調整
## 関連 Issue
https://github.com/VOICEVOX/voicevox_project/issues/15
## その他
