### PR TITLE
メモ機能・ルビ機能の記法を全角記号にも対応させた

### DIFF
--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -194,15 +194,19 @@ export function extractYomiText(
 
 function skipRubyReadingPart(text: string): string {
   // テキスト内の全ての{漢字|かんじ}パターンを探し、漢字部分だけを残す
-  return text.replace(/\{([^|]*)\|([^}]*)\}/g, "$1");
+  return text
+    .replace(/\{([^|]*)\|([^}]*)\}/g, "$1")
+    .replace(/｛([^|]*)｜([^}]*)｝/g, "$1");
 }
 function skipRubyWritingPart(text: string): string {
   // テキスト内の全ての{漢字|かんじ}パターンを探し、かんじ部分だけを残す
-  return text.replace(/\{([^|]*)\|([^}]*)\}/g, "$2");
+  return text
+    .replace(/\{([^|]*)\|([^}]*)\}/g, "$2")
+    .replace(/｛([^|]*)｜([^}]*)｝/g, "$2");
 }
 function skipMemoText(targettext: string): string {
   // []をスキップ
-  return targettext.replace(/\[.*?\]/g, "");
+  return targettext.replace(/\[.*?\]/g, "").replace(/［.*?］/g, "");
 }
 
 /**

--- a/tests/unit/store/utility.spec.ts
+++ b/tests/unit/store/utility.spec.ts
@@ -72,95 +72,85 @@ test("currentDateString", () => {
   expect(currentDateString()).toMatch(/\d{4}\d{2}\d{2}/);
 });
 
-describe("extractExportTextとextractYomiText", () => {
-  const memoText = "ダミー]ダミー[メモ]ダミー[ダミー";
-  const rubyText = "ダミー|}ダミー{漢字|読み}ダミー{|ダミー";
-  const fullWidthMemoText = "ダミー］ダミー［メモ］ダミー［ダミー";
-  const fullwidthRubyText = "ダミー｜｝ダミー｛漢字｜読み｝ダミー｛｜ダミー";
+describe.each([
+  // 半角記号
+  {
+    testName: "半角記号",
+    memoText: "ダミー]ダミー[メモ]ダミー[ダミー",
+    rubyText: "ダミー|}ダミー{漢字|読み}ダミー{|ダミー",
+    expectedSkippedMemoText: "ダミー]ダミーダミー[ダミー",
+    expectedSkippedRubyExportText: "ダミー|}ダミー読みダミー{|ダミー",
+    expectedSkippedRubyYomiText: "ダミー|}ダミー漢字ダミー{|ダミー",
+  },
+  // 全角記号
+  {
+    testName: "全角記号",
+    memoText: "ダミー］ダミー［メモ］ダミー［ダミー",
+    rubyText: "ダミー｜｝ダミー｛漢字｜読み｝ダミー｛｜ダミー",
+    expectedSkippedMemoText: "ダミー］ダミーダミー［ダミー",
+    expectedSkippedRubyExportText: "ダミー｜｝ダミー読みダミー｛｜ダミー",
+    expectedSkippedRubyYomiText: "ダミー｜｝ダミー漢字ダミー｛｜ダミー",
+  },
+])(
+  "extractExportTextとextractYomiText $testName",
+  ({
+    memoText,
+    rubyText,
+    expectedSkippedMemoText,
+    expectedSkippedRubyExportText,
+    expectedSkippedRubyYomiText,
+  }) => {
+    const text = memoText + rubyText;
 
-  const text = memoText + rubyText;
-  const fullWidthText = fullWidthMemoText + fullwidthRubyText;
+    it("無指定の場合はそのまま", () => {
+      const param = {
+        enableMemoNotation: false,
+        enableRubyNotation: false,
+      };
+      expect(extractExportText(text, param)).toBe(text);
+      expect(extractYomiText(text, param)).toBe(text);
+    });
 
-  // 半角記号[]{|}を使用した、メモとルビ
-  const expectedSkippedMemoText = "ダミー]ダミーダミー[ダミー";
-  const expectedSkippedRubyExportText = "ダミー|}ダミー読みダミー{|ダミー";
-  const expectedSkippedRubyYomiText = "ダミー|}ダミー漢字ダミー{|ダミー";
+    it("メモをスキップ", () => {
+      const param = {
+        enableMemoNotation: true,
+        enableRubyNotation: false,
+      };
+      expect(extractExportText(text, param)).toBe(
+        expectedSkippedMemoText + rubyText
+      );
+      expect(extractYomiText(text, param)).toBe(
+        expectedSkippedMemoText + rubyText
+      );
+    });
 
-  // 全角記号［］｛｜｝を使用した、メモとルビ
-  const expectedSkippedFullWidthMemoText = "ダミー］ダミーダミー［ダミー";
-  const expectedSkippedFullWidthRubyExportText =
-    "ダミー｜｝ダミー読みダミー｛｜ダミー";
-  const expectedSkippedFullWidthRubyYomiText =
-    "ダミー｜｝ダミー漢字ダミー｛｜ダミー";
+    it("ルビをスキップ", () => {
+      const param = {
+        enableMemoNotation: false,
+        enableRubyNotation: true,
+      };
+      expect(extractExportText(text, param)).toBe(
+        memoText + expectedSkippedRubyYomiText
+      );
+      expect(extractYomiText(text, param)).toBe(
+        memoText + expectedSkippedRubyExportText
+      );
+    });
 
-  it("無指定の場合はそのまま", () => {
-    const param = {
-      enableMemoNotation: false,
-      enableRubyNotation: false,
-    };
-    expect(extractExportText(text, param)).toBe(text);
-    expect(extractYomiText(text, param)).toBe(text);
-    expect(extractExportText(fullWidthText, param)).toBe(fullWidthText);
-    expect(extractYomiText(fullWidthText, param)).toBe(fullWidthText);
-  });
-
-  it("メモをスキップ", () => {
-    const param = {
-      enableMemoNotation: true,
-      enableRubyNotation: false,
-    };
-    expect(extractExportText(text, param)).toBe(
-      expectedSkippedMemoText + rubyText
-    );
-    expect(extractYomiText(text, param)).toBe(
-      expectedSkippedMemoText + rubyText
-    );
-    expect(extractExportText(fullWidthText, param)).toBe(
-      expectedSkippedFullWidthMemoText + fullwidthRubyText
-    );
-    expect(extractYomiText(fullWidthText, param)).toBe(
-      expectedSkippedFullWidthMemoText + fullwidthRubyText
-    );
-  });
-
-  it("ルビをスキップ", () => {
-    const param = {
-      enableMemoNotation: false,
-      enableRubyNotation: true,
-    };
-    expect(extractExportText(text, param)).toBe(
-      memoText + expectedSkippedRubyYomiText
-    );
-    expect(extractYomiText(text, param)).toBe(
-      memoText + expectedSkippedRubyExportText
-    );
-    expect(extractExportText(fullWidthText, param)).toBe(
-      fullWidthMemoText + expectedSkippedFullWidthRubyYomiText
-    );
-    expect(extractYomiText(fullWidthText, param)).toBe(
-      fullWidthMemoText + expectedSkippedFullWidthRubyExportText
-    );
-  });
-
-  it("メモとルビをスキップ", () => {
-    const param = {
-      enableMemoNotation: true,
-      enableRubyNotation: true,
-    };
-    expect(extractExportText(text, param)).toBe(
-      expectedSkippedMemoText + expectedSkippedRubyYomiText
-    );
-    expect(extractYomiText(text, param)).toBe(
-      expectedSkippedMemoText + expectedSkippedRubyExportText
-    );
-    expect(extractExportText(fullWidthText, param)).toBe(
-      expectedSkippedFullWidthMemoText + expectedSkippedFullWidthRubyYomiText
-    );
-    expect(extractYomiText(fullWidthText, param)).toBe(
-      expectedSkippedFullWidthMemoText + expectedSkippedFullWidthRubyExportText
-    );
-  });
-});
+    it("メモとルビをスキップ", () => {
+      const param = {
+        enableMemoNotation: true,
+        enableRubyNotation: true,
+      };
+      expect(extractExportText(text, param)).toBe(
+        expectedSkippedMemoText + expectedSkippedRubyYomiText
+      );
+      expect(extractYomiText(text, param)).toBe(
+        expectedSkippedMemoText + expectedSkippedRubyExportText
+      );
+    });
+  }
+);
 
 describe("TuningTranscription", () => {
   it("２つ以上のアクセント句でも正しくデータを転写できる", async () => {

--- a/tests/unit/store/utility.spec.ts
+++ b/tests/unit/store/utility.spec.ts
@@ -75,12 +75,23 @@ test("currentDateString", () => {
 describe("extractExportTextとextractYomiText", () => {
   const memoText = "ダミー]ダミー[メモ]ダミー[ダミー";
   const rubyText = "ダミー|}ダミー{漢字|読み}ダミー{|ダミー";
+  const fullWidthMemoText = "ダミー］ダミー［メモ］ダミー［ダミー";
+  const fullwidthRubyText = "ダミー｜｝ダミー｛漢字｜読み｝ダミー｛｜ダミー";
 
   const text = memoText + rubyText;
+  const fullWidthText = fullWidthMemoText + fullwidthRubyText;
 
+  // 半角機能を使用した、メモとルビ
   const expectedSkippedMemoText = "ダミー]ダミーダミー[ダミー";
   const expectedSkippedRubyExportText = "ダミー|}ダミー読みダミー{|ダミー";
   const expectedSkippedRubyYomiText = "ダミー|}ダミー漢字ダミー{|ダミー";
+
+  // 全角機能を使用した、メモとルビ
+  const expectedSkippedFullWidthMemoText = "ダミー］ダミーダミー［ダミー";
+  const expectedSkippedFullWidthRubyExportText =
+    "ダミー｜｝ダミー読みダミー｛｜ダミー";
+  const expectedSkippedFullWidthRubyYomiText =
+    "ダミー｜｝ダミー漢字ダミー｛｜ダミー";
 
   it("無指定の場合はそのまま", () => {
     const param = {
@@ -89,6 +100,8 @@ describe("extractExportTextとextractYomiText", () => {
     };
     expect(extractExportText(text, param)).toBe(text);
     expect(extractYomiText(text, param)).toBe(text);
+    expect(extractExportText(fullWidthText, param)).toBe(fullWidthText);
+    expect(extractYomiText(fullWidthText, param)).toBe(fullWidthText);
   });
 
   it("メモをスキップ", () => {
@@ -101,6 +114,12 @@ describe("extractExportTextとextractYomiText", () => {
     );
     expect(extractYomiText(text, param)).toBe(
       expectedSkippedMemoText + rubyText
+    );
+    expect(extractExportText(fullWidthText, param)).toBe(
+      expectedSkippedFullWidthMemoText + fullwidthRubyText
+    );
+    expect(extractYomiText(fullWidthText, param)).toBe(
+      expectedSkippedFullWidthMemoText + fullwidthRubyText
     );
   });
 
@@ -115,6 +134,12 @@ describe("extractExportTextとextractYomiText", () => {
     expect(extractYomiText(text, param)).toBe(
       memoText + expectedSkippedRubyExportText
     );
+    expect(extractExportText(fullWidthText, param)).toBe(
+      fullWidthMemoText + expectedSkippedFullWidthRubyYomiText
+    );
+    expect(extractYomiText(fullWidthText, param)).toBe(
+      fullWidthMemoText + expectedSkippedFullWidthRubyExportText
+    );
   });
 
   it("メモとルビをスキップ", () => {
@@ -127,6 +152,12 @@ describe("extractExportTextとextractYomiText", () => {
     );
     expect(extractYomiText(text, param)).toBe(
       expectedSkippedMemoText + expectedSkippedRubyExportText
+    );
+    expect(extractExportText(fullWidthText, param)).toBe(
+      expectedSkippedFullWidthMemoText + expectedSkippedFullWidthRubyYomiText
+    );
+    expect(extractYomiText(fullWidthText, param)).toBe(
+      expectedSkippedFullWidthMemoText + expectedSkippedFullWidthRubyExportText
     );
   });
 });

--- a/tests/unit/store/utility.spec.ts
+++ b/tests/unit/store/utility.spec.ts
@@ -81,12 +81,12 @@ describe("extractExportTextとextractYomiText", () => {
   const text = memoText + rubyText;
   const fullWidthText = fullWidthMemoText + fullwidthRubyText;
 
-  // 半角機能を使用した、メモとルビ
+  // 半角記号[]{|}を使用した、メモとルビ
   const expectedSkippedMemoText = "ダミー]ダミーダミー[ダミー";
   const expectedSkippedRubyExportText = "ダミー|}ダミー読みダミー{|ダミー";
   const expectedSkippedRubyYomiText = "ダミー|}ダミー漢字ダミー{|ダミー";
 
-  // 全角機能を使用した、メモとルビ
+  // 全角記号［］｛｜｝を使用した、メモとルビ
   const expectedSkippedFullWidthMemoText = "ダミー］ダミーダミー［ダミー";
   const expectedSkippedFullWidthRubyExportText =
     "ダミー｜｝ダミー読みダミー｛｜ダミー";


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

メモとルビを全角記号`［］,｛｜｝`を使って記述できるようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

close #1699 
