### PR TITLE
アップデート通知周りのUIと実装調整

### DIFF
--- a/src/components/PresetManageDialog.vue
+++ b/src/components/PresetManageDialog.vue
@@ -121,7 +121,7 @@ const deletePreset = async (key: PresetKey) => {
 };
 </script>
 
-<style>
+<style scoped lang="scss">
 .dialog-card {
   width: 700px;
   max-width: 80vw;

--- a/src/components/UpdateNotificationDialog.vue
+++ b/src/components/UpdateNotificationDialog.vue
@@ -117,11 +117,6 @@ const openOfficialWebsite = () => {
       font-weight: bold;
       margin: 0;
     }
-    h4 {
-      font-size: 1.1rem;
-      font-weight: bold;
-      margin: 0;
-    }
   }
 }
 </style>

--- a/src/components/UpdateNotificationDialog.vue
+++ b/src/components/UpdateNotificationDialog.vue
@@ -1,23 +1,21 @@
 <template>
   <q-dialog v-model="modelValueComputed">
-    <q-card class="q-py-sm q-px-md">
-      <q-card-section class="q-pb-sm" align="center">
-        <div class="text-h6">
-          <q-icon name="info" color="primary" />アップデート通知
-        </div>
-      </q-card-section>
-      <q-card-section class="q-pt-sm" align="center">
-        <div class="text-body1">
-          最新バージョン {{ props.latestVersion }} が利用可能です。<br />
+    <q-card class="q-py-sm q-px-md dialog-card">
+      <q-card-section>
+        <div class="text-h5">アップデートのお知らせ</div>
+        <div class="text-body2 text-grey-8">
           公式サイトから最新バージョンをダウンロードできます。
         </div>
       </q-card-section>
-      <q-card-section class="q-py-none scrollable-area">
+
+      <q-separator />
+
+      <q-card-section class="q-py-none scroll scrollable-area">
         <template
           v-for="(info, infoIndex) of props.newUpdateInfos"
           :key="infoIndex"
         >
-          <div class="text-h6">バージョン {{ info.version }}</div>
+          <h3>バージョン {{ info.version }}</h3>
           <ul>
             <template
               v-for="(item, descriptionIndex) of info.descriptions"
@@ -28,7 +26,10 @@
           </ul>
         </template>
       </q-card-section>
-      <q-card-actions class="button-area">
+
+      <q-separator />
+
+      <q-card-actions>
         <q-space />
         <q-btn
           padding="xs md"
@@ -101,21 +102,26 @@ const openOfficialWebsite = () => {
 <style scoped lang="scss">
 @use '@/styles/colors' as colors;
 
+.dialog-card {
+  width: 700px;
+  max-width: 80vw;
+}
+
 .scrollable-area {
   overflow-y: auto;
-  max-height: 250px;
-}
+  max-height: 50vh;
 
-.scrollable-area h5 {
-  margin: 10px 0;
-}
-
-.scrollable-area h6 {
-  margin: 15px 0;
-}
-
-.button-area {
-  border-top: 1px solid colors.$splitter;
-  /* ボタン領域の上部に線を引く */
+  :deep() {
+    h3 {
+      font-size: 1.3rem;
+      font-weight: bold;
+      margin: 0;
+    }
+    h4 {
+      font-size: 1.1rem;
+      font-weight: bold;
+      margin: 0;
+    }
+  }
 }
 </style>

--- a/src/components/UpdateNotificationDialog.vue
+++ b/src/components/UpdateNotificationDialog.vue
@@ -29,22 +29,25 @@
         </template>
       </q-card-section>
       <q-card-actions class="button-area">
-        <q-checkbox
-          v-model="skipThisVersion"
-          size="xs"
-          dense
-          label="このバージョンをスキップ"
-        />
         <q-space />
         <q-btn
           padding="xs md"
-          label="キャンセル"
+          label="閉じる"
+          unelevated
+          color="surface"
+          text-color="display"
+          class="q-mt-sm"
+          @click="closeUpdateNotificationDialog()"
+        />
+        <q-btn
+          padding="xs md"
+          label="このバージョンをスキップ"
           unelevated
           color="surface"
           text-color="display"
           class="q-mt-sm"
           @click="
-            setSkipVersion();
+            onSkipThisVersionClick(props.latestVersion);
             closeUpdateNotificationDialog();
           "
         />
@@ -66,7 +69,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { UpdateInfo } from "@/type/preload";
 
 const props =
@@ -74,20 +77,12 @@ const props =
     modelValue: boolean;
     latestVersion: string;
     newUpdateInfos: UpdateInfo[];
+    onSkipThisVersionClick: (version: string) => void;
   }>();
 const emit =
   defineEmits<{
     (e: "update:modelValue", value: boolean): void;
   }>();
-
-const skipThisVersion = ref<boolean>(false);
-
-const setSkipVersion = () => {
-  if (skipThisVersion.value) {
-    // FIXME: window.electronを直に呼ばないようにする
-    window.electron.setSetting("skipUpdateVersion", props.latestVersion);
-  }
-};
 
 const modelValueComputed = computed({
   get: () => props.modelValue,

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -45,6 +45,7 @@ export const settingStoreState: SettingStoreState = {
   editorFont: "default",
   showTextLineNumber: false,
   showAddAudioItemButton: true,
+  acceptTerms: "Unconfirmed",
   acceptRetrieveTelemetry: "Unconfirmed",
   experimentalSetting: {
     enablePreset: false,
@@ -144,6 +145,7 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         "enableMultiEngine",
         "enableRubyNotation",
         "enableMemoNotation",
+        "skipUpdateVersion",
       ] as const;
 
       // rootMiscSettingKeysに値を足し忘れていたときに型エラーを出す検出用コード

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1038,6 +1038,7 @@ export type SettingStoreState = {
   engineInfos: Record<EngineId, EngineInfo>;
   engineManifests: Record<EngineId, EngineManifest>;
   themeSetting: ThemeSetting;
+  acceptTerms: AcceptTermsStatus;
   acceptRetrieveTelemetry: AcceptRetrieveTelemetryStatus;
   experimentalSetting: ExperimentalSettingType;
   confirmedTips: ConfirmedTips;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -523,6 +523,7 @@ export const rootMiscSettingSchema = z.object({
   enableMultiEngine: z.boolean().default(false),
   enableMemoNotation: z.boolean().default(false), // メモ記法を有効にするか
   enableRubyNotation: z.boolean().default(false), // ルビ記法を有効にするか
+  skipUpdateVersion: z.string().optional(), // アップデートをスキップしたバージョン
 });
 export type RootMiscSettingType = z.infer<typeof rootMiscSettingSchema>;
 
@@ -606,7 +607,6 @@ export const configSchema = z
       .default({}),
     registeredEngineDirs: z.string().array().default([]),
     recentlyUsedProjects: z.string().array().default([]),
-    skipUpdateVersion: z.string().default(""), // FIXME: undefinedにする・rootMiscSettingSchemaに移す
   })
   .merge(rootMiscSettingSchema);
 export type ConfigType = z.infer<typeof configSchema>;

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -667,7 +667,7 @@ onMounted(async () => {
   if (newUpdateResult.value.status === "updateAvailable") {
     const skipUpdateVersion = store.state.skipUpdateVersion ?? "0.0.0";
     if (semver.valid(skipUpdateVersion) == undefined) {
-      // 問題だけど処理を止めるほどではないので警告だけ
+      // 処理を止めるほどではないので警告だけ
       store.dispatch(
         "LOG_WARN",
         `skipUpdateVersionが不正です: ${skipUpdateVersion}`

--- a/src/views/EditorHome.vue
+++ b/src/views/EditorHome.vue
@@ -182,6 +182,7 @@
     v-model="isUpdateNotificationDialogOpenComputed"
     :latest-version="newUpdateResult.latestVersion"
     :new-update-infos="newUpdateResult.newUpdateInfos"
+    @skip-this-version-click="handleSkipThisVersionClick"
   />
 </template>
 
@@ -562,6 +563,12 @@ const newUpdateResult = useFetchNewUpdateInfos(
   () => window.electron.getAppInfos().then((obj) => obj.version), // アプリのバージョン
   import.meta.env.VITE_LATEST_UPDATE_INFOS_URL
 );
+const handleSkipThisVersionClick = (version: string) => {
+  store.dispatch("SET_ROOT_MISC_SETTING", {
+    key: "skipUpdateVersion",
+    value: version,
+  });
+};
 
 // ソフトウェアを初期化
 const isCompletedInitialStartup = ref(false);
@@ -638,6 +645,17 @@ onMounted(async () => {
     document.addEventListener("keyup", item);
   });
 
+  // 設定の読み込みを待機する
+  // FIXME: 設定が必要な処理はINIT_VUEXを実行しているApp.vueで行うべき
+  let vuexReadyTimeout = 0;
+  while (!store.state.isVuexReady) {
+    if (vuexReadyTimeout >= 15000) {
+      throw new Error("Vuexが準備できませんでした");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    vuexReadyTimeout += 300;
+  }
+
   isAcceptRetrieveTelemetryDialogOpenComputed.value =
     store.state.acceptRetrieveTelemetry === "Unconfirmed";
 
@@ -645,12 +663,16 @@ onMounted(async () => {
     import.meta.env.MODE !== "development" &&
     store.state.acceptTerms !== "Accepted";
 
+  // アップデート通知ダイアログ
   if (newUpdateResult.value.status === "updateAvailable") {
-    const skipUpdateVersion = await window.electron.getSetting(
-      "skipUpdateVersion"
-    );
-    if (
-      semver.valid(skipUpdateVersion) == undefined ||
+    const skipUpdateVersion = store.state.skipUpdateVersion ?? "0.0.0";
+    if (semver.valid(skipUpdateVersion) == undefined) {
+      // 問題だけど処理を止めるほどではないので警告だけ
+      store.dispatch(
+        "LOG_WARN",
+        `skipUpdateVersionが不正です: ${skipUpdateVersion}`
+      );
+    } else if (
       semver.gt(newUpdateResult.value.latestVersion, skipUpdateVersion)
     ) {
       isUpdateNotificationDialogOpenComputed.value = true;


### PR DESCRIPTION
## 内容

0.15アプデに向けて、アップデート通知周りの実装を調整しつつ、UIを他のダイアログと混ざる感じにしてみました。

* 「このバージョンをスキップ」をチェックボックスからボタンに変更
* skipUpdateVersionを直に変更する形からVuexを介するように

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/1708


## スクリーンショット・動画など

こんな感じになりました。
<img src="https://github.com/VOICEVOX/voicevox/assets/4987327/0bcfbddf-9815-4196-80da-775663e43ed8" width="600" />

## その他

色々と試したりしてたら3時間ぐらいかかったけど、コードの変更行数が少なくて絶望しました。。