### PR TITLE
[project-s] レンダリングできなかったときの表示を修正

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -331,6 +331,7 @@ export default defineComponent({
     let dragStartNoteNumber = 0;
     let dragStartGuideLineTicks = 0;
     let draggingNoteId = ""; // FIXME: 無効状態はstring以外の型にする
+    let executePreviewProcess = false;
     let edited = false; // プレビュー終了時にScoreの変更を行うかどうかを表す変数
     // ダブルクリック
     let mouseDownNoteId: string | undefined;
@@ -518,17 +519,20 @@ export default defineComponent({
     };
 
     const preview = () => {
-      if (previewMode === "ADD") {
-        previewAdd();
-      }
-      if (previewMode === "MOVE") {
-        previewMove();
-      }
-      if (previewMode === "RESIZE_RIGHT") {
-        previewResizeRight();
-      }
-      if (previewMode === "RESIZE_LEFT") {
-        previewResizeLeft();
+      if (executePreviewProcess) {
+        if (previewMode === "ADD") {
+          previewAdd();
+        }
+        if (previewMode === "MOVE") {
+          previewMove();
+        }
+        if (previewMode === "RESIZE_RIGHT") {
+          previewResizeRight();
+        }
+        if (previewMode === "RESIZE_LEFT") {
+          previewResizeLeft();
+        }
+        executePreviewProcess = false;
       }
       previewRequestId = requestAnimationFrame(preview);
     };
@@ -628,6 +632,7 @@ export default defineComponent({
       dragStartNoteNumber = cursorNoteNumber;
       dragStartGuideLineTicks = guideLineTicks;
       draggingNoteId = note.id;
+      executePreviewProcess = true;
       edited = mode === "ADD";
       copiedNotesForPreview.clear();
       for (const copiedNote of copiedNotes) {
@@ -706,7 +711,9 @@ export default defineComponent({
       cursorX = getXInBorderBox(event.clientX, sequencerBodyElement);
       cursorY = getYInBorderBox(event.clientY, sequencerBodyElement);
 
-      if (!nowPreviewing.value) {
+      if (nowPreviewing.value) {
+        executePreviewProcess = true;
+      } else {
         const scrollLeft = sequencerBodyElement.scrollLeft;
         const cursorBaseX = (scrollLeft + cursorX) / zoomX.value;
         const cursorTicks = baseXToTick(cursorBaseX, tpqn.value);


### PR DESCRIPTION
## 内容
レンダリングできなかった（クエリのフェッチ・音声合成に失敗した）フレーズがレンダリング中の表示のままにならないように（赤く表示されるように）します。
また、プレビュー処理が毎フレーム実行されるようになっているので、マウスカーソルが動いたときにプレビュー処理が実行されるようにします。
## 関連 Issue
VOICEVOX/voicevox_project#15
## その他