### PR TITLE
[release-0.15] macOSのatributeからバージョン名が抜けているのを解決

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
             compressed_artifact_name: voicevox-macos-cpu
             app_asar_dir: prepackage/VOICEVOX.app/Contents/Resources
             installer_artifact_name: macos-cpu-dmg
-            macos_artifact_name: "VOICEVOX.${ext}"
+            macos_artifact_name: "VOICEVOX ${version}.${ext}"
             os: macos-11
 
     runs-on: ${{ matrix.os }}

--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -2,9 +2,9 @@
 
 ## 動作環境・仕様に関する質問
 
-## Q. 動作環境を教えてください
+### Q. 動作環境を教えてください
 
-### CPU 版
+#### CPU 版
 
 Windows／Mac／Linux 搭載の PC に対応しています。
 
@@ -12,7 +12,7 @@ Windows／Mac／Linux 搭載の PC に対応しています。
 ※Mac：macOS Catalina 以降  
 ※Linux：Ubuntu 20.04
 
-### GPU 版
+#### GPU 版
 
 DirectML 対応の GPU を搭載した Windows PC と、Nvidia 製 GPU 搭載の Linux PC に対応しています。
 


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/1736

の解決です。
release-0.15に含めていますが、この後mainブランチにも導入予定です。

ついでにQ&Aのところで段落ミスがあったので修正します。