### PR TITLE
[project-s] エンジン起動をApp.vueに移管

### DIFF
--- a/docs/res/起動シーケンス図.md
+++ b/docs/res/起動シーケンス図.md
@@ -2,54 +2,54 @@
 
 ```mermaid
 flowchart
-  174170["back.installVvppEngineWithWarning"] --> 786961["back.installVvppEngine"]
-  764022["（画面読み込み）"] --> 698565["App.vue"]
-  764022 --> 332024["EditorHome.vue"]
-  733212["back.createWindow"] -.-> 764022
-  448821>"アプリ停止中"] -.-> 430173["app.ready"]
-  style 448821 fill:#ffbbbb,stroke:#ff0000
-  430173 -->|"ある"| 174170
-  430173 -->|"ない"| 389651["back.start"]
-  698565 -.-> 704891>"アプリ実行中"]
-  style 704891 fill:#bbbbff,stroke:#0000ff
-  332024 -.-> 704891
-  786961 --> 389651
-  subgraph 332024["EditorHome.vue"]
-    709863["Vuex.GET_ENGINE_INFOS"] --> 773040["Vuex.POST_ENGINE_START"]
-    subgraph 773040["Vuex.POST_ENGINE_START"]
-      970396["get ALT_PORT_INFOS"] --> 467527["各エンジン"]
-      subgraph 467527["各エンジン"]
-        592206["Vuex.START_WAITING_ENGINE"] --> 799767["Vuex.FETCH_AND_SET_ENGINE_MANIFEST"]
-      end
-    end
-    subgraph 709863["Vuex.GET_ENGINE_INFOS"]
-      807081["back.get ENGINE_INFOS"] --> 423649["Vuex.set engineInfos"]
-      423649 --> 623418["Vuex.set engineIds"]
-    end
-  end
-  subgraph 389651["back.start"]
-    967432["engine.runEngineAll"] --> 733212
-    subgraph 733212["back.createWindow"]
-      613440["win.loadURL"]
-    end
-    subgraph 548965["launchEngines"]
-      250263["store.get engineSettings"] --> 222321["store.set engineSettings"]
-      870482["store.get registeredEngineDirs"] --> 250263
-      222321 --> 967432
-      656570["engine.fetchEngineInfos"] --> 870482
-      110954["engine.initializeEngineInfosAndAltPortInfo"] --> 656570
-      subgraph 656570["engine.fetchEngineInfos"]
-        267019["engine.fetchAdditionalEngineInfos"]
-      end
-    end
-  end
-  subgraph 430173["app.ready"]
-    546251{{"VVPPファイルがあるか"}}
-  end
-  subgraph 698565["App.vue"]
-    646647["Vuex.INIT_VUEX"] --> 632374["back.ON_VUEX_READY"]
-    subgraph 632374["back.ON_VUEX_READY"]
-      225701["win.show"]
-    end
-  end
+	174170["back.installVvppEngineWithWarning"] --> 786961["back.installVvppEngine"]
+	764022["（画面読み込み）"] --> 698565["App.vue"]
+	733212["back.createWindow"] -.-> 764022
+	448821>"アプリ停止中"] -.-> 430173["app.ready"]
+	style 448821 fill:#ffbbbb,stroke:#ff0000
+	430173 -->|"ある"| 174170
+	430173 -->|"ない"| 389651["back.start"]
+	332024["EditorHome.vue"] -.-> 704891>"アプリ実行中"]
+	style 704891 fill:#bbbbff,stroke:#0000ff
+	786961 --> 389651
+	698565 --> 332024
+	subgraph 332024["EditorHome.vue"]
+	end
+	subgraph 389651["back.start"]
+		967432["engine.runEngineAll"] --> 733212
+		subgraph 733212["back.createWindow"]
+			613440["win.loadURL"]
+		end
+		subgraph 548965["launchEngines"]
+			250263["store.get engineSettings"] --> 222321["store.set engineSettings"]
+			870482["store.get registeredEngineDirs"] --> 250263
+			222321 --> 967432
+			656570["engine.fetchEngineInfos"] --> 870482
+			110954["engine.initializeEngineInfosAndAltPortInfo"] --> 656570
+			subgraph 656570["engine.fetchEngineInfos"]
+				267019["engine.fetchAdditionalEngineInfos"]
+			end
+		end
+	end
+	subgraph 430173["app.ready"]
+		546251{{"VVPPファイルがあるか"}}
+	end
+	subgraph 698565["App.vue"]
+		709863["Vuex.GET_ENGINE_INFOS"] --> 773040["Vuex.POST_ENGINE_START"]
+		646647["Vuex.INIT_VUEX"] --> 632374["back.ON_VUEX_READY"]
+		632374 --> 709863
+		subgraph 632374["back.ON_VUEX_READY"]
+			225701["win.show"]
+		end
+		subgraph 709863["Vuex.GET_ENGINE_INFOS"]
+			807081["back.get ENGINE_INFOS"] --> 423649["Vuex.set engineInfos"]
+			423649 --> 623418["Vuex.set engineIds"]
+		end
+		subgraph 773040["Vuex.POST_ENGINE_START"]
+			970396["get ALT_PORT_INFOS"] --> 467527["各エンジン"]
+			subgraph 467527["各エンジン"]
+				592206["Vuex.START_WAITING_ENGINE"] --> 799767["Vuex.FETCH_AND_SET_ENGINE_MANIFEST"]
+			end
+		end
+	end
 ```

--- a/docs/res/起動シーケンス図.md
+++ b/docs/res/起動シーケンス図.md
@@ -2,54 +2,54 @@
 
 ```mermaid
 flowchart
-	174170["back.installVvppEngineWithWarning"] --> 786961["back.installVvppEngine"]
-	764022["（画面読み込み）"] --> 698565["App.vue"]
-	733212["back.createWindow"] -.-> 764022
-	448821>"アプリ停止中"] -.-> 430173["app.ready"]
-	style 448821 fill:#ffbbbb,stroke:#ff0000
-	430173 -->|"ある"| 174170
-	430173 -->|"ない"| 389651["back.start"]
-	332024["EditorHome.vue"] -.-> 704891>"アプリ実行中"]
-	style 704891 fill:#bbbbff,stroke:#0000ff
-	786961 --> 389651
-	698565 --> 332024
-	subgraph 332024["EditorHome.vue"]
-	end
-	subgraph 389651["back.start"]
-		967432["engine.runEngineAll"] --> 733212
-		subgraph 733212["back.createWindow"]
-			613440["win.loadURL"]
-		end
-		subgraph 548965["launchEngines"]
-			250263["store.get engineSettings"] --> 222321["store.set engineSettings"]
-			870482["store.get registeredEngineDirs"] --> 250263
-			222321 --> 967432
-			656570["engine.fetchEngineInfos"] --> 870482
-			110954["engine.initializeEngineInfosAndAltPortInfo"] --> 656570
-			subgraph 656570["engine.fetchEngineInfos"]
-				267019["engine.fetchAdditionalEngineInfos"]
-			end
-		end
-	end
-	subgraph 430173["app.ready"]
-		546251{{"VVPPファイルがあるか"}}
-	end
-	subgraph 698565["App.vue"]
-		709863["Vuex.GET_ENGINE_INFOS"] --> 773040["Vuex.POST_ENGINE_START"]
-		646647["Vuex.INIT_VUEX"] --> 632374["back.ON_VUEX_READY"]
-		632374 --> 709863
-		subgraph 632374["back.ON_VUEX_READY"]
-			225701["win.show"]
-		end
-		subgraph 709863["Vuex.GET_ENGINE_INFOS"]
-			807081["back.get ENGINE_INFOS"] --> 423649["Vuex.set engineInfos"]
-			423649 --> 623418["Vuex.set engineIds"]
-		end
-		subgraph 773040["Vuex.POST_ENGINE_START"]
-			970396["get ALT_PORT_INFOS"] --> 467527["各エンジン"]
-			subgraph 467527["各エンジン"]
-				592206["Vuex.START_WAITING_ENGINE"] --> 799767["Vuex.FETCH_AND_SET_ENGINE_MANIFEST"]
-			end
-		end
-	end
+  174170["back.installVvppEngineWithWarning"] --> 786961["back.installVvppEngine"]
+  764022["（画面読み込み）"] --> 698565["App.vue"]
+  733212["back.createWindow"] -.-> 764022
+  448821>"アプリ停止中"] -.-> 430173["app.ready"]
+  style 448821 fill:#ffbbbb,stroke:#ff0000
+  430173 -->|"ある"| 174170
+  430173 -->|"ない"| 389651["back.start"]
+  332024["EditorHome.vue"] -.-> 704891>"アプリ実行中"]
+  style 704891 fill:#bbbbff,stroke:#0000ff
+  786961 --> 389651
+  698565 --> 332024
+  subgraph 332024["EditorHome.vue"]
+  end
+  subgraph 389651["back.start"]
+    967432["engine.runEngineAll"] --> 733212
+    subgraph 733212["back.createWindow"]
+      613440["win.loadURL"]
+    end
+    subgraph 548965["launchEngines"]
+      250263["store.get engineSettings"] --> 222321["store.set engineSettings"]
+      870482["store.get registeredEngineDirs"] --> 250263
+      222321 --> 967432
+      656570["engine.fetchEngineInfos"] --> 870482
+      110954["engine.initializeEngineInfosAndAltPortInfo"] --> 656570
+      subgraph 656570["engine.fetchEngineInfos"]
+        267019["engine.fetchAdditionalEngineInfos"]
+      end
+    end
+  end
+  subgraph 430173["app.ready"]
+    546251{{"VVPPファイルがあるか"}}
+  end
+  subgraph 698565["App.vue"]
+    709863["Vuex.GET_ENGINE_INFOS"] --> 773040["Vuex.POST_ENGINE_START"]
+    646647["Vuex.INIT_VUEX"] --> 632374["back.ON_VUEX_READY"]
+    632374 --> 709863
+    subgraph 632374["back.ON_VUEX_READY"]
+      225701["win.show"]
+    end
+    subgraph 709863["Vuex.GET_ENGINE_INFOS"]
+      807081["back.get ENGINE_INFOS"] --> 423649["Vuex.set engineInfos"]
+      423649 --> 623418["Vuex.set engineIds"]
+    end
+    subgraph 773040["Vuex.POST_ENGINE_START"]
+      970396["get ALT_PORT_INFOS"] --> 467527["各エンジン"]
+      subgraph 467527["各エンジン"]
+        592206["Vuex.START_WAITING_ENGINE"] --> 799767["Vuex.FETCH_AND_SET_ENGINE_MANIFEST"]
+      end
+    end
+  end
 ```

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <error-boundary>
     <!-- TODO: メニューバーをEditorHomeから移動する -->
-    <router-view v-if="isVuexReady" v-slot="{ Component }">
+    <router-view v-slot="{ Component }">
       <keep-alive>
         <component
           :is="Component"
@@ -49,10 +49,9 @@ watch(
 );
 
 // ソフトウェアを初期化
-const isVuexReady = ref(false);
 const isEnginesReady = ref(false);
 onMounted(async () => {
-  const initVuexPromise = store.dispatch("INIT_VUEX");
+  await store.dispatch("INIT_VUEX");
 
   // Electronのデフォルトのundo/redoを無効化
   const disableDefaultUndoRedo = (event: KeyboardEvent) => {
@@ -83,9 +82,6 @@ onMounted(async () => {
       element.classList.contains("q-item")
     );
   };
-
-  await initVuexPromise;
-  isVuexReady.value = true;
 
   // エンジンの初期化開始
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,7 +6,6 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: "/home",
     component: EditorHome,
-    props: (route) => ({ projectFilePath: route.query["projectFilePath"] }),
   },
   {
     path: "/singer-home",


### PR DESCRIPTION
## 内容

エンジン起動をEditorHomeからApp.vueに移管します。
あとはメニューバーの移管して、切り替えをメニューバーへ移動させたらmainにマージしても大丈夫なはず！

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/issues/15
- https://github.com/VOICEVOX/voicevox/issues/1745


## その他

どなたか見てほしいけど難しそう。ちょっと時間おいてえいやでマージしようと思います。
