### PR TITLE
[project-s] シーケンサーのスクロール・編集周りを調整

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -364,10 +364,10 @@ export default defineComponent({
       if (!draggingNote) {
         throw new Error("draggingNote is undefined.");
       }
-      const noteEndPos = draggingNote.position + draggingNote.duration;
-      const newNoteEndPos =
-        Math.round(cursorTicks / snapTicks.value) * snapTicks.value;
-      const movingTicks = newNoteEndPos - noteEndPos;
+      const dragTicks = cursorTicks - dragStartTicks;
+      const noteDuration =
+        Math.round(dragTicks / snapTicks.value) * snapTicks.value;
+      const noteEndPos = draggingNote.position + noteDuration;
 
       const editedNotes = new Map<string, Note>();
       for (const note of previewNotes.value) {
@@ -375,12 +375,7 @@ export default defineComponent({
         if (!copiedNote) {
           throw new Error("copiedNote is undefined.");
         }
-        const notePos = copiedNote.position;
-        const noteEndPos = copiedNote.position + copiedNote.duration;
-        const duration = Math.max(
-          snapTicks.value,
-          noteEndPos + movingTicks - notePos
-        );
+        const duration = Math.max(snapTicks.value, noteDuration);
         if (note.duration !== duration) {
           editedNotes.set(note.id, { ...note, duration });
         }
@@ -391,7 +386,7 @@ export default defineComponent({
         });
       }
 
-      const guideLineBaseX = tickToBaseX(newNoteEndPos, tpqn.value);
+      const guideLineBaseX = tickToBaseX(noteEndPos, tpqn.value);
       guideLineX.value = guideLineBaseX * zoomX.value;
     };
 

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -354,8 +354,6 @@ export default defineComponent({
     // 入力を補助する線
     const showGuideLine = ref(true);
     const guideLineX = ref(0);
-    // 最初のonActivatedか判断するためのフラグ
-    let firstActivation = true;
 
     const previewAdd = () => {
       const cursorBaseX = (scrollX.value + cursorX) / zoomX.value;
@@ -996,6 +994,8 @@ export default defineComponent({
       }
     };
 
+    // 最初のonActivatedか判断するためのフラグ
+    let firstActivation = true;
     onActivated(() => {
       const sequencerBodyElement = sequencerBody.value;
       if (!sequencerBodyElement) {

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -183,7 +183,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, onMounted, onUnmounted } from "vue";
+import {
+  defineComponent,
+  computed,
+  ref,
+  onActivated,
+  onDeactivated,
+  nextTick,
+} from "vue";
 import { v4 as uuidv4 } from "uuid";
 import { useStore } from "@/store";
 import { Note } from "@/store/type";
@@ -347,6 +354,8 @@ export default defineComponent({
     // 入力を補助する線
     const showGuideLine = ref(true);
     const guideLineX = ref(0);
+    // 最初のonActivatedか判断するためのフラグ
+    let firstActivation = true;
 
     const previewAdd = () => {
       const cursorBaseX = (scrollX.value + cursorX) / zoomX.value;
@@ -992,22 +1001,37 @@ export default defineComponent({
       }
     };
 
-    onMounted(() => {
+    onActivated(() => {
       const sequencerBodyElement = sequencerBody.value;
       if (!sequencerBodyElement) {
         throw new Error("sequencerBodyElement is null.");
       }
-      // 上から2/3の位置がC4になるようにスクロールする
-      const clientHeight = sequencerBodyElement.clientHeight;
-      const c4BaseY = noteNumberToBaseY(60);
-      const clientBaseHeight = clientHeight / zoomY.value;
-      const scrollBaseY = c4BaseY - clientBaseHeight * (2 / 3);
-      sequencerBodyElement.scrollTo(0, scrollBaseY * zoomY.value);
 
-      // スクロールバーの幅を取得する
-      const clientWidth = sequencerBodyElement.clientWidth;
-      const offsetWidth = sequencerBodyElement.offsetWidth;
-      scrollBarWidth.value = offsetWidth - clientWidth;
+      let xToScroll = 0;
+      let yToScroll = 0;
+      if (firstActivation) {
+        // スクロール位置を設定（C4が上から2/3の位置になるようにする）
+        const clientHeight = sequencerBodyElement.clientHeight;
+        const c4BaseY = noteNumberToBaseY(60);
+        const clientBaseHeight = clientHeight / zoomY.value;
+        const scrollBaseY = c4BaseY - clientBaseHeight * (2 / 3);
+        xToScroll = 0;
+        yToScroll = scrollBaseY * zoomY.value;
+
+        // スクロールバーの幅を取得する
+        const clientWidth = sequencerBodyElement.clientWidth;
+        const offsetWidth = sequencerBodyElement.offsetWidth;
+        scrollBarWidth.value = offsetWidth - clientWidth;
+
+        firstActivation = false;
+      } else {
+        xToScroll = scrollX.value;
+        yToScroll = scrollY.value;
+      }
+      // 実際にスクロールする
+      nextTick().then(() => {
+        sequencerBodyElement.scrollTo(xToScroll, yToScroll);
+      });
 
       store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
         listener: playheadPositionChangeListener,
@@ -1016,7 +1040,7 @@ export default defineComponent({
       document.addEventListener("keydown", handleKeydown);
     });
 
-    onUnmounted(() => {
+    onDeactivated(() => {
       store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
         listener: playheadPositionChangeListener,
       });

--- a/src/infrastructures/AudioRenderer.ts
+++ b/src/infrastructures/AudioRenderer.ts
@@ -784,19 +784,19 @@ export class PolySynth implements Instrument {
       type: "square",
     };
     this.filterParams = options?.filter ?? {
-      cutoff: 3000,
+      cutoff: 2500,
       resonance: 0,
-      keyTrack: 0.26,
+      keyTrack: 0.25,
     };
     this.ampParams = options?.amp ?? {
       attack: 0.001,
       decay: 0.18,
-      sustain: 0.4,
+      sustain: 0.5,
       release: 0.02,
     };
 
     this.gainNode = new GainNode(this.audioContext);
-    this.gainNode.gain.value = options?.volume ?? 0.11;
+    this.gainNode.gain.value = options?.volume ?? 0.1;
   }
 
   /**

--- a/src/sing/viewHelper.ts
+++ b/src/sing/viewHelper.ts
@@ -7,7 +7,7 @@ export const ZOOM_X_STEP = 0.05;
 export const ZOOM_Y_MIN = 0.35;
 export const ZOOM_Y_MAX = 1;
 export const ZOOM_Y_STEP = 0.05;
-export const PREVIEW_SOUND_DURATION = 0.1;
+export const PREVIEW_SOUND_DURATION = 0.15;
 
 export function getKeyBaseHeight() {
   return BASE_Y_PER_SEMITONE;


### PR DESCRIPTION
## 内容
以下を行います。
- トーク・ソング切り替えでスクロール位置が変わらないようにする
- トーク・ソング切り替え時にイベントリスナーの追加・削除を行う
  - `onMounted`・`onUnmounted`から`onActivated`・`onDeactivated`に変更
- ノート追加のプレビュー（ノートの長さの設定）では、カーソル位置ではなくドラッグ量で判定を行うように変更
  - カーソル位置で判定だとグリッド・ノートを見る（判定を確認する）必要がある
  - ドラッグ量で判定だとグリッド・ノートを見ずに感覚（マウスの移動量）でノートの長さを設定できる
- シンセの音を調整
## 関連 Issue
VOICEVOX/voicevox_project#15
## その他