### PR TITLE
`store/audio.ts`から音声を生成する部分を分離

### DIFF
--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -253,6 +253,7 @@ import { computed, ref, watch } from "vue";
 import { QInput } from "quasar";
 import AudioAccent from "@/components/Talk/AudioAccent.vue";
 import { useStore } from "@/store";
+import type { FetchAudioResult } from "@/store/type";
 import { AccentPhrase, UserDictWord } from "@/openapi";
 import {
   convertHiraToKana,
@@ -448,9 +449,9 @@ const play = async () => {
 
   audioItem.query.accentPhrases = [accentPhrase.value];
 
-  let blob: Blob;
+  let fetchAudioResult: FetchAudioResult;
   try {
-    blob = await store.dispatch("FETCH_AUDIO_FROM_AUDIO_ITEM", {
+    fetchAudioResult = await store.dispatch("FETCH_AUDIO_FROM_AUDIO_ITEM", {
       audioItem,
     });
   } catch (e) {
@@ -463,6 +464,7 @@ const play = async () => {
     return;
   }
 
+  const { blob } = fetchAudioResult;
   nowGenerating.value = false;
   nowPlaying.value = true;
   await store.dispatch("PLAY_AUDIO_BLOB", { audioBlob: blob });

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -448,26 +448,21 @@ const play = async () => {
 
   audioItem.query.accentPhrases = [accentPhrase.value];
 
-  let blob = await store.dispatch("GET_AUDIO_CACHE_FROM_AUDIO_ITEM", {
-    audioItem,
-  });
-  if (!blob) {
-    try {
-      blob = await createUILockAction(
-        store.dispatch("GENERATE_AUDIO_FROM_AUDIO_ITEM", {
-          audioItem,
-        })
-      );
-    } catch (e) {
-      window.electron.logError(e);
-      nowGenerating.value = false;
-      store.dispatch("SHOW_ALERT_DIALOG", {
-        title: "生成に失敗しました",
-        message: "エンジンの再起動をお試しください。",
-      });
-      return;
-    }
+  let blob: Blob;
+  try {
+    blob = await store.dispatch("FETCH_AUDIO_FROM_AUDIO_ITEM", {
+      audioItem,
+    });
+  } catch (e) {
+    window.electron.logError(e);
+    nowGenerating.value = false;
+    store.dispatch("SHOW_ALERT_DIALOG", {
+      title: "生成に失敗しました",
+      message: "エンジンの再起動をお試しください。",
+    });
+    return;
   }
+
   nowGenerating.value = false;
   nowPlaying.value = true;
   await store.dispatch("PLAY_AUDIO_BLOB", { audioBlob: blob });

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -33,6 +33,7 @@ import {
   ToolbarButtonTagType,
 } from "@/type/preload";
 import { getToolbarButtonName } from "@/store/utility";
+import { handlePossiblyNotMorphableError } from "@/store/audioGenerate";
 
 type ButtonContent = {
   text: string;
@@ -106,13 +107,7 @@ const playContinuously = async () => {
   try {
     await store.dispatch("PLAY_CONTINUOUSLY_AUDIO");
   } catch (e) {
-    let msg: string | undefined;
-    // FIXME: GENERATE_AUDIO_FROM_AUDIO_ITEMのエラーを変えた場合変更する
-    if (e instanceof Error && e.message === "VALID_MORPHING_ERROR") {
-      msg = "モーフィングの設定が無効です。";
-    } else {
-      window.electron.logError(e);
-    }
+    const msg = handlePossiblyNotMorphableError(e);
     store.dispatch("SHOW_ALERT_DIALOG", {
       title: "再生に失敗しました",
       message: msg ?? "エンジンの再起動をお試しください。",

--- a/src/components/Talk/AudioDetail.vue
+++ b/src/components/Talk/AudioDetail.vue
@@ -94,6 +94,7 @@ import {
 import { setHotkeyFunctions } from "@/store/setting";
 import { EngineManifest } from "@/openapi/models";
 import { useShiftKey, useAltKey } from "@/composables/useModifierKey";
+import { handlePossiblyNotMorphableError } from "@/store/audioGenerate";
 
 const props =
   defineProps<{
@@ -248,13 +249,7 @@ const play = async () => {
       audioKey: props.activeAudioKey,
     });
   } catch (e) {
-    let msg: string | undefined;
-    // FIXME: GENERATE_AUDIO_FROM_AUDIO_ITEMのエラーを変えた場合変更する
-    if (e instanceof Error && e.message === "VALID_MORPHING_ERROR") {
-      msg = "モーフィングの設定が無効です。";
-    } else {
-      window.electron.logError(e);
-    }
+    const msg = handlePossiblyNotMorphableError(e);
     store.dispatch("SHOW_ALERT_DIALOG", {
       title: "再生に失敗しました",
       message: msg ?? "エンジンの再起動をお試しください。",

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -34,6 +34,7 @@ import {
   fetchAudioFromAudioItem,
   generateLabFromAudioQuery,
   handlePossiblyNotMorphableError,
+  isMorphable,
 } from "./audioGenerate";
 import {
   AudioKey,
@@ -888,14 +889,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   VALID_MORPHING_INFO: {
     getter: (state) => (audioItem: AudioItem) => {
-      if (audioItem.morphingInfo?.targetStyleId == undefined) return false;
-      const { engineId, styleId } = audioItem.voice;
-      const info =
-        state.morphableTargetsInfo[engineId]?.[styleId]?.[
-          audioItem.morphingInfo.targetStyleId
-        ];
-      if (info == undefined) return false;
-      return info.isMorphable;
+      return isMorphable(state, { audioItem });
     },
   },
 

--- a/src/store/audioGenerate.ts
+++ b/src/store/audioGenerate.ts
@@ -7,7 +7,7 @@ import {
   SettingStoreState,
 } from "./type";
 import { convertAudioQueryFromEditorToEngine } from "./proxy";
-import { generateUniqueId } from "./utility";
+import { generateTempUniqueId } from "./utility";
 
 const audioBlobCache: Record<string, Blob> = {};
 
@@ -126,7 +126,7 @@ async function generateUniqueIdAndQuery(
     audioQuery.outputStereo = state.savingSetting.outputStereo;
   }
 
-  const id = await generateUniqueId([
+  const id = await generateTempUniqueId([
     audioItem.text,
     audioQuery,
     audioItem.voice,

--- a/src/store/audioGenerate.ts
+++ b/src/store/audioGenerate.ts
@@ -136,7 +136,7 @@ async function generateUniqueIdAndQuery(
   return [id, audioQuery];
 }
 
-function isMorphable(
+export function isMorphable(
   state: AudioStoreState,
   {
     audioItem,

--- a/src/store/audioGenerate.ts
+++ b/src/store/audioGenerate.ts
@@ -1,0 +1,169 @@
+import {
+  AudioItem,
+  AudioStoreState,
+  EditorAudioQuery,
+  FetchAudioResult,
+  IEngineConnectorFactoryActionsMapper,
+  SettingStoreState,
+} from "./type";
+import { convertAudioQueryFromEditorToEngine } from "./proxy";
+import { generateUniqueId } from "./utility";
+
+const audioBlobCache: Record<string, Blob> = {};
+
+type Instance = {
+  invoke: IEngineConnectorFactoryActionsMapper;
+};
+
+export async function fetchAudioFromAudioItem(
+  state: AudioStoreState & SettingStoreState,
+  instance: Instance,
+  {
+    audioItem,
+    cacheOnly,
+  }: {
+    audioItem: AudioItem;
+    cacheOnly?: boolean;
+  }
+): Promise<FetchAudioResult> {
+  const engineId = audioItem.voice.engineId;
+
+  const [id, audioQuery] = await generateUniqueIdAndQuery(state, audioItem);
+  if (audioQuery == undefined)
+    throw new Error("audioQuery is not defined for audioItem");
+
+  if (Object.prototype.hasOwnProperty.call(audioBlobCache, id) || cacheOnly) {
+    const blob = audioBlobCache[id];
+    return { audioQuery, blob };
+  }
+
+  const speaker = audioItem.voice.styleId;
+
+  const engineAudioQuery = convertAudioQueryFromEditorToEngine(
+    audioQuery,
+    state.engineManifests[engineId].defaultSamplingRate
+  );
+
+  let blob: Blob;
+  // FIXME: モーフィングが設定で無効化されていてもモーフィングが行われるので気づけるUIを作成する
+  if (audioItem.morphingInfo != undefined) {
+    if (!isMorphable(state, { audioItem })) throw new NotMorphableError();
+    blob = await instance.invoke("synthesisMorphingSynthesisMorphingPost")({
+      audioQuery: engineAudioQuery,
+      baseSpeaker: speaker,
+      targetSpeaker: audioItem.morphingInfo.targetStyleId,
+      morphRate: audioItem.morphingInfo.rate,
+    });
+  } else {
+    blob = await instance.invoke("synthesisSynthesisPost")({
+      audioQuery: engineAudioQuery,
+      speaker,
+      enableInterrogativeUpspeak:
+        state.experimentalSetting.enableInterrogativeUpspeak,
+    });
+  }
+  audioBlobCache[id] = blob;
+  return { audioQuery, blob };
+}
+
+export async function generateLabFromAudioQuery(
+  audioQuery: EditorAudioQuery,
+  offset?: number
+) {
+  const speedScale = audioQuery.speedScale;
+
+  let labString = "";
+  let timestamp = offset ?? 0;
+
+  labString += timestamp.toFixed() + " ";
+  timestamp += (audioQuery.prePhonemeLength * 10000000) / speedScale;
+  labString += timestamp.toFixed() + " ";
+  labString += "pau" + "\n";
+
+  audioQuery.accentPhrases.forEach((accentPhrase) => {
+    accentPhrase.moras.forEach((mora) => {
+      if (mora.consonantLength != undefined && mora.consonant != undefined) {
+        labString += timestamp.toFixed() + " ";
+        timestamp += (mora.consonantLength * 10000000) / speedScale;
+        labString += timestamp.toFixed() + " ";
+        labString += mora.consonant + "\n";
+      }
+      labString += timestamp.toFixed() + " ";
+      timestamp += (mora.vowelLength * 10000000) / speedScale;
+      labString += timestamp.toFixed() + " ";
+      if (mora.vowel != "N") {
+        labString += mora.vowel.toLowerCase() + "\n";
+      } else {
+        labString += mora.vowel + "\n";
+      }
+    });
+    if (accentPhrase.pauseMora != undefined) {
+      labString += timestamp.toFixed() + " ";
+      timestamp += (accentPhrase.pauseMora.vowelLength * 10000000) / speedScale;
+      labString += timestamp.toFixed() + " ";
+      labString += accentPhrase.pauseMora.vowel + "\n";
+    }
+  });
+
+  labString += timestamp.toFixed() + " ";
+  timestamp += (audioQuery.postPhonemeLength * 10000000) / speedScale;
+  labString += timestamp.toFixed() + " ";
+  labString += "pau" + "\n";
+
+  return labString;
+}
+
+async function generateUniqueIdAndQuery(
+  state: SettingStoreState,
+  audioItem: AudioItem
+): Promise<[string, EditorAudioQuery | undefined]> {
+  audioItem = JSON.parse(JSON.stringify(audioItem)) as AudioItem;
+  const audioQuery = audioItem.query;
+  if (audioQuery != undefined) {
+    audioQuery.outputSamplingRate =
+      state.engineSettings[audioItem.voice.engineId].outputSamplingRate;
+    audioQuery.outputStereo = state.savingSetting.outputStereo;
+  }
+
+  const id = await generateUniqueId([
+    audioItem.text,
+    audioQuery,
+    audioItem.voice,
+    audioItem.morphingInfo,
+    state.experimentalSetting.enableInterrogativeUpspeak, // このフラグが違うと、同じAudioQueryで違う音声が生成されるので追加
+  ]);
+  return [id, audioQuery];
+}
+
+function isMorphable(
+  state: AudioStoreState,
+  {
+    audioItem,
+  }: {
+    audioItem: AudioItem;
+  }
+) {
+  if (audioItem.morphingInfo?.targetStyleId == undefined) return false;
+  const { engineId, styleId } = audioItem.voice;
+  const info =
+    state.morphableTargetsInfo[engineId]?.[styleId]?.[
+      audioItem.morphingInfo.targetStyleId
+    ];
+  if (info == undefined) return false;
+  return info.isMorphable;
+}
+
+class NotMorphableError extends Error {
+  constructor() {
+    super("モーフィングの設定が無効です。");
+  }
+}
+
+export function handlePossiblyNotMorphableError(e: unknown) {
+  if (e instanceof NotMorphableError) {
+    return e.message;
+  } else {
+    window.electron.logError(e);
+    return;
+  }
+}

--- a/src/store/audioGenerate.ts
+++ b/src/store/audioGenerate.ts
@@ -15,15 +15,16 @@ type Instance = {
   invoke: IEngineConnectorFactoryActionsMapper;
 };
 
+/**
+ * エンジンで音声を合成する。音声のキャッシュ機構も備える。
+ */
 export async function fetchAudioFromAudioItem(
   state: AudioStoreState & SettingStoreState,
   instance: Instance,
   {
     audioItem,
-    cacheOnly,
   }: {
     audioItem: AudioItem;
-    cacheOnly?: boolean;
   }
 ): Promise<FetchAudioResult> {
   const engineId = audioItem.voice.engineId;
@@ -32,7 +33,7 @@ export async function fetchAudioFromAudioItem(
   if (audioQuery == undefined)
     throw new Error("audioQuery is not defined for audioItem");
 
-  if (Object.prototype.hasOwnProperty.call(audioBlobCache, id) || cacheOnly) {
+  if (Object.prototype.hasOwnProperty.call(audioBlobCache, id)) {
     const blob = audioBlobCache[id];
     return { audioQuery, blob };
   }

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -75,6 +75,11 @@ export type AudioState = {
   nowGenerating: boolean;
 };
 
+export type FetchAudioResult = {
+  audioQuery: EditorAudioQuery;
+  blob: Blob;
+};
+
 export type Command = {
   unixMillisec: number;
   undoPatches: Patch[];
@@ -244,14 +249,6 @@ export type AudioStoreTypes = {
     action(): void;
   };
 
-  GET_AUDIO_CACHE: {
-    action(payload: { audioKey: AudioKey }): Promise<Blob | null>;
-  };
-
-  GET_AUDIO_CACHE_FROM_AUDIO_ITEM: {
-    action(payload: { audioItem: AudioItem }): Promise<Blob | null>;
-  };
-
   SET_AUDIO_TEXT: {
     mutation: { audioKey: AudioKey; text: string };
   };
@@ -387,23 +384,16 @@ export type AudioStoreTypes = {
     getter(audioKey: AudioKey): string;
   };
 
-  GENERATE_LAB: {
-    action(payload: {
-      audioKey: AudioKey;
-      offset?: number;
-    }): string | undefined;
-  };
-
   GET_AUDIO_PLAY_OFFSETS: {
     action(payload: { audioKey: AudioKey }): number[];
   };
 
-  GENERATE_AUDIO: {
-    action(payload: { audioKey: AudioKey }): Promise<Blob>;
+  FETCH_AUDIO: {
+    action(payload: { audioKey: AudioKey }): Promise<FetchAudioResult>;
   };
 
-  GENERATE_AUDIO_FROM_AUDIO_ITEM: {
-    action(payload: { audioItem: AudioItem }): Blob;
+  FETCH_AUDIO_FROM_AUDIO_ITEM: {
+    action(payload: { audioItem: AudioItem }): Promise<FetchAudioResult>;
   };
 
   CONNECT_AUDIO: {
@@ -1763,7 +1753,7 @@ export type IEngineConnectorFactoryActions = ReturnType<
   IEngineConnectorFactory["instance"]
 >;
 
-type IEngineConnectorFactoryActionsMapper = <
+export type IEngineConnectorFactoryActionsMapper = <
   K extends keyof IEngineConnectorFactoryActions
 >(
   action: K

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -404,6 +404,14 @@ export function buildAudioFileNameFromRawData(
   });
 }
 
+export async function generateUniqueId(serializable: unknown) {
+  const data = new TextEncoder().encode(JSON.stringify(serializable));
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((v) => v.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 export const getToolbarButtonName = (tag: ToolbarButtonTagType): string => {
   const tag2NameObj: Record<ToolbarButtonTagType, string> = {
     PLAY_CONTINUOUSLY: "連続再生",

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -404,7 +404,11 @@ export function buildAudioFileNameFromRawData(
   });
 }
 
-export async function generateUniqueId(serializable: unknown) {
+/**
+ * オブジェクトごとに一意なキーを作る。
+ * 一時的な利用のみを想定しているため、保存に利用すべきではない。
+ */
+export async function generateTempUniqueId(serializable: unknown) {
   const data = new TextEncoder().encode(JSON.stringify(serializable));
   const digest = await crypto.subtle.digest("SHA-256", data);
   return Array.from(new Uint8Array(digest))


### PR DESCRIPTION
## 内容

`src/store/audio.ts`にある`dispatch`群のうち，音声生成に関係する部分を`src/store/audioGenerate.ts`として分離します．それに伴い，いくつかのシグニチャを変更します．

## 関連 Issue

ref: #1475

## その他

もともと`GENERATE_AUDIO`系と`GET_AUDIO_CACHE`系が別々であったことを鑑み，`cacheOnly`フラグを生やしてありますが，現状使われていません．
