### PR TITLE
連続再生中にバックグラウンドで音声を合成する

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1730,12 +1730,15 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       }
 
       const player = new ContinuousPlayer(state.audioKeys.slice(index), {
-        dispatch,
+        generateAudio: ({ audioKey }) =>
+          dispatch("FETCH_AUDIO", { audioKey }).then((result) => result.blob),
+        playAudioBlob: ({ audioBlob, audioKey }) =>
+          dispatch("PLAY_AUDIO_BLOB", { audioBlob, audioKey }),
       });
-      player.addEventListener("playstart", async (e) => {
+      player.addEventListener("playstart", (e) => {
         commit("SET_ACTIVE_AUDIO_KEY", { audioKey: e.audioKey });
       });
-      player.addEventListener("waitstart", async (e) => {
+      player.addEventListener("waitstart", (e) => {
         dispatch("START_PROGRESS");
         commit("SET_ACTIVE_AUDIO_KEY", { audioKey: e.audioKey });
         commit("SET_AUDIO_NOW_GENERATING", {
@@ -1743,7 +1746,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           nowGenerating: true,
         });
       });
-      player.addEventListener("waitend", async (e) => {
+      player.addEventListener("waitend", (e) => {
         dispatch("RESET_PROGRESS");
         commit("SET_AUDIO_NOW_GENERATING", {
           audioKey: e.audioKey,
@@ -1753,7 +1756,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
       commit("SET_NOW_PLAYING_CONTINUOUSLY", { nowPlaying: true });
 
-      await player.play();
+      await player.start();
 
       commit("SET_ACTIVE_AUDIO_KEY", { audioKey: currentAudioKey });
       commit("SET_AUDIO_PLAY_START_POINT", {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -36,11 +36,7 @@ import {
   handlePossiblyNotMorphableError,
   isMorphable,
 } from "./audioGenerate";
-import {
-  ContinuousPlayer,
-  GenerateEndEvent,
-  PlayEndEvent,
-} from "./audioContinuousPlayer";
+import { ContinuousPlayer } from "./audioContinuousPlayer";
 import {
   AudioKey,
   CharacterInfo,
@@ -1733,20 +1729,11 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         index = state.audioKeys.findIndex((v) => v === currentAudioKey);
       }
 
-      const player = new ContinuousPlayer(state.audioKeys.slice(index));
-      player.addEventListener("generatestart", async (e) => {
-        const result = await dispatch("FETCH_AUDIO", {
-          audioKey: e.audioKey,
-        });
-        player.dispatchEvent(new GenerateEndEvent(e.audioKey, result));
+      const player = new ContinuousPlayer(state.audioKeys.slice(index), {
+        dispatch,
       });
       player.addEventListener("playstart", async (e) => {
         commit("SET_ACTIVE_AUDIO_KEY", { audioKey: e.audioKey });
-        const isEnded = await dispatch("PLAY_AUDIO_BLOB", {
-          audioBlob: e.result.blob,
-          audioKey: e.audioKey,
-        });
-        player.dispatchEvent(new PlayEndEvent(e.audioKey, !isEnded));
       });
       player.addEventListener("waitstart", async (e) => {
         dispatch("START_PROGRESS");

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1756,7 +1756,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
       commit("SET_NOW_PLAYING_CONTINUOUSLY", { nowPlaying: true });
 
-      await player.start();
+      await player.playUntilComplete();
 
       commit("SET_ACTIVE_AUDIO_KEY", { audioKey: currentAudioKey });
       commit("SET_AUDIO_PLAY_START_POINT", {

--- a/src/store/audioContinuousPlayer.ts
+++ b/src/store/audioContinuousPlayer.ts
@@ -33,7 +33,7 @@ export class ContinuousPlayer extends EventTarget {
   private promise: Promise<void>;
 
   constructor(
-    private generatingQueue: AudioKey[],
+    private generationQueue: AudioKey[],
     { generateAudio, playAudioBlob }: DI
   ) {
     super();
@@ -57,7 +57,7 @@ export class ContinuousPlayer extends EventTarget {
         this.dispatchEvent(new PlayStartEvent(audioKey, audioBlob));
       }
 
-      const next = this.generatingQueue.shift();
+      const next = this.generationQueue.shift();
       if (next) {
         this.dispatchEvent(new GenerateStartEvent(next));
       }
@@ -99,8 +99,12 @@ export class ContinuousPlayer extends EventTarget {
     this.resolve();
   }
 
-  async start() {
-    const next = this.generatingQueue.shift();
+  /**
+   * 音声の生成・再生を開始する。
+   * すべての音声の再生が完了するか、途中で停止されるとresolveする。
+   */
+  async playUntilComplete() {
+    const next = this.generationQueue.shift();
     if (!next) return;
     this.dispatchEvent(new WaitStartEvent(next));
     this.dispatchEvent(new GenerateStartEvent(next));

--- a/src/store/audioContinuousPlayer.ts
+++ b/src/store/audioContinuousPlayer.ts
@@ -1,0 +1,132 @@
+import { FetchAudioResult } from "./type";
+import { AudioKey } from "@/type/preload";
+
+export class ContinuousPlayer extends EventTarget {
+  private playQueue: ({ audioKey: AudioKey } & FetchAudioResult)[] = [];
+  private generating?: { audioKey: AudioKey };
+  private playing?: { audioKey: AudioKey } & FetchAudioResult;
+
+  private finished = false;
+  private resolve!: () => void;
+  private promise: Promise<void>;
+
+  constructor(private generateQueue: AudioKey[]) {
+    super();
+
+    this.addEventListener("generatestart", (e) => {
+      this.generating = { audioKey: e.audioKey };
+    });
+    this.addEventListener("generateend", (e) => {
+      delete this.generating;
+
+      const { audioKey, result } = e;
+      if (this.playing) {
+        this.playQueue.push({ audioKey, ...result });
+      } else {
+        this.dispatchEvent(new WaitEndEvent(e.audioKey));
+        if (this.finished) return;
+        this.dispatchEvent(new PlayStartEvent(audioKey, result));
+      }
+
+      const next = this.generateQueue.shift();
+      if (next) {
+        this.dispatchEvent(new GenerateStartEvent(next));
+      }
+    });
+    this.addEventListener("playstart", (e) => {
+      this.playing = { audioKey: e.audioKey, ...e.result };
+    });
+    this.addEventListener("playend", (e) => {
+      delete this.playing;
+      if (e.forceFinish) {
+        this.finish();
+        return;
+      }
+
+      const next = this.playQueue.shift();
+      if (next) {
+        this.dispatchEvent(new PlayStartEvent(next.audioKey, next));
+      } else if (this.generating) {
+        this.dispatchEvent(new WaitStartEvent(this.generating.audioKey));
+      } else {
+        this.finish();
+      }
+    });
+
+    this.promise = new Promise((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+
+  private finish() {
+    this.finished = true;
+    this.resolve();
+  }
+
+  async play() {
+    const next = this.generateQueue.shift();
+    if (!next) return;
+    this.dispatchEvent(new WaitStartEvent(next));
+    this.dispatchEvent(new GenerateStartEvent(next));
+
+    await this.promise;
+  }
+}
+
+export interface ContinuousPlayer extends EventTarget {
+  addEventListener<K extends keyof ContinuousPlayerEvents>(
+    type: K,
+    listener: (this: ContinuousPlayer, ev: ContinuousPlayerEvents[K]) => void,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+}
+
+interface ContinuousPlayerEvents {
+  generatestart: GenerateStartEvent;
+  generateend: GenerateEndEvent;
+  playstart: PlayStartEvent;
+  playend: PlayEndEvent;
+  waitstart: WaitStartEvent;
+  waitend: WaitEndEvent;
+}
+
+export class GenerateStartEvent extends Event {
+  constructor(public audioKey: AudioKey) {
+    super("generatestart");
+  }
+}
+
+export class GenerateEndEvent extends Event {
+  constructor(public audioKey: AudioKey, public result: FetchAudioResult) {
+    super("generateend");
+  }
+}
+
+export class PlayStartEvent extends Event {
+  constructor(public audioKey: AudioKey, public result: FetchAudioResult) {
+    super("playstart");
+  }
+}
+
+export class PlayEndEvent extends Event {
+  constructor(public audioKey: AudioKey, public forceFinish: boolean) {
+    super("playend");
+  }
+}
+
+export class WaitStartEvent extends Event {
+  constructor(public audioKey: AudioKey) {
+    super("waitstart");
+  }
+}
+
+export class WaitEndEvent extends Event {
+  constructor(public audioKey: AudioKey) {
+    super("waitend");
+  }
+}

--- a/src/store/audioContinuousPlayer.ts
+++ b/src/store/audioContinuousPlayer.ts
@@ -15,10 +15,14 @@ type DI = Pick<
   "dispatch"
 >;
 
+interface Generated extends FetchAudioResult {
+  audioKey: AudioKey;
+}
+
 export class ContinuousPlayer extends EventTarget {
-  private playQueue: ({ audioKey: AudioKey } & FetchAudioResult)[] = [];
-  private generating?: { audioKey: AudioKey };
-  private playing?: { audioKey: AudioKey } & FetchAudioResult;
+  private generating?: AudioKey;
+  private playQueue: Generated[] = [];
+  private playing?: Generated;
 
   private finished = false;
   private resolve!: () => void;
@@ -28,7 +32,7 @@ export class ContinuousPlayer extends EventTarget {
     super();
 
     this.addEventListener("generatestart", (e) => {
-      this.generating = { audioKey: e.audioKey };
+      this.generating = e.audioKey;
     });
     this.addEventListener("generatestart", async (e) => {
       const result = await dispatch("FETCH_AUDIO", { audioKey: e.audioKey });
@@ -72,7 +76,7 @@ export class ContinuousPlayer extends EventTarget {
       if (next) {
         this.dispatchEvent(new PlayStartEvent(next.audioKey, next));
       } else if (this.generating) {
-        this.dispatchEvent(new WaitStartEvent(this.generating.audioKey));
+        this.dispatchEvent(new WaitStartEvent(this.generating));
       } else {
         this.finish();
       }


### PR DESCRIPTION
## 内容

連続再生中に，バックグラウンドで音声を合成します．これにより，合成速度が再生速度を上回る場合，連続再生は途切れなく再生されるようになります．

`EventTarget`を継承した管理クラスのインスタンスにより，「合成が完了したら，次の合成を発火して，さらに再生中の音声がなければ今できたものを再生する」といったような処理の集合として実装しています．かなり複雑になりましたが，うまく動いてくれるようになりました．

補遺
- 最初のロードや，短い文の後に長い文が来て事前に合成が終わっていない場合など，どうしても待ち時間は存在します．ここではローディングのダイアログが出ます．
- 停止ボタンは，再生中は押すことができます．しかし，バックグラウンドで合成しているものがあれば，それが合成し終わるまで操作できません．なお，合成が終わったら他に再生されることなく，操作が可能になります．
- フローを表す図を置いておきます．
  <img width="431" alt="image" src="https://github.com/VOICEVOX/voicevox/assets/75649254/eb358ec1-ce12-45ce-ae90-d8a4bdb8bf98">
  <details>
  <summary>Mermaidのソース</summary>

  ```
  flowchart TD
    開始
    生成中/待機中
    生成中/再生中
    終了/再生中
    終了/終了
    次が生成済{次が生成済？}
    最後の生成{最後の生成？}
    最後の再生{最後の再生？}

    開始 --> 生成中/待機中
    
    生成中/待機中 -->|生成完了| 最後の生成

    生成中/再生中 -->|生成完了| 最後の生成
    生成中/再生中 -->|再生完了| 次が生成済

    終了/再生中 -->|再生完了| 最後の再生

    次が生成済 -->|true| 生成中/再生中
    次が生成済 -->|false| 生成中/待機中

    最後の生成 -->|true| 終了/再生中
    最後の生成 -->|false| 生成中/再生中

    最後の再生 -->|true| 終了/終了
    最後の再生 -->|false| 終了/再生中
  ```


## 関連 Issue

ref: #1773 （このPRの後にmergeする必要があります）
closes: #254 

## スクリーンショット・動画など

（録画方法の都合で，音と画が若干ずれています）

https://github.com/VOICEVOX/voicevox/assets/75649254/1a1c283c-7faf-470d-9ee3-820080997fe9

## その他
