### PR TITLE
トーク画面でハミング・歌のキャラクター・スタイルが表示されないように修正

### DIFF
--- a/src/components/DictionaryManageDialog.vue
+++ b/src/components/DictionaryManageDialog.vue
@@ -345,11 +345,13 @@ const surface = ref("");
 const yomi = ref("");
 
 const voiceComputed = computed(() => {
-  if (store.getters.USER_ORDERED_CHARACTER_INFOS == undefined)
+  const userOrderedCharacterInfos =
+    store.getters.USER_ORDERED_CHARACTER_INFOS("talk");
+  if (userOrderedCharacterInfos == undefined)
     throw new Error("assert USER_ORDERED_CHARACTER_INFOS");
   if (store.state.engineIds.length === 0)
     throw new Error("assert engineId.length > 0");
-  const characterInfo = store.getters.USER_ORDERED_CHARACTER_INFOS[0].metas;
+  const characterInfo = userOrderedCharacterInfos[0].metas;
   const speakerId = characterInfo.speakerUuid;
   const { engineId, styleId } = characterInfo.styles[0];
   return { engineId, speakerId, styleId };

--- a/src/components/Sing/CharacterMenuButton.vue
+++ b/src/components/Sing/CharacterMenuButton.vue
@@ -139,7 +139,7 @@ import { defineComponent, computed, ref } from "vue";
 import { debounce } from "quasar";
 import { useStore } from "@/store";
 import { base64ImageToUri } from "@/helpers/imageHelper";
-import { CharacterInfo, SpeakerId, StyleId } from "@/type/preload";
+import { SpeakerId, StyleId } from "@/type/preload";
 import { getStyleDescription } from "@/sing/viewHelper";
 
 export default defineComponent({
@@ -149,7 +149,7 @@ export default defineComponent({
     const store = useStore();
 
     const userOrderedCharacterInfos = computed(() => {
-      return store.getters.USER_ORDERED_CHARACTER_INFOS("sing");
+      return store.getters.USER_ORDERED_CHARACTER_INFOS("singerLike");
     });
 
     const subMenuOpenFlags = ref(

--- a/src/components/Sing/CharacterMenuButton.vue
+++ b/src/components/Sing/CharacterMenuButton.vue
@@ -86,9 +86,7 @@
                 >
                   <q-list>
                     <q-item
-                      v-for="(style, styleIndex) in getSingingStyles(
-                        characterInfo
-                      )"
+                      v-for="(style, styleIndex) in characterInfo.metas.styles"
                       :key="styleIndex"
                       v-close-popup
                       clickable
@@ -141,7 +139,7 @@ import { defineComponent, computed, ref } from "vue";
 import { debounce } from "quasar";
 import { useStore } from "@/store";
 import { base64ImageToUri } from "@/helpers/imageHelper";
-import { CharacterInfo, SpeakerId, StyleId, StyleInfo } from "@/type/preload";
+import { CharacterInfo, SpeakerId, StyleId } from "@/type/preload";
 import { getStyleDescription } from "@/sing/viewHelper";
 
 export default defineComponent({
@@ -150,18 +148,8 @@ export default defineComponent({
   setup() {
     const store = useStore();
 
-    const isSingingStyle = (styleInfo: StyleInfo) => {
-      return (
-        styleInfo.styleType === "humming" ||
-        styleInfo.styleType === "sing_teacher"
-      );
-    };
-
     const userOrderedCharacterInfos = computed(() => {
-      return store.getters.USER_ORDERED_CHARACTER_INFOS?.filter(
-        (characterInfo) =>
-          characterInfo.metas.styles.some((value) => isSingingStyle(value))
-      );
+      return store.getters.USER_ORDERED_CHARACTER_INFOS("sing");
     });
 
     const subMenuOpenFlags = ref(
@@ -214,12 +202,6 @@ export default defineComponent({
       return defaultStyle;
     };
 
-    const getSingingStyles = (characterInfo: CharacterInfo) => {
-      return characterInfo.metas.styles.filter((value) =>
-        isSingingStyle(value)
-      );
-    };
-
     const selectedCharacterInfo = computed(() => {
       if (
         userOrderedCharacterInfos.value == undefined ||
@@ -263,7 +245,6 @@ export default defineComponent({
       reassignSubMenuOpen,
       changeStyleId,
       getDefaultStyle,
-      getSingingStyles,
       getStyleDescription,
       selectedCharacterInfo,
       selectedSpeakerUuid,

--- a/src/components/Sing/CharacterPortrait.vue
+++ b/src/components/Sing/CharacterPortrait.vue
@@ -14,8 +14,8 @@ export default defineComponent({
     const store = useStore();
     const isShowSinger = computed(() => store.state.isShowSinger);
 
-    const userOrderedCharacterInfos = computed(
-      () => store.getters.USER_ORDERED_CHARACTER_INFOS
+    const userOrderedCharacterInfos = computed(() =>
+      store.getters.USER_ORDERED_CHARACTER_INFOS("all")
     );
 
     const characterInfo = computed(() => {

--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -137,7 +137,7 @@ export default defineComponent({
     const uiLocked = computed(() => store.getters.UI_LOCKED);
 
     const userOrderedCharacterInfos = computed(() =>
-      store.getters.USER_ORDERED_CHARACTER_INFOS("sing")
+      store.getters.USER_ORDERED_CHARACTER_INFOS("singerLike")
     );
     const selectedCharacterInfo = computed(() => {
       if (!userOrderedCharacterInfos.value || !store.state.singer) {

--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -136,8 +136,8 @@ export default defineComponent({
 
     const uiLocked = computed(() => store.getters.UI_LOCKED);
 
-    const userOrderedCharacterInfos = computed(
-      () => store.getters.USER_ORDERED_CHARACTER_INFOS
+    const userOrderedCharacterInfos = computed(() =>
+      store.getters.USER_ORDERED_CHARACTER_INFOS("sing")
     );
     const selectedCharacterInfo = computed(() => {
       if (!userOrderedCharacterInfos.value || !store.state.singer) {

--- a/src/components/Talk/AudioCell.vue
+++ b/src/components/Talk/AudioCell.vue
@@ -164,7 +164,7 @@ defineExpose({
 
 const store = useStore();
 const userOrderedCharacterInfos = computed(() => {
-  const infos = store.getters.USER_ORDERED_CHARACTER_INFOS;
+  const infos = store.getters.USER_ORDERED_CHARACTER_INFOS("talk");
   if (infos == undefined)
     throw new Error("USER_ORDERED_CHARACTER_INFOS == undefined");
   return infos;

--- a/src/components/Talk/AudioInfo.vue
+++ b/src/components/Talk/AudioInfo.vue
@@ -518,7 +518,7 @@ watchEffect(() => {
 });
 
 const morphingTargetCharacters = computed<CharacterInfo[]>(() => {
-  const allCharacterInfos = store.getters.USER_ORDERED_CHARACTER_INFOS;
+  const allCharacterInfos = store.getters.USER_ORDERED_CHARACTER_INFOS("talk");
   if (allCharacterInfos == undefined)
     throw new Error("USER_ORDERED_CHARACTER_INFOS == undefined");
 
@@ -598,10 +598,12 @@ const morphingTargetVoice = computed({
 });
 
 const morphingTargetCharacterInfo = computed(() =>
-  store.getters.USER_ORDERED_CHARACTER_INFOS?.find(
-    (character) =>
-      character.metas.speakerUuid === morphingTargetVoice.value?.speakerId
-  )
+  store.getters
+    .USER_ORDERED_CHARACTER_INFOS("talk")
+    ?.find(
+      (character) =>
+        character.metas.speakerUuid === morphingTargetVoice.value?.speakerId
+    )
 );
 
 const morphingTargetStyleInfo = computed(() => {

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -248,9 +248,10 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           if (
             semver.satisfies(projectAppVersion, "<0.15", semverSatisfiesOptions)
           ) {
-            const characterInfos = context.getters.USER_ORDERED_CHARACTER_INFOS;
+            const characterInfos =
+              context.getters.USER_ORDERED_CHARACTER_INFOS("talk");
             if (characterInfos == undefined)
-              throw new Error("USER_ORDERED_CHARACTER_INFOS == undefined");
+              throw new Error("characterInfos == undefined");
             for (const audioItemsKey in projectData.audioItems) {
               const audioItem = projectData.audioItems[audioItemsKey];
               if (audioItem.voice == undefined) {

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -178,7 +178,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       if (state.defaultStyleIds == undefined)
         throw new Error("state.defaultStyleIds == undefined");
       const userOrderedCharacterInfos =
-        getters.USER_ORDERED_CHARACTER_INFOS("sing");
+        getters.USER_ORDERED_CHARACTER_INFOS("singerLike");
       if (userOrderedCharacterInfos == undefined)
         throw new Error("userOrderedCharacterInfos == undefined");
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -177,9 +177,10 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
     ) {
       if (state.defaultStyleIds == undefined)
         throw new Error("state.defaultStyleIds == undefined");
-      if (getters.USER_ORDERED_CHARACTER_INFOS == undefined)
-        throw new Error("state.characterInfos == undefined");
-      const userOrderedCharacterInfos = getters.USER_ORDERED_CHARACTER_INFOS;
+      const userOrderedCharacterInfos =
+        getters.USER_ORDERED_CHARACTER_INFOS("sing");
+      if (userOrderedCharacterInfos == undefined)
+        throw new Error("userOrderedCharacterInfos == undefined");
 
       const engineId = singer?.engineId ?? state.engineIds[0];
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -163,7 +163,7 @@ export type AudioStoreTypes = {
   };
 
   USER_ORDERED_CHARACTER_INFOS: {
-    getter(type: "all" | "sing" | "talk"): CharacterInfo[] | undefined;
+    getter(type: "all" | "singerLike" | "talk"): CharacterInfo[] | undefined;
   };
 
   SETUP_SPEAKER: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -163,7 +163,7 @@ export type AudioStoreTypes = {
   };
 
   USER_ORDERED_CHARACTER_INFOS: {
-    getter: CharacterInfo[] | undefined;
+    getter(type: "all" | "sing" | "talk"): CharacterInfo[] | undefined;
   };
 
   SETUP_SPEAKER: {


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通りです。
根本のデータソースから修正しました。
このため、ソング画面でシングスタイルをフィルタリングしているコードをstoreに移植・利用しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

これ以外にもバグが起こりそうな箇所があるのですが、ひとまずここだけ修正して後でIssueにします。
