### PR TITLE
ソングエディタでキャラクター選択の挙動がおかしくなる問題を修正

### DIFF
--- a/src/components/Sing/CharacterMenuButton.vue
+++ b/src/components/Sing/CharacterMenuButton.vue
@@ -188,9 +188,11 @@ export default defineComponent({
       const characterInfo = userOrderedCharacterInfos.value?.find(
         (info) => info.metas.speakerUuid === speakerUuid
       );
-      const defaultStyleId = store.state.defaultStyleIds.find(
-        (x) => x.speakerUuid === speakerUuid
-      )?.defaultStyleId;
+
+      // FIXME: ソングエディタ向けのデフォルトスタイルを選択できるようにする
+      // ここで取得されるcharacterInfoには、ソングエディタ向けのスタイルのみ含まれるので、
+      // その中の最初のスタイルをソングエディタにおけるデフォルトスタイルとする
+      const defaultStyleId = characterInfo?.metas.styles[0].styleId;
 
       const defaultStyle = characterInfo?.metas.styles.find(
         (style) => style.styleId === defaultStyleId

--- a/src/components/Sing/CharacterMenuButton.vue
+++ b/src/components/Sing/CharacterMenuButton.vue
@@ -189,9 +189,9 @@ export default defineComponent({
         (info) => info.metas.speakerUuid === speakerUuid
       );
 
-      // FIXME: ソングエディタ向けのデフォルトスタイルを選択できるようにする
       // ここで取得されるcharacterInfoには、ソングエディタ向けのスタイルのみ含まれるので、
-      // その中の最初のスタイルをソングエディタにおけるデフォルトスタイルとする
+      // その中の最初のスタイルをソングエディタにおける仮のデフォルトスタイルとする
+      // TODO: ソングエディタ向けのデフォルトスタイルをどうするか考える
       const defaultStyleId = characterInfo?.metas.styles[0].styleId;
 
       const defaultStyle = characterInfo?.metas.styles.find(


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通りです。
簡易的に問題を解決します。
本質的な解決としては、「ソングエディタでもデフォルトスタイルが選べるようにする」だと思いますが、それは別途Issueに起こすべきかなと思いました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- close #1782 


