### PR TITLE
デフォルトスタイル選択ダイアログでトークスタイルのみを表示する

### DIFF
--- a/src/components/Talk/EditorHome.vue
+++ b/src/components/Talk/EditorHome.vue
@@ -167,9 +167,9 @@
     :character-infos="orderedAllCharacterInfos"
   />
   <default-style-list-dialog
-    v-if="orderedAllCharacterInfos.length > 0"
+    v-if="orderedTalkCharacterInfos.length > 0"
     v-model="isDefaultStyleSelectDialogOpenComputed"
-    :character-infos="orderedAllCharacterInfos"
+    :character-infos="orderedTalkCharacterInfos"
   />
   <dictionary-manage-dialog v-model="isDictionaryManageDialogOpenComputed" />
   <engine-manage-dialog v-model="isEngineManageDialogOpenComputed" />
@@ -723,7 +723,15 @@ const isCharacterOrderDialogOpenComputed = computed({
     }),
 });
 
-// デフォルトスタイル選択
+// TODO: デフォルトスタイル選択(ソング)の実装
+// デフォルトスタイル選択(トーク)
+const orderedTalkCharacterInfos = computed(() => {
+  const userOrderedCharacterInfos =
+    store.getters.USER_ORDERED_CHARACTER_INFOS("talk");
+  if (userOrderedCharacterInfos == undefined)
+    throw new Error("userOrderedCharacterInfos == undefined");
+  return userOrderedCharacterInfos;
+});
 const isDefaultStyleSelectDialogOpenComputed = computed({
   get: () =>
     !store.state.isAcceptTermsDialogOpen &&


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通りです。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- ref #1785

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
トークスタイルのみ表示・カウントされるようになります。
![image](https://github.com/VOICEVOX/voicevox/assets/34832037/d7e6b9e5-a5f7-4d12-b3c9-0565beacc01a)

![image](https://github.com/VOICEVOX/voicevox/assets/34832037/9ecf3325-865a-42b4-b3b2-8a785dd75533)
