### PR TITLE
UI_LOCK中はソング・トーク切り替えができないように

### DIFF
--- a/src/components/TitleBarEditorSwitcher.vue
+++ b/src/components/TitleBarEditorSwitcher.vue
@@ -8,6 +8,7 @@
   <q-btn-toggle
     :model-value="nowEditor"
     unelevated
+    :disable="uiLocked"
     dense
     toggle-color="primary"
     :options="[
@@ -21,8 +22,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useRouter } from "vue-router";
+import { useStore } from "@/store";
 
+const store = useStore();
 const router = useRouter();
+
+const uiLocked = computed(() => store.getters.UI_LOCKED);
+
 const nowEditor = computed<"talk" | "song">(() => {
   const path = router.currentRoute.value.path;
   if (path === "/talk") return "talk";

--- a/tests/e2e/browser/初回起動時.spec.ts
+++ b/tests/e2e/browser/初回起動時.spec.ts
@@ -8,3 +8,14 @@ test("起動したら「利用規約に関するお知らせ」が表示され�
     timeout: 90 * 1000,
   });
 });
+
+test("利用規約同意前に各種UIが無効になっている", async ({ page }) => {
+  await expect(page.getByText("利用規約に関するお知らせ")).toBeVisible({
+    timeout: 90 * 1000,
+  });
+
+  // ソングボタン
+  const songButton = await page.getByText("ソング");
+  await expect(songButton).toBeVisible();
+  await expect(songButton).toBeDisabled();
+});


### PR DESCRIPTION
## 内容

UI_LOCK中はソング・トーク切り替えができないようにします。
テストも書いてみました。

## 関連 Issue

close #1795 

## その他

操作感的にもそんなに問題がない（そもそもソング側でロックが発生することがほとんどない）感じでした。
唯一ソングに切り替えた直後はキャラクターが最初に表示されるまでロックがかかり続けるのでそこはちょっと不便でした。
