### PR TITLE
fix: 設定が壊れる問題を修正

### DIFF
--- a/src/shared/ConfigManager.ts
+++ b/src/shared/ConfigManager.ts
@@ -188,8 +188,8 @@ export abstract class BaseConfigManager {
   }
 
   private _save() {
-    this.lock.acquire(lockKey, () => {
-      this.save({
+    this.lock.acquire(lockKey, async () => {
+      await this.save({
         ...configSchema.parse({
           ...this.config,
         }),


### PR DESCRIPTION
## 内容

Discordで報告があった設定が同時に書き込まれる問題に(恐らく)対処します。

## その他

恐らく`save()`をawaitせずに呼び出したので保存完了前にlockを抜けていることが原因だと思います。