### PR TITLE
[docs] Q&AでMacのエラーログの場所が違っていたので修正

### DIFF
--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -145,7 +145,7 @@ VOICEVOX X アカウント [@voicevox_pj](https://x.com/voicevox_pj)
 
 #### Mac 版
 
-`/Users/（ユーザー名）/Library/Logs/voicevox-cpu`
+`/Users/（ユーザー名）/Library/Logs/voicevox`
 
 ### Q. Ubuntu 22.04 で動きません
 


### PR DESCRIPTION
## 内容

Q&AでMacのエラーログの場所が違っていたので修正しました。

## その他

なぜwindowsは`voicevox-cpu`から`voicevox`にしてるのにmacの方はしてないのか調べてみた感じ、

- https://github.com/VOICEVOX/voicevox/pull/1159

で１回voicevoxにしたあと、なんかmacのログディレクトリは違ってたらしく

- https://github.com/VOICEVOX/voicevox/pull/1455

で戻して、そのあと

- https://github.com/VOICEVOX/voicevox/issues/1456

で解決したけどQ&Aは変えてなかったという感じっぽみです。


