### PR TITLE
ソングエディタの編集状態を保存できるようにする

### DIFF
--- a/src/components/Sing/MenuBar.vue
+++ b/src/components/Sing/MenuBar.vue
@@ -31,6 +31,15 @@ const exportWaveFile = async () => {
 const fileSubMenuData: MenuItemData[] = [
   {
     type: "button",
+    label: "音声を出力",
+    onClick: () => {
+      exportWaveFile();
+    },
+    disableWhenUiLocked: true,
+  },
+  { type: "separator" },
+  {
+    type: "button",
     label: "MIDI読み込み",
     onClick: () => {
       importMidiFile();
@@ -42,15 +51,6 @@ const fileSubMenuData: MenuItemData[] = [
     label: "MusicXML読み込み",
     onClick: () => {
       importMusicXMLFile();
-    },
-    disableWhenUiLocked: true,
-  },
-  { type: "separator" },
-  {
-    type: "button",
-    label: "音声を出力",
-    onClick: () => {
-      exportWaveFile();
     },
     disableWhenUiLocked: true,
   },

--- a/src/components/Talk/MenuBar.vue
+++ b/src/components/Talk/MenuBar.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed } from "vue";
 import { MenuItemData } from "@/components/Menu/type";
 import {
   generateAndConnectAndSaveAudioWithDialog,

--- a/src/components/Talk/MenuBar.vue
+++ b/src/components/Talk/MenuBar.vue
@@ -20,12 +20,6 @@ import { setHotkeyFunctions } from "@/store/setting";
 const store = useStore();
 const uiLocked = computed(() => store.getters.UI_LOCKED);
 
-const createNewProject = async () => {
-  if (!uiLocked.value) {
-    await store.dispatch("CREATE_NEW_PROJECT", {});
-  }
-};
-
 const generateAndSaveAllAudio = async () => {
   if (!uiLocked.value) {
     await multiGenerateAndSaveAudioWithDialog({
@@ -91,59 +85,6 @@ const importTextFile = () => {
   }
 };
 
-const saveProject = async () => {
-  if (!uiLocked.value) {
-    await store.dispatch("SAVE_PROJECT_FILE", { overwrite: true });
-  }
-};
-
-const saveProjectAs = async () => {
-  if (!uiLocked.value) {
-    await store.dispatch("SAVE_PROJECT_FILE", {});
-  }
-};
-
-const importProject = () => {
-  if (!uiLocked.value) {
-    store.dispatch("LOAD_PROJECT_FILE", {});
-  }
-};
-
-// 「最近使ったプロジェクト」のメニュー
-const recentProjectsSubMenuData = ref<MenuItemData[]>([]);
-const updateRecentProjects = async () => {
-  const recentlyUsedProjects = await store.dispatch(
-    "GET_RECENTLY_USED_PROJECTS"
-  );
-  recentProjectsSubMenuData.value =
-    recentlyUsedProjects.length === 0
-      ? [
-          {
-            type: "button",
-            label: "最近使ったプロジェクトはありません",
-            onClick: () => {
-              // 何もしない
-            },
-            disabled: true,
-            disableWhenUiLocked: false,
-          },
-        ]
-      : recentlyUsedProjects.map((projectFilePath) => ({
-          type: "button",
-          label: projectFilePath,
-          onClick: () => {
-            store.dispatch("LOAD_PROJECT_FILE", {
-              filePath: projectFilePath,
-            });
-          },
-          disableWhenUiLocked: false,
-        }));
-};
-const projectFilePath = computed(() => store.state.projectFilePath);
-watch(projectFilePath, updateRecentProjects, {
-  immediate: true,
-});
-
 // 「ファイル」メニュー
 const fileSubMenuData = computed<MenuItemData[]>(() => [
   {
@@ -187,54 +128,13 @@ const fileSubMenuData = computed<MenuItemData[]>(() => [
     },
     disableWhenUiLocked: true,
   },
-  { type: "separator" },
-  {
-    type: "button",
-    label: "新規プロジェクト",
-    onClick: createNewProject,
-    disableWhenUiLocked: true,
-  },
-  {
-    type: "button",
-    label: "プロジェクトを上書き保存",
-    onClick: async () => {
-      await saveProject();
-    },
-    disableWhenUiLocked: true,
-  },
-  {
-    type: "button",
-    label: "プロジェクトを名前を付けて保存",
-    onClick: async () => {
-      await saveProjectAs();
-    },
-    disableWhenUiLocked: true,
-  },
-  {
-    type: "button",
-    label: "プロジェクト読み込み",
-    onClick: () => {
-      importProject();
-    },
-    disableWhenUiLocked: true,
-  },
-  {
-    type: "root",
-    label: "最近使ったプロジェクト",
-    disableWhenUiLocked: true,
-    subMenu: recentProjectsSubMenuData.value,
-  },
 ]);
 
 const hotkeyMap = new Map<HotkeyActionType, () => HotkeyReturnType>([
-  ["新規プロジェクト", createNewProject],
   ["音声書き出し", generateAndSaveAllAudio],
   ["選択音声を書き出し", generateAndSaveSelectedAudio],
   ["音声を繋げて書き出し", generateAndConnectAndSaveAllAudio],
   ["テキスト読み込む", importTextFile],
-  ["プロジェクトを上書き保存", saveProject],
-  ["プロジェクトを名前を付けて保存", saveProjectAs],
-  ["プロジェクト読み込み", importProject],
 ]);
 
 setHotkeyFunctions(hotkeyMap);

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -2,6 +2,7 @@ import semver from "semver";
 import { z } from "zod";
 import { getBaseName } from "./utility";
 import { createPartialStore } from "./vuex";
+import { generateSingingStoreInitialScore } from "./singing";
 import { createUILockAction } from "@/store/ui";
 import {
   AudioItem,
@@ -302,14 +303,11 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               audioKeys: projectData.audioKeys,
               audioItems: projectData.audioItems,
             };
-            // singについてはストアの初期値を使う
-            projectData.sing = {
-              tpqn: context.state.tpqn,
-              tempos: context.state.tempos,
-              timeSignatures: context.state.timeSignatures,
-              tracks: context.state.tracks,
-              phrases: context.state.phrases,
-            };
+
+            projectData.sing = generateSingingStoreInitialScore();
+            // phrasesはmapではなくrecordにしないとパースに失敗する
+            projectData.sing.phrases = {};
+
             projectData.isOpenSongEditor = false;
             delete projectData.audioKeys;
             delete projectData.audioItems;

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -36,6 +36,49 @@ export const projectStoreState: ProjectStoreState = {
   savedLastCommandUnixMillisec: null,
 };
 
+const validateTalkProject = (talkProject: LatestProjectType["talk"]) => {
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) => audioKey in talkProject.audioItems
+    )
+  ) {
+    throw new Error(
+      "Every audioKey in audioKeys should be a key of audioItems"
+    );
+  }
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) => talkProject.audioItems[audioKey]?.voice != undefined
+    )
+  ) {
+    throw new Error('Every audioItem should have a "voice" attribute.');
+  }
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) =>
+        talkProject.audioItems[audioKey]?.voice.engineId != undefined
+    )
+  ) {
+    throw new Error('Every voice should have a "engineId" attribute.');
+  }
+  // FIXME: assert engineId is registered
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) =>
+        talkProject.audioItems[audioKey]?.voice.speakerId != undefined
+    )
+  ) {
+    throw new Error('Every voice should have a "speakerId" attribute.');
+  }
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) => talkProject.audioItems[audioKey]?.voice.styleId != undefined
+    )
+  ) {
+    throw new Error('Every voice should have a "styleId" attribute.');
+  }
+};
+
 export const projectStore = createPartialStore<ProjectStoreTypes>({
   PROJECT_NAME: {
     getter(state) {
@@ -350,53 +393,10 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           }
 
           // Validation check
+          // トークはvalidateTalkProjectで検証する
+          // ソングはSET_SCOREの中の`isValidScore`関数で検証される
           const parsedProjectData = projectSchema.parse(projectData);
-          if (
-            !parsedProjectData.talk.audioKeys.every(
-              (audioKey) => audioKey in parsedProjectData.talk.audioItems
-            )
-          ) {
-            throw new Error(
-              projectFileErrorMsg +
-                " Every audioKey in audioKeys should be a key of audioItems"
-            );
-          }
-          if (
-            !parsedProjectData.talk.audioKeys.every(
-              (audioKey) =>
-                parsedProjectData.talk.audioItems[audioKey]?.voice != undefined
-            )
-          ) {
-            throw new Error('Every audioItem should have a "voice" attribute.');
-          }
-          if (
-            !parsedProjectData.talk.audioKeys.every(
-              (audioKey) =>
-                parsedProjectData.talk.audioItems[audioKey]?.voice.engineId !=
-                undefined
-            )
-          ) {
-            throw new Error('Every voice should have a "engineId" attribute.');
-          }
-          // FIXME: assert engineId is registered
-          if (
-            !parsedProjectData.talk.audioKeys.every(
-              (audioKey) =>
-                parsedProjectData.talk.audioItems[audioKey]?.voice.speakerId !=
-                undefined
-            )
-          ) {
-            throw new Error('Every voice should have a "speakerId" attribute.');
-          }
-          if (
-            !parsedProjectData.talk.audioKeys.every(
-              (audioKey) =>
-                parsedProjectData.talk.audioItems[audioKey]?.voice.styleId !=
-                undefined
-            )
-          ) {
-            throw new Error('Every voice should have a "styleId" attribute.');
-          }
+          validateTalkProject(parsedProjectData.talk);
 
           if (confirm !== false && context.getters.IS_EDITED) {
             const result = await context.dispatch(

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -406,10 +406,10 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           const { tpqn, tempos, timeSignatures, tracks } =
             parsedProjectData.song;
           // TODO: マルチトラック対応
-          context.dispatch("SET_SINGER", {
+          await context.dispatch("SET_SINGER", {
             singer: tracks[0].singer,
           });
-          context.dispatch("SET_SCORE", {
+          await context.dispatch("SET_SCORE", {
             score: {
               tpqn,
               tempos,

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -365,6 +365,9 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               audioItems: projectData.audioItems,
             };
 
+            // ソングの情報を初期化
+            // generateSingingStoreInitialScoreが今後変わることがあるかもしれないので、
+            // 0.16.2時点のスコア情報を直接書く
             projectData.song = {
               tpqn: DEFAULT_TPQN,
               tempos: [

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -398,10 +398,11 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           const { tpqn, tempos, timeSignatures, tracks, phrases } =
             parsedProjectData.sing;
           // TODO: マルチトラック対応
-          await context.dispatch("SET_SINGER", {
+          // RENDERが無駄に走らないように、commitにしておく
+          context.commit("SET_SINGER", {
             singer: tracks[0].singer,
           });
-          await context.dispatch("SET_SCORE", {
+          context.commit("SET_SCORE", {
             score: {
               tpqn,
               tempos,
@@ -414,7 +415,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             value.state = "WAITING_TO_BE_RENDERED";
             context.commit("SET_PHRASE", { phraseKey: key, phrase: value });
           }
-          await context.dispatch("RENDER");
+          context.dispatch("RENDER");
 
           context.commit("SET_PROJECT_FILEPATH", { filePath });
           context.commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -461,8 +461,14 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             }
           }
 
-          applyTalkProjectToStore(context.dispatch, parsedProjectData.talk);
-          applySongProjectToStore(context.dispatch, parsedProjectData.song);
+          await applyTalkProjectToStore(
+            context.dispatch,
+            parsedProjectData.talk
+          );
+          await applySongProjectToStore(
+            context.dispatch,
+            parsedProjectData.song
+          );
 
           context.commit("SET_PROJECT_FILEPATH", { filePath });
           context.commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -102,6 +102,28 @@ const applyTalkProjectToStore = async (
   }
 };
 
+const applySongProjectToStore = async (
+  dispatch: Dispatch<AllActions>,
+  songProject: LatestProjectType["song"]
+) => {
+  const { tpqn, tempos, timeSignatures, tracks } = songProject;
+  // TODO: マルチトラック対応
+  await dispatch("SET_SINGER", {
+    singer: tracks[0].singer,
+  });
+  await dispatch("SET_VOICE_KEY_SHIFT", {
+    voiceKeyShift: tracks[0].voiceKeyShift,
+  });
+  await dispatch("SET_SCORE", {
+    score: {
+      tpqn,
+      tempos,
+      timeSignatures,
+      notes: tracks[0].notes,
+    },
+  });
+};
+
 export const projectStore = createPartialStore<ProjectStoreTypes>({
   PROJECT_NAME: {
     getter(state) {
@@ -440,24 +462,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           }
 
           applyTalkProjectToStore(context.dispatch, parsedProjectData.talk);
-
-          const { tpqn, tempos, timeSignatures, tracks } =
-            parsedProjectData.song;
-          // TODO: マルチトラック対応
-          await context.dispatch("SET_SINGER", {
-            singer: tracks[0].singer,
-          });
-          await context.dispatch("SET_VOICE_KEY_SHIFT", {
-            voiceKeyShift: tracks[0].voiceKeyShift,
-          });
-          await context.dispatch("SET_SCORE", {
-            score: {
-              tpqn,
-              tempos,
-              timeSignatures,
-              notes: tracks[0].notes,
-            },
-          });
+          applySongProjectToStore(context.dispatch, parsedProjectData.song);
 
           context.commit("SET_PROJECT_FILEPATH", { filePath });
           context.commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -406,11 +406,10 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           const { tpqn, tempos, timeSignatures, tracks } =
             parsedProjectData.song;
           // TODO: マルチトラック対応
-          // RENDERが無駄に走らないように、commitにしておく
-          context.commit("SET_SINGER", {
+          context.dispatch("SET_SINGER", {
             singer: tracks[0].singer,
           });
-          context.commit("SET_SCORE", {
+          context.dispatch("SET_SCORE", {
             score: {
               tpqn,
               tempos,
@@ -418,7 +417,6 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               notes: tracks[0].notes,
             },
           });
-          context.dispatch("RENDER");
 
           context.commit("SET_PROJECT_FILEPATH", { filePath });
           context.commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -24,6 +24,12 @@ import {
   styleIdSchema,
 } from "@/type/preload";
 import { getValueOrThrow, ResultError } from "@/type/result";
+import {
+  DEFAULT_BEAT_TYPE,
+  DEFAULT_BEATS,
+  DEFAULT_BPM,
+  DEFAULT_TPQN,
+} from "@/sing/storeHelper";
 
 const DEFAULT_SAMPLING_RATE = 24000;
 
@@ -317,7 +323,28 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               audioItems: projectData.audioItems,
             };
 
-            projectData.song = generateSingingStoreInitialScore();
+            projectData.song = {
+              tpqn: DEFAULT_TPQN,
+              tempos: [
+                {
+                  position: 0,
+                  bpm: DEFAULT_BPM,
+                },
+              ],
+              timeSignatures: [
+                {
+                  measureNumber: 1,
+                  beats: DEFAULT_BEATS,
+                  beatType: DEFAULT_BEAT_TYPE,
+                },
+              ],
+              tracks: [
+                {
+                  singer: undefined,
+                  notes: [],
+                },
+              ],
+            };
 
             projectData.lastActiveEditor = false;
             delete projectData.audioKeys;

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -318,8 +318,6 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             };
 
             projectData.sing = generateSingingStoreInitialScore();
-            // phrasesはmapではなくrecordにしないとパースに失敗する
-            projectData.sing.phrases = {};
 
             projectData.lastActiveEditor = false;
             delete projectData.audioKeys;
@@ -405,7 +403,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             });
           }
 
-          const { tpqn, tempos, timeSignatures, tracks, phrases } =
+          const { tpqn, tempos, timeSignatures, tracks } =
             parsedProjectData.sing;
           // TODO: マルチトラック対応
           // RENDERが無駄に走らないように、commitにしておく
@@ -420,11 +418,6 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               notes: tracks[0].notes,
             },
           });
-          for (const [key, value] of Object.entries(phrases)) {
-            // stateをレンダリング前にセットする
-            value.state = "WAITING_TO_BE_RENDERED";
-            context.commit("SET_PHRASE", { phraseKey: key, phrase: value });
-          }
           context.dispatch("RENDER");
 
           context.commit("SET_PROJECT_FILEPATH", { filePath });
@@ -505,7 +498,6 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             tempos,
             timeSignatures,
             tracks,
-            phrases,
           } = context.state;
           const projectData: LatestProjectType = {
             appVersion: appInfos.version,
@@ -520,7 +512,6 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               tempos,
               timeSignatures,
               tracks,
-              phrases: Object.fromEntries(phrases.entries()),
             },
           };
 
@@ -669,9 +660,6 @@ const projectSchema = z.object({
     tempos: z.array(tempoSchema),
     timeSignatures: z.array(timeSignatureSchema),
     tracks: z.array(trackSchema),
-    // storeではmapになっているが、mapをそのまま保存すると普通のオブジェクトに
-    // なってしまい、パースに失敗するのであえてrecordにしている
-    phrases: z.record(z.string(), phraseSchema),
   }),
 });
 

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -321,7 +321,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             // phrasesはmapではなくrecordにしないとパースに失敗する
             projectData.sing.phrases = {};
 
-            projectData.isOpenSongEditor = false;
+            projectData.lastActiveEditor = false;
             delete projectData.audioKeys;
             delete projectData.audioItems;
           }
@@ -510,7 +510,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           const projectData: LatestProjectType = {
             appVersion: appInfos.version,
             // TODO: 将来的にプロジェクトファイルによって開かれるエディタが決まるようにする
-            isOpenSongEditor: false,
+            lastActiveEditor: false,
             talk: {
               audioKeys,
               audioItems,
@@ -657,7 +657,7 @@ const audioItemSchema = z.object({
 
 const projectSchema = z.object({
   appVersion: z.string(),
-  isOpenSongEditor: z.boolean(),
+  lastActiveEditor: z.boolean(),
   talk: z.object({
     // description: "Attribute keys of audioItems.",
     audioKeys: z.array(audioKeySchema),

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -386,6 +386,8 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               tracks: [
                 {
                   singer: undefined,
+                  notesKeyShift: 0,
+                  voiceKeyShift: 0,
                   notes: [],
                 },
               ],

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -345,7 +345,6 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               ],
             };
 
-            projectData.lastActiveEditor = false;
             delete projectData.audioKeys;
             delete projectData.audioItems;
           }
@@ -525,8 +524,6 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           } = context.state;
           const projectData: LatestProjectType = {
             appVersion: appInfos.version,
-            // TODO: 将来的にプロジェクトファイルによって開かれるエディタが決まるようにする
-            lastActiveEditor: false,
             talk: {
               audioKeys,
               audioItems,
@@ -672,7 +669,6 @@ const audioItemSchema = z.object({
 
 const projectSchema = z.object({
   appVersion: z.string(),
-  lastActiveEditor: z.boolean(),
   talk: z.object({
     // description: "Attribute keys of audioItems.",
     audioKeys: z.array(audioKeySchema),

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -317,7 +317,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               audioItems: projectData.audioItems,
             };
 
-            projectData.sing = generateSingingStoreInitialScore();
+            projectData.song = generateSingingStoreInitialScore();
 
             projectData.lastActiveEditor = false;
             delete projectData.audioKeys;
@@ -404,7 +404,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           }
 
           const { tpqn, tempos, timeSignatures, tracks } =
-            parsedProjectData.sing;
+            parsedProjectData.song;
           // TODO: マルチトラック対応
           // RENDERが無駄に走らないように、commitにしておく
           context.commit("SET_SINGER", {
@@ -507,7 +507,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               audioKeys,
               audioItems,
             },
-            sing: {
+            song: {
               tpqn,
               tempos,
               timeSignatures,
@@ -655,7 +655,7 @@ const projectSchema = z.object({
     // description: "VOICEVOX states per cell",
     audioItems: z.record(audioKeySchema, audioItemSchema),
   }),
-  sing: z.object({
+  song: z.object({
     tpqn: z.number(),
     tempos: z.array(tempoSchema),
     timeSignatures: z.array(timeSignatureSchema),

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -15,7 +15,6 @@ import {
 
 import { AccentPhrase } from "@/openapi";
 import {
-  AudioKey,
   audioKeySchema,
   EngineId,
   engineIdSchema,

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -303,6 +303,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               audioKeys: projectData.audioKeys,
               audioItems: projectData.audioItems,
             };
+            projectData.isOpenSongEditor = false;
             delete projectData.audioKeys;
             delete projectData.audioItems;
           }

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -6,7 +6,6 @@ import { generateSingingStoreInitialScore } from "./singing";
 import { createUILockAction } from "@/store/ui";
 import {
   AudioItem,
-  phraseSchema,
   ProjectStoreState,
   ProjectStoreTypes,
   tempoSchema,

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -59,6 +59,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           }
         }
 
+        // トークプロジェクトの初期化
         await context.dispatch("REMOVE_ALL_AUDIO_ITEM");
 
         const audioItem: AudioItem = await context.dispatch(
@@ -67,6 +68,18 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
         );
         await context.dispatch("REGISTER_AUDIO_ITEM", {
           audioItem,
+        });
+
+        // ソングプロジェクトの初期化
+        const { tpqn, tempos, timeSignatures, tracks } =
+          generateSingingStoreInitialScore();
+        await context.dispatch("SET_SCORE", {
+          score: {
+            tpqn,
+            tempos,
+            timeSignatures,
+            notes: tracks[0].notes,
+          },
         });
 
         context.commit("SET_PROJECT_FILEPATH", { filePath: undefined });

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -439,6 +439,9 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           await context.dispatch("SET_SINGER", {
             singer: tracks[0].singer,
           });
+          await context.dispatch("SET_VOICE_KEY_SHIFT", {
+            voiceKeyShift: tracks[0].voiceKeyShift,
+          });
           await context.dispatch("SET_SCORE", {
             score: {
               tpqn,

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -310,8 +310,8 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               semverSatisfiesOptions
             )
           ) {
-            // 0.16.2 未満のプロジェクトファイルはトークモードの情報(audioKeys/audioItems)しか
-            // 保存されていなかったので、それをtalkに移動する
+            // 0.16.2 未満のプロジェクトファイルはトークの情報のみ
+            // なので全情報(audioKeys/audioItems)をtalkに移動する
             projectData.talk = {
               audioKeys: projectData.audioKeys,
               audioItems: projectData.audioItems,

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -119,30 +119,36 @@ const animationTimer = new AnimationTimer();
 // TODO: マルチトラックに対応する
 const selectedTrackIndex = 0;
 
+export const generateSingingStoreInitialScore = () => {
+  return {
+    tpqn: DEFAULT_TPQN,
+    tempos: [
+      {
+        position: 0,
+        bpm: DEFAULT_BPM,
+      },
+    ],
+    timeSignatures: [
+      {
+        measureNumber: 1,
+        beats: DEFAULT_BEATS,
+        beatType: DEFAULT_BEAT_TYPE,
+      },
+    ],
+    tracks: [
+      {
+        singer: undefined,
+        notesKeyShift: 0,
+        voiceKeyShift: 0,
+        notes: [],
+      },
+    ],
+    phrases: new Map(),
+  };
+};
+
 export const singingStoreState: SingingStoreState = {
-  tpqn: DEFAULT_TPQN,
-  tempos: [
-    {
-      position: 0,
-      bpm: DEFAULT_BPM,
-    },
-  ],
-  timeSignatures: [
-    {
-      measureNumber: 1,
-      beats: DEFAULT_BEATS,
-      beatType: DEFAULT_BEAT_TYPE,
-    },
-  ],
-  tracks: [
-    {
-      singer: undefined,
-      notesKeyShift: 0,
-      voiceKeyShift: 0,
-      notes: [],
-    },
-  ],
-  phrases: new Map(),
+  ...generateSingingStoreInitialScore(),
   // NOTE: UIの状態は試行のためsinging.tsに局所化する+Hydrateが必要
   isShowSinger: true,
   sequencerZoomX: 0.5,

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1056,7 +1056,10 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           const phraseKey = hash;
           if (!state.phrases.has(phraseKey)) {
             commit("SET_PHRASE", { phraseKey, phrase });
+          }
 
+          // SET_PHRASEがRENDER外から呼ばれた場合にはphraseDataMapにデータが存在しないので、ここで追加する
+          if (!phraseDataMap.has(phraseKey)) {
             // フレーズ追加時の処理
             const noteEvents = generateNoteEvents(
               phrase.notes,

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1062,10 +1062,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           const phraseKey = hash;
           if (!state.phrases.has(phraseKey)) {
             commit("SET_PHRASE", { phraseKey, phrase });
-          }
 
-          // SET_PHRASEがRENDER外から呼ばれた場合にはphraseDataMapにデータが存在しないので、ここで追加する
-          if (!phraseDataMap.has(phraseKey)) {
             // フレーズ追加時の処理
             const noteEvents = generateNoteEvents(
               phrase.notes,

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -143,12 +143,12 @@ export const generateSingingStoreInitialScore = () => {
         notes: [],
       },
     ],
-    phrases: new Map(),
   };
 };
 
 export const singingStoreState: SingingStoreState = {
   ...generateSingingStoreInitialScore(),
+  phrases: new Map(),
   // NOTE: UIの状態は試行のためsinging.tsに局所化する+Hydrateが必要
   isShowSinger: true,
   sequencerZoomX: 0.5,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -755,39 +755,25 @@ export const trackSchema = z.object({
 });
 export type Track = z.infer<typeof trackSchema>;
 
-export const phraseStateSchema = z.union([
-  z.literal("WAITING_TO_BE_RENDERED"),
-  z.literal("NOW_RENDERING"),
-  z.literal("COULD_NOT_RENDER"),
-  z.literal("PLAYABLE"),
-]);
-export type PhraseState = z.infer<typeof phraseStateSchema>;
+export type PhraseState =
+  | "WAITING_TO_BE_RENDERED"
+  | "NOW_RENDERING"
+  | "COULD_NOT_RENDER"
+  | "PLAYABLE";
 
-export const phraseSchema = z.object({
-  singer: singerSchema.optional(),
-  notesKeyShift: z.number(),
-  voiceKeyShift: z.number(),
-  tpqn: z.number(),
-  tempos: z.array(tempoSchema),
-  notes: z.array(noteSchema),
-  startTicks: z.number(),
-  endTicks: z.number(),
-  state: phraseStateSchema,
-  query: z
-    .object({
-      f0: z.array(z.number()),
-      volume: z.array(z.number()),
-      phonemes: z.array(
-        z.object({ phoneme: z.string(), frameLength: z.number() })
-      ),
-      volumeScale: z.number(),
-      outputSamplingRate: z.number(),
-      outputStereo: z.boolean(),
-    })
-    .optional(),
-  startTime: z.number().optional(),
-});
-export type Phrase = z.infer<typeof phraseSchema>;
+export type Phrase = {
+  singer?: Singer;
+  notesKeyShift: number;
+  voiceKeyShift: number;
+  tpqn: number;
+  tempos: Tempo[];
+  notes: Note[];
+  startTicks: number;
+  endTicks: number;
+  state: PhraseState;
+  query?: FrameAudioQuery;
+  startTime?: number;
+};
 
 export type SingingStoreState = {
   tpqn: number;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -709,8 +709,8 @@ export type AudioPlayerStoreTypes = {
  * Singing Store Types
  */
 
-// schemaはproject向けのものだが、そこから型定義を生成できるので一旦ここに置いておく
-// TODO: schemaをいい感じにおけるファイルを作る
+// schemaはプロジェクトファイル用
+// TODO: schemaをsrc/domain/projectSchema.tsに移動する
 export const tempoSchema = z.object({
   position: z.number(),
   bpm: z.number(),


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通りです。ソングエディタの状態をプロジェクトとして保存できるようにします。
また、これに合わせてプロジェクトの構造を変更しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #1781 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
![image](https://github.com/VOICEVOX/voicevox/assets/34832037/7654ff54-753a-409f-9741-832942f8ba76)


## その他

zodのスキーマを有効活用するために一部リファクタリングを行っています。

また、現状ではソング部分のプロジェクトの変更検知を行っていない(変更検知がCOMMANDに依存しているため)ので、変更していてもプロジェクトを保存せずに閉じれてしまう問題があります。wipでもいいので、ソング部分のプロジェクト変更検知機能を付けるか迷ったのですが、変更前のプロジェクトを保持しておく以外に変更検知をする手段が思いつかなかったので、このPRでは取り組んでいません。