### PR TITLE
ヘルプ画面の音声ライブラリの利用規約セクションのリデザイン

### DIFF
--- a/src/components/help/HelpDialog.vue
+++ b/src/components/help/HelpDialog.vue
@@ -93,7 +93,7 @@ import UpdateInfo from "../template/HelpUpdateInfoSection.vue";
 import OssCommunityInfo from "../template/HelpOssCommunityInfoSection.vue";
 import QAndA from "../template/HelpQAndASection.vue";
 import ContactInfo from "../template/HelpContactInfoSection.vue";
-import LibraryPolicy from "./LibraryPolicy.vue";
+import LibraryPolicy from "../template/HelpLibraryPolicySection.vue";
 import { UpdateInfo as UpdateInfoObject } from "@/type/preload";
 import { useStore } from "@/store";
 import { useFetchNewUpdateInfos } from "@/composables/useFetchNewUpdateInfos";

--- a/src/components/template/HelpLibraryPolicySection.vue
+++ b/src/components/template/HelpLibraryPolicySection.vue
@@ -58,6 +58,7 @@
           }}
         </h1>
         <BaseDocumentView>
+          <!-- eslint-disable-next-line vue/no-v-html -->
           <div v-if="policy" class="markdown" v-html="policy"></div>
         </BaseDocumentView>
       </div>

--- a/src/components/template/HelpLibraryPolicySection.vue
+++ b/src/components/template/HelpLibraryPolicySection.vue
@@ -57,7 +57,6 @@
             )
           }}
         </h1>
-        <!-- eslint-disable-next-line vue/no-v-html -->
         <BaseDocumentView>
           <div v-if="policy" class="markdown" v-html="policy"></div>
         </BaseDocumentView>


### PR DESCRIPTION
## 内容

残っていたヘルプ画面の音声ライブラリの利用規約セクションの新しいデザインへの変更を行います。デザインはライセンス情報のものとほぼ同一のものです。

## スクリーンショット・動画など

![image](https://github.com/VOICEVOX/voicevox/assets/53995265/506071f6-8cff-4471-9773-906c290f4dbf)
![image](https://github.com/VOICEVOX/voicevox/assets/53995265/8289f486-02e8-4e34-a428-b06350166d29)

## その他