### PR TITLE
fix: dev版のアップロードが失敗する問題を修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -471,21 +471,14 @@ jobs:
             dist_electron/*.dmg
           target_commitish: ${{ github.sha }}
 
-      - name: Create Windows NSIS Web artifact directory
-        if: endsWith(matrix.installer_artifact_name, '-nsis-web')
-        run: |
-          mkdir -p nsis-web-artifact
-          mv dist_electron/nsis-web/out/*.7z.* nsis-web-artifact/
-          mv dist_electron/nsis-web/*.exe nsis-web-artifact/
-
       - name: Upload Windows NSIS Web to Artifacts
         if: endsWith(matrix.installer_artifact_name, '-nsis-web') && github.event.inputs.upload_artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.installer_artifact_name }}-release
           path: |-
-            nsis-web-artifact/*.7z.*
-            nsis-web-artifact/*.exe
+            dist_electron/nsis-web/out/*.7z.*
+            dist_electron/nsis-web/*.exe
 
       - name: Upload Windows NSIS Web to Release Assets
         if: endsWith(matrix.installer_artifact_name, '-nsis-web') && (github.event.release.tag_name || github.event.inputs.version) != ''
@@ -494,6 +487,6 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
           tag_name: ${{ env.VOICEVOX_EDITOR_VERSION }}
           files: |-
-            nsis-web-artifact/*.7z.*
-            nsis-web-artifact/*.exe
+            dist_electron/nsis-web/out/*.7z.*
+            dist_electron/nsis-web/*.exe
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,7 +294,6 @@ jobs:
       - name: Recover file permissions for macOS build
         if: startsWith(matrix.artifact_name, 'macos-') # macOS
         run: |
-          chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/${{ matrix.macos_executable_name }}"
           chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/vv-engine/run"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (GPU).app/Contents/MacOS/VOICEVOX Helper (GPU)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Plugin).app/Contents/MacOS/VOICEVOX Helper (Plugin)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
             compressed_artifact_name: voicevox-windows-nvidia
             app_asar_dir: prepackage/resources
             installer_artifact_name: windows-nvidia-nsis-web
-            nsis_web_artifact_name: "VOICEVOX-CUDA Web Setup ${version}.${ext}"
+            nsis_web_artifact_name: "VOICEVOX-CUDA.Web.Setup.${version}.${ext}"
             os: windows-2019
           # Windows CPU
           - artifact_name: windows-cpu-prepackage
@@ -99,7 +99,7 @@ jobs:
             compressed_artifact_name: voicevox-windows-cpu
             app_asar_dir: prepackage/resources
             installer_artifact_name: windows-cpu-nsis-web
-            nsis_web_artifact_name: "VOICEVOX-CPU Web Setup ${version}.${ext}"
+            nsis_web_artifact_name: "VOICEVOX-CPU.Web.Setup.${version}.${ext}"
             os: windows-2019
           # Windows DirectML
           - artifact_name: windows-directml-prepackage
@@ -109,7 +109,7 @@ jobs:
             compressed_artifact_name: voicevox-windows-directml
             app_asar_dir: prepackage/resources
             installer_artifact_name: windows-directml-nsis-web
-            nsis_web_artifact_name: "VOICEVOX Web Setup ${version}.${ext}"
+            nsis_web_artifact_name: "VOICEVOX.Web.Setup.${version}.${ext}"
             os: windows-2019
           # macOS CPU
           - artifact_name: macos-cpu-prepackage
@@ -119,7 +119,7 @@ jobs:
             compressed_artifact_name: voicevox-macos-cpu
             app_asar_dir: prepackage/VOICEVOX.app/Contents/Resources
             installer_artifact_name: macos-cpu-dmg
-            macos_artifact_name: "VOICEVOX ${version}.${ext}"
+            macos_artifact_name: "VOICEVOX.${version}.${ext}"
             os: macos-11
 
     runs-on: ${{ matrix.os }}
@@ -477,16 +477,6 @@ jobs:
           mkdir -p nsis-web-artifact
           mv dist_electron/nsis-web/out/*.7z.* nsis-web-artifact/
           mv dist_electron/nsis-web/*.exe nsis-web-artifact/
-
-      # Rename file name like "VOICEVOX Web Setup X.X.X.exe" to "VOICEVOX.Web.Setup.X.X.X.exe".
-      - name: Rename Windows NSIS Web Installer
-        if: endsWith(matrix.installer_artifact_name, '-nsis-web')
-        run: |
-          cd nsis-web-artifact
-          OLD_NAME=`find . -maxdepth 1 -name '*.exe'`
-          # replace space by dot(.)
-          NEW_NAME=${OLD_NAME// /.}
-          mv "${OLD_NAME}" $NEW_NAME
 
       - name: Upload Windows NSIS Web to Artifacts
         if: endsWith(matrix.installer_artifact_name, '-nsis-web') && github.event.inputs.upload_artifact


### PR DESCRIPTION
## 内容

dmgのファイル名のスペースをピリオドに変更することで問題を修正します。
これによるリリース後のファイル名に影響はありません。

また、Windowsのインストーラーはビルド後にファイル名を置換してからアップロードしていましたが最初からスペースのないファイル名でビルドするように変更しました。

## 関連 Issue

- fix #1845

## その他

この処理はいらない？
https://github.com/sabonerune/voicevox/blob/02fbce2e7c7ccd323f6a7210b8da1094b162ca9f/.github/workflows/build.yml#L474-L479