### PR TITLE
[ソング] Macにおいて、スコアシーケンサー内でCtrlキーではなくCommandキーを使うようにする

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -217,6 +217,7 @@ import SequencerKeys from "@/components/Sing/SequencerKeys.vue";
 import SequencerNote from "@/components/Sing/SequencerNote.vue";
 import SequencerPhraseIndicator from "@/components/Sing/SequencerPhraseIndicator.vue";
 import CharacterPortrait from "@/components/Sing/CharacterPortrait.vue";
+import { isOnCommandOrCtrlKeyDown } from "@/store/utility";
 
 type PreviewMode = "ADD" | "MOVE" | "RESIZE_RIGHT" | "RESIZE_LEFT";
 
@@ -606,7 +607,7 @@ const startPreview = (event: MouseEvent, mode: PreviewMode, note?: Note) => {
         }
       }
       store.dispatch("SELECT_NOTES", { noteIds: noteIdsToSelect });
-    } else if (event.ctrlKey) {
+    } else if (isOnCommandOrCtrlKeyDown(event)) {
       store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
     } else if (!state.selectedNoteIds.has(note.id)) {
       selectOnlyThis(note);
@@ -926,7 +927,7 @@ const onWheel = (event: WheelEvent) => {
   if (!sequencerBodyElement) {
     throw new Error("sequencerBodyElement is null.");
   }
-  if (event.ctrlKey) {
+  if (isOnCommandOrCtrlKeyDown(event)) {
     cursorX = getXInBorderBox(event.clientX, sequencerBodyElement);
     // マウスカーソル位置を基準に水平方向のズームを行う
     const oldZoomX = zoomX.value;


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題のとおりです。
複数選択をしたい際や、マウスホイールに関連した操作をする際に、Ctrlキーが使われていましたが、MacだとCtrlキーは右クリックの扱いで操作が吸われる事があり、特に複数選択で支障があります。
これを既存の`isOnCommandOrCtrlKeyDown`関数を使うことで解決します。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
