### PR TITLE
fix 歌wave出力時のデフォルトファイル名を変更

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1888,7 +1888,21 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         };
 
         const exportWaveFile = async (): Promise<SaveResultObject> => {
-          const fileName = "test_export.wav"; // TODO: 設定できるようにする
+          var fileName = "song.wav"
+          const singer = getters.SELECTED_TRACK.singer;
+          const singerName = (getters.CHARACTER_INFO(singer!.engineId, (singer!.styleId))!.metas.speakerName);
+          if(singerName){
+          const notes = getters.SELECTED_TRACK.notes.slice(0, 5);
+          const beginningPartLyrics = notes.map((elem) => elem.lyric).join("");
+           fileName = singerName + "_" + beginningPartLyrics + ".wav";
+          }
+          
+          const projectName = getters.PROJECT_NAME
+          if (projectName){
+            fileName = projectName.split(".")[0] + ".wav";
+          }
+
+           // TODO: 設定できるようにする
           const numberOfChannels = 2;
           const sampleRate = 48000; // TODO: 設定できるようにする
           const withLimiter = false; // TODO: 設定できるようにする

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -15,6 +15,7 @@ import {
   Phrase,
   PhraseState,
 } from "./type";
+import { sanitizeFileName } from "./utility";
 import { EngineId } from "@/type/preload";
 import { FrameAudioQuery, Note as NoteForRequestToEngine } from "@/openapi";
 import { ResultError, getValueOrThrow } from "@/type/result";
@@ -1886,6 +1887,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           const lastNoteEndTime = getters.TICK_TO_SECOND(lastNoteEndPosition);
           return Math.max(1, lastNoteEndTime + 1);
         };
+
         const generateDefaultSongFileName = () => {
           const projectName = getters.PROJECT_NAME;
           if (projectName) {
@@ -1903,11 +1905,15 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               const beginningPartLyrics = notes
                 .map((note) => note.lyric)
                 .join("");
-              return `${singerName}_${beginningPartLyrics}.wav`;
+              return sanitizeFileName(
+                `${singerName}_${beginningPartLyrics}.wav`
+              );
             }
           }
-          return "song.wav";
+
+          return "Untitled.wav";
         };
+
         const exportWaveFile = async (): Promise<SaveResultObject> => {
           const fileName = generateDefaultSongFileName();
           const numberOfChannels = 2;

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1886,23 +1886,30 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           const lastNoteEndTime = getters.TICK_TO_SECOND(lastNoteEndPosition);
           return Math.max(1, lastNoteEndTime + 1);
         };
+        const generateDefaultSongFileName = () => {
+          const projectName = getters.PROJECT_NAME;
+          if (projectName) {
+            return projectName.split(".")[0] + ".wav";
+          }
 
-        const exportWaveFile = async (): Promise<SaveResultObject> => {
-          var fileName = "song.wav"
           const singer = getters.SELECTED_TRACK.singer;
-          const singerName = (getters.CHARACTER_INFO(singer!.engineId, (singer!.styleId))!.metas.speakerName);
-          if(singerName){
-          const notes = getters.SELECTED_TRACK.notes.slice(0, 5);
-          const beginningPartLyrics = notes.map((elem) => elem.lyric).join("");
-           fileName = singerName + "_" + beginningPartLyrics + ".wav";
+          if (singer) {
+            const singerName = getters.CHARACTER_INFO(
+              singer.engineId,
+              singer.styleId
+            )?.metas.speakerName;
+            if (singerName) {
+              const notes = getters.SELECTED_TRACK.notes.slice(0, 5);
+              const beginningPartLyrics = notes
+                .map((note) => note.lyric)
+                .join("");
+              return `${singerName}_${beginningPartLyrics}.wav`;
+            }
           }
-          
-          const projectName = getters.PROJECT_NAME
-          if (projectName){
-            fileName = projectName.split(".")[0] + ".wav";
-          }
-
-           // TODO: 設定できるようにする
+          return "song.wav";
+        };
+        const exportWaveFile = async (): Promise<SaveResultObject> => {
+          const fileName = generateDefaultSongFileName();
           const numberOfChannels = 2;
           const sampleRate = 48000; // TODO: 設定できるようにする
           const withLimiter = false; // TODO: 設定できるようにする


### PR DESCRIPTION
## 内容
src/store/singing.tsの1981行目に以下を追加しました。
```javascript
var fileName = "song.wav"

const singer = getters.SELECTED_TRACK.singer;
const singerName = 
(getters.CHARACTER_INFO(singer!.engineId,(singer!.styleId))!.metas.speakerName);
          
if(singerName){
    const notes = getters.SELECTED_TRACK.notes.slice(0, 5);
    const beginningPartLyrics = notes.map((elem) => elem.lyric).join("");
    fileName = singerName + "_" + beginningPartLyrics + ".wav";
 }
            
const projectName = getters.PROJECT_NAME
if (projectName){
     fileName = projectName.split(".")[0] + ".wav";
 }
```

## 関連 Issue
ref #1833 

## その他
> プロジェクトファイル名が指定されている場合はプロジェクトファイル名.wavが良い気がします。
> プロジェクトファイル名が指定されていない場合は、たとえば[キャラ名]_[出だしの歌詞数文字]とかが良いと思います。

両方に対応しました。