### PR TITLE
[ソング] undoとredoのショートカットキー登録

### DIFF
--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -136,10 +136,34 @@ import CharacterMenuButton from "@/components/Sing/CharacterMenuButton/MenuButto
 import { useHotkeyManager } from "@/plugins/hotkeyPlugin";
 
 const store = useStore();
+
+const uiLocked = computed(() => store.getters.UI_LOCKED);
+const editor = "song";
+const canUndo = computed(() => store.getters.CAN_UNDO(editor));
+const canRedo = computed(() => store.getters.CAN_REDO(editor));
+
 const { registerHotkeyWithCleanup } = useHotkeyManager();
+registerHotkeyWithCleanup({
+  editor,
+  name: "元に戻す",
+  callback: () => {
+    if (!uiLocked.value && canUndo.value) {
+      undo();
+    }
+  },
+});
+registerHotkeyWithCleanup({
+  editor,
+  name: "やり直す",
+  callback: () => {
+    if (!uiLocked.value && canRedo.value) {
+      redo();
+    }
+  },
+});
 
 registerHotkeyWithCleanup({
-  editor: "song",
+  editor,
   name: "再生/停止",
   callback: () => {
     if (nowPlaying.value) {
@@ -149,10 +173,6 @@ registerHotkeyWithCleanup({
     }
   },
 });
-
-const editor = "song";
-const canUndo = computed(() => store.getters.CAN_UNDO(editor));
-const canRedo = computed(() => store.getters.CAN_REDO(editor));
 
 const undo = () => {
   store.dispatch("UNDO", { editor });

--- a/src/components/Talk/ToolBar.vue
+++ b/src/components/Talk/ToolBar.vue
@@ -54,7 +54,7 @@ const nowPlayingContinuously = computed(
 
 const { registerHotkeyWithCleanup } = useHotkeyManager();
 registerHotkeyWithCleanup({
-  editor: "talk",
+  editor,
   name: "元に戻す",
   callback: () => {
     if (!uiLocked.value && canUndo.value) {
@@ -63,7 +63,7 @@ registerHotkeyWithCleanup({
   },
 });
 registerHotkeyWithCleanup({
-  editor: "talk",
+  editor,
   name: "やり直す",
   callback: () => {
     if (!uiLocked.value && canRedo.value) {
@@ -73,7 +73,7 @@ registerHotkeyWithCleanup({
 });
 
 registerHotkeyWithCleanup({
-  editor: "talk",
+  editor,
   name: "連続再生/停止",
   callback: () => {
     if (!uiLocked.value) {


### PR DESCRIPTION
## 内容

ソングでのundo/redoがショートカットキー設定されてなかったので追加します。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/1822
- https://github.com/VOICEVOX/voicevox/pull/1836

## その他

macでcmdキーが効かなくなってることに気づいたのでissue作成します。