### PR TITLE
[Docs] READMEにworkflow_dispatchを使ったビルド方法を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ npm run browser:serve
 npm run electron:build
 ```
 
+### Github Actions でビルド
+
+fork したリポジトリで Actions を ON にし、workflow_dispatch で`build.yml`を起動すればビルドできます。
+成果物は Release にアップロードされます。
+
 ## テスト
 
 ### 単体テスト


### PR DESCRIPTION
## 内容

タイトルの通りです。
Github Actionsでのビルド方法を忘れるかもだったのでメモしておきました。
たぶんコントリビューターの方にも役に立つはず。

## その他
