### PR TITLE
feat: 書き出し先を固定を有効にしたときに書き出し先が未選択の場合は自動的にダイアログを表示する

### DIFF
--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -127,7 +127,7 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
     ">=0.16",
     (config) => {
       // 書き出し先のディレクトリが空文字の場合書き出し先固定を無効化する
-      // FIXME: ダイアログで案内する
+      // FIXME: 勝手に書き換えるのは少し不親切なので、ダイアログで書き換えたことを案内する
       const savingSetting = config.savingSetting as ConfigType["savingSetting"];
       if (
         savingSetting.fixedExportEnabled &&

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -127,8 +127,12 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
     ">=0.16",
     (config) => {
       // 書き出し先のディレクトリが空文字の場合書き出し先固定を無効化する
-      if (config.fixedExportEnabled && config.fixedExportDir === "") {
-        config.fixedExportEnabled = false;
+      const savingSetting = config.savingSetting as ConfigType["savingSetting"];
+      if (
+        savingSetting.fixedExportEnabled &&
+        savingSetting.fixedExportDir === ""
+      ) {
+        savingSetting.fixedExportEnabled = false;
       }
     },
   ],

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -123,6 +123,15 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
       return config;
     },
   ],
+  [
+    ">=0.16",
+    (config) => {
+      // 書き出し先のディレクトリが空文字の場合書き出し先固定を無効化する
+      if (config.fixedExportEnabled && config.fixedExportDir === "") {
+        config.fixedExportEnabled = false;
+      }
+    },
+  ],
 ];
 
 export type Metadata = {

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -127,6 +127,7 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
     ">=0.16",
     (config) => {
       // 書き出し先のディレクトリが空文字の場合書き出し先固定を無効化する
+      // FIXME: ダイアログで案内する
       const savingSetting = config.savingSetting as ConfigType["savingSetting"];
       if (
         savingSetting.fixedExportEnabled &&

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -124,7 +124,7 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
     },
   ],
   [
-    ">=0.16",
+    ">=0.17",
     (config) => {
       // 書き出し先のディレクトリが空文字の場合書き出し先固定を無効化する
       // FIXME: 勝手に書き換えるのは少し不親切なので、ダイアログで書き換えたことを案内する


### PR DESCRIPTION
## 内容

書き出し先を固定を有効にしたときに書き出し先が未選択の場合、自動的にダイアログを表示するようにします。
これにより意図せずインストールディレクトリにファイルが保存されてしまう問題を回避します。

## 関連 Issue

- fix #1847 

## その他

既に書き出し先を固定・未選択の場合起動直後に突然ダイアログが表示されてしまうのでとりあえずマイグレーション処理で書き出し先の固定を無効に切り替えるようにしてしまいました。