### PR TITLE
Add: キャラクターを選択するショートカットキー

### DIFF
--- a/src/components/Talk/AudioCell.vue
+++ b/src/components/Talk/AudioCell.vue
@@ -50,6 +50,7 @@
       :loading="isInitializingSpeaker"
       :show-engine-info="isMultipleEngine"
       :ui-locked="uiLocked"
+      :is-active-audio-cell="isActiveAudioCell"
       @focus="
         if (!isSelectedAudioCell) {
           selectAndSetActiveAudioKey();


### PR DESCRIPTION
## 内容

talk内において、ctrl/command+番号で「上から N 番目のキャラクターの選択」するショートカットキーの追加

isActiveAudioCellがtrueのAudioCellのCharacterButtonが ショートカットキー入力を待ちます

## 関連 Issue

ref #1187

## その他
- 未検証な点
AudioCellを複数選択した時の動作
Mac/Linuxの動作
- Cons 悪い点
キー割り当てと衝突してもわからない
新たに別のctrl+数字のショートカットキーを作るときに邪魔になりそう

hotkeyの方を変更するのが大変そうだったのでやめたのですが、やっぱりそっちに追加した方が良さそう...？といったところです！