### PR TITLE
#1864 ノートのエラー時にツールチップ表示

### DIFF
--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -36,26 +36,29 @@
       @keydown.stop="onLyricInputKeyDown"
       @blur="onLyricInputBlur"
     />
-    <QTooltip
-      v-if="hasOverlappingError && !showLyricInput"
-      anchor="bottom left"
-      self="top left"
-      :offset="[0, 8]"
-      transition-show=""
-      transition-hide=""
-    >
-      ノートが重なっています
-    </QTooltip>
-    <QTooltip
-      v-if="hasPhraseError && !showLyricInput"
-      anchor="bottom left"
-      self="top left"
-      :offset="[0, 8]"
-      transition-show=""
-      transition-hide=""
-    >
-      フレーズが生成できません。歌詞は日本語1文字までです。
-    </QTooltip>
+    <template v-else>
+      <!-- エラー内容を表示 -->
+      <QTooltip
+        v-if="hasOverlappingError"
+        anchor="bottom left"
+        self="top left"
+        :offset="[0, 8]"
+        transition-show=""
+        transition-hide=""
+      >
+        ノートが重なっています
+      </QTooltip>
+      <QTooltip
+        v-if="hasPhraseError"
+        anchor="bottom left"
+        self="top left"
+        :offset="[0, 8]"
+        transition-show=""
+        transition-hide=""
+      >
+        フレーズが生成できません。歌詞は日本語1文字までです。
+      </QTooltip>
+    </template>
   </div>
 </template>
 

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -3,7 +3,8 @@
     class="note"
     :class="{
       selected: noteState === 'SELECTED',
-      overlapping: noteState === 'OVERLAPPING',
+      overlapping: hasOverlappingError,
+      'invalid-phrase': hasPhraseError,
       'below-pitch': showPitch,
     }"
     :style="{
@@ -35,6 +36,26 @@
       @keydown.stop="onLyricInputKeyDown"
       @blur="onLyricInputBlur"
     />
+    <QTooltip
+      v-if="hasOverlappingError && !showLyricInput"
+      anchor="bottom left"
+      self="top left"
+      :offset="[0, 8]"
+      transition-show=""
+      transition-hide=""
+    >
+      ノートが重なっています
+    </QTooltip>
+    <QTooltip
+      v-if="hasPhraseError && !showLyricInput"
+      anchor="bottom left"
+      self="top left"
+      :offset="[0, 8]"
+      transition-show=""
+      transition-hide=""
+    >
+      フレーズが生成できません。歌詞は日本語1文字までです。
+    </QTooltip>
   </div>
 </template>
 
@@ -50,7 +71,12 @@ import {
 import ContextMenu from "@/components/Menu/ContextMenu.vue";
 import { MenuItemButton } from "@/components/Menu/type";
 
-type NoteState = "NORMAL" | "SELECTED" | "OVERLAPPING";
+type NoteState =
+  | "NORMAL"
+  | "SELECTED"
+  | "RESIZING_LEFT"
+  | "RESIZING_RIGHT"
+  | "MOVING";
 
 const vFocus = {
   mounted(el: HTMLInputElement) {
@@ -102,11 +128,27 @@ const noteState = computed((): NoteState => {
   if (props.isSelected) {
     return "SELECTED";
   }
-  if (state.overlappingNoteIds.has(props.note.id)) {
-    return "OVERLAPPING";
-  }
   return "NORMAL";
 });
+
+// ノートの重なりエラー
+const hasOverlappingError = computed(() => {
+  return state.overlappingNoteIds.has(props.note.id);
+});
+
+// フレーズ生成エラー
+const hasPhraseError = computed(() => {
+  const phrases = state.phrases;
+  return Array.from(phrases.values()).some((phrase) => {
+    if (phrase.state !== "COULD_NOT_RENDER") {
+      return false;
+    }
+    if (phrase.notes.some((note) => note.id === props.note.id)) {
+      return true;
+    }
+  });
+});
+
 const lyric = computed({
   get() {
     return props.note.lyric;
@@ -209,19 +251,32 @@ const onLyricInputBlur = () => {
   &.selected {
     // 色は仮
     .note-bar {
-      background-color: hsl(33, 100%, 50%);
+      background-color: hsl(130, 35%, 90%);
+      border: 2px solid colors.$primary;
     }
 
     &.below-pitch {
       .note-bar {
-        background-color: rgba(hsl(33, 100%, 50%), 0.18);
+        background-color: rgba(hsl(130, 100%, 50%), 0.18);
       }
     }
   }
 
-  &.overlapping {
+  &.overlapping,
+  &.invalid-phrase {
     .note-bar {
-      background-color: hsl(130, 35%, 85%);
+      background-color: rgba(colors.$warning-rgb, 0.5);
+    }
+
+    .note-lyric {
+      opacity: 0.6;
+    }
+
+    &.selected {
+      .note-bar {
+        background-color: rgba(colors.$warning-rgb, 0.5);
+        border-color: colors.$warning;
+      }
     }
   }
 }
@@ -274,8 +329,10 @@ const onLyricInputBlur = () => {
   position: absolute;
   bottom: 0;
   font-weight: 700;
-  width: 2rem;
-  border: 1px solid hsl(33, 100%, 73%);
+  min-width: 3rem;
+  max-width: 6rem;
+  border: 0;
+  outline: 2px solid colors.$primary;
   border-radius: 0.25rem;
 }
 </style>

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -71,12 +71,7 @@ import {
 import ContextMenu from "@/components/Menu/ContextMenu.vue";
 import { MenuItemButton } from "@/components/Menu/type";
 
-type NoteState =
-  | "NORMAL"
-  | "SELECTED"
-  | "RESIZING_LEFT"
-  | "RESIZING_RIGHT"
-  | "MOVING";
+type NoteState = "NORMAL" | "SELECTED";
 
 const vFocus = {
   mounted(el: HTMLInputElement) {

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -133,15 +133,12 @@ const hasOverlappingError = computed(() => {
 
 // フレーズ生成エラー
 const hasPhraseError = computed(() => {
-  const phrases = state.phrases;
-  return Array.from(phrases.values()).some((phrase) => {
-    if (phrase.state !== "COULD_NOT_RENDER") {
-      return false;
-    }
-    if (phrase.notes.some((note) => note.id === props.note.id)) {
-      return true;
-    }
-  });
+  // エラーがあるフレーズに自身が含まれているか
+  return Array.from(state.phrases.values()).some(
+    (phrase) =>
+      phrase.state === "COULD_NOT_RENDER" &&
+      phrase.notes.some((note) => note.id === props.note.id)
+  );
 });
 
 const lyric = computed({


### PR DESCRIPTION
## 内容

- ノートの重なりエラー時にホバーでツールチップ表示
- ノートのフレーズエラー時にホバーでツールチップ表示

**いったん動作しますが、可能であればホバー表示条件のリファクタをおこなればと思います**
(来週火曜まで時間とれるか不明なため、プルリクとして作成)

## 関連 Issue

ref #1864
close #1864

## スクリーンショット・動画など

<img width="997" alt="スクリーンショット 2024-03-03 14 58 34" src="https://github.com/VOICEVOX/voicevox/assets/9082140/5859ec94-8a83-4f82-a68b-cd09bfc037ae">

<img width="992" alt="スクリーンショット 2024-03-03 14 55 19" src="https://github.com/VOICEVOX/voicevox/assets/9082140/492ec8c2-e3b8-4274-87ad-ee3bedd62225">


## その他

※ 色は仮です・別途別Issue