### PR TITLE
音域補正用のパラメーターを増やしつつ、開発時のみの機能に

### DIFF
--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -135,7 +135,7 @@ import {
   isValidBeatType,
   isValidBeats,
   isValidBpm,
-  isValidVoiceKeyShift,
+  isValidGuidePitchShift,
 } from "@/sing/domain";
 import CharacterMenuButton from "@/components/Sing/CharacterMenuButton/MenuButton.vue";
 import { useHotkeyManager } from "@/plugins/hotkeyPlugin";
@@ -188,7 +188,7 @@ const redo = () => {
 
 const tempos = computed(() => store.state.tempos);
 const timeSignatures = computed(() => store.state.timeSignatures);
-const keyShift = computed(() => store.getters.SELECTED_TRACK.voiceKeyShift);
+const keyShift = computed(() => store.getters.SELECTED_TRACK.guidePitchShift);
 
 const bpmInputBuffer = ref(120);
 const beatsInputBuffer = ref(4);
@@ -242,7 +242,7 @@ const setBeatTypeInputBuffer = (beatTypeStr: string | number | null) => {
 
 const setKeyShiftInputBuffer = (keyShiftStr: string | number | null) => {
   const keyShiftValue = Number(keyShiftStr);
-  if (!isValidVoiceKeyShift(keyShiftValue)) {
+  if (!isValidGuidePitchShift(keyShiftValue)) {
     return;
   }
   keyShiftInputBuffer.value = keyShiftValue;
@@ -271,8 +271,8 @@ const setTimeSignature = () => {
 };
 
 const setKeyShift = () => {
-  const voiceKeyShift = keyShiftInputBuffer.value;
-  store.dispatch("COMMAND_SET_VOICE_KEY_SHIFT", { voiceKeyShift });
+  const guidePitchShift = keyShiftInputBuffer.value;
+  store.dispatch("COMMAND_SET_GUIDE_PITCH_SHIFT", { guidePitchShift });
 };
 
 const playheadTicks = ref(0);

--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -8,7 +8,7 @@
         <QInput
           type="number"
           :model-value="keyShiftInputBuffer"
-          label="音域補正"
+          label="音域調整"
           dense
           hide-bottom-space
           class="key-shift"

--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -8,7 +8,7 @@
         <QInput
           type="number"
           :model-value="keyShiftInputBuffer"
-          label="音高補正"
+          label="音域補正"
           dense
           hide-bottom-space
           class="key-shift"
@@ -135,7 +135,7 @@ import {
   isValidBeatType,
   isValidBeats,
   isValidBpm,
-  isValidGuidePitchShift,
+  isValidKeyShift,
 } from "@/sing/domain";
 import CharacterMenuButton from "@/components/Sing/CharacterMenuButton/MenuButton.vue";
 import { useHotkeyManager } from "@/plugins/hotkeyPlugin";
@@ -188,7 +188,7 @@ const redo = () => {
 
 const tempos = computed(() => store.state.tempos);
 const timeSignatures = computed(() => store.state.timeSignatures);
-const keyShift = computed(() => store.getters.SELECTED_TRACK.guidePitchShift);
+const keyShift = computed(() => store.getters.SELECTED_TRACK.guideKeyShift);
 
 const bpmInputBuffer = ref(120);
 const beatsInputBuffer = ref(4);
@@ -242,7 +242,7 @@ const setBeatTypeInputBuffer = (beatTypeStr: string | number | null) => {
 
 const setKeyShiftInputBuffer = (keyShiftStr: string | number | null) => {
   const keyShiftValue = Number(keyShiftStr);
-  if (!isValidGuidePitchShift(keyShiftValue)) {
+  if (!isValidKeyShift(keyShiftValue)) {
     return;
   }
   keyShiftInputBuffer.value = keyShiftValue;
@@ -271,8 +271,8 @@ const setTimeSignature = () => {
 };
 
 const setKeyShift = () => {
-  const guidePitchShift = keyShiftInputBuffer.value;
-  store.dispatch("COMMAND_SET_GUIDE_PITCH_SHIFT", { guidePitchShift });
+  const guideKeyShift = keyShiftInputBuffer.value;
+  store.dispatch("COMMAND_SET_GUIDE_KEY_SHIFT", { guideKeyShift });
 };
 
 const playheadTicks = ref(0);

--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -188,7 +188,9 @@ const redo = () => {
 
 const tempos = computed(() => store.state.tempos);
 const timeSignatures = computed(() => store.state.timeSignatures);
-const keyShift = computed(() => store.getters.SELECTED_TRACK.guideKeyShift);
+const keyShift = computed(
+  () => store.getters.SELECTED_TRACK.keyRangeAdjustment
+);
 
 const bpmInputBuffer = ref(120);
 const beatsInputBuffer = ref(4);
@@ -271,8 +273,8 @@ const setTimeSignature = () => {
 };
 
 const setKeyShift = () => {
-  const guideKeyShift = keyShiftInputBuffer.value;
-  store.dispatch("COMMAND_SET_GUIDE_KEY_SHIFT", { guideKeyShift });
+  const keyRangeAdjustment = keyShiftInputBuffer.value;
+  store.dispatch("COMMAND_SET_KEY_RANGE_ADJUSTMENT", { keyRangeAdjustment });
 };
 
 const playheadTicks = ref(0);

--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -3,16 +3,19 @@
     <!-- configs for entire song -->
     <div class="sing-configs">
       <CharacterMenuButton />
-      <QInput
-        type="number"
-        :model-value="keyShiftInputBuffer"
-        label="ﾄﾗﾝｽﾎﾟｰｽﾞ"
-        dense
-        hide-bottom-space
-        class="key-shift"
-        @update:model-value="setKeyShiftInputBuffer"
-        @change="setKeyShift"
-      />
+      <!-- 開発時のみ機能 -->
+      <template v-if="!isProduction">
+        <QInput
+          type="number"
+          :model-value="keyShiftInputBuffer"
+          label="音高補正"
+          dense
+          hide-bottom-space
+          class="key-shift"
+          @update:model-value="setKeyShiftInputBuffer"
+          @change="setKeyShift"
+        />
+      </template>
       <QInput
         type="number"
         :model-value="bpmInputBuffer"
@@ -124,6 +127,8 @@
 <script setup lang="ts">
 import { computed, watch, ref, onMounted, onUnmounted } from "vue";
 import { useStore } from "@/store";
+import { isProduction } from "@/type/preload";
+
 import {
   getSnapTypes,
   isTriplet,

--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -7,13 +7,13 @@
       <template v-if="!isProduction">
         <QInput
           type="number"
-          :model-value="keyShiftInputBuffer"
+          :model-value="keyRangeAdjustmentInputBuffer"
           label="音域調整"
           dense
           hide-bottom-space
           class="key-shift"
-          @update:model-value="setKeyShiftInputBuffer"
-          @change="setKeyShift"
+          @update:model-value="setKeyRangeAdjustmentInputBuffer"
+          @change="setKeyRangeAdjustment"
         />
       </template>
       <QInput
@@ -135,7 +135,7 @@ import {
   isValidBeatType,
   isValidBeats,
   isValidBpm,
-  isValidKeyShift,
+  isValidKeyRangeAdjustment,
 } from "@/sing/domain";
 import CharacterMenuButton from "@/components/Sing/CharacterMenuButton/MenuButton.vue";
 import { useHotkeyManager } from "@/plugins/hotkeyPlugin";
@@ -188,14 +188,14 @@ const redo = () => {
 
 const tempos = computed(() => store.state.tempos);
 const timeSignatures = computed(() => store.state.timeSignatures);
-const keyShift = computed(
+const keyRangeAdjustment = computed(
   () => store.getters.SELECTED_TRACK.keyRangeAdjustment
 );
 
 const bpmInputBuffer = ref(120);
 const beatsInputBuffer = ref(4);
 const beatTypeInputBuffer = ref(4);
-const keyShiftInputBuffer = ref(0);
+const keyRangeAdjustmentInputBuffer = ref(0);
 
 watch(
   tempos,
@@ -214,8 +214,8 @@ watch(
   { deep: true }
 );
 
-watch(keyShift, () => {
-  keyShiftInputBuffer.value = keyShift.value;
+watch(keyRangeAdjustment, () => {
+  keyRangeAdjustmentInputBuffer.value = keyRangeAdjustment.value;
 });
 
 const setBpmInputBuffer = (bpmStr: string | number | null) => {
@@ -242,12 +242,14 @@ const setBeatTypeInputBuffer = (beatTypeStr: string | number | null) => {
   beatTypeInputBuffer.value = beatTypeValue;
 };
 
-const setKeyShiftInputBuffer = (keyShiftStr: string | number | null) => {
-  const keyShiftValue = Number(keyShiftStr);
-  if (!isValidKeyShift(keyShiftValue)) {
+const setKeyRangeAdjustmentInputBuffer = (
+  KeyRangeAdjustmentStr: string | number | null
+) => {
+  const KeyRangeAdjustmentValue = Number(KeyRangeAdjustmentStr);
+  if (!isValidKeyRangeAdjustment(KeyRangeAdjustmentValue)) {
     return;
   }
-  keyShiftInputBuffer.value = keyShiftValue;
+  keyRangeAdjustmentInputBuffer.value = KeyRangeAdjustmentValue;
 };
 
 const setTempo = () => {
@@ -272,8 +274,8 @@ const setTimeSignature = () => {
   });
 };
 
-const setKeyShift = () => {
-  const keyRangeAdjustment = keyShiftInputBuffer.value;
+const setKeyRangeAdjustment = () => {
+  const keyRangeAdjustment = keyRangeAdjustmentInputBuffer.value;
   store.dispatch("COMMAND_SET_KEY_RANGE_ADJUSTMENT", { keyRangeAdjustment });
 };
 

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -279,10 +279,10 @@ export function isValidSnapType(snapType: number, tpqn: number) {
   return getSnapTypes(tpqn).some((value) => value === snapType);
 }
 
-export function isValidVoiceKeyShift(voiceKeyShift: number) {
+export function isValidGuidePitchShift(guidePitchShift: number) {
   return (
-    Number.isInteger(voiceKeyShift) &&
-    voiceKeyShift <= 24 &&
-    voiceKeyShift >= -24
+    Number.isInteger(guidePitchShift) &&
+    guidePitchShift <= 24 &&
+    guidePitchShift >= -24
   );
 }

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -279,6 +279,10 @@ export function isValidSnapType(snapType: number, tpqn: number) {
   return getSnapTypes(tpqn).some((value) => value === snapType);
 }
 
-export function isValidKeyShift(keyShift: number) {
-  return Number.isInteger(keyShift) && keyShift <= 24 && keyShift >= -24;
+export function isValidKeyRangeAdjustment(keyRangeAdjustment: number) {
+  return (
+    Number.isInteger(keyRangeAdjustment) &&
+    keyRangeAdjustment <= 24 &&
+    keyRangeAdjustment >= -24
+  );
 }

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -279,10 +279,6 @@ export function isValidSnapType(snapType: number, tpqn: number) {
   return getSnapTypes(tpqn).some((value) => value === snapType);
 }
 
-export function isValidGuidePitchShift(guidePitchShift: number) {
-  return (
-    Number.isInteger(guidePitchShift) &&
-    guidePitchShift <= 24 &&
-    guidePitchShift >= -24
-  );
+export function isValidKeyShift(keyShift: number) {
+  return Number.isInteger(keyShift) && keyShift <= 24 && keyShift >= -24;
 }

--- a/src/sing/storeHelper.ts
+++ b/src/sing/storeHelper.ts
@@ -9,7 +9,7 @@ export const DEFAULT_BEAT_TYPE = 4;
 export const generatePhraseHash = async (obj: {
   singer: Singer | undefined;
   notesKeyShift: number;
-  guideKeyShift: number;
+  keyRangeAdjustment: number;
   tpqn: number;
   tempos: Tempo[];
   notes: Note[];

--- a/src/sing/storeHelper.ts
+++ b/src/sing/storeHelper.ts
@@ -8,7 +8,6 @@ export const DEFAULT_BEAT_TYPE = 4;
 
 export const generatePhraseHash = async (obj: {
   singer: Singer | undefined;
-  notesKeyShift: number;
   keyRangeAdjustment: number;
   tpqn: number;
   tempos: Tempo[];

--- a/src/sing/storeHelper.ts
+++ b/src/sing/storeHelper.ts
@@ -9,7 +9,7 @@ export const DEFAULT_BEAT_TYPE = 4;
 export const generatePhraseHash = async (obj: {
   singer: Singer | undefined;
   notesKeyShift: number;
-  voiceKeyShift: number;
+  guidePitchShift: number;
   tpqn: number;
   tempos: Tempo[];
   notes: Note[];

--- a/src/sing/storeHelper.ts
+++ b/src/sing/storeHelper.ts
@@ -9,7 +9,7 @@ export const DEFAULT_BEAT_TYPE = 4;
 export const generatePhraseHash = async (obj: {
   singer: Singer | undefined;
   notesKeyShift: number;
-  guidePitchShift: number;
+  guideKeyShift: number;
   tpqn: number;
   tempos: Tempo[];
   notes: Note[];

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -111,8 +111,8 @@ const applySongProjectToStore = async (
   await dispatch("SET_SINGER", {
     singer: tracks[0].singer,
   });
-  await dispatch("SET_VOICE_KEY_SHIFT", {
-    voiceKeyShift: tracks[0].voiceKeyShift,
+  await dispatch("SET_GUIDE_PITCH_SHIFT", {
+    guidePitchShift: tracks[0].guidePitchShift,
   });
   await dispatch("SET_SCORE", {
     score: {
@@ -432,7 +432,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
                 {
                   singer: undefined,
                   notesKeyShift: 0,
-                  voiceKeyShift: 0,
+                  guidePitchShift: 0,
                   notes: [],
                 },
               ],

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -111,8 +111,8 @@ const applySongProjectToStore = async (
   await dispatch("SET_SINGER", {
     singer: tracks[0].singer,
   });
-  await dispatch("SET_GUIDE_KEY_SHIFT", {
-    guideKeyShift: tracks[0].guideKeyShift,
+  await dispatch("SET_KEY_RANGE_ADJUSTMENT", {
+    keyRangeAdjustment: tracks[0].keyRangeAdjustment,
   });
   await dispatch("SET_SCORE", {
     score: {
@@ -433,6 +433,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
                   singer: undefined,
                   notesKeyShift: 0,
                   guideKeyShift: 0,
+                  keyRangeAdjustment: 0,
                   notes: [],
                 },
               ],

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -431,8 +431,6 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               tracks: [
                 {
                   singer: undefined,
-                  notesKeyShift: 0,
-                  guideKeyShift: 0,
                   keyRangeAdjustment: 0,
                   notes: [],
                 },

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -111,8 +111,8 @@ const applySongProjectToStore = async (
   await dispatch("SET_SINGER", {
     singer: tracks[0].singer,
   });
-  await dispatch("SET_GUIDE_PITCH_SHIFT", {
-    guidePitchShift: tracks[0].guidePitchShift,
+  await dispatch("SET_GUIDE_KEY_SHIFT", {
+    guideKeyShift: tracks[0].guideKeyShift,
   });
   await dispatch("SET_SCORE", {
     score: {
@@ -432,7 +432,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
                 {
                   singer: undefined,
                   notesKeyShift: 0,
-                  guidePitchShift: 0,
+                  guideKeyShift: 0,
                   notes: [],
                 },
               ],

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -146,6 +146,7 @@ export const generateSingingStoreInitialScore = () => {
         singer: undefined,
         notesKeyShift: 0,
         guideKeyShift: 0,
+        keyRangeAdjustment: 0,
         notes: [],
       },
     ],
@@ -230,18 +231,18 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
     },
   },
 
-  SET_GUIDE_KEY_SHIFT: {
-    mutation(state, { guideKeyShift }: { guideKeyShift: number }) {
-      state.tracks[selectedTrackIndex].guideKeyShift = guideKeyShift;
+  SET_KEY_RANGE_ADJUSTMENT: {
+    mutation(state, { keyRangeAdjustment }: { keyRangeAdjustment: number }) {
+      state.tracks[selectedTrackIndex].keyRangeAdjustment = keyRangeAdjustment;
     },
     async action(
       { dispatch, commit },
-      { guideKeyShift }: { guideKeyShift: number }
+      { keyRangeAdjustment }: { keyRangeAdjustment: number }
     ) {
-      if (!isValidKeyShift(guideKeyShift)) {
-        throw new Error("The guideKeyShift is invalid.");
+      if (!isValidKeyShift(keyRangeAdjustment)) {
+        throw new Error("The keyRangeAdjustment is invalid.");
       }
-      commit("SET_GUIDE_KEY_SHIFT", { guideKeyShift });
+      commit("SET_KEY_RANGE_ADJUSTMENT", { keyRangeAdjustment });
 
       dispatch("RENDER");
     },
@@ -747,7 +748,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const searchPhrases = async (
         singer: Singer | undefined,
         notesKeyShift: number,
-        guideKeyShift: number,
+        keyRangeAdjustment: number,
         tpqn: number,
         tempos: Tempo[],
         notes: Note[]
@@ -768,7 +769,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             const hash = await generatePhraseHash({
               singer,
               notesKeyShift,
-              guideKeyShift,
+              keyRangeAdjustment,
               tpqn,
               tempos,
               notes: phraseNotes,
@@ -776,7 +777,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             foundPhrases.set(hash, {
               singer,
               notesKeyShift,
-              guideKeyShift,
+              keyRangeAdjustment,
               tpqn,
               tempos,
               notes: phraseNotes,
@@ -803,7 +804,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         tempos: Tempo[],
         tpqn: number,
         notesKeyShift: number,
-        guideKeyShift: number,
+        keyRangeAdjustment: number,
         frameRate: number,
         restDurationSeconds: number
       ) => {
@@ -836,7 +837,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             .replace("は", "ハ")
             .replace("へ", "ヘ");
           // トランスポーズする
-          const key = note.noteNumber + notesKeyShift - guideKeyShift;
+          const key = note.noteNumber + notesKeyShift - keyRangeAdjustment;
           notesForRequestToEngine.push({
             key,
             frameLength: noteFrameLength,
@@ -881,11 +882,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       };
 
       const shiftGuidePitch = (
-        guideKeyShift: number,
+        keyShift: number,
         frameAudioQuery: FrameAudioQuery
       ) => {
         frameAudioQuery.f0 = frameAudioQuery.f0.map((value) => {
-          return value * Math.pow(2, guideKeyShift / 12);
+          return value * Math.pow(2, keyShift / 12);
         });
       };
 
@@ -946,7 +947,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         const track = getters.SELECTED_TRACK;
         const singer = track.singer ? { ...track.singer } : undefined;
         const notesKeyShift = track.notesKeyShift;
-        const guideKeyShift = track.guideKeyShift;
+        const keyRangeAdjustment = track.keyRangeAdjustment;
         const notes = track.notes
           .map((value) => ({ ...value }))
           .filter((value) => !state.overlappingNoteIds.has(value.id));
@@ -955,7 +956,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         const foundPhrases = await searchPhrases(
           singer,
           notesKeyShift,
-          guideKeyShift,
+          keyRangeAdjustment,
           tpqn,
           tempos,
           notes
@@ -1040,7 +1041,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               phrase.tempos,
               phrase.tpqn,
               phrase.notesKeyShift,
-              phrase.guideKeyShift,
+              phrase.keyRangeAdjustment,
               frameRate,
               restDurationSeconds
             ).catch((error) => {
@@ -1056,7 +1057,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               `Fetched frame audio query. Phonemes are "${phonemes}".`
             );
 
-            shiftGuidePitch(phrase.guideKeyShift, frameAudioQuery);
+            shiftGuidePitch(phrase.keyRangeAdjustment, frameAudioQuery);
 
             const startTime = calcStartTime(
               phrase.notes,
@@ -1981,20 +1982,20 @@ export const singingCommandStore = transformCommandStore(
         dispatch("RENDER");
       },
     },
-    COMMAND_SET_GUIDE_KEY_SHIFT: {
-      mutation(draft, { guideKeyShift }) {
-        singingStore.mutations.SET_GUIDE_KEY_SHIFT(draft, {
-          guideKeyShift,
+    COMMAND_SET_KEY_RANGE_ADJUSTMENT: {
+      mutation(draft, { keyRangeAdjustment }) {
+        singingStore.mutations.SET_KEY_RANGE_ADJUSTMENT(draft, {
+          keyRangeAdjustment,
         });
       },
       async action(
         { dispatch, commit },
-        { guideKeyShift }: { guideKeyShift: number }
+        { keyRangeAdjustment }: { keyRangeAdjustment: number }
       ) {
-        if (!isValidKeyShift(guideKeyShift)) {
-          throw new Error("The guideKeyShift is invalid.");
+        if (!isValidKeyShift(keyRangeAdjustment)) {
+          throw new Error("The keyRangeAdjustment is invalid.");
         }
-        commit("COMMAND_SET_GUIDE_KEY_SHIFT", { guideKeyShift });
+        commit("COMMAND_SET_KEY_RANGE_ADJUSTMENT", { keyRangeAdjustment });
 
         dispatch("RENDER");
       },

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -144,8 +144,6 @@ export const generateSingingStoreInitialScore = () => {
     tracks: [
       {
         singer: undefined,
-        notesKeyShift: 0,
-        guideKeyShift: 0,
         keyRangeAdjustment: 0,
         notes: [],
       },
@@ -747,7 +745,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
     async action({ state, getters, commit, dispatch }) {
       const searchPhrases = async (
         singer: Singer | undefined,
-        notesKeyShift: number,
         keyRangeAdjustment: number,
         tpqn: number,
         tempos: Tempo[],
@@ -768,7 +765,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             const phraseLastNote = phraseNotes[phraseNotes.length - 1];
             const hash = await generatePhraseHash({
               singer,
-              notesKeyShift,
               keyRangeAdjustment,
               tpqn,
               tempos,
@@ -776,7 +772,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             });
             foundPhrases.set(hash, {
               singer,
-              notesKeyShift,
               keyRangeAdjustment,
               tpqn,
               tempos,
@@ -803,7 +798,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         notes: Note[],
         tempos: Tempo[],
         tpqn: number,
-        notesKeyShift: number,
         keyRangeAdjustment: number,
         frameRate: number,
         restDurationSeconds: number
@@ -837,7 +831,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             .replace("は", "ハ")
             .replace("へ", "ヘ");
           // トランスポーズする
-          const key = note.noteNumber + notesKeyShift - keyRangeAdjustment;
+          const key = note.noteNumber - keyRangeAdjustment;
           notesForRequestToEngine.push({
             key,
             frameLength: noteFrameLength,
@@ -946,7 +940,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         const tempos = state.tempos.map((value) => ({ ...value }));
         const track = getters.SELECTED_TRACK;
         const singer = track.singer ? { ...track.singer } : undefined;
-        const notesKeyShift = track.notesKeyShift;
         const keyRangeAdjustment = track.keyRangeAdjustment;
         const notes = track.notes
           .map((value) => ({ ...value }))
@@ -955,7 +948,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         // フレーズを更新する
         const foundPhrases = await searchPhrases(
           singer,
-          notesKeyShift,
           keyRangeAdjustment,
           tpqn,
           tempos,
@@ -1040,7 +1032,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               phrase.notes,
               phrase.tempos,
               phrase.tpqn,
-              phrase.notesKeyShift,
               phrase.keyRangeAdjustment,
               frameRate,
               restDurationSeconds

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -44,7 +44,7 @@ import {
   isValidSnapType,
   isValidTempo,
   isValidTimeSignature,
-  isValidKeyShift,
+  isValidKeyRangeAdjustment,
   secondToTick,
   tickToSecond,
 } from "@/sing/domain";
@@ -237,7 +237,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       { dispatch, commit },
       { keyRangeAdjustment }: { keyRangeAdjustment: number }
     ) {
-      if (!isValidKeyShift(keyRangeAdjustment)) {
+      if (!isValidKeyRangeAdjustment(keyRangeAdjustment)) {
         throw new Error("The keyRangeAdjustment is invalid.");
       }
       commit("SET_KEY_RANGE_ADJUSTMENT", { keyRangeAdjustment });
@@ -876,11 +876,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       };
 
       const shiftGuidePitch = (
-        keyShift: number,
+        pitchShift: number,
         frameAudioQuery: FrameAudioQuery
       ) => {
         frameAudioQuery.f0 = frameAudioQuery.f0.map((value) => {
-          return value * Math.pow(2, keyShift / 12);
+          return value * Math.pow(2, pitchShift / 12);
         });
       };
 
@@ -1983,7 +1983,7 @@ export const singingCommandStore = transformCommandStore(
         { dispatch, commit },
         { keyRangeAdjustment }: { keyRangeAdjustment: number }
       ) {
-        if (!isValidKeyShift(keyRangeAdjustment)) {
+        if (!isValidKeyRangeAdjustment(keyRangeAdjustment)) {
           throw new Error("The keyRangeAdjustment is invalid.");
         }
         commit("COMMAND_SET_KEY_RANGE_ADJUSTMENT", { keyRangeAdjustment });

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -44,7 +44,7 @@ import {
   isValidSnapType,
   isValidTempo,
   isValidTimeSignature,
-  isValidVoiceKeyShift,
+  isValidGuidePitchShift,
   secondToTick,
   tickToSecond,
 } from "@/sing/domain";
@@ -145,7 +145,7 @@ export const generateSingingStoreInitialScore = () => {
       {
         singer: undefined,
         notesKeyShift: 0,
-        voiceKeyShift: 0,
+        guidePitchShift: 0,
         notes: [],
       },
     ],
@@ -230,18 +230,18 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
     },
   },
 
-  SET_VOICE_KEY_SHIFT: {
-    mutation(state, { voiceKeyShift }: { voiceKeyShift: number }) {
-      state.tracks[selectedTrackIndex].voiceKeyShift = voiceKeyShift;
+  SET_GUIDE_PITCH_SHIFT: {
+    mutation(state, { guidePitchShift }: { guidePitchShift: number }) {
+      state.tracks[selectedTrackIndex].guidePitchShift = guidePitchShift;
     },
     async action(
       { dispatch, commit },
-      { voiceKeyShift }: { voiceKeyShift: number }
+      { guidePitchShift }: { guidePitchShift: number }
     ) {
-      if (!isValidVoiceKeyShift(voiceKeyShift)) {
-        throw new Error("The voiceKeyShift is invalid.");
+      if (!isValidGuidePitchShift(guidePitchShift)) {
+        throw new Error("The guidePitchShift is invalid.");
       }
-      commit("SET_VOICE_KEY_SHIFT", { voiceKeyShift });
+      commit("SET_GUIDE_PITCH_SHIFT", { guidePitchShift });
 
       dispatch("RENDER");
     },
@@ -747,7 +747,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const searchPhrases = async (
         singer: Singer | undefined,
         notesKeyShift: number,
-        voiceKeyShift: number,
+        guidePitchShift: number,
         tpqn: number,
         tempos: Tempo[],
         notes: Note[]
@@ -768,7 +768,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             const hash = await generatePhraseHash({
               singer,
               notesKeyShift,
-              voiceKeyShift,
+              guidePitchShift,
               tpqn,
               tempos,
               notes: phraseNotes,
@@ -776,7 +776,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             foundPhrases.set(hash, {
               singer,
               notesKeyShift,
-              voiceKeyShift,
+              guidePitchShift,
               tpqn,
               tempos,
               notes: phraseNotes,
@@ -877,12 +877,12 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         return frameAudioQuery.phonemes.map((value) => value.phoneme).join(" ");
       };
 
-      const shiftVoiceKey = (
-        voiceKeyShift: number,
+      const shiftGuidePitch = (
+        guidePitchShift: number,
         frameAudioQuery: FrameAudioQuery
       ) => {
         frameAudioQuery.f0 = frameAudioQuery.f0.map((value) => {
-          return value * Math.pow(2, voiceKeyShift / 12);
+          return value * Math.pow(2, guidePitchShift / 12);
         });
       };
 
@@ -943,7 +943,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         const track = getters.SELECTED_TRACK;
         const singer = track.singer ? { ...track.singer } : undefined;
         const notesKeyShift = track.notesKeyShift;
-        const voiceKeyShift = track.voiceKeyShift;
+        const guidePitchShift = track.guidePitchShift;
         const notes = track.notes
           .map((value) => ({ ...value }))
           .filter((value) => !state.overlappingNoteIds.has(value.id));
@@ -952,7 +952,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         const foundPhrases = await searchPhrases(
           singer,
           notesKeyShift,
-          voiceKeyShift,
+          guidePitchShift,
           tpqn,
           tempos,
           notes
@@ -1052,7 +1052,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               `Fetched frame audio query. Phonemes are "${phonemes}".`
             );
 
-            shiftVoiceKey(phrase.voiceKeyShift, frameAudioQuery);
+            shiftGuidePitch(phrase.guidePitchShift, frameAudioQuery);
 
             const startTime = calcStartTime(
               phrase.notes,
@@ -1977,18 +1977,20 @@ export const singingCommandStore = transformCommandStore(
         dispatch("RENDER");
       },
     },
-    COMMAND_SET_VOICE_KEY_SHIFT: {
-      mutation(draft, { voiceKeyShift }) {
-        singingStore.mutations.SET_VOICE_KEY_SHIFT(draft, { voiceKeyShift });
+    COMMAND_SET_GUIDE_PITCH_SHIFT: {
+      mutation(draft, { guidePitchShift }) {
+        singingStore.mutations.SET_GUIDE_PITCH_SHIFT(draft, {
+          guidePitchShift,
+        });
       },
       async action(
         { dispatch, commit },
-        { voiceKeyShift }: { voiceKeyShift: number }
+        { guidePitchShift }: { guidePitchShift: number }
       ) {
-        if (!isValidVoiceKeyShift(voiceKeyShift)) {
-          throw new Error("The voiceKeyShift is invalid.");
+        if (!isValidGuidePitchShift(guidePitchShift)) {
+          throw new Error("The guidePitchShift is invalid.");
         }
-        commit("COMMAND_SET_VOICE_KEY_SHIFT", { voiceKeyShift });
+        commit("COMMAND_SET_GUIDE_PITCH_SHIFT", { guidePitchShift });
 
         dispatch("RENDER");
       },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -753,6 +753,7 @@ export const trackSchema = z.object({
   singer: singerSchema.optional(),
   notesKeyShift: z.number(), // ノートのトランスポーズ量
   guideKeyShift: z.number(), // 歌い方のトランスポーズ量
+  keyRangeAdjustment: z.number(), // 音域補正量
   notes: z.array(noteSchema),
 });
 export type Track = z.infer<typeof trackSchema>;
@@ -766,7 +767,7 @@ export type PhraseState =
 export type Phrase = {
   singer?: Singer;
   notesKeyShift: number;
-  guideKeyShift: number;
+  keyRangeAdjustment: number;
   tpqn: number;
   tempos: Tempo[];
   notes: Note[];
@@ -818,9 +819,9 @@ export type SingingStoreTypes = {
     action(payload: { singer?: Singer }): void;
   };
 
-  SET_GUIDE_KEY_SHIFT: {
-    mutation: { guideKeyShift: number };
-    action(payload: { guideKeyShift: number }): void;
+  SET_KEY_RANGE_ADJUSTMENT: {
+    mutation: { keyRangeAdjustment: number };
+    action(payload: { keyRangeAdjustment: number }): void;
   };
 
   SET_SCORE: {
@@ -1033,9 +1034,9 @@ export type SingingCommandStoreTypes = {
     action(payload: { singer: Singer }): void;
   };
 
-  COMMAND_SET_GUIDE_KEY_SHIFT: {
-    mutation: { guideKeyShift: number };
-    action(payload: { guideKeyShift: number }): void;
+  COMMAND_SET_KEY_RANGE_ADJUSTMENT: {
+    mutation: { keyRangeAdjustment: number };
+    action(payload: { keyRangeAdjustment: number }): void;
   };
 
   COMMAND_SET_TEMPO: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -751,9 +751,7 @@ export type Singer = z.infer<typeof singerSchema>;
 
 export const trackSchema = z.object({
   singer: singerSchema.optional(),
-  notesKeyShift: z.number(), // ノートのトランスポーズ量
-  guideKeyShift: z.number(), // 歌い方のトランスポーズ量
-  keyRangeAdjustment: z.number(), // 音域補正量
+  keyRangeAdjustment: z.number(), // 音域調整量
   notes: z.array(noteSchema),
 });
 export type Track = z.infer<typeof trackSchema>;
@@ -766,7 +764,6 @@ export type PhraseState =
 
 export type Phrase = {
   singer?: Singer;
-  notesKeyShift: number;
   keyRangeAdjustment: number;
   tpqn: number;
   tempos: Tempo[];

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -751,8 +751,8 @@ export type Singer = z.infer<typeof singerSchema>;
 
 export const trackSchema = z.object({
   singer: singerSchema.optional(),
-  notesKeyShift: z.number(),
-  guidePitchShift: z.number(),
+  notesKeyShift: z.number(), // ノートのトランスポーズ量
+  guideKeyShift: z.number(), // 歌い方のトランスポーズ量
   notes: z.array(noteSchema),
 });
 export type Track = z.infer<typeof trackSchema>;
@@ -766,7 +766,7 @@ export type PhraseState =
 export type Phrase = {
   singer?: Singer;
   notesKeyShift: number;
-  guidePitchShift: number;
+  guideKeyShift: number;
   tpqn: number;
   tempos: Tempo[];
   notes: Note[];
@@ -818,9 +818,9 @@ export type SingingStoreTypes = {
     action(payload: { singer?: Singer }): void;
   };
 
-  SET_GUIDE_PITCH_SHIFT: {
-    mutation: { guidePitchShift: number };
-    action(payload: { guidePitchShift: number }): void;
+  SET_GUIDE_KEY_SHIFT: {
+    mutation: { guideKeyShift: number };
+    action(payload: { guideKeyShift: number }): void;
   };
 
   SET_SCORE: {
@@ -1033,9 +1033,9 @@ export type SingingCommandStoreTypes = {
     action(payload: { singer: Singer }): void;
   };
 
-  COMMAND_SET_GUIDE_PITCH_SHIFT: {
-    mutation: { guidePitchShift: number };
-    action(payload: { guidePitchShift: number }): void;
+  COMMAND_SET_GUIDE_KEY_SHIFT: {
+    mutation: { guideKeyShift: number };
+    action(payload: { guideKeyShift: number }): void;
   };
 
   COMMAND_SET_TEMPO: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -752,7 +752,7 @@ export type Singer = z.infer<typeof singerSchema>;
 export const trackSchema = z.object({
   singer: singerSchema.optional(),
   notesKeyShift: z.number(),
-  voiceKeyShift: z.number(),
+  guidePitchShift: z.number(),
   notes: z.array(noteSchema),
 });
 export type Track = z.infer<typeof trackSchema>;
@@ -766,7 +766,7 @@ export type PhraseState =
 export type Phrase = {
   singer?: Singer;
   notesKeyShift: number;
-  voiceKeyShift: number;
+  guidePitchShift: number;
   tpqn: number;
   tempos: Tempo[];
   notes: Note[];
@@ -818,9 +818,9 @@ export type SingingStoreTypes = {
     action(payload: { singer?: Singer }): void;
   };
 
-  SET_VOICE_KEY_SHIFT: {
-    mutation: { voiceKeyShift: number };
-    action(payload: { voiceKeyShift: number }): void;
+  SET_GUIDE_PITCH_SHIFT: {
+    mutation: { guidePitchShift: number };
+    action(payload: { guidePitchShift: number }): void;
   };
 
   SET_SCORE: {
@@ -1033,9 +1033,9 @@ export type SingingCommandStoreTypes = {
     action(payload: { singer: Singer }): void;
   };
 
-  COMMAND_SET_VOICE_KEY_SHIFT: {
-    mutation: { voiceKeyShift: number };
-    action(payload: { voiceKeyShift: number }): void;
+  COMMAND_SET_GUIDE_PITCH_SHIFT: {
+    mutation: { guidePitchShift: number };
+    action(payload: { guidePitchShift: number }): void;
   };
 
   COMMAND_SET_TEMPO: {


### PR DESCRIPTION
## 内容

色々考えた結果、音域補正用のパラメーターを増やすのが良さそうだったので増やしました。
ついでにリリースに向けて開発時のみの機能にしました。

変更点は以下の４点です。

* GUIでのラベルと仕様を「音域補正」に
	* 見た目の音程と出力の音程は一致させるやつ
	* https://github.com/VOICEVOX/voicevox/issues/1838#issuecomment-1944175490 の反映
* `voiceKeyShift`を`guideKeyShift`に
	* https://github.com/VOICEVOX/voicevox/issues/1899#issuecomment-1975468968 の反映
* 音域補正を保管する`keyRangeAdjustment`パラメータを追加
	* 今ある`notesKeyShift`と`guideKeyShift`の２つともに干渉する値なので別定義が必要だった

## 関連 Issue

resolve #1899 

## その他

迷ってることがいくつかあります。

* `keyRangeAdjustment`は直訳すると音域"調整"だけどこれで良いか
	* 補正`Correction`と迷ったのですが、何を持って「正しい」とするのかわからなかったので調整にしてみました
	* ラベルの方も「音域調整」のが合ってるかも？　手動ですし。
* `notesKeyShift`と`guideKeyShift`を削除するかそのままにするか
	* YAGNI則的には消しても良いかも
	* 特に`guideKeyShift`は将来的に使わない可能性がありそう
	* どちらかというと`guideKeyShift`が議論の結果`keyRangeAdjustment`に変わったという感じかも
