### PR TITLE
[project-redisign-help-dialog] ヘルプダイアログのデザインの最終調整

### DIFF
--- a/src/components/base/BaseDocumentView.vue
+++ b/src/components/base/BaseDocumentView.vue
@@ -60,6 +60,10 @@
 
   :deep(a) {
     color: colors.$display-link;
+
+    &:focus-visible {
+      @include mixin.on-focus;
+    }
   }
 
   :deep(img) {

--- a/src/components/template/HelpLibraryPolicySection.vue
+++ b/src/components/template/HelpLibraryPolicySection.vue
@@ -134,10 +134,10 @@ const selectCharacterInfo = (index: DetailKey | undefined) => {
   // TODO: 親コンポーネントからheightを取得できないため一時的にcalcを使用、HelpDialogの構造を再設計後100%に変更する
   // height: 100%;
   height: calc(100vh - 90px);
+  background-color: colors.$background;
 }
 
 .container-detail {
-  border-left: 1px solid colors.$border;
   background-color: colors.$surface;
 }
 

--- a/src/components/template/HelpLibraryPolicySection.vue
+++ b/src/components/template/HelpLibraryPolicySection.vue
@@ -146,6 +146,8 @@ const selectCharacterInfo = (index: DetailKey | undefined) => {
   flex-direction: column;
   padding: vars.$padding-2;
   gap: vars.$gap-1;
+  max-width: 960px;
+  margin: auto;
 }
 
 .title {

--- a/src/components/template/HelpMarkdownViewSection.vue
+++ b/src/components/template/HelpMarkdownViewSection.vue
@@ -44,5 +44,7 @@ onMounted(async () => {
 
 .inner {
   padding: vars.$padding-2;
+  max-width: 960px;
+  margin: auto;
 }
 </style>

--- a/src/components/template/HelpOssLicenseSection.vue
+++ b/src/components/template/HelpOssLicenseSection.vue
@@ -76,6 +76,8 @@ const selectLicenseIndex = (index: number | undefined) => {
   flex-direction: column;
   padding: vars.$padding-2;
   gap: vars.$gap-1;
+  max-width: 960px;
+  margin: auto;
 }
 
 .title {

--- a/src/components/template/HelpUpdateInfoSection.vue
+++ b/src/components/template/HelpUpdateInfoSection.vue
@@ -70,6 +70,8 @@ const props =
 
 .inner {
   padding: vars.$padding-2;
+  max-width: 960px;
+  margin: auto;
 }
 
 .info {

--- a/src/components/template/HelpUpdateInfoSection.vue
+++ b/src/components/template/HelpUpdateInfoSection.vue
@@ -65,12 +65,11 @@ const props =
   // TODO: 親コンポーネントからheightを取得できないため一時的にcalcを使用、HelpDialogの構造を再設計後100%に変更する
   // height: 100%;
   height: calc(100vh - 90px);
-  background-color: colors.$background;
+  background-color: colors.$surface;
 }
 
 .inner {
   padding: vars.$padding-2;
-  background-color: colors.$surface;
 }
 
 .info {

--- a/src/styles/mixin.scss
+++ b/src/styles/mixin.scss
@@ -6,7 +6,7 @@
 
 // 見出し1(h1)用のスタイル
 @mixin headline-1 {
-  font-size: 1.5rem;
+  font-size: 1.75rem;
   font-weight: 600;
   line-height: 2;
   margin: 0;


### PR DESCRIPTION
## 内容

ヘルプダイアログのリデザインの最終調整です。具体的には以下のことを行います。

- スタイルにブレがあった箇所を統一
- a要素がfocusされた際のoutlineのデザインを合わせる
- 見出し1のフォントサイズを少し増加
- セクションの内容に最大幅と中央揃えを設定

## スクリーンショット・動画など

![image](https://github.com/VOICEVOX/voicevox/assets/53995265/79e695f5-fb6f-4bad-a593-7ad2d7c49359)
![image](https://github.com/VOICEVOX/voicevox/assets/53995265/f591e63b-fef9-4160-9d52-43b31eac241c)

## その他

これがマージされた後はmainブランチとディレクトリ等々合わせてマージに持っていくのみになりそうです。