### PR TITLE
undo/redo時にノートの選択が解除されないのを修正

### DIFF
--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -118,6 +118,8 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
     action({ commit, dispatch }, { editor }: { editor: EditorType }) {
       commit("UNDO", { editor });
       if (editor === "song") {
+        // TODO: 存在しないノートが選択されていた場合にのみ選択を解除するようにしても良いかも
+        commit("DESELECT_ALL_NOTES");
         dispatch("RENDER");
       }
     },
@@ -134,6 +136,8 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
     action({ commit, dispatch }, { editor }: { editor: EditorType }) {
       commit("REDO", { editor });
       if (editor === "song") {
+        // TODO: 存在しないノートが選択されていた場合にのみ選択を解除するようにしても良いかも
+        commit("DESELECT_ALL_NOTES");
         dispatch("RENDER");
       }
     },

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -118,7 +118,7 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
     action({ commit, dispatch }, { editor }: { editor: EditorType }) {
       commit("UNDO", { editor });
       if (editor === "song") {
-        // TODO: 存在しないノートが選択されていた場合にのみ選択を解除するようにしても良いかも
+        // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         commit("DESELECT_ALL_NOTES");
         dispatch("RENDER");
       }
@@ -136,7 +136,7 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
     action({ commit, dispatch }, { editor }: { editor: EditorType }) {
       commit("REDO", { editor });
       if (editor === "song") {
-        // TODO: 存在しないノートが選択されていた場合にのみ選択を解除するようにしても良いかも
+        // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         commit("DESELECT_ALL_NOTES");
         dispatch("RENDER");
       }


### PR DESCRIPTION
## 内容

undo/redo時にノートの選択が解除されておらず、`ADD_NOTES`をundoしたときに存在しないノートのIDが`selectedNoteIds`に入ってしまっていたので、修正します。

## その他