### PR TITLE
音域・音量域調整機能を開発環境じゃなくても使えるようにする

### DIFF
--- a/src/components/Sing/ToolBar.vue
+++ b/src/components/Sing/ToolBar.vue
@@ -3,29 +3,26 @@
     <!-- configs for entire song -->
     <div class="sing-configs">
       <CharacterMenuButton />
-      <!-- 開発時のみ機能 -->
-      <template v-if="!isProduction">
-        <QInput
-          type="number"
-          :model-value="keyRangeAdjustmentInputBuffer"
-          label="音域調整"
-          dense
-          hide-bottom-space
-          class="key-range-adjustment"
-          @update:model-value="setKeyRangeAdjustmentInputBuffer"
-          @change="setKeyRangeAdjustment"
-        />
-        <QInput
-          type="number"
-          :model-value="volumeRangeAdjustmentInputBuffer"
-          label="音量域調整"
-          dense
-          hide-bottom-space
-          class="volume-range-adjustment"
-          @update:model-value="setVolumeRangeAdjustmentInputBuffer"
-          @change="setVolumeRangeAdjustment"
-        />
-      </template>
+      <QInput
+        type="number"
+        :model-value="keyRangeAdjustmentInputBuffer"
+        label="音域調整"
+        dense
+        hide-bottom-space
+        class="key-range-adjustment"
+        @update:model-value="setKeyRangeAdjustmentInputBuffer"
+        @change="setKeyRangeAdjustment"
+      />
+      <QInput
+        type="number"
+        :model-value="volumeRangeAdjustmentInputBuffer"
+        label="音量域調整"
+        dense
+        hide-bottom-space
+        class="volume-range-adjustment"
+        @update:model-value="setVolumeRangeAdjustmentInputBuffer"
+        @change="setVolumeRangeAdjustment"
+      />
       <QInput
         type="number"
         :model-value="bpmInputBuffer"


### PR DESCRIPTION
## 内容

音域・音量域調整機能を開発環境じゃなくても使えるようにします。

ちょっと緊急で必要になっているのでマージします 🙇 

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1870
- https://github.com/VOICEVOX/voicevox/issues/1899
- https://github.com/VOICEVOX/voicevox/issues/1838

## その他

どう考えても手動補正するUIは難しい･･･････。
使い方案内と適切な値を SNS で案内するのは必須。
自動調整も入れたいけどさすがに間に合わなさそう。。。。
