### PR TITLE
ソング：leftLocatorPositionとrightLocatorPositionが使われていないので削除

### DIFF
--- a/src/components/Sing/SingEditor.vue
+++ b/src/components/Sing/SingEditor.vue
@@ -93,12 +93,6 @@ onetimeWatch(
 
     await store.dispatch("SET_VOLUME", { volume: 0.6 });
     await store.dispatch("SET_PLAYHEAD_POSITION", { position: 0 });
-    await store.dispatch("SET_LEFT_LOCATOR_POSITION", {
-      position: 0,
-    });
-    await store.dispatch("SET_RIGHT_LOCATOR_POSITION", {
-      position: 480 * 4 * 16,
-    });
     isCompletedInitialStartup.value = true;
 
     await store.dispatch("SET_SINGER", {});

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -166,8 +166,6 @@ export const singingStoreState: SingingStoreState = {
   overlappingNoteInfos: new Map(),
   nowPlaying: false,
   volume: 0,
-  leftLocatorPosition: 0,
-  rightLocatorPosition: 0,
   startRenderingRequested: false,
   stopRenderingRequested: false,
   nowRendering: false,
@@ -633,24 +631,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
   REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER: {
     async action(_, { listener }: { listener: (position: number) => void }) {
       playheadPosition.removeValueChangeListener(listener);
-    },
-  },
-
-  SET_LEFT_LOCATOR_POSITION: {
-    mutation(state, { position }) {
-      state.leftLocatorPosition = position;
-    },
-    async action({ commit }, { position }) {
-      commit("SET_LEFT_LOCATOR_POSITION", { position });
-    },
-  },
-
-  SET_RIGHT_LOCATOR_POSITION: {
-    mutation(state, { position }) {
-      state.rightLocatorPosition = position;
-    },
-    async action({ commit }, { position }) {
-      commit("SET_RIGHT_LOCATOR_POSITION", { position });
     },
   },
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -794,8 +794,6 @@ export type SingingStoreState = {
   editingLyricNoteId?: string;
   nowPlaying: boolean;
   volume: number;
-  leftLocatorPosition: number;
-  rightLocatorPosition: number;
   startRenderingRequested: boolean;
   stopRenderingRequested: boolean;
   nowRendering: boolean;
@@ -962,16 +960,6 @@ export type SingingStoreTypes = {
 
   REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER: {
     action(payload: { listener: (position: number) => void }): void;
-  };
-
-  SET_LEFT_LOCATOR_POSITION: {
-    mutation: { position: number };
-    action(payload: { position: number }): void;
-  };
-
-  SET_RIGHT_LOCATOR_POSITION: {
-    mutation: { position: number };
-    action(payload: { position: number }): void;
   };
 
   SET_PLAYBACK_STATE: {


### PR DESCRIPTION
## 内容

ソングのエディター起動時に初期化されているけれども使われていなさそうだったので、いっそのこと消しちゃいました。

## その他

どちらかというと消しても大丈夫かなという確認ですが、特に使う予定がなかったら消しちゃってもいいかも？
初期化するにあたって大事な初期化なのかそうでもないのかがわからないので、ない方がメンテナンスが高いなと感じました！