### PR TITLE
バージョン0.18.0に向けてデザインを少し調整

### DIFF
--- a/src/components/Dialog/ImportMidiDialog.vue
+++ b/src/components/Dialog/ImportMidiDialog.vue
@@ -3,7 +3,9 @@
     <QLayout container view="hHh lpr fFf" class="q-dialog-plugin bg-background">
       <QHeader>
         <QToolbar>
-          <QToolbarTitle>MIDIファイルのインポート</QToolbarTitle>
+          <QToolbarTitle class="text-display"
+            >MIDIファイルのインポート</QToolbarTitle
+          >
         </QToolbar>
       </QHeader>
       <QPageContainer class="q-px-lg q-py-md">

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -277,13 +277,12 @@ const onLyricInputBlur = () => {
   &.selected {
     // 色は仮
     .note-bar {
-      background-color: hsl(130, 35%, 90%);
-      border: 2px solid colors.$primary;
+      background-color: hsl(33, 100%, 50%);
     }
 
     &.below-pitch {
       .note-bar {
-        background-color: rgba(hsl(130, 100%, 50%), 0.18);
+        background-color: rgba(hsl(33, 100%, 50%), 0.18);
       }
     }
   }


### PR DESCRIPTION
## 内容

バージョン0.18.0に向けてデザインを少し調整しました。２点だけです。

* ノートを選択したときの色を以前のオレンジのに戻した
	* まだノートの色周りをダークモード含めるとまだ調整しきれていない
	* もしかしたら次に選択デザインを変える可能性がある
	* 今回変えた上でまた変更があるとUXが落ちてしまう
	* ので、一旦前回のに戻してリリースして差分をなるべく少なくし、次回のデザイン調整を受けいれてもらえやすくする
* MIDIインポートダイアログのツールバー上の文字の色を変えた
	* デザイン調整だけ
	* ツールバーの有るダイアログとないダイアログの２種が産まれることになったが、一旦これで良いかなと

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1810


## その他

マージします！
