### PR TITLE
ソング: 一部のUSTが読めないのを修正 #1956

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1794,7 +1794,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             if (tempo) tempos[0].bpm = tempo;
           }
           // ノートセクション
-          if (params.sectionName.match(/^#\d{4}/)) {
+          // #以降に数字の場合はノートセクション ex: #0, #0000
+          if (params.sectionName.match(/^#\d+$/)) {
             // テンポ変更があれば追加
             const tempo = Number(params["Tempo"]);
             if (tempo) tempos.push({ position, bpm: tempo });


### PR DESCRIPTION
## 内容

一部のUST(SynthesizerVなど)でノートセクションの形式が異なるため
インポートできないのを修正

正規表現で #以降数字4桁 `/^#\d{4}/`としていたが、 #以降数字 `/^#\d+$/)` に変更

## 関連 Issue

ref #1956
close #1956

## スクリーンショット・動画など

なし

## その他
