### PR TITLE
FIX: ホットキーでshift+数字を登録時のエラーをなくす

### DIFF
--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -324,7 +324,7 @@ export const eventToCombination = (event: KeyboardEvent): HotkeyCombination => {
   ) {
     recordedCombination += eventKey;
   }
-  // 末尾がスペースならそれを削除
+  // 修飾キーのみだった場合末尾がスペースになるので削除
   recordedCombination = recordedCombination.replace(/\s$/, "");
   return HotkeyCombination(recordedCombination);
 };

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -279,10 +279,12 @@ const combinationToBindingKey = (
   // MetaキーはCommandキーとして扱う
   // NOTE: hotkeys-jsにはWinキーが無く、Commandキーとして扱われている
   // NOTE: Metaキーは以前採用していたmousetrapがそうだった名残り
+  // hotkeys-jsでは方向キーをup, down, left, rightで表す
   const bindingKey = combination
     .toLowerCase()
     .split(" ")
     .map((key) => (key === "meta" ? "command" : key))
+    .map((key) => key.replace("arrow", ""))
     .join("+");
   return bindingKey as BindingKey;
 };
@@ -311,12 +313,15 @@ export const eventToCombination = (event: KeyboardEvent): HotkeyCombination => {
   if (event.metaKey) {
     recordedCombination += "Meta ";
   }
-  // event.codeから保存する形へと変換
-  let eventKey = event.code.replace(/Key|Digit|Numpad|Arrow/, "");
-  eventKey = eventKey.length > 1 ? eventKey : eventKey.toUpperCase();
-  // 英字 数字 上下左右 Enter Space Backspace Delete Escape F1~のみ認める
+  // event.codeから以前のevent.key形式へと変換
+  // 列挙するのは将来的に変更する
+  let eventKey = event.code
+    .replace(/Key|Digit|Numpad/, "")
+    .replace("Minus", "-")
+    .replace("Slash", "/");
+  // 英字 数字 上下左右 Enter Space Backspace Delete Escape F1~ - /のみ認める
   if (
-    /^([A-Z]|\d|Up|Down|Left|Right|Enter|Space|Backspace|Delete|Escape|F\d+)$/.test(
+    /^([A-Z]|\d|Arrow(Up|Down|Left|Right)|Enter|Space|Backspace|Delete|Escape|F\d+|-|\/)$/.test(
       eventKey
     )
   ) {

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -279,7 +279,7 @@ const combinationToBindingKey = (
   // MetaキーはCommandキーとして扱う
   // NOTE: hotkeys-jsにはWinキーが無く、Commandキーとして扱われている
   // NOTE: Metaキーは以前採用していたmousetrapがそうだった名残り
-  // hotkeys-jsでは方向キーをup, down, left, rightで表す
+  // NOTE: hotkeys-jsでは方向キーのarrowプレフィックスが不要
   const bindingKey = combination
     .toLowerCase()
     .split(" ")

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -311,15 +311,18 @@ export const eventToCombination = (event: KeyboardEvent): HotkeyCombination => {
   if (event.metaKey) {
     recordedCombination += "Meta ";
   }
-  if (event.key === " ") {
-    recordedCombination += "Space";
-  } else {
-    if (["Control", "Shift", "Alt", "Meta"].includes(event.key)) {
-      recordedCombination = recordedCombination.slice(0, -1);
-    } else {
-      recordedCombination +=
-        event.key.length > 1 ? event.key : event.key.toUpperCase();
-    }
+  // event.codeから保存する形へと変換
+  let eventKey = event.code.replace(/Key|Digit|Numpad|Arrow/, "");
+  eventKey = eventKey.length > 1 ? eventKey : eventKey.toUpperCase();
+  // 英字 数字 上下左右 Enter Space Backspace Delete Escape F1~のみ認める
+  if (
+    /^([A-Z]|\d|Up|Down|Left|Right|Enter|Space|Backspace|Delete|Escape|F\d+)$/.test(
+      eventKey
+    )
+  ) {
+    recordedCombination += eventKey;
   }
+  // 末尾がスペースならそれを削除
+  recordedCombination = recordedCombination.replace(/\s$/, "");
   return HotkeyCombination(recordedCombination);
 };

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -315,10 +315,7 @@ export const eventToCombination = (event: KeyboardEvent): HotkeyCombination => {
   }
   // event.codeからevent.key形式へと変換
   // TODO: 主要なキーも使えるようにする
-  const eventKey = event.code
-    .replace(/Key|Digit|Numpad/, "")
-    .replace("Minus", "-")
-    .replace("Slash", "/");
+  const eventKey = event.code.replace(/Key|Digit|Numpad/, "");
   // 英字 数字 上下左右 Enter Space Backspace Delete Escape F1~ - /のみ認める
   if (
     /^([A-Z]|\d|Arrow(Up|Down|Left|Right)|Enter|Space|Backspace|Delete|Escape|F\d+|-|\/)$/.test(

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -313,8 +313,8 @@ export const eventToCombination = (event: KeyboardEvent): HotkeyCombination => {
   if (event.metaKey) {
     recordedCombination += "Meta ";
   }
-  // event.codeから以前のevent.key形式へと変換
-  // 列挙するのは将来的に変更する
+  // event.codeからevent.key形式へと変換
+  // TODO: 主要なキーも使えるようにする
   const eventKey = event.code
     .replace(/Key|Digit|Numpad/, "")
     .replace("Minus", "-")

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -315,14 +315,14 @@ export const eventToCombination = (event: KeyboardEvent): HotkeyCombination => {
   }
   // event.codeから以前のevent.key形式へと変換
   // 列挙するのは将来的に変更する
-  let eventKey = event.code
+  const eventKey = event.code
     .replace(/Key|Digit|Numpad/, "")
     .replace("Minus", "-")
     .replace("Slash", "/");
   // 英字 数字 上下左右 Enter Space Backspace Delete Escape F1~ - /のみ認める
   if (
     /^([A-Z]|\d|Arrow(Up|Down|Left|Right)|Enter|Space|Backspace|Delete|Escape|F\d+|-|\/)$/.test(
-      eventKey
+      eventKey,
     )
   ) {
     recordedCombination += eventKey;


### PR DESCRIPTION
## 内容

event.code式に書き換え
.がPeriodだったりと様々な対応しきれないものがあるので対応しているもの以外は弾くようにした

## 関連 Issue

ref #1947