### PR TITLE
[refactor] projectのschemaをdomainディレクトリ以下に移動

### DIFF
--- a/src/domain/project/schema.ts
+++ b/src/domain/project/schema.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+
+import {
+  audioKeySchema,
+  engineIdSchema,
+  presetKeySchema,
+  speakerIdSchema,
+  styleIdSchema,
+} from "@/type/preload";
+
+// トーク系のスキーマ
+const moraSchema = z.object({
+  text: z.string(),
+  vowel: z.string(),
+  vowelLength: z.number(),
+  pitch: z.number(),
+  consonant: z.string().optional(),
+  consonantLength: z.number().optional(),
+});
+
+const accentPhraseSchema = z.object({
+  moras: z.array(moraSchema),
+  accent: z.number(),
+  pauseMora: moraSchema.optional(),
+  isInterrogative: z.boolean().optional(),
+});
+
+const audioQuerySchema = z.object({
+  accentPhrases: z.array(accentPhraseSchema),
+  speedScale: z.number(),
+  pitchScale: z.number(),
+  intonationScale: z.number(),
+  volumeScale: z.number(),
+  prePhonemeLength: z.number(),
+  postPhonemeLength: z.number(),
+  outputSamplingRate: z.union([z.number(), z.literal("engineDefault")]),
+  outputStereo: z.boolean(),
+  kana: z.string().optional(),
+});
+
+const morphingInfoSchema = z.object({
+  rate: z.number(),
+  targetEngineId: engineIdSchema,
+  targetSpeakerId: speakerIdSchema,
+  targetStyleId: styleIdSchema,
+});
+
+const audioItemSchema = z.object({
+  text: z.string(),
+  voice: z.object({
+    engineId: engineIdSchema,
+    speakerId: speakerIdSchema,
+    styleId: styleIdSchema,
+  }),
+  query: audioQuerySchema.optional(),
+  presetKey: presetKeySchema.optional(),
+  morphingInfo: morphingInfoSchema.optional(),
+});
+
+// ソング系のスキーマ
+export const tempoSchema = z.object({
+  position: z.number(),
+  bpm: z.number(),
+});
+
+export const timeSignatureSchema = z.object({
+  measureNumber: z.number(),
+  beats: z.number(),
+  beatType: z.number(),
+});
+
+export const noteSchema = z.object({
+  id: z.string(),
+  position: z.number(),
+  duration: z.number(),
+  noteNumber: z.number(),
+  lyric: z.string(),
+});
+
+export const singerSchema = z.object({
+  engineId: engineIdSchema,
+  styleId: styleIdSchema,
+});
+
+export const trackSchema = z.object({
+  singer: singerSchema.optional(),
+  keyRangeAdjustment: z.number(), // 音域調整量
+  volumeRangeAdjustment: z.number(), // 声量調整量
+  notes: z.array(noteSchema),
+});
+
+// プロジェクトファイルのスキーマ
+export const projectSchema = z.object({
+  appVersion: z.string(),
+  talk: z.object({
+    // description: "Attribute keys of audioItems.",
+    audioKeys: z.array(audioKeySchema),
+    // description: "VOICEVOX states per cell",
+    audioItems: z.record(audioKeySchema, audioItemSchema),
+  }),
+  song: z.object({
+    tpqn: z.number(),
+    tempos: z.array(tempoSchema),
+    timeSignatures: z.array(timeSignatureSchema),
+    tracks: z.array(trackSchema),
+  }),
+});
+
+export type LatestProjectType = z.infer<typeof projectSchema>;

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,5 +1,4 @@
 import semver from "semver";
-import { z } from "zod";
 import { getBaseName } from "./utility";
 import { createPartialStore, Dispatch } from "./vuex";
 import { generateSingingStoreInitialScore } from "./singing";
@@ -9,20 +8,10 @@ import {
   AudioItem,
   ProjectStoreState,
   ProjectStoreTypes,
-  tempoSchema,
-  timeSignatureSchema,
-  trackSchema,
 } from "@/store/type";
 
 import { AccentPhrase } from "@/openapi";
-import {
-  audioKeySchema,
-  EngineId,
-  engineIdSchema,
-  presetKeySchema,
-  speakerIdSchema,
-  styleIdSchema,
-} from "@/type/preload";
+import { EngineId } from "@/type/preload";
 import { getValueOrThrow, ResultError } from "@/type/result";
 import {
   DEFAULT_BEAT_TYPE,
@@ -30,6 +19,7 @@ import {
   DEFAULT_BPM,
   DEFAULT_TPQN,
 } from "@/sing/storeHelper";
+import { LatestProjectType, projectSchema } from "@/domain/project/schema";
 
 const DEFAULT_SAMPLING_RATE = 24000;
 
@@ -656,69 +646,3 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
     },
   },
 });
-
-const moraSchema = z.object({
-  text: z.string(),
-  vowel: z.string(),
-  vowelLength: z.number(),
-  pitch: z.number(),
-  consonant: z.string().optional(),
-  consonantLength: z.number().optional(),
-});
-
-const accentPhraseSchema = z.object({
-  moras: z.array(moraSchema),
-  accent: z.number(),
-  pauseMora: moraSchema.optional(),
-  isInterrogative: z.boolean().optional(),
-});
-
-const audioQuerySchema = z.object({
-  accentPhrases: z.array(accentPhraseSchema),
-  speedScale: z.number(),
-  pitchScale: z.number(),
-  intonationScale: z.number(),
-  volumeScale: z.number(),
-  prePhonemeLength: z.number(),
-  postPhonemeLength: z.number(),
-  outputSamplingRate: z.union([z.number(), z.literal("engineDefault")]),
-  outputStereo: z.boolean(),
-  kana: z.string().optional(),
-});
-
-const morphingInfoSchema = z.object({
-  rate: z.number(),
-  targetEngineId: engineIdSchema,
-  targetSpeakerId: speakerIdSchema,
-  targetStyleId: styleIdSchema,
-});
-
-const audioItemSchema = z.object({
-  text: z.string(),
-  voice: z.object({
-    engineId: engineIdSchema,
-    speakerId: speakerIdSchema,
-    styleId: styleIdSchema,
-  }),
-  query: audioQuerySchema.optional(),
-  presetKey: presetKeySchema.optional(),
-  morphingInfo: morphingInfoSchema.optional(),
-});
-
-const projectSchema = z.object({
-  appVersion: z.string(),
-  talk: z.object({
-    // description: "Attribute keys of audioItems.",
-    audioKeys: z.array(audioKeySchema),
-    // description: "VOICEVOX states per cell",
-    audioItems: z.record(audioKeySchema, audioItemSchema),
-  }),
-  song: z.object({
-    tpqn: z.number(),
-    tempos: z.array(tempoSchema),
-    timeSignatures: z.array(timeSignatureSchema),
-    tracks: z.array(trackSchema),
-  }),
-});
-
-export type LatestProjectType = z.infer<typeof projectSchema>;

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -17,7 +17,6 @@ import {
   Phrase,
   PhraseState,
   transformCommandStore,
-  noteSchema,
 } from "./type";
 import { sanitizeFileName } from "./utility";
 import { EngineId } from "@/type/preload";
@@ -70,6 +69,7 @@ import {
   createPromiseThatResolvesWhen,
   round,
 } from "@/sing/utility";
+import { noteSchema } from "@/domain/project/schema";
 
 const generateAudioEvents = async (
   audioContext: BaseAudioContext,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -48,8 +48,6 @@ import {
   AudioKey,
   PresetKey,
   RootMiscSettingType,
-  engineIdSchema,
-  styleIdSchema,
   EditorType,
 } from "@/type/preload";
 import { IEngineConnectorFactory } from "@/infrastructures/EngineConnector";
@@ -60,6 +58,7 @@ import {
   LoadingScreenOption,
 } from "@/components/Dialog/Dialog";
 import { OverlappingNoteInfos } from "@/sing/storeHelper";
+import { singerSchema, trackSchema } from "@/domain/project/schema";
 
 /**
  * エディタ用のAudioQuery
@@ -742,19 +741,8 @@ export type Score = {
   notes: Note[];
 };
 
-export const singerSchema = z.object({
-  engineId: engineIdSchema,
-  styleId: styleIdSchema,
-});
-
 export type Singer = z.infer<typeof singerSchema>;
 
-export const trackSchema = z.object({
-  singer: singerSchema.optional(),
-  keyRangeAdjustment: z.number(), // 音域調整量
-  volumeRangeAdjustment: z.number(), // 声量調整量
-  notes: z.array(noteSchema),
-});
 export type Track = z.infer<typeof trackSchema>;
 
 export type PhraseState =

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -58,7 +58,13 @@ import {
   LoadingScreenOption,
 } from "@/components/Dialog/Dialog";
 import { OverlappingNoteInfos } from "@/sing/storeHelper";
-import { singerSchema, trackSchema } from "@/domain/project/schema";
+import {
+  noteSchema,
+  singerSchema,
+  tempoSchema,
+  timeSignatureSchema,
+  trackSchema,
+} from "@/domain/project/schema";
 
 /**
  * エディタ用のAudioQuery
@@ -711,27 +717,10 @@ export type AudioPlayerStoreTypes = {
  */
 
 // schemaはプロジェクトファイル用
-// TODO: schemaをsrc/domain/projectSchema.tsに移動する
-export const tempoSchema = z.object({
-  position: z.number(),
-  bpm: z.number(),
-});
 export type Tempo = z.infer<typeof tempoSchema>;
 
-export const timeSignatureSchema = z.object({
-  measureNumber: z.number(),
-  beats: z.number(),
-  beatType: z.number(),
-});
 export type TimeSignature = z.infer<typeof timeSignatureSchema>;
 
-export const noteSchema = z.object({
-  id: z.string(),
-  position: z.number(),
-  duration: z.number(),
-  noteNumber: z.number(),
-  lyric: z.string(),
-});
 export type Note = z.infer<typeof noteSchema>;
 
 export type Score = {


### PR DESCRIPTION
## 内容

プロジェクトファイルのマイグレーションをファイル切り出ししてテスト可能にしたいです。
その第1弾として、マイグレーションで使っている部分の型宣言をdomainディレクトリ以下に移動します。
domain/projectディレクトリを新たに作ってそちらに移動しています。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/1912


## その他

```bash
git --no-pager  diff -w --color-moved=dimmed-zebra --color-moved-ws=ignore-all-space upstream/main
```
したら変更は移動だけなことがわかるかと！