### PR TITLE
ノートをドラッグ移動する処理の際に上下への境界チェック処理を入れる

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -451,7 +451,7 @@ const previewMove = () => {
   const cursorBaseY = (scrollY.value + cursorY.value) / zoomY.value;
   const cursorTicks = baseXToTick(cursorBaseX, tpqn.value);
   const cursorNoteNumber = baseYToNoteNumber(cursorBaseY);
-  if (cursorNoteNumber < 0 || cursorNoteNumber > 127) {
+  if (cursorNoteNumber < 0 || cursorNoteNumber >= keyInfos.length) {
     return;
   }
   const draggingNote = copiedNotesForPreview.get(draggingNoteId);

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -476,6 +476,7 @@ const previewMove = () => {
   }
   for (const note of editedNotes.values()) {
     if (note.noteNumber < 0 || note.noteNumber >= keyInfos.length) {
+      // MIDIキー範囲外へはドラッグしない
       return;
     }
 

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -451,9 +451,6 @@ const previewMove = () => {
   const cursorBaseY = (scrollY.value + cursorY.value) / zoomY.value;
   const cursorTicks = baseXToTick(cursorBaseX, tpqn.value);
   const cursorNoteNumber = baseYToNoteNumber(cursorBaseY);
-  if (cursorNoteNumber < 0 || cursorNoteNumber >= keyInfos.length) {
-    return;
-  }
   const draggingNote = copiedNotesForPreview.get(draggingNoteId);
   if (!draggingNote) {
     throw new Error("draggingNote is undefined.");
@@ -478,6 +475,10 @@ const previewMove = () => {
     }
   }
   for (const note of editedNotes.values()) {
+    if (note.noteNumber < 0 || note.noteNumber >= keyInfos.length) {
+      return;
+    }
+
     if (note.position < 0) {
       // 左端より前はドラッグしない
       return;

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -451,6 +451,10 @@ const previewMove = () => {
   const cursorBaseY = (scrollY.value + cursorY.value) / zoomY.value;
   const cursorTicks = baseXToTick(cursorBaseX, tpqn.value);
   const cursorNoteNumber = baseYToNoteNumber(cursorBaseY);
+  if (cursorNoteNumber < 0 || cursorNoteNumber > 127) {
+    return;
+  }
+
   const draggingNote = copiedNotesForPreview.get(draggingNoteId);
   if (!draggingNote) {
     throw new Error("draggingNote is undefined.");

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -454,7 +454,6 @@ const previewMove = () => {
   if (cursorNoteNumber < 0 || cursorNoteNumber > 127) {
     return;
   }
-
   const draggingNote = copiedNotesForPreview.get(draggingNoteId);
   if (!draggingNote) {
     throw new Error("draggingNote is undefined.");


### PR DESCRIPTION
## 内容

cursorNoteNumberをチェックして境界を越えないようにします．

## 関連 Issue

close #1959
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
