### PR TITLE
change: HotkeysJSを代替

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -139,5 +139,10 @@ onMounted(async () => {
   } else {
     isProjectFileLoaded.value = false;
   }
+
+  // ショートカットキーを動作させる
+  document.addEventListener("keydown", (e) => {
+    hotkeyManager.keyInput(e);
+  });
 });
 </script>

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -276,7 +276,6 @@ export class HotkeyManager {
 
   keyInput(e: KeyboardEvent): void {
     const element = e.target;
-    console.log(element);
     // メニュー項目ではショートカットキーを無効化
     if (
       element instanceof HTMLElement &&

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -91,6 +91,8 @@ const isNotSameHotkeyTarget = (a: HotkeyTarget) => (b: HotkeyTarget) => {
 export class HotkeyManager {
   /** 登録されたHotkeyAction */
   private actions: HotkeyAction[] = [];
+  /** スコープ */
+  private scope: Editor = "talk";
   /** ユーザーのショートカットキー設定 */
   private settings: HotkeySettingType[] | undefined; // ユーザーのショートカットキー設定
   /** hotkeys-jsに登録されたショートカットキーの組み合わせ */
@@ -171,7 +173,7 @@ export class HotkeyManager {
     for (const combination of combinations) {
       const bindingKey = combinationToBindingKey(combination.combination);
       this.log("Unbind:", bindingKey, "in", combination.editor);
-      this.hotkeys.unbind(bindingKey, combination.editor);
+      /* this.hotkeys.unbind(bindingKey, combination.editor); */
       this.registeredCombinations = this.registeredCombinations.filter(
         isNotSameHotkeyTarget(combination)
       );
@@ -189,7 +191,7 @@ export class HotkeyManager {
         "in",
         action.editor
       );
-      this.hotkeys(
+      /* this.hotkeys(
         combinationToBindingKey(setting.combination),
         { scope: action.editor },
         (e) => {
@@ -215,7 +217,7 @@ export class HotkeyManager {
           e.preventDefault();
           action.callback(e);
         }
-      );
+      ); */
       this.registeredCombinations = this.registeredCombinations.filter(
         isNotSameHotkeyTarget(action)
       );
@@ -267,8 +269,40 @@ export class HotkeyManager {
    * エディタが変更されたときに呼び出される。
    */
   onEditorChange(editor: "talk" | "song"): void {
-    this.hotkeys.setScope(editor);
+    // this.hotkeys.setScope(editor);
+    this.scope = editor;
     this.log("Editor changed to", editor);
+  }
+
+  keyInput(e: KeyboardEvent): void {
+    const element = e.target;
+    console.log(element);
+    // メニュー項目ではショートカットキーを無効化
+    if (
+      element instanceof HTMLElement &&
+      element.getAttribute("role") == "menu"
+    ) {
+      return;
+    }
+
+    const isInTextbox =
+      element instanceof HTMLElement &&
+      (element.tagName === "INPUT" ||
+        element.tagName === "SELECT" ||
+        element.tagName === "TEXTAREA" ||
+        element.contentEditable === "true");
+
+    const combination: HotkeyCombination = eventToCombination(e);
+
+    const action = this.actions
+      .filter((item) => item.editor == this.scope)
+      .filter((item) => !isInTextbox || item.enableInTextbox)
+      .find((item) => this.getSetting(item).combination == combination);
+    if (action == null) {
+      return;
+    }
+    e.preventDefault();
+    action.callback(e);
   }
 }
 


### PR DESCRIPTION
## 内容

- 動作
1. App.vueでキー入力を受け付ける
2. hotkeyPluginでキー入力に反応する
3. 以前のkeyInputされたときの動作（190~200行目あたり）と同じことを行う
4. actions内で入力されたものと一致するか検索しあれば実行する
- 削除
hotkeysJsの部分をコメントアウト

hotkeysJsの為に書かれた部分を消す作業はしていませんが一応動作の中心部分はこんな感じで大丈夫だと思います

## 関連 Issue

ref #1947 ：一応解決することはできていますが保存形式に関する議論は解決していないのでrefとしました
ref https://github.com/VOICEVOX/voicevox/pull/1964 ：同じissueですがこちらとは衝突しません

## その他
`combinationToBindingKey`関数を利用して一致検索しているので`.code`、`.key`どちらで保存する仕様にしても動作します。shift+"となっていても（表示は変ですが）実行できます（未実装の複合キーが困りますが）。