### PR TITLE
perf: キャラクター一覧をキャッシュして、２回目以降の表示にかかる時間を短くする

### DIFF
--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -410,6 +410,7 @@ const openMenu = () => {
   overflow-y: scroll;
   max-height: v-bind(maxMenuHeight);
   visibility: v-bind(shouldShowMenu);
+  background: colors.$background;
   z-index: 10;
 
   .character-item-container {

--- a/src/components/CharacterButton.vue
+++ b/src/components/CharacterButton.vue
@@ -342,14 +342,15 @@ const menuPosition = ref({ top: 0, left: 0 });
 const menuPositionTopStyle = computed(() => `${menuPosition.value.top}px`);
 const menuPositionLeftStyle = computed(() => `${menuPosition.value.left}px`);
 
-const hideMenu = () => {
-  document.removeEventListener("click", hideMenu);
+const hideMenu = debounce(() => {
+  document.removeEventListener("click", hideMenu, { capture: true });
   shouldShowMenu.value = "hidden";
-};
-const showMenu = () => {
-  document.addEventListener("click", hideMenu);
+}, 50);
+const showMenu = debounce(() => {
+  document.addEventListener("click", hideMenu, { capture: true });
   shouldShowMenu.value = "visible";
-};
+}, 50);
+
 const openMenu = () => {
   hasMenuOpen.value = true;
 

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,7 @@
       <strong>JavaScriptが無効化されている環境では動作しません。</strong>
     </noscript>
     <div id="app" style="height: 100%"></div>
+    <div id="character-icon-teleport"></div>
     <script type="module">
       // https://stackoverflow.com/questions/70714690/buffer-is-not-defined-in-react-vite#:~:text=installing%20buffer%20as%20a%20dev%20dependency%20yarn%20add%20buffer%20(use%20npm%20equivalent%20if%20you%20use%20npm)
       import { Buffer } from "buffer";


### PR DESCRIPTION
## 内容
> 作業中です

キャラクター一覧の2回目以降の表示にかかる時間を短くします

## 関連 Issue

Ref: #1627

## スクリーンショット・動画など

下のようになる予定です

![menu-sample](https://github.com/VOICEVOX/voicevox/assets/79092292/b1410d2e-5fcf-49a8-8caa-2adb9b0808f5)

## その他
 
