### PR TITLE
ソング：水平方向の拡大縮小時に垂直スクロールするのを修正

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -1064,6 +1064,9 @@ const onWheel = (event: WheelEvent) => {
     throw new Error("sequencerBodyElement is null.");
   }
   if (isOnCommandOrCtrlKeyDown(event)) {
+    // scrollイベントの発火を阻止する
+    event.preventDefault();
+
     cursorX.value = getXInBorderBox(event.clientX, sequencerBodyElement);
     // マウスカーソル位置を基準に水平方向のズームを行う
     const oldZoomX = zoomX.value;


### PR DESCRIPTION
## 内容

ソングエディタで、Cmdキー + マウススクロールでのピアノロールの水平方向の拡大縮小を行うと、同時に垂直方向にスクロールする問題を修正しました。

## 関連 Issue

ref #1995

## スクリーンショット・動画など

## その他
