### PR TITLE
macOSのみ、e2eテストを実行しない

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
           target: ${{ matrix.voicevox_engine_asset_name }}
 
       - name: Setup
-        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在は最新バージョンでテストが落ちる)
+        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在、最新バージョンでテストが落ちる)
         run: |
           # playwright
           npx playwright install
@@ -113,7 +113,7 @@ jobs:
           cp .env.test .env
 
       - name: Run npm run test:browser-e2e
-        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在は最新バージョンでテストが落ちる)
+        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在、最新バージョンでテストが落ちる)
         run: |
           if [ -n "${{ runner.debug }}" ]; then
             export DEBUG="pw:browser*"
@@ -125,7 +125,7 @@ jobs:
           npm run test:browser-e2e -- $ARGS
 
       - name: Run npm run test:electron-e2e
-        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在は最新バージョンでテストが落ちる)
+        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在、最新バージョンでテストが落ちる)
         run: |
           if [ -n "${{ runner.debug }}" ]; then
             export DEBUG="pw:browser*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,7 @@ jobs:
           target: ${{ matrix.voicevox_engine_asset_name }}
 
       - name: Setup
+        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在は最新バージョンでテストが落ちる)
         run: |
           # playwright
           npx playwright install
@@ -112,6 +113,7 @@ jobs:
           cp .env.test .env
 
       - name: Run npm run test:browser-e2e
+        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在は最新バージョンでテストが落ちる)
         run: |
           if [ -n "${{ runner.debug }}" ]; then
             export DEBUG="pw:browser*"
@@ -123,6 +125,7 @@ jobs:
           npm run test:browser-e2e -- $ARGS
 
       - name: Run npm run test:electron-e2e
+        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在は最新バージョンでテストが落ちる)
         run: |
           if [ -n "${{ runner.debug }}" ]; then
             export DEBUG="pw:browser*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,6 @@ jobs:
           target: ${{ matrix.voicevox_engine_asset_name }}
 
       - name: Setup
-        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在、最新バージョンでテストが落ちる)
         run: |
           # playwright
           npx playwright install
@@ -113,7 +112,6 @@ jobs:
           cp .env.test .env
 
       - name: Run npm run test:browser-e2e
-        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在、最新バージョンでテストが落ちる)
         run: |
           if [ -n "${{ runner.debug }}" ]; then
             export DEBUG="pw:browser*"
@@ -125,7 +123,6 @@ jobs:
           npm run test:browser-e2e -- $ARGS
 
       - name: Run npm run test:electron-e2e
-        if: matrix.os != 'macos-latest' # TODO: 最新バージョンのmacOSで動作できるようにする(2024年4月現在、最新バージョンでテストが落ちる)
         run: |
           if [ -n "${{ runner.debug }}" ]; then
             export DEBUG="pw:browser*"

--- a/tests/e2e/browser/song/ソング.spec.ts
+++ b/tests/e2e/browser/song/ソング.spec.ts
@@ -21,7 +21,8 @@ async function getCurrentPlayhead(page: Page) {
 test("再生ボタンを押して再生できる", async ({ page }) => {
   test.skip(
     process.platform === "darwin",
-    "macOSだと原因不明でテストが落ちるためスキップします",
+    // https://github.com/VOICEVOX/voicevox/issues/2007
+    "macOSだと原因不明でテストが落ちるためスキップします"
   );
   await navigateToSong(page);
   // TODO: ページ内のオーディオを検出するテストを追加する

--- a/tests/e2e/browser/song/ソング.spec.ts
+++ b/tests/e2e/browser/song/ソング.spec.ts
@@ -22,7 +22,7 @@ test("再生ボタンを押して再生できる", async ({ page }) => {
   test.skip(
     process.platform === "darwin",
     // https://github.com/VOICEVOX/voicevox/issues/2007
-    "macOSだと原因不明でテストが落ちるためスキップします"
+    "macOSだと原因不明でテストが落ちるためスキップします",
   );
   await navigateToSong(page);
   // TODO: ページ内のオーディオを検出するテストを追加する

--- a/tests/e2e/browser/song/ソング.spec.ts
+++ b/tests/e2e/browser/song/ソング.spec.ts
@@ -19,6 +19,10 @@ async function getCurrentPlayhead(page: Page) {
 }
 
 test("再生ボタンを押して再生できる", async ({ page }) => {
+  test.skip(
+    process.platform === "darwin",
+    "macOSだと原因不明でテストが落ちるためスキップします",
+  );
   await navigateToSong(page);
   // TODO: ページ内のオーディオを検出するテストを追加する
 

--- a/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
+++ b/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
@@ -47,7 +47,7 @@ test("アップデートが通知されたりスキップしたりできる", as
   test.skip(
     process.platform === "darwin",
     // https://github.com/VOICEVOX/voicevox/issues/2007
-    "macOSだと原因不明でテストが落ちるためスキップします"
+    "macOSだと原因不明でテストが落ちるためスキップします",
   );
   await page.waitForTimeout(500);
 

--- a/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
+++ b/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async ({ page }) => {
   // 動作環境より新しいバージョン
   const latestVersion = semver.inc(
     process.env.VITE_APP_VERSION ?? process.env.npm_package_version ?? "0.0.0",
-    "major"
+    "major",
   );
   assertNonNullable(latestVersion);
 

--- a/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
+++ b/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
@@ -44,6 +44,10 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("アップデートが通知されたりスキップしたりできる", async ({ page }) => {
+  test.skip(
+    process.platform === "darwin",
+    "macOSだと原因不明でテストが落ちるためスキップします",
+  );
   await page.waitForTimeout(500);
 
   // 通知されている

--- a/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
+++ b/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async ({ page }) => {
   // 動作環境より新しいバージョン
   const latestVersion = semver.inc(
     process.env.VITE_APP_VERSION ?? process.env.npm_package_version ?? "0.0.0",
-    "major",
+    "major"
   );
   assertNonNullable(latestVersion);
 
@@ -46,7 +46,8 @@ test.beforeEach(async ({ page }) => {
 test("アップデートが通知されたりスキップしたりできる", async ({ page }) => {
   test.skip(
     process.platform === "darwin",
-    "macOSだと原因不明でテストが落ちるためスキップします",
+    // https://github.com/VOICEVOX/voicevox/issues/2007
+    "macOSだと原因不明でテストが落ちるためスキップします"
   );
   await page.waitForTimeout(500);
 


### PR DESCRIPTION
## 内容

2024年4月25日現在、github actionsにて最新バージョンのmacOSでe2eテストが落ちるようです。

https://discord.com/channels/879570910208733277/893889888208977960/1232870129809883156

応急措置としてテストをスキップします。


## 関連 Issue

ref #2003

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
