### PR TITLE
ソング：macOSでのピッチ編集結果削除の操作をcommandキーを押しながら左クリックに変更

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -242,7 +242,6 @@ import { v4 as uuidv4 } from "uuid";
 import ContextMenu, {
   ContextMenuItemData,
 } from "@/components/Menu/ContextMenu.vue";
-import { isMac } from "@/type/preload";
 import { useStore } from "@/store";
 import { Note, SequencerEditTarget } from "@/store/type";
 import {
@@ -1056,7 +1055,7 @@ const onMouseDown = (event: MouseEvent) => {
     }
   } else if (editTarget.value === "PITCH") {
     if (mouseButton === "LEFT_BUTTON") {
-      if (isMac ? event.metaKey : event.ctrlKey) {
+      if (isOnCommandOrCtrlKeyDown(event)) {
         startPreview(event, "ERASE_PITCH");
       } else {
         startPreview(event, "DRAW_PITCH");

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -1055,16 +1055,8 @@ const onMouseDown = (event: MouseEvent) => {
       store.dispatch("DESELECT_ALL_NOTES");
     }
   } else if (editTarget.value === "PITCH") {
-    if (isMac) {
-      // Macの場合、左ボタンでDRAW、右ボタンでERASE
-      if (mouseButton === "LEFT_BUTTON") {
-        startPreview(event, "DRAW_PITCH");
-      } else if (mouseButton === "RIGHT_BUTTON") {
-        startPreview(event, "ERASE_PITCH");
-      }
-    } else if (mouseButton === "LEFT_BUTTON") {
-      // Mac以外の場合、左ボタンでDRAW、左ボタン+CtrlでERASE
-      if (event.ctrlKey) {
+    if (mouseButton === "LEFT_BUTTON") {
+      if (isMac ? event.metaKey : event.ctrlKey) {
         startPreview(event, "ERASE_PITCH");
       } else {
         startPreview(event, "DRAW_PITCH");


### PR DESCRIPTION
## 内容

macOSでのピッチ編集結果削除の操作をcommandキーを押しながら左クリックに変更します。

## 関連 Issue

close #2009

## その他
