### PR TITLE
Add: 0.19のマイグレーションを追加

### DIFF
--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -142,7 +142,9 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
     (config) => {
       // ピッチ表示機能の設定をピッチ編集機能に引き継ぐ
       const experimentalSetting =
-        config.experimentalSetting as ExperimentalSettingType;
+        config.experimentalSetting as ExperimentalSettingType & {
+          showPitchInSongEditor?: boolean; // FIXME: TypeScript 5.4.5ならこの型の結合は不要
+        };
       if (
         "showPitchInSongEditor" in experimentalSetting &&
         typeof experimentalSetting.showPitchInSongEditor === "boolean"

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -137,6 +137,13 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
       }
     },
   ],
+  [
+    ">=0.19",
+    (config) => {
+      config.enablePitchEditInSongEditor = config.showPitchInSongEditor;
+      delete config.showPitchInSongEditor;
+    },
+  ],
 ];
 
 export type Metadata = {

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -140,11 +140,16 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
   [
     ">=0.19",
     (config) => {
+      // ピッチ表示機能の設定をピッチ編集機能に引き継ぐ
+      const experimentalSetting =
+        config.experimentalSetting as ExperimentalSettingType;
       if (
-        Object.prototype.hasOwnProperty.call(config, "showPitchInSongEditor")
+        "showPitchInSongEditor" in experimentalSetting &&
+        typeof experimentalSetting.showPitchInSongEditor === "boolean"
       ) {
-        config.enablePitchEditInSongEditor = config.showPitchInSongEditor;
-        delete config.showPitchInSongEditor;
+        experimentalSetting.enablePitchEditInSongEditor =
+          experimentalSetting.showPitchInSongEditor;
+        delete experimentalSetting.showPitchInSongEditor;
       }
     },
   ],

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -140,8 +140,12 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
   [
     ">=0.19",
     (config) => {
-      config.enablePitchEditInSongEditor = config.showPitchInSongEditor;
-      delete config.showPitchInSongEditor;
+      if (
+        Object.prototype.hasOwnProperty.call(config, "showPitchInSongEditor")
+      ) {
+        config.enablePitchEditInSongEditor = config.showPitchInSongEditor;
+        delete config.showPitchInSongEditor;
+      }
     },
   ],
 ];

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -442,6 +442,19 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             }
           }
 
+          if (
+            semver.satisfies(
+              projectAppVersion,
+              "<0.19.0",
+              semverSatisfiesOptions,
+            )
+          ) {
+            // pitchEditDataの追加
+            for (const track of projectData.song.tracks) {
+              track.pitchEditData = [];
+            }
+          }
+
           // Validation check
           // トークはvalidateTalkProjectで検証する
           // ソングはSET_SCOREの中の`isValidScore`関数で検証される

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -436,7 +436,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               semverSatisfiesOptions,
             )
           ) {
-            // volumeRangeAdjustmentの追加
+            // 声量調整値の追加
             for (const track of projectData.song.tracks) {
               track.volumeRangeAdjustment = 0;
             }
@@ -449,7 +449,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               semverSatisfiesOptions,
             )
           ) {
-            // pitchEditDataの追加
+            // ピッチ編集値の追加
             for (const track of projectData.song.tracks) {
               track.pitchEditData = [];
             }


### PR DESCRIPTION
## 内容

コンフィグのshowPitchInSongEditor -> enablePitchEditInSongEditor、
トラックのpitchEditDataの追加をマイグレーションするコードを追加します。

## 関連 Issue

- ref: https://github.com/VOICEVOX/voicevox_project/discussions/49 ：ソフトウェアアップデート/マイグレーション

## スクリーンショット・動画など

（なし）

## その他

（なし）