### PR TITLE
ソング：プロジェクトファイル読み込みでピッチ編集データもロードする

### DIFF
--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -325,6 +325,14 @@ export function isValidvolumeRangeAdjustment(volumeRangeAdjustment: number) {
   );
 }
 
+export function isValidPitchEditData(pitchEditData: number[]) {
+  return pitchEditData.every(
+    (value) =>
+      Number.isFinite(value) &&
+      (value > 0 || value === VALUE_INDICATING_NO_DATA),
+  );
+}
+
 export const calculateNotesHash = async (notes: Note[]) => {
   return await calculateHash({ notes });
 };

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -116,6 +116,11 @@ const applySongProjectToStore = async (
       notes: tracks[0].notes,
     },
   });
+  await dispatch("CLEAR_PITCH_EDIT_DATA"); // FIXME: SET_PITCH_EDIT_DATAがセッターになれば不要
+  await dispatch("SET_PITCH_EDIT_DATA", {
+    data: tracks[0].pitchEditData,
+    startFrame: 0,
+  });
 };
 
 export const projectStore = createPartialStore<ProjectStoreTypes>({
@@ -168,6 +173,8 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             notes: tracks[0].notes,
           },
         });
+        await context.dispatch("SET_SINGER", {});
+        await context.dispatch("CLEAR_PITCH_EDIT_DATA");
 
         context.commit("SET_PROJECT_FILEPATH", { filePath: undefined });
         context.commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -913,10 +913,16 @@ export type SingingStoreTypes = {
 
   SET_PITCH_EDIT_DATA: {
     mutation: { data: number[]; startFrame: number };
+    action(payload: { data: number[]; startFrame: number }): void;
   };
 
   ERASE_PITCH_EDIT_DATA: {
     mutation: { startFrame: number; frameLength: number };
+  };
+
+  CLEAR_PITCH_EDIT_DATA: {
+    mutation: undefined;
+    action(): void;
   };
 
   SET_PHRASES: {


### PR DESCRIPTION
## 内容

プロジェクトファイルにピッチ編集データが保存されていましたが、ロードができてなかったのでロードするようにしました。
ついでに新規プロジェクトファイルを作った時にピッチ編集データが消えない問題に気づいたのでそっちも修正しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

ピッチ編集データのセッターがなかったのでクリア関数を作りました。
セッターになればクリア関数いらないと思うので、こちらのissueが解決されるタイミングでクリア関数を消してもよさそう？

- https://github.com/VOICEVOX/voicevox/issues/2020
