### PR TITLE
[fix] ソングで保存ショートカットキーが効かないバグを修正

### DIFF
--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -34,7 +34,7 @@ import TitleBarButtons from "./TitleBarButtons.vue";
 import TitleBarEditorSwitcher from "./TitleBarEditorSwitcher.vue";
 import { useStore } from "@/store";
 import { base64ImageToUri } from "@/helpers/imageHelper";
-import { useHotkeyManager } from "@/plugins/hotkeyPlugin";
+import { HotkeyAction, useHotkeyManager } from "@/plugins/hotkeyPlugin";
 
 const props = defineProps<{
   /** 「ファイル」メニューのサブメニュー */
@@ -477,23 +477,34 @@ watch(uiLocked, () => {
   }
 });
 
-registerHotkeyWithCleanup({
-  editor: props.editor,
+/**
+ * 全エディタに対してホットキーを登録する
+ * FIXME: hotkeyPlugin側で全エディタに対して登録できるようにする
+ */
+function registerHotkeyForAllEditors(action: Omit<HotkeyAction, "editor">) {
+  registerHotkeyWithCleanup({
+    editor: "talk",
+    ...action,
+  });
+  registerHotkeyWithCleanup({
+    editor: "song",
+    ...action,
+  });
+}
+
+registerHotkeyForAllEditors({
   callback: createNewProject,
   name: "新規プロジェクト",
 });
-registerHotkeyWithCleanup({
-  editor: props.editor,
+registerHotkeyForAllEditors({
   callback: saveProject,
   name: "プロジェクトを上書き保存",
 });
-registerHotkeyWithCleanup({
-  editor: props.editor,
+registerHotkeyForAllEditors({
   callback: saveProjectAs,
   name: "プロジェクトを名前を付けて保存",
 });
-registerHotkeyWithCleanup({
-  editor: props.editor,
+registerHotkeyForAllEditors({
   callback: importProject,
   name: "プロジェクト読み込み",
 });


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/2022

の解決プルリクエストです。

## 関連 Issue

close #2022 


## その他

エディターを指定しなくても全体でショートカットキーが効くような方法も欲しいところ
