### PR TITLE
デザインをバージョン0.19.0に向けて調整

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -1683,7 +1683,7 @@ const contextMenuData = ref<ContextMenuItemData[]>([
   left: -1px;
   width: 2px;
   height: 100%;
-  background: rgba(colors.$display-rgb, 0.8);
+  background: rgba(colors.$display-rgb, 0.6);
   will-change: transform;
 }
 

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -310,9 +310,9 @@ const onLyricInput = (event: Event) => {
   &.selected {
     // 色は仮
     .note-bar {
-      background-color: rgb(179 241 191);
-      border-color: #65bd7f;
-      outline: solid 2px #80d998;
+      background-color: lab(90, -22.953, 14.365);
+      border-color: lab(75, -22.953, 14.365);
+      outline: solid 2px lab(80, -22.953, 14.365);
     }
 
     &.below-pitch {
@@ -324,9 +324,9 @@ const onLyricInput = (event: Event) => {
   // TODO：もっといい見た目を考える
   &.preview-lyric {
     .note-bar {
-      background-color: rgb(179 241 191);
-      border-color: #65bd7f;
-      outline: solid 2px #80d998;
+      background-color: lab(90, -22.953, 14.365);
+      border-color: lab(75, -22.953, 14.365);
+      outline: solid 2px lab(80, -22.953, 14.365);
     }
 
     .note-lyric {
@@ -398,7 +398,7 @@ const onLyricInput = (event: Event) => {
 
   &:hover {
     // FIXME: hoverだとカーソル位置によって適用されないので、プレビュー中に明示的にクラス指定する
-    background-color: #80d998;
+    background-color: lab(80, -22.953, 14.365);
   }
 }
 
@@ -411,7 +411,7 @@ const onLyricInput = (event: Event) => {
 
   &:hover {
     // FIXME: hoverだとカーソル位置によって適用されないので、プレビュー中に明示的にクラス指定する
-    background-color: #80d998;
+    background-color: lab(80, -22.953, 14.365);
   }
 }
 
@@ -422,7 +422,7 @@ const onLyricInput = (event: Event) => {
   min-width: 3rem;
   max-width: 6rem;
   border: 0;
-  outline: 2px solid #80d998;
+  outline: 2px solid lab(80, -22.953, 14.365);
   border-radius: 4px;
 }
 

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -310,9 +310,9 @@ const onLyricInput = (event: Event) => {
   &.selected {
     // 色は仮
     .note-bar {
-      background-color: lab(90, -22.953, 14.365);
-      border-color: lab(75, -22.953, 14.365);
-      outline: solid 2px lab(80, -22.953, 14.365);
+      background-color: lab(95, -22.953, 14.365);
+      border-color: lab(65, -22.953, 14.365);
+      outline: solid 2px lab(70, -22.953, 14.365);
     }
 
     &.below-pitch {

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -387,7 +387,6 @@ const onLyricInput = (event: Event) => {
   background-color: colors.$primary;
   border: 1px solid rgba(colors.$background-rgb, 0.5);
   border-radius: 4px;
-  transition: all ease-out 0.16s;
 }
 
 .note-left-edge {

--- a/src/components/Sing/SequencerRuler.vue
+++ b/src/components/Sing/SequencerRuler.vue
@@ -209,7 +209,7 @@ onUnmounted(() => {
   left: -1px;
   width: 2px;
   height: 100%;
-  background: rgba(colors.$display-rgb, 0.8);
+  background: rgba(colors.$display-rgb, 0.6);
   pointer-events: none;
   will-change: transform;
 }

--- a/src/components/Sing/SingEditor.vue
+++ b/src/components/Sing/SingEditor.vue
@@ -27,7 +27,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import ToolBar from "./ToolBar.vue";
+import ToolBar from "./ToolBar/ToolBar.vue";
 import ScoreSequencer from "./ScoreSequencer.vue";
 import EngineStartupOverlay from "@/components/EngineStartupOverlay.vue";
 import { useStore } from "@/store";

--- a/src/components/Sing/ToolBar/EditTargetSwicher.vue
+++ b/src/components/Sing/ToolBar/EditTargetSwicher.vue
@@ -8,7 +8,7 @@
     dense
     icon="piano"
     :color="editTarget === 'NOTE' ? 'primary' : undefined"
-    :text-color="editTarget === 'NOTE' ? 'display' : undefined"
+    :text-color="editTarget === 'NOTE' ? 'display-on-primary' : undefined"
     @click="editTarget !== 'NOTE' && changeEditTarget('NOTE')"
     ><QTooltip :delay="500" anchor="bottom middle">ノート編集</QTooltip></QBtn
   >
@@ -18,7 +18,7 @@
     dense
     icon="show_chart"
     :color="editTarget === 'PITCH' ? 'primary' : undefined"
-    :text-color="editTarget === 'PITCH' ? 'display' : undefined"
+    :text-color="editTarget === 'PITCH' ? 'display-on-primary' : undefined"
     class="margin-right"
     @click="editTarget !== 'PITCH' && changeEditTarget('PITCH')"
     ><QTooltip :delay="500" anchor="bottom middle"

--- a/src/components/Sing/ToolBar/EditTargetSwicher.vue
+++ b/src/components/Sing/ToolBar/EditTargetSwicher.vue
@@ -1,0 +1,43 @@
+<!-- 
+  ノートやピッチなどの編集対象を切り替えるボタン
+-->
+
+<template>
+  <!-- ノート -->
+  <QBtn
+    dense
+    icon="piano"
+    :color="editTarget === 'NOTE' ? 'primary' : undefined"
+    :text-color="editTarget === 'NOTE' ? 'display' : undefined"
+    @click="editTarget !== 'NOTE' && changeEditTarget('NOTE')"
+    ><QTooltip :delay="500" anchor="bottom middle">ノート編集</QTooltip></QBtn
+  >
+
+  <!-- ピッチ -->
+  <QBtn
+    dense
+    icon="show_chart"
+    :color="editTarget === 'PITCH' ? 'primary' : undefined"
+    :text-color="editTarget === 'PITCH' ? 'display' : undefined"
+    class="margin-right"
+    @click="editTarget !== 'PITCH' && changeEditTarget('PITCH')"
+    ><QTooltip :delay="500" anchor="bottom middle"
+      >ピッチ編集<br />Ctrl+クリックで消去</QTooltip
+    ></QBtn
+  >
+</template>
+
+<script setup lang="ts">
+import { SequencerEditTarget } from "@/store/type";
+
+defineProps<{
+  editTarget: SequencerEditTarget;
+  changeEditTarget: (editTarget: SequencerEditTarget) => void;
+}>();
+</script>
+
+<style scoped lang="scss">
+.margin-right {
+  margin-right: 6px;
+}
+</style>

--- a/src/components/Sing/ToolBar/ToolBar.vue
+++ b/src/components/Sing/ToolBar/ToolBar.vue
@@ -93,14 +93,10 @@
     </div>
     <!-- settings for edit controls -->
     <div class="sing-controls">
-      <QBtn
+      <EditTargetSwicher
         v-if="showEditTargetSwitchButton"
-        dense
-        icon="show_chart"
-        :color="editTarget === 'PITCH' ? 'primary' : undefined"
-        :text-color="editTarget === 'PITCH' ? 'white' : undefined"
-        class="edit-target-switch-button"
-        @click="switchEditTarget"
+        :edit-target="editTarget"
+        :change-edit-target="changeEditTarget"
       />
       <QBtn
         flat
@@ -142,6 +138,7 @@
 
 <script setup lang="ts">
 import { computed, watch, ref, onMounted, onUnmounted } from "vue";
+import EditTargetSwicher from "./EditTargetSwicher.vue";
 import { useStore } from "@/store";
 
 import {
@@ -155,7 +152,7 @@ import {
 } from "@/sing/domain";
 import CharacterMenuButton from "@/components/Sing/CharacterMenuButton/MenuButton.vue";
 import { useHotkeyManager } from "@/plugins/hotkeyPlugin";
-import { ExhaustiveError } from "@/type/utility";
+import { SequencerEditTarget } from "@/store/type";
 
 const store = useStore();
 
@@ -209,14 +206,8 @@ const showEditTargetSwitchButton = computed(() => {
 
 const editTarget = computed(() => store.state.sequencerEditTarget);
 
-const switchEditTarget = () => {
-  if (editTarget.value === "NOTE") {
-    store.dispatch("SET_EDIT_TARGET", { editTarget: "PITCH" });
-  } else if (editTarget.value === "PITCH") {
-    store.dispatch("SET_EDIT_TARGET", { editTarget: "NOTE" });
-  } else {
-    throw new ExhaustiveError(editTarget.value);
-  }
+const changeEditTarget = (editTarget: SequencerEditTarget) => {
+  store.dispatch("SET_EDIT_TARGET", { editTarget });
 };
 
 const tempos = computed(() => store.state.tempos);
@@ -549,10 +540,6 @@ onUnmounted(() => {
   justify-content: flex-end;
   display: flex;
   flex: 1;
-}
-
-.edit-target-switch-button {
-  margin-right: 6px;
 }
 
 .sing-undo-button,


### PR DESCRIPTION
## 内容

デザインをちょっとだけ調整させていただきました！

* ノートの選択色をプライマリーカラーに寄せる
* ノートのアニメーションをなくす
* ピッチとノート編集の切り替えボタンをトグル形式からグループボタン形式に変える
	* コンポーネント化しました
	* ついでにツールチップ置いておきました
* 再生位置インジケーターの線の色を薄く

## スクリーンショット・動画など

![image](https://github.com/VOICEVOX/voicevox/assets/4987327/43a89a62-b766-4617-bce5-51fd5770c77e)

![image](https://github.com/VOICEVOX/voicevox/assets/4987327/598c73df-8a24-4b7c-a1a9-0cc401e59889)


## その他

- https://github.com/VOICEVOX/voicevox/pull/2014