### PR TITLE
ソング：音量が正しく生成されていないのを修正

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1393,16 +1393,17 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               // f0をもう一度シフトして、f0生成時の（シフトする前の）高さに戻す
               const queryForVolume = structuredClone(singingGuide.query);
               shiftGuidePitch(-keyRangeAdjustment, queryForVolume);
+
+              // 音量生成用のクエリから音量を作る
+              // 音量値はAPIを叩く毎に変わるので、calc hashしたあとに音量を取得している
               const notesForRequestToEngine = createNotesForRequestToEngine(
                 phrase.notes,
                 tempos,
                 tpqn,
-                keyRangeAdjustment,
+                keyRangeAdjustment, // f0を生成するときと同様に、noteのkeyのシフトを行う
                 singingGuide.frameRate,
                 restDurationSeconds,
               );
-              // 音量生成用のクエリから音量を作る
-              // 音量値はAPIを叩く毎に変わるので、calc hashしたあとに音量を取得している
               const volumes = await dispatch("FETCH_SING_FRAME_VOLUME", {
                 notes: notesForRequestToEngine,
                 frameAudioQuery: queryForVolume,

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1338,8 +1338,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
                   `Fetched frame audio query. Phonemes are "${phonemes}".`,
                 );
 
+                // 音域調整を適用する
                 shiftGuidePitch(keyRangeAdjustment, query);
-                scaleGuideVolume(volumeRangeAdjustment, query);
 
                 const startTime = calcStartTime(
                   phrase.notes,
@@ -1363,9 +1363,12 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               });
             }
 
-            // 歌い方をコピーして、ピッチ編集を適用する
+            // ピッチ編集を適用する前に、歌い方をコピーする
 
             singingGuide = structuredClone(toRaw(singingGuide));
+
+            // ピッチ編集を適用する
+
             applyPitchEdit(singingGuide, pitchEditData, editFrameRate);
 
             // 歌声のキャッシュがあれば取得し、なければ音声合成を行う
@@ -1391,11 +1394,10 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
                 phrase.notes,
                 tempos,
                 tpqn,
-                keyRangeAdjustment,
+                0, // クエリのピッチは音域調整済みなので、音域調整の処理（noteのkeyのシフト）は行わない
                 singingGuide.frameRate,
                 restDurationSeconds,
               );
-
               const volumes = await dispatch("FETCH_SING_FRAME_VOLUME", {
                 notes: notesForRequestToEngine,
                 frameAudioQuery: singingGuide.query,
@@ -1403,6 +1405,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
                 engineId: singerAndFrameRate.singer.engineId,
               });
               singingGuide.query.volume = volumes;
+
+              // 声量調整を適用する
               scaleGuideVolume(volumeRangeAdjustment, singingGuide.query);
 
               const blob = await synthesize(


### PR DESCRIPTION
## 内容

<s>音量生成時に音域調整の処理（noteのkeyのシフト）が行われて</s>、正しく音量が生成されていないのを修正します。
また、歌い方生成直後の`scaleGuideVolume`は行う必要はないので、削除します。

## スクリーンショット・動画など
VOICEVOX小夜、音域調整-3、声量調整-4
0.18.1→このPRの順です。

https://github.com/VOICEVOX/voicevox/assets/62321214/a4d5324f-4d8f-402b-bb86-cf48b14dbebf

## その他
たぶんこれで0.18.1以前と同じ声量に戻ったはず