### PR TITLE
ソング：startFrameがマイナス値になりf0にundefinedが入るバグを修正

### DIFF
--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -274,9 +274,6 @@ const updateOriginalPitchDataSectionMap = async () => {
       throw new Error("phonemes.length is 0.");
     }
     const f0 = singingGuide.query.f0;
-    const startTime = singingGuide.startTime;
-    const startFrame = Math.round(startTime * frameRate);
-    const endFrame = startFrame + f0.length;
 
     // 各フレームの音素の配列を生成する
     const framePhonemes = convertToFramePhonemes(phonemes);
@@ -284,19 +281,29 @@ const updateOriginalPitchDataSectionMap = async () => {
       throw new Error("f0.length and framePhonemes.length do not match.");
     }
 
+    // 歌い方の開始フレームと終了フレームを計算する
+    const singingGuideFrameLength = f0.length;
+    const singingGuideStartFrame = Math.round(
+      singingGuide.startTime * frameRate,
+    );
+    const singingGuideEndFrame =
+      singingGuideStartFrame + singingGuideFrameLength;
+
     // 無声子音区間以外のf0をtempDataにコピーする
     // NOTE: 無声子音区間は音程が無く、f0の値が大きく上下するので表示しない
-    if (tempData.length < endFrame) {
-      const valuesToPush = new Array(endFrame - tempData.length).fill(
-        VALUE_INDICATING_NO_DATA,
-      );
+    if (tempData.length < singingGuideEndFrame) {
+      const valuesToPush = new Array(
+        singingGuideEndFrame - tempData.length,
+      ).fill(VALUE_INDICATING_NO_DATA);
       tempData.push(...valuesToPush);
     }
-    for (let i = 0; i < f0.length; i++) {
-      const phoneme = framePhonemes[i];
+    const startFrame = Math.max(0, singingGuideStartFrame);
+    const endFrame = singingGuideEndFrame;
+    for (let i = startFrame; i < endFrame; i++) {
+      const phoneme = framePhonemes[i - singingGuideStartFrame];
       const unvoiced = unvoicedPhonemes.includes(phoneme);
       if (!unvoiced) {
-        tempData[startFrame + i] = f0[i];
+        tempData[i] = f0[i - singingGuideStartFrame];
       }
     }
   }

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -443,10 +443,15 @@ export function applyPitchEdit(
     throw new Error("f0.length and framePhonemes.length do not match.");
   }
 
-  const startFrame = Math.round(
+  // f0の開始フレームと終了フレームを計算する
+  const f0StartFrame = Math.round(
     singingGuide.startTime * singingGuide.frameRate,
   );
-  const endFrame = Math.min(startFrame + f0.length, pitchEditData.length);
+  const f0EndFrame = f0StartFrame + f0.length;
+
+  // ピッチ編集をf0に適用する
+  const startFrame = Math.max(0, f0StartFrame);
+  const endFrame = Math.min(pitchEditData.length, f0EndFrame);
   for (let i = startFrame; i < endFrame; i++) {
     const phoneme = framePhonemes[i - startFrame];
     const voiced = !unvoicedPhonemes.includes(phoneme);

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -443,20 +443,21 @@ export function applyPitchEdit(
     throw new Error("f0.length and framePhonemes.length do not match.");
   }
 
-  // f0の開始フレームと終了フレームを計算する
-  const f0StartFrame = Math.round(
+  // 歌い方の開始フレームと終了フレームを計算する
+  const singingGuideFrameLength = f0.length;
+  const singingGuideStartFrame = Math.round(
     singingGuide.startTime * singingGuide.frameRate,
   );
-  const f0EndFrame = f0StartFrame + f0.length;
+  const singingGuideEndFrame = singingGuideStartFrame + singingGuideFrameLength;
 
   // ピッチ編集をf0に適用する
-  const startFrame = Math.max(0, f0StartFrame);
-  const endFrame = Math.min(pitchEditData.length, f0EndFrame);
+  const startFrame = Math.max(0, singingGuideStartFrame);
+  const endFrame = Math.min(pitchEditData.length, singingGuideEndFrame);
   for (let i = startFrame; i < endFrame; i++) {
-    const phoneme = framePhonemes[i - startFrame];
+    const phoneme = framePhonemes[i - singingGuideStartFrame];
     const voiced = !unvoicedPhonemes.includes(phoneme);
     if (voiced && pitchEditData[i] !== VALUE_INDICATING_NO_DATA) {
-      f0[i - startFrame] = pitchEditData[i];
+      f0[i - singingGuideStartFrame] = pitchEditData[i];
     }
   }
 }


### PR DESCRIPTION
## 内容

#2031 の修正PRです。
`applyPitchEdit`で`startFrame`がマイナス値になり、f0にundefinedが入ってレンダリングに失敗するのを修正します。

SequencerPitchの方も`startFrame`がマイナス値になってました…それも修正します。

## 関連 Issue

close #2031

## その他
- `applyPitchEdit`のテストがあれば防げたと思うので、テストを書いていった方が良さそう
- 区間を扱うユーティリティー関数を作った方が良いかも
- 1小節目の頭からノートを入力すると書き出し時に一番最初の子音が消えるので、1小節目は入力不可にするorノートをエラー表示でも良いかも