### PR TITLE
ソング：フレーズのレンダリングがエラーで止まらないようにする

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1456,7 +1456,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               phraseKey,
               phraseState: "COULD_NOT_RENDER",
             });
-            throw error;
+            // とりあえずエラーはロギングしてcontinueする
+            // NOTE: ほとんどは歌詞のエラー
+            // FIXME: 歌詞以外のエラーの場合はthrowするようにする
+            logger.error("An error occurred while rendering a phrase.", error);
+            continue;
           }
         }
       };

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1458,7 +1458,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             });
             // とりあえずエラーはロギングしてcontinueする
             // NOTE: ほとんどは歌詞のエラー
-            // FIXME: 歌詞以外のエラーの場合はthrowするようにする
+            // FIXME: 歌詞以外のエラーの場合はthrowして、エラーダイアログを表示するようにする
             logger.error("An error occurred while rendering a phrase.", error);
             continue;
           }


### PR DESCRIPTION
## 内容

フレーズのレンダリングがエラーで止まらないように、ひとまずロギングしてcontinueするようにします。

## 関連 Issue

ref #1976

## その他
レンダリング中に発生するエラーはほとんどが歌詞のエラーですが、現在は歌詞のエラーなのかそうでないのかが分からない（エンジンとのやり取りでエラーが発生したということしか分からない）ので、ひとまずロギングしてcontinueする形にしています。