### PR TITLE
[project-redisign-help-dialog]各セクションの背景色の統合

### DIFF
--- a/src/components/base/BaseRowCard.vue
+++ b/src/components/base/BaseRowCard.vue
@@ -42,6 +42,7 @@ defineEmits<{
   padding: vars.$padding-2;
   gap: vars.$gap-2;
   transition: background-color vars.$transition-duration;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .clickable:not(:disabled) {

--- a/src/components/help/HelpDialog.vue
+++ b/src/components/help/HelpDialog.vue
@@ -277,15 +277,7 @@ const openLogDirectory = window.electron.openLogDirectory;
   display: grid;
   grid-template-columns: auto 1fr;
   backdrop-filter: blur(32px);
-
-  &::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    background-color: colors.$background;
-    opacity: 0.75;
-    z-index: -1;
-  }
+  background-color: colors.$background-drawer;
 }
 
 // TODO: MenuBar+Header分のマージン。Dialogコンポーネント置き換え後削除

--- a/src/components/template/HelpLibraryPolicySection.vue
+++ b/src/components/template/HelpLibraryPolicySection.vue
@@ -37,7 +37,7 @@
       </div>
     </BaseScrollArea>
   </div>
-  <div v-else class="container container-detail">
+  <div v-else class="container">
     <BaseScrollArea>
       <div class="inner">
         <div>
@@ -134,10 +134,7 @@ const selectCharacterInfo = (index: DetailKey | undefined) => {
   // TODO: 親コンポーネントからheightを取得できないため一時的にcalcを使用、HelpDialogの構造を再設計後100%に変更する
   // height: 100%;
   height: calc(100vh - 90px);
-}
-
-.container-detail {
-  background-color: colors.$surface;
+  background-color: colors.$background;
   border-left: 1px solid colors.$border;
 }
 

--- a/src/components/template/HelpMarkdownViewSection.vue
+++ b/src/components/template/HelpMarkdownViewSection.vue
@@ -39,7 +39,7 @@ onMounted(async () => {
   // TODO: 親コンポーネントからheightを取得できないため一時的にcalcを使用、HelpDialogの構造を再設計後100%に変更する
   // height: 100%;
   height: calc(100vh - 90px);
-  background-color: colors.$surface;
+  background-color: colors.$background;
   border-left: 1px solid colors.$border;
 }
 

--- a/src/components/template/HelpOssLicenseSection.vue
+++ b/src/components/template/HelpOssLicenseSection.vue
@@ -20,7 +20,7 @@
       </div>
     </BaseScrollArea>
   </div>
-  <div v-else class="container container-detail">
+  <div v-else class="container">
     <BaseScrollArea>
       <div class="inner">
         <div>
@@ -64,10 +64,7 @@ const selectLicenseIndex = (index: number | undefined) => {
   // TODO: 親コンポーネントからheightを取得できないため一時的にcalcを使用、HelpDialogの構造を再設計後100%に変更する
   // height: 100%;
   height: calc(100vh - 90px);
-}
-
-.container-detail {
-  background-color: colors.$surface;
+  background-color: colors.$background;
   border-left: 1px solid colors.$border;
 }
 

--- a/src/components/template/HelpUpdateInfoSection.vue
+++ b/src/components/template/HelpUpdateInfoSection.vue
@@ -65,7 +65,7 @@ const props =
   // TODO: 親コンポーネントからheightを取得できないため一時的にcalcを使用、HelpDialogの構造を再設計後100%に変更する
   // height: 100%;
   height: calc(100vh - 90px);
-  background-color: colors.$surface;
+  background-color: colors.$background;
   border-left: 1px solid colors.$border;
 }
 

--- a/src/styles/new-colors.scss
+++ b/src/styles/new-colors.scss
@@ -7,7 +7,9 @@ $primitive-red: #d04756;
 
 // ライトテーマの色
 :root[is-dark-theme="false"] {
-  --newcolor-background: #{lighten($primitive-primary, 20%)};
+  --newcolor-background: #{$primitive-white};
+  --newcolor-background-drawer: #{rgba(lighten($primitive-primary, 20%), 0.75)};
+
   --newcolor-surface: #{lighten($primitive-primary, 25%)};
   --newcolor-border: #{rgba($primitive-black, 0.2)};
   --newcolor-selected: #{rgba($primitive-primary, 0.3)};
@@ -42,6 +44,8 @@ $primitive-red: #d04756;
 // ダークテーマの色
 :root[is-dark-theme="true"] {
   --newcolor-background: #{$primitive-black};
+  --newcolor-background-drawer: #{rgba($primitive-black, 0.75)};
+
   --newcolor-surface: #{lighten($primitive-black, 3%)};
   --newcolor-border: #{rgba($primitive-white, 0.2)};
   --newcolor-selected: #{rgba($primitive-primary, 0.3)};
@@ -74,6 +78,8 @@ $primitive-red: #d04756;
 }
 
 $background: var(--newcolor-background);
+$background-drawer: var(--newcolor-background-drawer);
+
 $surface: var(--newcolor-surface);
 $border: var(--newcolor-border);
 $selected: var(--newcolor-selected);


### PR DESCRIPTION
## 内容

ヘルプダイアログの各セクションの背景色の統合と、それに伴う--newcolor-background-drawer色変数の追加を行います。
また、ライトテーマ時のリストと背景の色が同一になったため、階層表現できるようリストに微量な影を付与しました。

## スクリーンショット・動画など

![image](https://github.com/VOICEVOX/voicevox/assets/53995265/4f7b317c-0dee-448e-b5dd-496855589e07)
![image](https://github.com/VOICEVOX/voicevox/assets/53995265/1e2b00c4-42b4-4324-bacc-78aa4c915c1d)
