### PR TITLE
macos-11を使わないようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
             app_asar_dir: prepackage/VOICEVOX.app/Contents/Resources
             installer_artifact_name: macos-cpu-dmg
             macos_artifact_name: "VOICEVOX.${version}.${ext}"
-            os: macos-11
+            os: macos-12
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## 内容

Github Actionsのmacos-11が来月にサポート終了になるので、早めにアップデートPRを作っておこうかなと。

CIの`build-test`が通ればとりあえず大丈夫かなと思ってます。
マージ後にdevでビルドされたのを実行テストすれば、まあ。

## その他

ちなみになぜかエンジン側では、macos-11でビルドできるけどmacos-11で動かないということになったので、一足先に[移行PR](https://github.com/VOICEVOX/voicevox_engine/pull/1205)を作りました。