### PR TITLE
Fix #1996

### DIFF
--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -191,6 +191,8 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
     (config) => {
       const defaultPresetKeys =
         config.defaultPresetKeys as ConfigType["defaultPresetKeys"];
+      if (Object.keys(defaultPresetKeys).length < 1) return;
+
       const filteredVoiceIdOnlySinger = Object.keys(defaultPresetKeys).filter(
         (voiceId) => {
           const splited = voiceId.split(":");

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -189,8 +189,11 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
   [
     ">=999.999.999",
     (config) => {
-      const defaultPresetKeys =
-        config.defaultPresetKeys as ConfigType["defaultPresetKeys"];
+      const defaultPresetKeys = config.defaultPresetKeys as
+        | ConfigType["defaultPresetKeys"]
+        | undefined;
+      // unit testの0.13からマイグレーションできるかどうかに引っかかるので回避するためのundefinedチェック
+      if (defaultPresetKeys == undefined) return;
       if (Object.keys(defaultPresetKeys).length < 1) return;
 
       const filteredVoiceIdOnlySinger = Object.keys(defaultPresetKeys).filter(

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -187,7 +187,7 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
     },
   ],
   [
-    ">=999.999.999",
+    ">=0.21",
     (config) => {
       const defaultPresetKeys = config.defaultPresetKeys as
         | ConfigType["defaultPresetKeys"]

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -207,21 +207,21 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
       );
 
       const presets = config.presets as ConfigType["presets"];
-      const singerPresetsKeys: string[] = [];
+      const singerPresetKeys: string[] = [];
       for (const voiceId of filteredVoiceIdOnlySinger) {
         const defaultPresetKey = defaultPresetKeys[
           voiceId as VoiceId
         ] as PresetKey;
-        singerPresetsKeys.push(defaultPresetKey);
+        singerPresetKeys.push(defaultPresetKey);
         delete presets.items[defaultPresetKey];
         delete defaultPresetKeys[voiceId as VoiceId];
       }
 
-      if (singerPresetsKeys.length === 0) return;
-      const newPresetsKeys = presets.keys.filter(
-        (key) => !singerPresetsKeys.includes(key),
+      if (singerPresetKeys.length === 0) return;
+      const newPresetKeys = presets.keys.filter(
+        (key) => !singerPresetKeys.includes(key),
       );
-      presets.keys = newPresetsKeys;
+      presets.keys = newPresetKeys;
     },
   ],
 ];

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -32,6 +32,7 @@ import { dictionaryStoreState, dictionaryStore } from "./dictionary";
 import { proxyStore, proxyStoreState } from "./proxy";
 import { createPartialStore } from "./vuex";
 import { engineStoreState, engineStore } from "./engine";
+import { filterCharacterInfosByStyleType } from "./utility";
 import {
   DefaultStyleId,
   EngineId,
@@ -124,10 +125,16 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
   },
 
   GET_ALL_VOICES: {
-    getter(state) {
-      const flattenCharacters = Object.values(state.characterInfos).flatMap(
+    getter: (state) => (styleType: "all" | "singerLike" | "talk") => {
+      let flattenCharacters = Object.values(state.characterInfos).flatMap(
         (characterInfos) => characterInfos,
       );
+      if (styleType !== "all") {
+        flattenCharacters = filterCharacterInfosByStyleType(
+          flattenCharacters,
+          styleType,
+        );
+      }
       const flattenVoices: Voice[] = flattenCharacters.flatMap((c) =>
         c.metas.styles.map((s) => ({
           engineId: EngineId(s.engineId),

--- a/src/store/preset.ts
+++ b/src/store/preset.ts
@@ -200,7 +200,7 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
 
   CREATE_ALL_DEFAULT_PRESET: {
     async action({ state, dispatch, getters }) {
-      const voices = getters.GET_ALL_VOICES;
+      const voices = getters.GET_ALL_VOICES("talk");
 
       for (const voice of voices) {
         const voiceId = VoiceId(voice);

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1371,7 +1371,7 @@ export type IndexStoreTypes = {
   };
 
   GET_ALL_VOICES: {
-    getter: Voice[];
+    getter(styleType: "all" | "singerLike" | "talk"): Voice[];
   };
 
   GET_HOW_TO_USE_TEXT: {


### PR DESCRIPTION
## 内容

- GET_ALL_VOICESをUSER_ORDERED_CHARACTER_INFOSのようにしてトークスタイルのみでデフォルトプリセットを生成するようにしました。
- config.jsonのdefaultPresetKeysのkeyにスタイルIDが記録されているのでそれを使ってプリセットKeyを取得して記録されているプリセットからハミング/ソングの物を削除する処理をConfigManagerのマイグレーション機能ところに実装しました。

マイグレーションのところのバージョン指定、とりあえず0.21にしてあります。動作確認は999.999.999にして行いました。

## 関連 Issue
close #1996
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
