### PR TITLE
FIX: メインプロセスで未捕捉のエラーが発生したときの処理を変更

### DIFF
--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -113,16 +113,21 @@ if (errorForRemoveBeforeUserDataDir != undefined) {
 let win: BrowserWindow;
 
 process.on("uncaughtException", (error) => {
-  const stack = error.stack ? error.stack : `${error.name}: ${error.message}`;
-  const message = "Uncaught Exception:\n" + stack;
-  log.error(message);
+  log.error(error);
+
   if (isDevelopment) {
     app.exit(1);
   } else {
-    dialog.showErrorBox(
-      "メインプロセスで原因不明のエラーが発生しました",
-      message,
-    );
+    const { message, name } = error;
+    let detailedMessage = "";
+    detailedMessage += `メインプロセスで原因不明のエラーが発生しました。\n`;
+    detailedMessage += `エラー名: ${name}\n`;
+    detailedMessage += `メッセージ: ${message}\n`;
+    if (error.stack) {
+      detailedMessage += `スタックトレース: \n${error.stack}`;
+    }
+
+    dialog.showErrorBox("エラー", detailedMessage);
   }
 });
 process.on("unhandledRejection", (reason) => {

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -113,7 +113,17 @@ if (errorForRemoveBeforeUserDataDir != undefined) {
 let win: BrowserWindow;
 
 process.on("uncaughtException", (error) => {
-  log.error(error);
+  const stack = error.stack ? error.stack : `${error.name}: ${error.message}`;
+  const message = "Uncaught Exception:\n" + stack;
+  log.error(message);
+  if (isDevelopment) {
+    app.exit(1);
+  } else {
+    dialog.showErrorBox(
+      "メインプロセスで原因不明のエラーが発生しました",
+      message,
+    );
+  }
 });
 process.on("unhandledRejection", (reason) => {
   log.error(reason);


### PR DESCRIPTION
## 内容

メインプロセス内で未捕捉の例外が発生した場合の処理を変更します。
製品版ではログの記録とダイアログの表示、
開発環境ではログを記録後に強制終了するように変更します。

## 関連 Issue

- ref #1581

## その他

例外を補足した後に強制終了するかしないかはどちらにもリスクがあります。
強制終了すると今までは無視していた些細なエラーによって強制終了するリスクがあります。
逆に強制終了をしない場合エディタのプロセスが残った状態で停止してしまうリスクがあります。

理想を言えば継続可能な例外は全て捕捉してここには到達しないようにすることが一番いいのですが…