### PR TITLE
FIX: node-tree-killのエラー処理のミスを修正

### DIFF
--- a/src/backend/electron/manager/engineManager.ts
+++ b/src/backend/electron/manager/engineManager.ts
@@ -420,10 +420,13 @@ export class EngineManager {
       return undefined;
     }
 
+    const enginePid = engineProcess.pid;
+    if (enginePid == undefined) {
+      log.error(`ENGINE ${engineId}: Pid is ${enginePid}`);
+      return undefined;
+    }
     return new Promise<void>((resolve, reject) => {
-      log.info(
-        `ENGINE ${engineId}: Killing process (PID=${engineProcess.pid})`,
-      );
+      log.info(`ENGINE ${engineId}: Killing process (PID=${enginePid})`);
 
       // エラーダイアログを抑制
       engineProcessContainer.willQuitEngine = true;
@@ -434,12 +437,12 @@ export class EngineManager {
         resolve();
       });
 
-      try {
-        engineProcess.pid != undefined && treeKill(engineProcess.pid);
-      } catch (error: unknown) {
-        log.error(`ENGINE ${engineId}: Error during killing process`);
-        reject(error);
-      }
+      treeKill(enginePid, (error) => {
+        if (error != undefined) {
+          log.error(`ENGINE ${engineId}: Error during killing process`);
+          reject(error);
+        }
+      });
     });
   }
 

--- a/src/backend/electron/manager/engineManager.ts
+++ b/src/backend/electron/manager/engineManager.ts
@@ -422,7 +422,11 @@ export class EngineManager {
 
     const enginePid = engineProcess.pid;
     if (enginePid == undefined) {
-      log.error(`ENGINE ${engineId}: Pid is ${enginePid}`);
+      // エンジン起動済みの場合来ないはず
+      // 万が一の場合はエンジン停止済みとみなす
+      log.error(
+        `ENGINE ${engineId}: Process PID is undefined, assuming closed`,
+      );
       return undefined;
     }
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## 内容

`node-tree-kill`のエラー処理が間違っていると思います。
現在、エンジンのキルは`try-chatch`を使用しています。
https://github.com/VOICEVOX/voicevox/blob/0fb559dd3d4a8a14b67a09b7bfdfdb73de67ae3b/src/backend/electron/manager/engineManager.ts#L437-L442
しかし`node-tree-kill`のWindowsでの処理は`child_process.exec()`で`taskkill`コマンドを呼び出しているため`child_process.exec()`には成功したが`taskkill`のコマンドに失敗した場合`resolve`も`reject`も呼ばれないため処理が停止してしまいます。
https://github.com/pkrumins/node-tree-kill/blob/cb478381547107f5c53362668533f634beff7e6e/index.js#L29

## その他

`node-tree-kill`で処理が停止することはなくなりますが何かしらの理由で`node-tree-kill`でエンジンのキルが不可能になっている場合無限ループに陥るリスクが残っています。