### PR TITLE
doc: OSのサポートバージョンを更新する

### DIFF
--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -9,7 +9,7 @@
 Windows／Mac／Linux 搭載の PC に対応しています。
 
 ※Windows：Windows 10・Windows 11  
-※Mac：macOS Catalina 以降  
+※Mac：macOS 12(Monterey)以降  
 ※Linux：Ubuntu 20.04
 
 #### GPU 版


### PR DESCRIPTION
## 内容

macOS Catalinaはテストできてなかった･･･。
その次のBig Surも動かなくなったので、2段階バージョンを引き上げます。

- https://github.com/VOICEVOX/voicevox_engine/issues/1191

## その他

ubuntu 20.04はもうちょっと持つはず。
