### PR TITLE
辞書保存ダイアログ・ツールバーカスタマイズの編集破棄の案内がわかりにくかったので修正

### DIFF
--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -596,7 +596,7 @@ const discardOrNotDialog = async (okCallback: () => void) => {
       title: "単語の追加・変更を破棄しますか？",
       message:
         "このまま続行すると、単語の追加・変更は破棄されてリセットされます。",
-      actionName: "続行",
+      actionName: "破棄",
     });
     if (result === "OK") {
       okCallback();

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -559,7 +559,7 @@ const isDeletable = computed(() => !!selectedId.value);
 const deleteWord = async () => {
   const result = await store.dispatch("SHOW_WARNING_DIALOG", {
     title: "登録された単語を削除しますか？",
-    message: "削除された単語は復旧できません。",
+    message: "削除された単語は元に戻せません。",
     actionName: "削除",
   });
   if (result === "OK") {
@@ -594,8 +594,7 @@ const discardOrNotDialog = async (okCallback: () => void) => {
   if (isWordChanged.value) {
     const result = await store.dispatch("SHOW_WARNING_DIALOG", {
       title: "単語の追加・変更を破棄しますか？",
-      message:
-        "このまま続行すると、単語の追加・変更は破棄されてリセットされます。",
+      message: "破棄すると、単語の追加・変更はリセットされます。",
       actionName: "破棄",
     });
     if (result === "OK") {

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -228,7 +228,8 @@ const finishOrNotDialog = async () => {
   if (isChanged.value) {
     const result = await store.dispatch("SHOW_WARNING_DIALOG", {
       title: "カスタマイズを終了しますか？",
-      message: "このまま終了すると、カスタマイズは破棄されてリセットされます。",
+      message:
+        "保存せずに終了すると、カスタマイズは破棄されてリセットされます。",
       actionName: "終了",
     });
     if (result === "OK") {


### PR DESCRIPTION
## 内容

「単語の追加・変更を破棄しますか？このまま続行すると、単語の追加・変更は破棄されてリセットされます。」という文言に対し「キャンセル」「続行」となってた。
続行が何を示すのかわからなかったので案内を変更しました。

あと「このまま」という代名詞で分かりにくいので条件を崩しました。


## その他
