### PR TITLE
【読み方&アクセント辞書 単語一覧】登録単語の編集・削除ボタンの常時表示をやめてOOUI的に

### DIFF
--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -89,20 +89,20 @@
                       flat
                       dense
                       round
-                      icon="delete"
-                      @click.stop="deleteWord"
+                      icon="edit"
+                      @click.stop="editWord"
                     >
-                      <QTooltip :delay="500">削除</QTooltip>
+                      <QTooltip :delay="500">編集</QTooltip>
                     </QBtn>
                     <QBtn
                       size="12px"
                       flat
                       dense
                       round
-                      icon="edit"
-                      @click.stop="editWord"
+                      icon="delete"
+                      @click.stop="deleteWord"
                     >
-                      <QTooltip :delay="500">編集</QTooltip>
+                      <QTooltip :delay="500">削除</QTooltip>
                     </QBtn>
                   </div>
                 </QItemSection>

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -69,8 +69,8 @@
                 active-class="active-word"
                 @click="selectWord(key)"
                 @dblclick="editWord"
-                @mouseover="hover.add(key)"
-                @mouseleave="hover.delete(key)"
+                @mouseover="hoveredKey = key"
+                @mouseleave="hoveredKey = undefined"
               >
                 <QItemSection>
                   <QItemLabel lines="1" class="text-display">{{
@@ -80,7 +80,7 @@
                 </QItemSection>
 
                 <QItemSection
-                  v-if="!uiLocked && (hover.has(key) || selectedId === key)"
+                  v-if="!uiLocked && (hoveredKey === key || selectedId === key)"
                   side
                 >
                   <div class="q-gutter-xs">
@@ -263,7 +263,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { QInput } from "quasar";
 import AudioAccent from "@/components/Talk/AudioAccent.vue";
 import { useStore } from "@/store";
@@ -294,9 +294,8 @@ const uiLocked = ref(false); // ダイアログ内でstore.getters.UI_LOCKEDは�
 const nowGenerating = ref(false);
 const nowPlaying = ref(false);
 
-// word-list の要素のうち、どの要素がホバーされているかを管理する Set。
-// レースコンディションを確実に避けられそうなので Set を使用している。
-const hover = reactive(new Set<string>());
+// word-list の要素のうち、どの要素がホバーされているか
+const hoveredKey = ref<string | undefined>(undefined);
 
 const loadingDictState = ref<null | "loading" | "synchronizing">("loading");
 const userDict = ref<Record<string, UserDictWord>>({});

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -85,7 +85,7 @@
                       dense
                       round
                       icon="delete"
-                      @click="deleteWord"
+                      @click.stop="deleteWord"
                     >
                       <QTooltip :delay="500">削除</QTooltip>
                     </QBtn>

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -99,7 +99,7 @@
                       flat
                       dense
                       round
-                      icon="delete"
+                      icon="delete_outline"
                       @click.stop="deleteWord"
                     >
                       <QTooltip :delay="500">削除</QTooltip>

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -85,18 +85,20 @@
                       dense
                       round
                       icon="delete"
-                      title="削除"
                       @click="deleteWord"
-                    />
+                    >
+                      <QTooltip :delay="500">削除</QTooltip>
+                    </QBtn>
                     <QBtn
                       size="12px"
                       flat
                       dense
                       round
                       icon="edit"
-                      title="編集"
                       @click.stop="editWord"
-                    />
+                    >
+                      <QTooltip :delay="500">編集</QTooltip>
+                    </QBtn>
                   </div>
                 </QItemSection>
               </QItem>

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -46,28 +46,12 @@
               @click="discardOrNotDialog(cancel)"
             />
             <div class="word-list-header text-no-wrap">
-              <div class="row word-list-title text-h5">単語一覧</div>
-              <div class="row no-wrap">
-                <QBtn
-                  outline
-                  text-color="warning"
-                  class="text-no-wrap text-bold col-sm q-ma-sm"
-                  :disable="uiLocked || !isDeletable"
-                  @click="deleteWord"
-                  >削除</QBtn
-                >
+              <div class="row word-list-title">
+                <span class="text-h5 col-8">単語一覧</span>
                 <QBtn
                   outline
                   text-color="display"
-                  class="text-no-wrap text-bold col-sm q-ma-sm"
-                  :disable="uiLocked || !selectedId"
-                  @click="editWord"
-                  >編集</QBtn
-                >
-                <QBtn
-                  outline
-                  text-color="display"
-                  class="text-no-wrap text-bold col-sm q-ma-sm"
+                  class="text-no-wrap text-bold col"
                   :disable="uiLocked"
                   @click="newWord"
                   >追加</QBtn
@@ -87,10 +71,33 @@
                 @dblclick="editWord"
               >
                 <QItemSection>
-                  <QItemLabel class="text-display">{{
+                  <QItemLabel lines="1" class="text-display">{{
                     value.surface
                   }}</QItemLabel>
-                  <QItemLabel caption>{{ value.yomi }}</QItemLabel>
+                  <QItemLabel lines="1" caption>{{ value.yomi }}</QItemLabel>
+                </QItemSection>
+
+                <QItemSection v-if="!uiLocked && selectedId === key" side>
+                  <div class="q-gutter-xs">
+                    <QBtn
+                      size="12px"
+                      flat
+                      dense
+                      round
+                      icon="delete"
+                      title="削除"
+                      @click="deleteWord"
+                    />
+                    <QBtn
+                      size="12px"
+                      flat
+                      dense
+                      round
+                      icon="edit"
+                      title="編集"
+                      @click.stop="editWord"
+                    />
+                  </div>
                 </QItemSection>
               </QItem>
             </QList>
@@ -555,7 +562,6 @@ const saveWord = async () => {
   await loadingDictProcess();
   toInitialState();
 };
-const isDeletable = computed(() => !!selectedId.value);
 const deleteWord = async () => {
   const result = await store.dispatch("SHOW_WARNING_DIALOG", {
     title: "登録された単語を削除しますか？",
@@ -676,13 +682,14 @@ const toDialogClosedState = () => {
 
 .word-list {
   // menubar-height + toolbar-height + window-border-width +
-  // 82(title & buttons) + 30(margin 15x2)
+  // 36(title & buttons) + 30(margin 15x2)
   height: calc(
     100vh - #{vars.$menubar-height + vars.$toolbar-height +
-      vars.$window-border-width + 82px + 30px}
+      vars.$window-border-width + 36px + 30px}
   );
   width: 100%;
   overflow-y: auto;
+  padding-bottom: 16px;
 }
 
 .active-word {

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -69,6 +69,8 @@
                 active-class="active-word"
                 @click="selectWord(key)"
                 @dblclick="editWord"
+                @mouseover="hover.add(key)"
+                @mouseleave="hover.delete(key)"
               >
                 <QItemSection>
                   <QItemLabel lines="1" class="text-display">{{
@@ -77,7 +79,10 @@
                   <QItemLabel lines="1" caption>{{ value.yomi }}</QItemLabel>
                 </QItemSection>
 
-                <QItemSection v-if="!uiLocked && selectedId === key" side>
+                <QItemSection
+                  v-if="!uiLocked && (hover.has(key) || selectedId === key)"
+                  side
+                >
                   <div class="q-gutter-xs">
                     <QBtn
                       size="12px"
@@ -258,7 +263,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, reactive, ref, watch } from "vue";
 import { QInput } from "quasar";
 import AudioAccent from "@/components/Talk/AudioAccent.vue";
 import { useStore } from "@/store";
@@ -288,6 +293,10 @@ const dictionaryManageDialogOpenedComputed = computed({
 const uiLocked = ref(false); // ダイアログ内でstore.getters.UI_LOCKEDは常にtrueなので独自に管理
 const nowGenerating = ref(false);
 const nowPlaying = ref(false);
+
+// word-list の要素のうち、どの要素がホバーされているかを管理する Set。
+// レースコンディションを確実に避けられそうなので Set を使用している。
+const hover = reactive(new Set<string>());
 
 const loadingDictState = ref<null | "loading" | "synchronizing">("loading");
 const userDict = ref<Record<string, UserDictWord>>({});

--- a/tests/e2e/browser/辞書ダイアログ.spec.ts
+++ b/tests/e2e/browser/辞書ダイアログ.spec.ts
@@ -114,9 +114,9 @@ test("「設定」→「読み方＆アクセント辞書」で「読み方＆�
     .click();
   await page.waitForTimeout(100);
   await page
-    .locator(".word-list-header")
-    .getByRole("button")
-    .filter({ hasText: "削除" })
+    .getByRole("listitem")
+    .filter({ hasText: zenkakuRandomString })
+    .getByText("delete")
     .click();
   await page.waitForTimeout(100);
   await getNewestQuasarDialog(page)


### PR DESCRIPTION
## 内容

表題の通り、「編集」「削除」ボタンは、タスク指向的ではなく、OOUI的に配置されるのが相応しいので、そのようにスタイルを変更してみました。


- Before
    - リストのヘッダ部分
        - 削除ボタン (選択中のアイテムがあるときのみクリック可)
        - 編集ボタン (選択中のアイテムがあるときのみクリック可)
        - 追加ボタン
    - リスト本体
        - アイテム1
        - アイテム2 
        - ... 
- After
    - リストのヘッダ部分
        - 追加ボタン
    - リスト本体
        - アイテム1 (選択中の場合)
            - 削除ボタン 
            - 編集ボタン
        - アイテム2
        - アイテム3
        - ...


ついでに、

- リストの一番下の部分が少し窮屈にならないように 16px の padding を追加しました。
- リストの各項目を1行のみ表示、あふれたらエリプシス「…」に設定しました。
    - アイコンボタンが現れたり消えたりするとき、行数が変わるとガタつくので


<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

### Before

![改修前のUI](https://github.com/VOICEVOX/voicevox/assets/22636511/2f491caa-f7f4-45f5-aa0f-89ab9e5ed742)


### After

https://github.com/VOICEVOX/voicevox/assets/22636511/0a777765-f601-444b-8e69-6542e4fa45bd


<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
