### PR TITLE
feat: sandboxを有効化

### DIFF
--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -400,9 +400,6 @@ async function createWindow() {
     backgroundColor,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
-      nodeIntegration: false,
-      contextIsolation: true,
-      sandbox: false, // TODO: 外しても問題ないか検証して外す
     },
     icon: path.join(__static, "icon.png"),
   });

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -100,6 +100,7 @@ export default defineConfig((options) => {
             },
           },
           {
+            // ref: https://electron-vite.github.io/guide/preload-not-split.html
             entry: "./src/backend/electron/preload.ts",
             onstart({ reload }) {
               reload();

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -82,25 +82,40 @@ export default defineConfig((options) => {
         }),
       isElectron && [
         cleanDistPlugin(),
-        electron({
-          entry: [
-            "./src/backend/electron/main.ts",
-            "./src/backend/electron/preload.ts",
-          ],
-          // ref: https://github.com/electron-vite/vite-plugin-electron/pull/122
-          onstart: ({ startup }) => {
-            if (options.mode !== "test") {
-              startup([".", "--no-sandbox"]);
-            }
-          },
-          vite: {
-            plugins: [tsconfigPaths({ root: __dirname })],
-            build: {
-              outDir: path.resolve(__dirname, "dist"),
-              sourcemap,
+        electron([
+          {
+            entry: "./src/backend/electron/main.ts",
+            // ref: https://github.com/electron-vite/vite-plugin-electron/pull/122
+            onstart: ({ startup }) => {
+              if (options.mode !== "test") {
+                startup([".", "--no-sandbox"]);
+              }
+            },
+            vite: {
+              plugins: [tsconfigPaths({ root: __dirname })],
+              build: {
+                outDir: path.resolve(__dirname, "dist"),
+                sourcemap,
+              },
             },
           },
-        }),
+          {
+            entry: "./src/backend/electron/preload.ts",
+            onstart({ reload }) {
+              reload();
+            },
+            vite: {
+              plugins: [tsconfigPaths({ root: __dirname })],
+              build: {
+                outDir: path.resolve(__dirname, "dist"),
+                sourcemap,
+                rollupOptions: {
+                  output: { inlineDynamicImports: true },
+                },
+              },
+            },
+          },
+        ]),
       ],
       isBrowser && injectBrowserPreloadPlugin(),
     ],


### PR DESCRIPTION
## 内容

プロセスのサンドボックス化を有効化してセキュリティを向上させます。
ref: https://www.electronjs.org/ja/docs/latest/tutorial/sandbox

## 関連 Issue

- close: #1017

## その他

`preload.js`が分割されていることがそのまま動かすことができないことの原因でした。
https://electron-vite.github.io/guide/preload-not-split.html

https://github.com/VOICEVOX/voicevox/issues/2071#issuecomment-2103801741 で触れて作業を開始したのですが本当に直接的に関係なかったかもしれません。
`--no-sandbox`を付けても`preload.js`が分割された状態では正常に動作しませんし、この機能を有効化してもUbuntu24.04(VirtualBox上)で`--no-sandbox`を付けて起動させることができました。