### PR TITLE
fix: テキスト読み込みでルビ文字列を削除

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -639,7 +639,10 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       const baseAudioItem = payload.baseAudioItem;
 
       const fetchQueryParams = {
-        text,
+        text: extractYomiText(text, {
+          enableMemoNotation: state.enableMemoNotation,
+          enableRubyNotation: state.enableRubyNotation,
+        }),
         engineId: voice.engineId,
         styleId: voice.styleId,
       };


### PR DESCRIPTION
## 内容



## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- https://github.com/VOICEVOX/voicevox/issues/2067

## スクリーンショット・動画など

https://github.com/VOICEVOX/voicevox/assets/100256521/2027a166-7e6e-4e41-a642-6e9409b946ff

## その他

テキストを無視する処理は、audio_queryや、accent_phrasesを生成する処理の直前に行った方が、記述ミスが減りそうな気がしました。
https://github.com/VOICEVOX/voicevox/blob/4c9550b089aeda07153a2ba203c54d27b988e9ff/src/store/audio.ts#L958-L963
