### PR TITLE
no-unused-varを開発時以外はエラーに

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,7 +46,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-unused-vars": [
-      "warn",
+      process.env.NODE_ENV === "development" ? "warn" : "error", // 開発時のみwarn
       {
         ignoreRestSiblings: true,
       },

--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ npm run license:generate -- -o voicevox_licenses.json
 npm run license:merge -- -o public/licenses.json -i engine_licenses.json -i voicevox_licenses.json
 ```
 
+## リント（静的解析）
+
+コードの静的解析を行い、バグを未然に防ぎます。プルリクエストを送る前に実行してください。
+
+```bash
+npm run lint
+```
+
 ## コードフォーマット
 
 コードのフォーマットを整えます。プルリクエストを送る前に実行してください。

--- a/tests/unit/backend/common/configManager.spec.ts
+++ b/tests/unit/backend/common/configManager.spec.ts
@@ -1,7 +1,7 @@
 import pastConfigs from "./pastConfigs";
 import configBugDefaultPreset1996 from "./pastConfigs/0.19.1-bug_default_preset.json";
 import { BaseConfigManager } from "@/backend/common/ConfigManager";
-import { Preset, PresetKey, VoiceId, configSchema } from "@/type/preload";
+import { configSchema } from "@/type/preload";
 
 const configBase = {
   ...configSchema.parse({}),


### PR DESCRIPTION
## 内容

デバッグしていると不便なのでno-unused-varがwarnレベルになっていますが、mainブランチにマージされる段階では排除しておきたいです。
ということで開発レベルではwarnにし、そうじゃない時はエラーになるようにしてみました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

実際にエラーが出るか確認中です。
→ ちゃんとエラーになってそう！ https://github.com/Hiroshiba/voicevox/actions/runs/9235857203/job/25411080723

productionならエラーになっている場合でも`npm run electron:serve`はちゃんと動くことを確認しました！
