### PR TITLE
設定ファイルの保存をアトミック操作に変更

### DIFF
--- a/src/backend/electron/electronConfig.ts
+++ b/src/backend/electron/electronConfig.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 import fs from "fs";
 import { app } from "electron";
+import { moveFile } from "move-file";
 import { BaseConfigManager, Metadata } from "@/backend/common/ConfigManager";
 import { ConfigType } from "@/type/preload";
 
@@ -21,10 +22,16 @@ export class ElectronConfigManager extends BaseConfigManager {
   }
 
   protected async save(config: ConfigType & Metadata) {
+    // ファイル書き込みに失敗したときに設定が消えないように、tempファイル書き込み後上書き移動する
+    const temp_path = `${this.configPath}.tmp`;
     await fs.promises.writeFile(
-      this.configPath,
+      temp_path,
       JSON.stringify(config, undefined, 2),
     );
+
+    await moveFile(temp_path, this.configPath, {
+      overwrite: true,
+    });
   }
 
   private get configPath(): string {


### PR DESCRIPTION
## 内容
設定ファイルの書き込み失敗時にファイルが消失しないようにしました。
設定ファイル保存は以下の手順で行うようにしています。
1. <設定ファイル名>.tmpに設定の書き込み
2. 1で作成したファイル名を<設定ファイル名>に書き換え
2のタイミングで既存ファイルが存在する場合は上書きするようにしています。

テストは関連しそうなものが見つかりませんでしたので、追加していません。
手動テストとしては、以下の手順を実行しています。
- 設定変更を行い(メモ機能のON)、```config.json```に反映されていること
- ```ElectronConfigManager.save```の```moveFile```の直前に強制終了し、再起動後設定が消失していないこと

Issueの中に記載のあった、以下の記述に関しては現状```ElectronConfigManager.save```でしか使用しない処理なのでhelper関数には移動していません。
> 直接ファイルを書き込んでいるところはいくつかあるので、一度同じディレクトリの.tmpに書き込んだ後moveFileする便利関数を作って使いますと便利そう。

## 関連 Issue
ref #2082 
close #2082 
