### PR TITLE
vuexのstoreの呼び出しをリテラル引数からDot記法へ

### DIFF
--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -1,11 +1,11 @@
-import { createDotNotationPartialStore as createDotPartialStore } from "./vuex";
+import { createDotNotationPartialStore as createDotPartStore } from "./vuex";
 import { UserDictWord, UserDictWordToJSON } from "@/openapi";
 import { DictionaryStoreState, DictionaryStoreTypes } from "@/store/type";
 import { EngineId } from "@/type/preload";
 
 export const dictionaryStoreState: DictionaryStoreState = {};
 
-export const dictionaryStore = createDotPartialStore<DictionaryStoreTypes>({
+export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
   LOAD_USER_DICT: {
     async action({ actions }, { engineId }) {
       const engineDict = await actions

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -1,198 +1,195 @@
-import { createDotNotationPartialStore } from "./vuex";
+import { createDotNotationPartialStore as createDotPartialStore } from "./vuex";
 import { UserDictWord, UserDictWordToJSON } from "@/openapi";
 import { DictionaryStoreState, DictionaryStoreTypes } from "@/store/type";
 import { EngineId } from "@/type/preload";
 
 export const dictionaryStoreState: DictionaryStoreState = {};
 
-export const dictionaryStore =
-  createDotNotationPartialStore<DictionaryStoreTypes>({
-    LOAD_USER_DICT: {
-      async action({ actions }, { engineId }) {
-        const engineDict = await actions
-          .INSTANTIATE_ENGINE_CONNECTOR({
-            engineId,
-          })
-          .then((instance) =>
-            instance.invoke("getUserDictWordsUserDictGet")({}),
-          );
+export const dictionaryStore = createDotPartialStore<DictionaryStoreTypes>({
+  LOAD_USER_DICT: {
+    async action({ actions }, { engineId }) {
+      const engineDict = await actions
+        .INSTANTIATE_ENGINE_CONNECTOR({
+          engineId,
+        })
+        .then((instance) => instance.invoke("getUserDictWordsUserDictGet")({}));
 
-        // 50音順にソートするために、一旦arrayにする
-        const dictArray = Object.keys(engineDict).map((k) => {
-          return { key: k, ...engineDict[k] };
-        });
-        dictArray.sort((a, b) => {
-          if (a.yomi > b.yomi) {
-            return 1;
-          } else {
-            return -1;
-          }
-        });
-        const dictEntries: [string, UserDictWord][] = dictArray.map((v) => {
-          const { key, ...newV } = v;
-          return [key, newV];
-        });
-        return Object.fromEntries(dictEntries);
-      },
+      // 50音順にソートするために、一旦arrayにする
+      const dictArray = Object.keys(engineDict).map((k) => {
+        return { key: k, ...engineDict[k] };
+      });
+      dictArray.sort((a, b) => {
+        if (a.yomi > b.yomi) {
+          return 1;
+        } else {
+          return -1;
+        }
+      });
+      const dictEntries: [string, UserDictWord][] = dictArray.map((v) => {
+        const { key, ...newV } = v;
+        return [key, newV];
+      });
+      return Object.fromEntries(dictEntries);
     },
+  },
 
-    LOAD_ALL_USER_DICT: {
-      async action({ actions, state }) {
-        const allDict = await Promise.all(
-          state.engineIds.map((engineId) => {
-            return actions.LOAD_USER_DICT({ engineId });
+  LOAD_ALL_USER_DICT: {
+    async action({ actions, state }) {
+      const allDict = await Promise.all(
+        state.engineIds.map((engineId) => {
+          return actions.LOAD_USER_DICT({ engineId });
+        }),
+      );
+      const mergedDictMap = new Map<string, [string, UserDictWord]>();
+      for (const dict of allDict) {
+        for (const [id, dictItem] of Object.entries(dict)) {
+          mergedDictMap.set(`${dictItem.yomi}-${dictItem.surface}`, [
+            id,
+            dictItem,
+          ]);
+        }
+      }
+      const mergedDict = [...mergedDictMap.values()];
+      mergedDict.sort((a, b) => {
+        if (a[1].yomi > b[1].yomi) {
+          return 1;
+        } else {
+          return -1;
+        }
+      });
+      return Object.fromEntries(mergedDict);
+    },
+  },
+
+  ADD_WORD: {
+    async action(
+      { state, actions },
+      { surface, pronunciation, accentType, priority },
+    ) {
+      // 同じ単語IDで登録するために、１つのエンジンで登録したあと全エンジンに同期する。
+      const engineId: EngineId | undefined = state.engineIds[0];
+
+      if (engineId == undefined)
+        throw new Error(`No such engine registered: index == 0`);
+      await actions
+        .INSTANTIATE_ENGINE_CONNECTOR({
+          engineId,
+        })
+        .then((instance) =>
+          instance.invoke("addUserDictWordUserDictWordPost")({
+            surface,
+            pronunciation,
+            accentType,
+            priority,
           }),
         );
-        const mergedDictMap = new Map<string, [string, UserDictWord]>();
-        for (const dict of allDict) {
-          for (const [id, dictItem] of Object.entries(dict)) {
-            mergedDictMap.set(`${dictItem.yomi}-${dictItem.surface}`, [
-              id,
-              dictItem,
-            ]);
-          }
-        }
-        const mergedDict = [...mergedDictMap.values()];
-        mergedDict.sort((a, b) => {
-          if (a[1].yomi > b[1].yomi) {
-            return 1;
-          } else {
-            return -1;
-          }
-        });
-        return Object.fromEntries(mergedDict);
-      },
+
+      await actions.SYNC_ALL_USER_DICT();
     },
+  },
 
-    ADD_WORD: {
-      async action(
-        { state, actions },
-        { surface, pronunciation, accentType, priority },
-      ) {
-        // 同じ単語IDで登録するために、１つのエンジンで登録したあと全エンジンに同期する。
-        const engineId: EngineId | undefined = state.engineIds[0];
-
-        if (engineId == undefined)
-          throw new Error(`No such engine registered: index == 0`);
+  REWRITE_WORD: {
+    async action(
+      { state, actions },
+      { wordUuid, surface, pronunciation, accentType, priority },
+    ) {
+      if (state.engineIds.length === 0)
+        throw new Error(`At least one engine must be registered`);
+      for (const engineId of state.engineIds) {
         await actions
           .INSTANTIATE_ENGINE_CONNECTOR({
             engineId,
           })
           .then((instance) =>
-            instance.invoke("addUserDictWordUserDictWordPost")({
+            instance.invoke("rewriteUserDictWordUserDictWordWordUuidPut")({
+              wordUuid,
               surface,
               pronunciation,
               accentType,
               priority,
             }),
           );
-
-        await actions.SYNC_ALL_USER_DICT();
-      },
+      }
     },
+  },
 
-    REWRITE_WORD: {
-      async action(
-        { state, actions },
-        { wordUuid, surface, pronunciation, accentType, priority },
-      ) {
-        if (state.engineIds.length === 0)
-          throw new Error(`At least one engine must be registered`);
-        for (const engineId of state.engineIds) {
-          await actions
-            .INSTANTIATE_ENGINE_CONNECTOR({
-              engineId,
-            })
-            .then((instance) =>
-              instance.invoke("rewriteUserDictWordUserDictWordWordUuidPut")({
-                wordUuid,
-                surface,
-                pronunciation,
-                accentType,
-                priority,
-              }),
-            );
-        }
-      },
+  DELETE_WORD: {
+    async action({ state, actions }, { wordUuid }) {
+      if (state.engineIds.length === 0)
+        throw new Error(`At least one engine must be registered`);
+      for (const engineId of state.engineIds) {
+        await actions
+          .INSTANTIATE_ENGINE_CONNECTOR({
+            engineId,
+          })
+          .then((instance) =>
+            instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")({
+              wordUuid,
+            }),
+          );
+      }
     },
+  },
 
-    DELETE_WORD: {
-      async action({ state, actions }, { wordUuid }) {
-        if (state.engineIds.length === 0)
-          throw new Error(`At least one engine must be registered`);
-        for (const engineId of state.engineIds) {
-          await actions
-            .INSTANTIATE_ENGINE_CONNECTOR({
-              engineId,
-            })
-            .then((instance) =>
-              instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")({
-                wordUuid,
-              }),
-            );
-        }
-      },
-    },
-
-    SYNC_ALL_USER_DICT: {
-      async action({ actions, state }) {
-        const mergedDict = await actions.LOAD_ALL_USER_DICT();
-        for (const engineId of state.engineIds) {
-          // エンジンの辞書のIDリストを取得する。
-          const dictIdSet = await actions
-            .INSTANTIATE_ENGINE_CONNECTOR({
-              engineId,
-            })
-            .then(
-              async (instance) =>
-                new Set(
-                  Object.keys(
-                    await instance.invoke("getUserDictWordsUserDictGet")({}),
-                  ),
+  SYNC_ALL_USER_DICT: {
+    async action({ actions, state }) {
+      const mergedDict = await actions.LOAD_ALL_USER_DICT();
+      for (const engineId of state.engineIds) {
+        // エンジンの辞書のIDリストを取得する。
+        const dictIdSet = await actions
+          .INSTANTIATE_ENGINE_CONNECTOR({
+            engineId,
+          })
+          .then(
+            async (instance) =>
+              new Set(
+                Object.keys(
+                  await instance.invoke("getUserDictWordsUserDictGet")({}),
                 ),
-            );
-          if (Object.keys(mergedDict).some((id) => !dictIdSet.has(id))) {
-            await actions
-              .INSTANTIATE_ENGINE_CONNECTOR({
-                engineId,
-              })
-              .then((instance) =>
-                // マージした辞書をエンジンにインポートする。
-                instance.invoke("importUserDictWordsImportUserDictPost")({
-                  override: true,
-                  requestBody: Object.fromEntries(
-                    Object.entries(mergedDict).map(([k, v]) => [
-                      k,
-                      UserDictWordToJSON(v),
-                    ]),
-                  ),
-                }),
-              );
-          }
-          const removedDictIdSet = new Set(dictIdSet);
-          // マージされた辞書にあるIDを削除する。
-          // これにより、マージ処理で削除された項目のIDが残る。
-          for (const id of Object.keys(mergedDict)) {
-            if (removedDictIdSet.has(id)) {
-              removedDictIdSet.delete(id);
-            }
-          }
-
+              ),
+          );
+        if (Object.keys(mergedDict).some((id) => !dictIdSet.has(id))) {
           await actions
-            .INSTANTIATE_ENGINE_CONNECTOR({ engineId })
-            .then((instance) => {
-              // マージ処理で削除された項目をエンジンから削除する。
-              Promise.all(
-                [...removedDictIdSet].map((id) =>
-                  instance.invoke(
-                    "deleteUserDictWordUserDictWordWordUuidDelete",
-                  )({
+            .INSTANTIATE_ENGINE_CONNECTOR({
+              engineId,
+            })
+            .then((instance) =>
+              // マージした辞書をエンジンにインポートする。
+              instance.invoke("importUserDictWordsImportUserDictPost")({
+                override: true,
+                requestBody: Object.fromEntries(
+                  Object.entries(mergedDict).map(([k, v]) => [
+                    k,
+                    UserDictWordToJSON(v),
+                  ]),
+                ),
+              }),
+            );
+        }
+        const removedDictIdSet = new Set(dictIdSet);
+        // マージされた辞書にあるIDを削除する。
+        // これにより、マージ処理で削除された項目のIDが残る。
+        for (const id of Object.keys(mergedDict)) {
+          if (removedDictIdSet.has(id)) {
+            removedDictIdSet.delete(id);
+          }
+        }
+
+        await actions
+          .INSTANTIATE_ENGINE_CONNECTOR({ engineId })
+          .then((instance) => {
+            // マージ処理で削除された項目をエンジンから削除する。
+            Promise.all(
+              [...removedDictIdSet].map((id) =>
+                instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")(
+                  {
                     wordUuid: id,
-                  }),
+                  },
                 ),
-              );
-            });
-        }
-      },
+              ),
+            );
+          });
+      }
     },
-  });
+  },
+});

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -1,183 +1,198 @@
-import { createPartialStore } from "./vuex";
+import { createDotNotationPartialStore } from "./vuex";
 import { UserDictWord, UserDictWordToJSON } from "@/openapi";
 import { DictionaryStoreState, DictionaryStoreTypes } from "@/store/type";
 import { EngineId } from "@/type/preload";
 
 export const dictionaryStoreState: DictionaryStoreState = {};
 
-export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
-  LOAD_USER_DICT: {
-    async action({ dispatch }, { engineId }) {
-      const engineDict = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineId,
-      }).then((instance) => instance.invoke("getUserDictWordsUserDictGet")({}));
-
-      // 50音順にソートするために、一旦arrayにする
-      const dictArray = Object.keys(engineDict).map((k) => {
-        return { key: k, ...engineDict[k] };
-      });
-      dictArray.sort((a, b) => {
-        if (a.yomi > b.yomi) {
-          return 1;
-        } else {
-          return -1;
-        }
-      });
-      const dictEntries: [string, UserDictWord][] = dictArray.map((v) => {
-        const { key, ...newV } = v;
-        return [key, newV];
-      });
-      return Object.fromEntries(dictEntries);
-    },
-  },
-
-  LOAD_ALL_USER_DICT: {
-    async action({ dispatch, state }) {
-      const allDict = await Promise.all(
-        state.engineIds.map((engineId) => {
-          return dispatch("LOAD_USER_DICT", { engineId });
-        }),
-      );
-      const mergedDictMap = new Map<string, [string, UserDictWord]>();
-      for (const dict of allDict) {
-        for (const [id, dictItem] of Object.entries(dict)) {
-          mergedDictMap.set(`${dictItem.yomi}-${dictItem.surface}`, [
-            id,
-            dictItem,
-          ]);
-        }
-      }
-      const mergedDict = [...mergedDictMap.values()];
-      mergedDict.sort((a, b) => {
-        if (a[1].yomi > b[1].yomi) {
-          return 1;
-        } else {
-          return -1;
-        }
-      });
-      return Object.fromEntries(mergedDict);
-    },
-  },
-
-  ADD_WORD: {
-    async action(
-      { state, dispatch },
-      { surface, pronunciation, accentType, priority },
-    ) {
-      // 同じ単語IDで登録するために、１つのエンジンで登録したあと全エンジンに同期する。
-      const engineId: EngineId | undefined = state.engineIds[0];
-
-      if (engineId == undefined)
-        throw new Error(`No such engine registered: index == 0`);
-      await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineId,
-      }).then((instance) =>
-        instance.invoke("addUserDictWordUserDictWordPost")({
-          surface,
-          pronunciation,
-          accentType,
-          priority,
-        }),
-      );
-
-      await dispatch("SYNC_ALL_USER_DICT");
-    },
-  },
-
-  REWRITE_WORD: {
-    async action(
-      { state, dispatch },
-      { wordUuid, surface, pronunciation, accentType, priority },
-    ) {
-      if (state.engineIds.length === 0)
-        throw new Error(`At least one engine must be registered`);
-      for (const engineId of state.engineIds) {
-        await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-          engineId,
-        }).then((instance) =>
-          instance.invoke("rewriteUserDictWordUserDictWordWordUuidPut")({
-            wordUuid,
-            surface,
-            pronunciation,
-            accentType,
-            priority,
-          }),
-        );
-      }
-    },
-  },
-
-  DELETE_WORD: {
-    async action({ state, dispatch }, { wordUuid }) {
-      if (state.engineIds.length === 0)
-        throw new Error(`At least one engine must be registered`);
-      for (const engineId of state.engineIds) {
-        await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-          engineId,
-        }).then((instance) =>
-          instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")({
-            wordUuid,
-          }),
-        );
-      }
-    },
-  },
-
-  SYNC_ALL_USER_DICT: {
-    async action({ dispatch, state }) {
-      const mergedDict = await dispatch("LOAD_ALL_USER_DICT");
-      for (const engineId of state.engineIds) {
-        // エンジンの辞書のIDリストを取得する。
-        const dictIdSet = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-          engineId,
-        }).then(
-          async (instance) =>
-            new Set(
-              Object.keys(
-                await instance.invoke("getUserDictWordsUserDictGet")({}),
-              ),
-            ),
-        );
-        if (Object.keys(mergedDict).some((id) => !dictIdSet.has(id))) {
-          await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
+export const dictionaryStore =
+  createDotNotationPartialStore<DictionaryStoreTypes>({
+    LOAD_USER_DICT: {
+      async action({ actions }, { engineId }) {
+        const engineDict = await actions
+          .INSTANTIATE_ENGINE_CONNECTOR({
             engineId,
-          }).then((instance) =>
-            // マージした辞書をエンジンにインポートする。
-            instance.invoke("importUserDictWordsImportUserDictPost")({
-              override: true,
-              requestBody: Object.fromEntries(
-                Object.entries(mergedDict).map(([k, v]) => [
-                  k,
-                  UserDictWordToJSON(v),
-                ]),
-              ),
-            }),
+          })
+          .then((instance) =>
+            instance.invoke("getUserDictWordsUserDictGet")({}),
           );
-        }
-        const removedDictIdSet = new Set(dictIdSet);
-        // マージされた辞書にあるIDを削除する。
-        // これにより、マージ処理で削除された項目のIDが残る。
-        for (const id of Object.keys(mergedDict)) {
-          if (removedDictIdSet.has(id)) {
-            removedDictIdSet.delete(id);
+
+        // 50音順にソートするために、一旦arrayにする
+        const dictArray = Object.keys(engineDict).map((k) => {
+          return { key: k, ...engineDict[k] };
+        });
+        dictArray.sort((a, b) => {
+          if (a.yomi > b.yomi) {
+            return 1;
+          } else {
+            return -1;
+          }
+        });
+        const dictEntries: [string, UserDictWord][] = dictArray.map((v) => {
+          const { key, ...newV } = v;
+          return [key, newV];
+        });
+        return Object.fromEntries(dictEntries);
+      },
+    },
+
+    LOAD_ALL_USER_DICT: {
+      async action({ actions, state }) {
+        const allDict = await Promise.all(
+          state.engineIds.map((engineId) => {
+            return actions.LOAD_USER_DICT({ engineId });
+          }),
+        );
+        const mergedDictMap = new Map<string, [string, UserDictWord]>();
+        for (const dict of allDict) {
+          for (const [id, dictItem] of Object.entries(dict)) {
+            mergedDictMap.set(`${dictItem.yomi}-${dictItem.surface}`, [
+              id,
+              dictItem,
+            ]);
           }
         }
-
-        await dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId }).then(
-          (instance) => {
-            // マージ処理で削除された項目をエンジンから削除する。
-            Promise.all(
-              [...removedDictIdSet].map((id) =>
-                instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")(
-                  {
-                    wordUuid: id,
-                  },
-                ),
-              ),
-            );
-          },
-        );
-      }
+        const mergedDict = [...mergedDictMap.values()];
+        mergedDict.sort((a, b) => {
+          if (a[1].yomi > b[1].yomi) {
+            return 1;
+          } else {
+            return -1;
+          }
+        });
+        return Object.fromEntries(mergedDict);
+      },
     },
-  },
-});
+
+    ADD_WORD: {
+      async action(
+        { state, actions },
+        { surface, pronunciation, accentType, priority },
+      ) {
+        // 同じ単語IDで登録するために、１つのエンジンで登録したあと全エンジンに同期する。
+        const engineId: EngineId | undefined = state.engineIds[0];
+
+        if (engineId == undefined)
+          throw new Error(`No such engine registered: index == 0`);
+        await actions
+          .INSTANTIATE_ENGINE_CONNECTOR({
+            engineId,
+          })
+          .then((instance) =>
+            instance.invoke("addUserDictWordUserDictWordPost")({
+              surface,
+              pronunciation,
+              accentType,
+              priority,
+            }),
+          );
+
+        await actions.SYNC_ALL_USER_DICT();
+      },
+    },
+
+    REWRITE_WORD: {
+      async action(
+        { state, actions },
+        { wordUuid, surface, pronunciation, accentType, priority },
+      ) {
+        if (state.engineIds.length === 0)
+          throw new Error(`At least one engine must be registered`);
+        for (const engineId of state.engineIds) {
+          await actions
+            .INSTANTIATE_ENGINE_CONNECTOR({
+              engineId,
+            })
+            .then((instance) =>
+              instance.invoke("rewriteUserDictWordUserDictWordWordUuidPut")({
+                wordUuid,
+                surface,
+                pronunciation,
+                accentType,
+                priority,
+              }),
+            );
+        }
+      },
+    },
+
+    DELETE_WORD: {
+      async action({ state, actions }, { wordUuid }) {
+        if (state.engineIds.length === 0)
+          throw new Error(`At least one engine must be registered`);
+        for (const engineId of state.engineIds) {
+          await actions
+            .INSTANTIATE_ENGINE_CONNECTOR({
+              engineId,
+            })
+            .then((instance) =>
+              instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")({
+                wordUuid,
+              }),
+            );
+        }
+      },
+    },
+
+    SYNC_ALL_USER_DICT: {
+      async action({ actions, state }) {
+        const mergedDict = await actions.LOAD_ALL_USER_DICT();
+        for (const engineId of state.engineIds) {
+          // エンジンの辞書のIDリストを取得する。
+          const dictIdSet = await actions
+            .INSTANTIATE_ENGINE_CONNECTOR({
+              engineId,
+            })
+            .then(
+              async (instance) =>
+                new Set(
+                  Object.keys(
+                    await instance.invoke("getUserDictWordsUserDictGet")({}),
+                  ),
+                ),
+            );
+          if (Object.keys(mergedDict).some((id) => !dictIdSet.has(id))) {
+            await actions
+              .INSTANTIATE_ENGINE_CONNECTOR({
+                engineId,
+              })
+              .then((instance) =>
+                // マージした辞書をエンジンにインポートする。
+                instance.invoke("importUserDictWordsImportUserDictPost")({
+                  override: true,
+                  requestBody: Object.fromEntries(
+                    Object.entries(mergedDict).map(([k, v]) => [
+                      k,
+                      UserDictWordToJSON(v),
+                    ]),
+                  ),
+                }),
+              );
+          }
+          const removedDictIdSet = new Set(dictIdSet);
+          // マージされた辞書にあるIDを削除する。
+          // これにより、マージ処理で削除された項目のIDが残る。
+          for (const id of Object.keys(mergedDict)) {
+            if (removedDictIdSet.has(id)) {
+              removedDictIdSet.delete(id);
+            }
+          }
+
+          await actions
+            .INSTANTIATE_ENGINE_CONNECTOR({ engineId })
+            .then((instance) => {
+              // マージ処理で削除された項目をエンジンから削除する。
+              Promise.all(
+                [...removedDictIdSet].map((id) =>
+                  instance.invoke(
+                    "deleteUserDictWordUserDictWordWordUuidDelete",
+                  )({
+                    wordUuid: id,
+                  }),
+                ),
+              );
+            });
+        }
+      },
+    },
+  });

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -1,11 +1,11 @@
-import { createDotNotationPartialStore as createDotPartStore } from "./vuex";
+import { createDotNotationPartialStore as createPartialStore } from "./vuex";
 import { UserDictWord, UserDictWordToJSON } from "@/openapi";
 import { DictionaryStoreState, DictionaryStoreTypes } from "@/store/type";
 import { EngineId } from "@/type/preload";
 
 export const dictionaryStoreState: DictionaryStoreState = {};
 
-export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
+export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
   LOAD_USER_DICT: {
     async action({ actions }, { engineId }) {
       const engineDict = await actions
@@ -38,7 +38,7 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
       const allDict = await Promise.all(
         state.engineIds.map((engineId) => {
           return actions.LOAD_USER_DICT({ engineId });
-        }),
+        })
       );
       const mergedDictMap = new Map<string, [string, UserDictWord]>();
       for (const dict of allDict) {
@@ -64,7 +64,7 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
   ADD_WORD: {
     async action(
       { state, actions },
-      { surface, pronunciation, accentType, priority },
+      { surface, pronunciation, accentType, priority }
     ) {
       // 同じ単語IDで登録するために、１つのエンジンで登録したあと全エンジンに同期する。
       const engineId: EngineId | undefined = state.engineIds[0];
@@ -81,7 +81,7 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
             pronunciation,
             accentType,
             priority,
-          }),
+          })
         );
 
       await actions.SYNC_ALL_USER_DICT();
@@ -91,7 +91,7 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
   REWRITE_WORD: {
     async action(
       { state, actions },
-      { wordUuid, surface, pronunciation, accentType, priority },
+      { wordUuid, surface, pronunciation, accentType, priority }
     ) {
       if (state.engineIds.length === 0)
         throw new Error(`At least one engine must be registered`);
@@ -107,7 +107,7 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
               pronunciation,
               accentType,
               priority,
-            }),
+            })
           );
       }
     },
@@ -125,7 +125,7 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
           .then((instance) =>
             instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")({
               wordUuid,
-            }),
+            })
           );
       }
     },
@@ -144,9 +144,9 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
             async (instance) =>
               new Set(
                 Object.keys(
-                  await instance.invoke("getUserDictWordsUserDictGet")({}),
-                ),
-              ),
+                  await instance.invoke("getUserDictWordsUserDictGet")({})
+                )
+              )
           );
         if (Object.keys(mergedDict).some((id) => !dictIdSet.has(id))) {
           await actions
@@ -161,9 +161,9 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
                   Object.entries(mergedDict).map(([k, v]) => [
                     k,
                     UserDictWordToJSON(v),
-                  ]),
+                  ])
                 ),
-              }),
+              })
             );
         }
         const removedDictIdSet = new Set(dictIdSet);
@@ -184,9 +184,9 @@ export const dictionaryStore = createDotPartStore<DictionaryStoreTypes>({
                 instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")(
                   {
                     wordUuid: id,
-                  },
-                ),
-              ),
+                  }
+                )
+              )
             );
           });
       }

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -38,7 +38,7 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
       const allDict = await Promise.all(
         state.engineIds.map((engineId) => {
           return actions.LOAD_USER_DICT({ engineId });
-        })
+        }),
       );
       const mergedDictMap = new Map<string, [string, UserDictWord]>();
       for (const dict of allDict) {
@@ -64,7 +64,7 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
   ADD_WORD: {
     async action(
       { state, actions },
-      { surface, pronunciation, accentType, priority }
+      { surface, pronunciation, accentType, priority },
     ) {
       // 同じ単語IDで登録するために、１つのエンジンで登録したあと全エンジンに同期する。
       const engineId: EngineId | undefined = state.engineIds[0];
@@ -81,7 +81,7 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
             pronunciation,
             accentType,
             priority,
-          })
+          }),
         );
 
       await actions.SYNC_ALL_USER_DICT();
@@ -91,7 +91,7 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
   REWRITE_WORD: {
     async action(
       { state, actions },
-      { wordUuid, surface, pronunciation, accentType, priority }
+      { wordUuid, surface, pronunciation, accentType, priority },
     ) {
       if (state.engineIds.length === 0)
         throw new Error(`At least one engine must be registered`);
@@ -107,7 +107,7 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
               pronunciation,
               accentType,
               priority,
-            })
+            }),
           );
       }
     },
@@ -125,7 +125,7 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
           .then((instance) =>
             instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")({
               wordUuid,
-            })
+            }),
           );
       }
     },
@@ -144,9 +144,9 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
             async (instance) =>
               new Set(
                 Object.keys(
-                  await instance.invoke("getUserDictWordsUserDictGet")({})
-                )
-              )
+                  await instance.invoke("getUserDictWordsUserDictGet")({}),
+                ),
+              ),
           );
         if (Object.keys(mergedDict).some((id) => !dictIdSet.has(id))) {
           await actions
@@ -161,9 +161,9 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
                   Object.entries(mergedDict).map(([k, v]) => [
                     k,
                     UserDictWordToJSON(v),
-                  ])
+                  ]),
                 ),
-              })
+              }),
             );
         }
         const removedDictIdSet = new Set(dictIdSet);
@@ -184,9 +184,9 @@ export const dictionaryStore = createPartialStore<DictionaryStoreTypes>({
                 instance.invoke("deleteUserDictWordUserDictWordWordUuidDelete")(
                   {
                     wordUuid: id,
-                  }
-                )
-              )
+                  },
+                ),
+              ),
             );
           });
       }

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -31,7 +31,7 @@ export class Store<
   S,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase
+  M extends MutationsBase,
 > extends BaseStore<S> {
   constructor(options: StoreOptions<S, G, A, M>) {
     super(options as OriginalStoreOptions<S>);
@@ -39,7 +39,7 @@ export class Store<
     this.actions = dotNotationDispatchProxy(this.dispatch.bind(this));
     this.mutations = dotNotationCommitProxy(
       // @ts-expect-error Storeの型を書き換えている影響で未初期化として判定される
-      this.commit.bind(this) as Commit<M>
+      this.commit.bind(this) as Commit<M>,
     );
   }
 
@@ -65,7 +65,7 @@ export function createStore<
   S,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase
+  M extends MutationsBase,
 >(options: StoreOptions<S, G, A, M>): Store<S, G, A, M> {
   return new Store<S, G, A, M>(options);
 }
@@ -74,16 +74,17 @@ export function useStore<
   S,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase
+  M extends MutationsBase,
 >(injectKey?: InjectionKey<Store<S, G, A, M>> | string): Store<S, G, A, M> {
   // FIXME: dispatchとcommitの型を戻せばsuper typeになるのでunknownを消せる。
   return baseUseStore<S>(injectKey) as unknown as Store<S, G, A, M>;
 }
 
 export interface Dispatch<A extends ActionsBase> {
-  <T extends keyof A>(type: T, ...payload: Parameters<A[T]>): Promise<
-    PromiseType<ReturnType<A[T]>>
-  >;
+  <T extends keyof A>(
+    type: T,
+    ...payload: Parameters<A[T]>
+  ): Promise<PromiseType<ReturnType<A[T]>>>;
   <T extends keyof A>(
     payloadWithType: { type: T } & (Parameters<A[T]>[0] extends Record<
       string,
@@ -91,7 +92,7 @@ export interface Dispatch<A extends ActionsBase> {
     >
       ? Parameters<A[T]>[0]
       : // eslint-disable-next-line @typescript-eslint/ban-types
-        {})
+        {}),
   ): Promise<PromiseType<ReturnType<A[T]>>>;
 }
 
@@ -104,7 +105,7 @@ export interface Commit<M extends MutationsBase> {
     payloadWithType: { type: T } & (M[T] extends Record<string, any>
       ? M[T]
       : // eslint-disable-next-line @typescript-eslint/ban-types
-        {})
+        {}),
   ): void;
 }
 
@@ -115,7 +116,7 @@ export type DotNotationDispatch<A extends ActionsBase> = {
 };
 
 const dotNotationDispatchProxy = <A extends ActionsBase>(
-  dispatch: Dispatch<A>
+  dispatch: Dispatch<A>,
 ): DotNotationDispatch<A> =>
   new Proxy(
     { dispatch },
@@ -124,7 +125,7 @@ const dotNotationDispatchProxy = <A extends ActionsBase>(
         return (...payloads: Parameters<A[string]>) =>
           target.dispatch(tag, ...payloads);
       },
-    }
+    },
   ) as DotNotationDispatch<A>;
 
 export type DotNotationCommit<M extends MutationsBase> = {
@@ -134,7 +135,7 @@ export type DotNotationCommit<M extends MutationsBase> = {
 };
 
 const dotNotationCommitProxy = <M extends MutationsBase>(
-  commit: Commit<M>
+  commit: Commit<M>,
 ): DotNotationCommit<M> =>
   new Proxy(
     { commit },
@@ -142,7 +143,7 @@ const dotNotationCommitProxy = <M extends MutationsBase>(
       get(target, tag: string) {
         return (...payloads: [M[string]]) => target.commit(tag, ...payloads);
       },
-    }
+    },
   ) as DotNotationCommit<M>;
 
 export interface StoreOptions<
@@ -152,7 +153,7 @@ export interface StoreOptions<
   M extends MutationsBase,
   SG extends GettersBase = G,
   SA extends ActionsBase = A,
-  SM extends MutationsBase = M
+  SM extends MutationsBase = M,
 > {
   state?: S | (() => S);
   getters: GetterTree<S, S, G, SG>;
@@ -169,7 +170,7 @@ export interface ActionContext<
   R,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase
+  SM extends MutationsBase,
 > {
   dispatch: Dispatch<SA>;
   commit: Commit<SM>;
@@ -185,11 +186,11 @@ export type ActionHandler<
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-  K extends keyof SA
+  K extends keyof SA,
 > = (
   this: Store<S, SG, SA, SM>,
   injectee: ActionContext<S, R, SG, SA, SM>,
-  payload: Parameters<SA[K]>[0]
+  payload: Parameters<SA[K]>[0],
 ) => ReturnType<SA[K]>;
 export interface ActionObject<
   S,
@@ -197,7 +198,7 @@ export interface ActionObject<
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-  K extends keyof SA
+  K extends keyof SA,
 > {
   root?: boolean;
   handler: ActionHandler<S, R, SG, SA, SM, K>;
@@ -208,7 +209,7 @@ export type DotNotationActionContext<
   R,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase
+  SM extends MutationsBase,
 > = {
   /**
    * ドット記法用のActionを直接呼べる。エラーになる場合はdispatchを使う。
@@ -228,11 +229,11 @@ export type DotNotationActionHandler<
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-  K extends keyof SA
+  K extends keyof SA,
 > = (
   this: Store<S, SG, SA, SM>,
   injectee: DotNotationActionContext<S, R, SG, SA, SM>,
-  payload: Parameters<SA[K]>[0]
+  payload: Parameters<SA[K]>[0],
 ) => ReturnType<SA[K]>;
 export interface DotNotationActionObject<
   S,
@@ -240,7 +241,7 @@ export interface DotNotationActionObject<
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-  K extends keyof SA
+  K extends keyof SA,
 > {
   root?: boolean;
   handler: DotNotationActionHandler<S, R, SG, SA, SM, K>;
@@ -250,7 +251,7 @@ export type Getter<S, R, G, K extends keyof G, SG extends GettersBase> = (
   state: S,
   getters: SG,
   rootState: R,
-  rootGetters: any
+  rootGetters: any,
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
 ) => SG[K];
@@ -262,13 +263,13 @@ export type Action<
   K extends keyof A,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase
+  SM extends MutationsBase,
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
 > = ActionHandler<S, R, SG, SA, SM, K> | ActionObject<S, R, SG, SA, SM, K>;
 export type Mutation<S, M extends MutationsBase, K extends keyof M> = (
   state: S,
-  payload: M[K]
+  payload: M[K],
 ) => void;
 
 export type DotNotationAction<
@@ -278,7 +279,7 @@ export type DotNotationAction<
   K extends keyof A,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase
+  SM extends MutationsBase,
 > =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -295,9 +296,9 @@ const unwrapDotNotationAction = <
   K extends keyof A,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase
+  SM extends MutationsBase,
 >(
-  dotNotationAction: DotNotationAction<S, R, A, K, SG, SA, SM>
+  dotNotationAction: DotNotationAction<S, R, A, K, SG, SA, SM>,
 ): Action<S, R, A, K, SG, SA, SM> => {
   const wrappedHandler =
     typeof dotNotationAction === "function"
@@ -308,7 +309,7 @@ const unwrapDotNotationAction = <
   // @ts-ignore
   const handler: ActionHandler<S, R, SG, SA, SM, K> = function (
     injectee,
-    payload
+    payload,
   ) {
     const dotNotationInjectee = {
       ...injectee,
@@ -332,7 +333,7 @@ export type GetterTree<
   S,
   R,
   G extends GettersBase,
-  SG extends GettersBase = G
+  SG extends GettersBase = G,
 > = G extends GettersBase
   ? CustomGetterTree<S, R, G, SG>
   : OriginalGetterTree<S, R>;
@@ -341,7 +342,7 @@ export type CustomGetterTree<
   S,
   R,
   G extends GettersBase,
-  SG extends GettersBase
+  SG extends GettersBase,
 > = {
   [K in keyof G]: Getter<S, R, G, K, SG>;
 };
@@ -352,7 +353,7 @@ export type ActionTree<
   A,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase
+  SM extends MutationsBase,
 > = A extends ActionsBase
   ? SA extends ActionsBase
     ? CustomActionTree<S, R, A, SG, SA, SM>
@@ -365,7 +366,7 @@ export type CustomActionTree<
   A extends ActionsBase,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase
+  SM extends MutationsBase,
 > = {
   [K in keyof A]: Action<S, R, A, K, SG, SA, SM>;
 };
@@ -391,7 +392,7 @@ type PartialStoreOptions<
   T extends StoreTypesBase,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase
+  M extends MutationsBase,
 > = {
   [K in keyof T]: {
     [GAM in keyof T[K]]: GAM extends "getter"
@@ -399,14 +400,14 @@ type PartialStoreOptions<
         ? Getter<S, S, G, K, AllGetters>
         : never
       : GAM extends "action"
-      ? K extends keyof A
-        ? Action<S, S, A, K, AllGetters, AllActions, AllMutations>
-        : never
-      : GAM extends "mutation"
-      ? K extends keyof M
-        ? Mutation<S, M, K>
-        : never
-      : never;
+        ? K extends keyof A
+          ? Action<S, S, A, K, AllGetters, AllActions, AllMutations>
+          : never
+        : GAM extends "mutation"
+          ? K extends keyof M
+            ? Mutation<S, M, K>
+            : never
+          : never;
   };
 };
 
@@ -415,7 +416,7 @@ type DotNotationPartialStoreOptions<
   T extends StoreTypesBase,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase
+  M extends MutationsBase,
 > = {
   [K in keyof T]: {
     [GAM in keyof T[K]]: GAM extends "getter"
@@ -423,14 +424,14 @@ type DotNotationPartialStoreOptions<
         ? Getter<S, S, G, K, AllGetters>
         : never
       : GAM extends "action"
-      ? K extends keyof A
-        ? DotNotationAction<S, S, A, K, AllGetters, AllActions, AllMutations>
-        : never
-      : GAM extends "mutation"
-      ? K extends keyof M
-        ? Mutation<S, M, K>
-        : never
-      : never;
+        ? K extends keyof A
+          ? DotNotationAction<S, S, A, K, AllGetters, AllActions, AllMutations>
+          : never
+        : GAM extends "mutation"
+          ? K extends keyof M
+            ? Mutation<S, M, K>
+            : never
+          : never;
   };
 };
 
@@ -438,9 +439,9 @@ export const createPartialStore = <
   T extends StoreTypesBase,
   G extends GettersBase = StoreType<T, "getter">,
   A extends ActionsBase = StoreType<T, "action">,
-  M extends MutationsBase = StoreType<T, "mutation">
+  M extends MutationsBase = StoreType<T, "mutation">,
 >(
-  options: PartialStoreOptions<State, T, G, A, M>
+  options: PartialStoreOptions<State, T, G, A, M>,
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
   const obj = Object.keys(options).reduce(
     (acc, cur) => {
@@ -462,7 +463,7 @@ export const createPartialStore = <
       getters: Object.create(null),
       mutations: Object.create(null),
       actions: Object.create(null),
-    }
+    },
   );
 
   return obj;
@@ -472,9 +473,9 @@ export const createDotNotationPartialStore = <
   T extends StoreTypesBase,
   G extends GettersBase = StoreType<T, "getter">,
   A extends ActionsBase = StoreType<T, "action">,
-  M extends MutationsBase = StoreType<T, "mutation">
+  M extends MutationsBase = StoreType<T, "mutation">,
 >(
-  options: DotNotationPartialStoreOptions<State, T, G, A, M>
+  options: DotNotationPartialStoreOptions<State, T, G, A, M>,
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
   const obj = Object.keys(options).reduce(
     (acc, cur) => {
@@ -496,7 +497,7 @@ export const createDotNotationPartialStore = <
       getters: Object.create(null),
       mutations: Object.create(null),
       actions: Object.create(null),
-    }
+    },
   );
 
   return obj;

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -31,7 +31,7 @@ export class Store<
   S,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase,
+  M extends MutationsBase
 > extends BaseStore<S> {
   constructor(options: StoreOptions<S, G, A, M>) {
     super(options as OriginalStoreOptions<S>);
@@ -39,7 +39,7 @@ export class Store<
     this.actions = dotNotationDispatchProxy(this.dispatch.bind(this));
     this.mutations = dotNotationCommitProxy(
       // @ts-expect-error Storeの型を書き換えている影響で未初期化として判定される
-      this.commit.bind(this) as Commit<M>,
+      this.commit.bind(this) as Commit<M>
     );
   }
 
@@ -50,7 +50,7 @@ export class Store<
   // @ts-expect-error Storeの型を非互換な型で書き換えているためエラー
   commit: Commit<M>;
   /**
-   * ドット記法用のActionを直接呼べる。エラーになる場合はdispatchを使ってください。
+   * ドット記法用のActionを直接呼べる。エラーになる場合はdispatchを使う。
    * 詳細 https://github.com/VOICEVOX/voicevox/issues/2088
    */
   actions: DotNotationDispatch<A>;
@@ -65,7 +65,7 @@ export function createStore<
   S,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase,
+  M extends MutationsBase
 >(options: StoreOptions<S, G, A, M>): Store<S, G, A, M> {
   return new Store<S, G, A, M>(options);
 }
@@ -74,16 +74,15 @@ export function useStore<
   S,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase,
+  M extends MutationsBase
 >(injectKey?: InjectionKey<Store<S, G, A, M>> | string): Store<S, G, A, M> {
   return baseUseStore<S>(injectKey) as unknown as Store<S, G, A, M>;
 }
 
 export interface Dispatch<A extends ActionsBase> {
-  <T extends keyof A>(
-    type: T,
-    ...payload: Parameters<A[T]>
-  ): Promise<PromiseType<ReturnType<A[T]>>>;
+  <T extends keyof A>(type: T, ...payload: Parameters<A[T]>): Promise<
+    PromiseType<ReturnType<A[T]>>
+  >;
   <T extends keyof A>(
     payloadWithType: { type: T } & (Parameters<A[T]>[0] extends Record<
       string,
@@ -91,7 +90,7 @@ export interface Dispatch<A extends ActionsBase> {
     >
       ? Parameters<A[T]>[0]
       : // eslint-disable-next-line @typescript-eslint/ban-types
-        {}),
+        {})
   ): Promise<PromiseType<ReturnType<A[T]>>>;
 }
 
@@ -104,7 +103,7 @@ export interface Commit<M extends MutationsBase> {
     payloadWithType: { type: T } & (M[T] extends Record<string, any>
       ? M[T]
       : // eslint-disable-next-line @typescript-eslint/ban-types
-        {}),
+        {})
   ): void;
 }
 
@@ -115,7 +114,7 @@ export type DotNotationDispatch<A extends ActionsBase> = {
 };
 
 const dotNotationDispatchProxy = <A extends ActionsBase>(
-  dispatch: Dispatch<A>,
+  dispatch: Dispatch<A>
 ): DotNotationDispatch<A> =>
   new Proxy(
     { dispatch },
@@ -124,7 +123,7 @@ const dotNotationDispatchProxy = <A extends ActionsBase>(
         return (...payloads: Parameters<A[string]>) =>
           target.dispatch(tag, ...payloads);
       },
-    },
+    }
   ) as DotNotationDispatch<A>;
 
 export type DotNotationCommit<M extends MutationsBase> = {
@@ -134,7 +133,7 @@ export type DotNotationCommit<M extends MutationsBase> = {
 };
 
 const dotNotationCommitProxy = <M extends MutationsBase>(
-  commit: Commit<M>,
+  commit: Commit<M>
 ): DotNotationCommit<M> =>
   new Proxy(
     { commit },
@@ -142,7 +141,7 @@ const dotNotationCommitProxy = <M extends MutationsBase>(
       get(target, tag: string) {
         return (...payloads: [M[string]]) => target.commit(tag, ...payloads);
       },
-    },
+    }
   ) as DotNotationCommit<M>;
 
 export interface StoreOptions<
@@ -152,7 +151,7 @@ export interface StoreOptions<
   M extends MutationsBase,
   SG extends GettersBase = G,
   SA extends ActionsBase = A,
-  SM extends MutationsBase = M,
+  SM extends MutationsBase = M
 > {
   state?: S | (() => S);
   getters: GetterTree<S, S, G, SG>;
@@ -169,7 +168,7 @@ export interface ActionContext<
   R,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase,
+  SM extends MutationsBase
 > {
   dispatch: Dispatch<SA>;
   commit: Commit<SM>;
@@ -185,11 +184,11 @@ export type ActionHandler<
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-  K extends keyof SA,
+  K extends keyof SA
 > = (
   this: Store<S, SG, SA, SM>,
   injectee: ActionContext<S, R, SG, SA, SM>,
-  payload: Parameters<SA[K]>[0],
+  payload: Parameters<SA[K]>[0]
 ) => ReturnType<SA[K]>;
 export interface ActionObject<
   S,
@@ -197,7 +196,7 @@ export interface ActionObject<
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-  K extends keyof SA,
+  K extends keyof SA
 > {
   root?: boolean;
   handler: ActionHandler<S, R, SG, SA, SM, K>;
@@ -208,10 +207,10 @@ export type DotNotationActionContext<
   R,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase,
+  SM extends MutationsBase
 > = {
   /**
-   * ドット記法用のActionを直接呼べる。エラーになる場合はdispatchを使ってください。
+   * ドット記法用のActionを直接呼べる。エラーになる場合はdispatchを使う。
    * 詳細 https://github.com/VOICEVOX/voicevox/issues/2088
    */
   actions: DotNotationDispatch<SA>;
@@ -228,11 +227,11 @@ export type DotNotationActionHandler<
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-  K extends keyof SA,
+  K extends keyof SA
 > = (
   this: Store<S, SG, SA, SM>,
   injectee: DotNotationActionContext<S, R, SG, SA, SM>,
-  payload: Parameters<SA[K]>[0],
+  payload: Parameters<SA[K]>[0]
 ) => ReturnType<SA[K]>;
 export interface DotNotationActionObject<
   S,
@@ -240,7 +239,7 @@ export interface DotNotationActionObject<
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-  K extends keyof SA,
+  K extends keyof SA
 > {
   root?: boolean;
   handler: DotNotationActionHandler<S, R, SG, SA, SM, K>;
@@ -250,7 +249,7 @@ export type Getter<S, R, G, K extends keyof G, SG extends GettersBase> = (
   state: S,
   getters: SG,
   rootState: R,
-  rootGetters: any,
+  rootGetters: any
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
 ) => SG[K];
@@ -262,13 +261,13 @@ export type Action<
   K extends keyof A,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase,
+  SM extends MutationsBase
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
 > = ActionHandler<S, R, SG, SA, SM, K> | ActionObject<S, R, SG, SA, SM, K>;
 export type Mutation<S, M extends MutationsBase, K extends keyof M> = (
   state: S,
-  payload: M[K],
+  payload: M[K]
 ) => void;
 
 export type DotNotationAction<
@@ -278,7 +277,7 @@ export type DotNotationAction<
   K extends keyof A,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase,
+  SM extends MutationsBase
 > =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -295,9 +294,9 @@ const unwrapDotNotationAction = <
   K extends keyof A,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase,
+  SM extends MutationsBase
 >(
-  dotNotationAction: DotNotationAction<S, R, A, K, SG, SA, SM>,
+  dotNotationAction: DotNotationAction<S, R, A, K, SG, SA, SM>
 ): Action<S, R, A, K, SG, SA, SM> => {
   const wrappedHandler =
     typeof dotNotationAction === "function"
@@ -308,7 +307,7 @@ const unwrapDotNotationAction = <
   // @ts-ignore
   const handler: ActionHandler<S, R, SG, SA, SM, K> = function (
     injectee,
-    payload,
+    payload
   ) {
     const dotNotationInjectee = {
       ...injectee,
@@ -332,7 +331,7 @@ export type GetterTree<
   S,
   R,
   G extends GettersBase,
-  SG extends GettersBase = G,
+  SG extends GettersBase = G
 > = G extends GettersBase
   ? CustomGetterTree<S, R, G, SG>
   : OriginalGetterTree<S, R>;
@@ -341,7 +340,7 @@ export type CustomGetterTree<
   S,
   R,
   G extends GettersBase,
-  SG extends GettersBase,
+  SG extends GettersBase
 > = {
   [K in keyof G]: Getter<S, R, G, K, SG>;
 };
@@ -352,7 +351,7 @@ export type ActionTree<
   A,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase,
+  SM extends MutationsBase
 > = A extends ActionsBase
   ? SA extends ActionsBase
     ? CustomActionTree<S, R, A, SG, SA, SM>
@@ -365,7 +364,7 @@ export type CustomActionTree<
   A extends ActionsBase,
   SG extends GettersBase,
   SA extends ActionsBase,
-  SM extends MutationsBase,
+  SM extends MutationsBase
 > = {
   [K in keyof A]: Action<S, R, A, K, SG, SA, SM>;
 };
@@ -391,7 +390,7 @@ type PartialStoreOptions<
   T extends StoreTypesBase,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase,
+  M extends MutationsBase
 > = {
   [K in keyof T]: {
     [GAM in keyof T[K]]: GAM extends "getter"
@@ -399,14 +398,14 @@ type PartialStoreOptions<
         ? Getter<S, S, G, K, AllGetters>
         : never
       : GAM extends "action"
-        ? K extends keyof A
-          ? Action<S, S, A, K, AllGetters, AllActions, AllMutations>
-          : never
-        : GAM extends "mutation"
-          ? K extends keyof M
-            ? Mutation<S, M, K>
-            : never
-          : never;
+      ? K extends keyof A
+        ? Action<S, S, A, K, AllGetters, AllActions, AllMutations>
+        : never
+      : GAM extends "mutation"
+      ? K extends keyof M
+        ? Mutation<S, M, K>
+        : never
+      : never;
   };
 };
 
@@ -415,7 +414,7 @@ type DotNotationPartialStoreOptions<
   T extends StoreTypesBase,
   G extends GettersBase,
   A extends ActionsBase,
-  M extends MutationsBase,
+  M extends MutationsBase
 > = {
   [K in keyof T]: {
     [GAM in keyof T[K]]: GAM extends "getter"
@@ -423,14 +422,14 @@ type DotNotationPartialStoreOptions<
         ? Getter<S, S, G, K, AllGetters>
         : never
       : GAM extends "action"
-        ? K extends keyof A
-          ? DotNotationAction<S, S, A, K, AllGetters, AllActions, AllMutations>
-          : never
-        : GAM extends "mutation"
-          ? K extends keyof M
-            ? Mutation<S, M, K>
-            : never
-          : never;
+      ? K extends keyof A
+        ? DotNotationAction<S, S, A, K, AllGetters, AllActions, AllMutations>
+        : never
+      : GAM extends "mutation"
+      ? K extends keyof M
+        ? Mutation<S, M, K>
+        : never
+      : never;
   };
 };
 
@@ -438,9 +437,9 @@ export const createPartialStore = <
   T extends StoreTypesBase,
   G extends GettersBase = StoreType<T, "getter">,
   A extends ActionsBase = StoreType<T, "action">,
-  M extends MutationsBase = StoreType<T, "mutation">,
+  M extends MutationsBase = StoreType<T, "mutation">
 >(
-  options: PartialStoreOptions<State, T, G, A, M>,
+  options: PartialStoreOptions<State, T, G, A, M>
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
   const obj = Object.keys(options).reduce(
     (acc, cur) => {
@@ -462,7 +461,7 @@ export const createPartialStore = <
       getters: Object.create(null),
       mutations: Object.create(null),
       actions: Object.create(null),
-    },
+    }
   );
 
   return obj;
@@ -472,9 +471,9 @@ export const createDotNotationPartialStore = <
   T extends StoreTypesBase,
   G extends GettersBase = StoreType<T, "getter">,
   A extends ActionsBase = StoreType<T, "action">,
-  M extends MutationsBase = StoreType<T, "mutation">,
+  M extends MutationsBase = StoreType<T, "mutation">
 >(
-  options: DotNotationPartialStoreOptions<State, T, G, A, M>,
+  options: DotNotationPartialStoreOptions<State, T, G, A, M>
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
   const obj = Object.keys(options).reduce(
     (acc, cur) => {
@@ -496,7 +495,7 @@ export const createDotNotationPartialStore = <
       getters: Object.create(null),
       mutations: Object.create(null),
       actions: Object.create(null),
-    },
+    }
   );
 
   return obj;

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -76,6 +76,7 @@ export function useStore<
   A extends ActionsBase,
   M extends MutationsBase
 >(injectKey?: InjectionKey<Store<S, G, A, M>> | string): Store<S, G, A, M> {
+  // FIXME: dispatchとcommitの型を戻せばsuper typeになるのでunknownを消せる。
   return baseUseStore<S>(injectKey) as unknown as Store<S, G, A, M>;
 }
 

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -49,8 +49,15 @@ export class Store<
   dispatch: Dispatch<A>;
   // @ts-expect-error Storeの型を非互換な型で書き換えているためエラー
   commit: Commit<M>;
-
+  /**
+   * ドット記法用のActionを直接呼べる。エラーになる場合はdispatchを使ってください。
+   * 詳細 https://github.com/VOICEVOX/voicevox/issues/2088
+   */
   actions: DotNotationDispatch<A>;
+  /**
+   * ドット記法用のMutationを直接呼べる。エラーになる場合はcommitを使う。
+   * 詳細 https://github.com/VOICEVOX/voicevox/issues/2088
+   */
   mutations: DotNotationCommit<M>;
 }
 
@@ -196,20 +203,24 @@ export interface ActionObject<
   handler: ActionHandler<S, R, SG, SA, SM, K>;
 }
 
-export interface DotNotationActionContext<
+export type DotNotationActionContext<
   S,
   R,
   SG extends GettersBase,
   SA extends ActionsBase,
   SM extends MutationsBase,
-> {
+> = {
+  /**
+   * ドット記法用のActionを直接呼べる。エラーになる場合はdispatchを使ってください。
+   * 詳細 https://github.com/VOICEVOX/voicevox/issues/2088
+   */
   actions: DotNotationDispatch<SA>;
+  /**
+   * ドット記法用のMutationを直接呼べる。エラーになる場合はcommitを使う。
+   * 詳細 https://github.com/VOICEVOX/voicevox/issues/2088
+   */
   mutations: DotNotationCommit<SM>;
-  state: S;
-  getters: SG;
-  rootState: R;
-  rootGetters: any;
-}
+} & ActionContext<S, R, SG, SA, SM>;
 
 export type DotNotationActionHandler<
   S,

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -28,25 +28,14 @@ export type MutationsBase = Record<string, any>;
 
 export type PromiseType<T> = T extends Promise<infer P> ? P : T;
 
-export class Store<
+export interface Store<
   S,
   G extends GettersBase,
   A extends ActionsBase,
   M extends MutationsBase,
-> extends BaseStore<S> {
-  constructor(options: OriginalStoreOptions<S>) {
-    super(options);
-  }
-
-  readonly getters!: G;
-
-  // 既に型がつけられているものを上書きすることになるので、TS2564を吐く、それの回避
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+> extends Omit<BaseStore<S>, "getters" | "dispatch" | "commit"> {
+  readonly getters: G;
   dispatch: Dispatch<A>;
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   commit: Commit<M>;
 }
 
@@ -66,6 +55,15 @@ export function createStore<
 }
 
 export function useStore<
+  S,
+  G extends GettersBase,
+  A extends ActionsBase,
+  M extends MutationsBase,
+>(injectKey?: InjectionKey<Store<S, G, A, M>> | string): Store<S, G, A, M> {
+  return baseUseStore<S>(injectKey) as Store<S, G, A, M>;
+}
+
+export function useDotNotationStore<
   S,
   G extends GettersBase,
   A extends ActionsBase,


### PR DESCRIPTION
## 内容

store.ts内における関数の呼び出しにおいて、`dispatch("ACTION1", payloads)` のような引数におけるリテラル指定から `actions.ACTION(payload)` のようにdot記法によるアクセスに変更します。
とりあえずどのくらいの規模でPRを分割すべきかわからなかったので、元のコードは残し、`dictionary.ts`だけ新しい記法に変えています。

type.tsは残したままなので lsp上で `goto definition` をしても `type.ts` に移動するだけですが、 `goto implementation` で実装に飛べます。

## 関連 Issue

ref #2088

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
