### PR TITLE
darwin-arm64プラットフォーム対応

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   VOICEVOX_ENGINE_REPO_URL: "https://github.com/VOICEVOX/voicevox_engine"
-  VOICEVOX_ENGINE_VERSION: 0.19.1
+  VOICEVOX_ENGINE_VERSION: 0.20-preview.0
   VOICEVOX_RESOURCE_VERSION: 0.19.1
   VOICEVOX_EDITOR_VERSION:
     |- # releaseタグ名か、workflow_dispatchでのバージョン名か、999.999.999-developが入る
@@ -55,7 +55,8 @@ jobs:
           - windows-nvidia-prepackage
           - windows-cpu-prepackage
           - windows-directml-prepackage
-          - macos-cpu-prepackage
+          - macos-x64-cpu-prepackage
+          - macos-arm64-cpu-prepackage
         include:
           # Linux NVIDIA GPU
           - artifact_name: linux-nvidia-prepackage
@@ -111,16 +112,26 @@ jobs:
             installer_artifact_name: windows-directml-nsis-web
             nsis_web_artifact_name: "VOICEVOX.Web.Setup.${version}.${ext}"
             os: windows-2019
-          # macOS CPU
-          - artifact_name: macos-cpu-prepackage
+          # macOS CPU (x64)
+          - artifact_name: macos-x64-cpu-prepackage
             artifact_path: dist_electron/mac
             voicevox_engine_asset_name: macos-x64
             package_name: voicevox-cpu
-            compressed_artifact_name: voicevox-macos-cpu
+            compressed_artifact_name: voicevox-macos-x64-cpu
             app_asar_dir: prepackage/VOICEVOX.app/Contents/Resources
-            installer_artifact_name: macos-cpu-dmg
-            macos_artifact_name: "VOICEVOX.${version}.${ext}"
+            installer_artifact_name: macos-x64-cpu-dmg
+            macos_artifact_name: "VOICEVOX.${version}-x64.${ext}"
             os: macos-12
+          # macOS CPU (arm64)
+          - artifact_name: macos-arm64-cpu-prepackage
+            artifact_path: dist_electron/mac-arm64
+            voicevox_engine_asset_name: macos-arm64
+            package_name: voicevox-cpu
+            compressed_artifact_name: voicevox-macos-arm64-cpu
+            app_asar_dir: prepackage/VOICEVOX.app/Contents/Resources
+            installer_artifact_name: macos-arm64-cpu-dmg
+            macos_artifact_name: "VOICEVOX.${version}-arm64.${ext}"
+            os: macos-14
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,6 +317,10 @@ jobs:
         if: startsWith(matrix.artifact_name, 'macos-')
         run: mkdir -p prepackage/VOICEVOX.app/Contents/Resources/ja.lproj prepackage/VOICEVOX.app/Contents/Resources/en.lproj
 
+      - name: Ad hoc code signing
+        if: endsWith(matrix.installer_artifact_name, '-dmg') # macOS
+        run: codesign --force --deep -s - prepackage/VOICEVOX.app
+
       - name: Create Linux tar.gz (without nvidia)
         if: startsWith(matrix.artifact_name, 'linux-') && !contains(matrix.artifact_name, 'nvidia')
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,10 +205,15 @@ jobs:
 
           cp resource/editor/PRIVACYPOLICY.md public/privacyPolicy.md
 
-      - name: Overwrite .env.production for Linux and macOS
-        if: startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-')
+      - name: Overwrite .env.production for Linux
+        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           $sed -i 's|run.exe|./run|g' .env.production
+
+      - name: Overwrite .env.production for macOS
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          $sed -i 's|vv-engine/run.exe|../Resources/vv-engine/run|g' .env.production
 
       - name: Replace .env.production infomations
         run: |
@@ -291,10 +296,10 @@ jobs:
         run: |
           mv voicevox_engine/ prepackage/vv-engine/
 
-      - name: Merge VOICEVOX ENGINE into prepackage/VOICEVOX.app/Contents/MacOS/
+      - name: Merge VOICEVOX ENGINE into prepackage/VOICEVOX.app/Contents/Resources/
         if: startsWith(matrix.artifact_name, 'macos-')
         run: |
-          mv voicevox_engine/ prepackage/VOICEVOX.app/Contents/MacOS/vv-engine/
+          mv voicevox_engine/ prepackage/VOICEVOX.app/Contents/Resources/vv-engine/
 
       - name: Recover file permissions
         if: startsWith(matrix.artifact_name, 'linux-') # linux
@@ -305,7 +310,7 @@ jobs:
       - name: Recover file permissions for macOS build
         if: startsWith(matrix.artifact_name, 'macos-') # macOS
         run: |
-          chmod +x "prepackage/VOICEVOX.app/Contents/MacOS/vv-engine/run"
+          chmod +x "prepackage/VOICEVOX.app/Contents/Resources/vv-engine/run"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (GPU).app/Contents/MacOS/VOICEVOX Helper (GPU)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Plugin).app/Contents/MacOS/VOICEVOX Helper (Plugin)"
           chmod +x "prepackage/VOICEVOX.app/Contents/Frameworks/VOICEVOX Helper (Renderer).app/Contents/MacOS/VOICEVOX Helper (Renderer)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,9 @@ jobs:
             voicevox_engine_asset_name: linux-cpu
           - os: macos-latest
             voicevox_engine_asset_name: macos-x64
-          - os: macos-latest
-            voicevox_engine_asset_name: macos-arm64
+          # TODO: voicevox_nemo_negineがarm64に対応したら変更する 
+          # - os: macos-latest
+          #   voicevox_engine_asset_name: macos-arm64
           - os: windows-latest
             voicevox_engine_asset_name: windows-cpu
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
             voicevox_engine_asset_name: linux-cpu
           - os: macos-latest
             voicevox_engine_asset_name: macos-x64
+          - os: macos-latest
+            voicevox_engine_asset_name: macos-arm64
           - os: windows-latest
             voicevox_engine_asset_name: windows-cpu
     steps:

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -29,6 +29,8 @@ const WIN_SIGNING_HASH_ALGORITHMS = process.env.WIN_SIGNING_HASH_ALGORITHMS
 
 const isMac = process.platform === "darwin";
 
+const isArm64 = process.arch === "arm64";
+
 // electron-builderのextraFilesは、ファイルのコピー先としてVOICEVOX.app/Contents/を使用する。
 // しかし、実行ファイルはVOICEVOX.app/Contents/MacOS/にあるため、extraFilesをVOICEVOX.app/Contents/ディレクトリにコピーするのは正しくない。
 // VOICEVOX.app/Contents/MacOS/ディレクトリにコピーされるように修正する。
@@ -154,7 +156,7 @@ const builderOptions = {
     target: [
       {
         target: "dmg",
-        arch: ["x64"],
+        arch: [isArm64 ? "arm64" : "x64"],
       },
     ],
   },


### PR DESCRIPTION
## 内容
GitHub Actionにdarwin-arm64ビルドを追加しました。
このPRのリリースは次のリンクでご覧いただけます: https://github.com/nix6839/voicevox/releases/tag/0.20.0-nix6839-macos-arm64.1
~~このPRのリリースは次のリンクでご覧いただけます: https://github.com/nix6839/voicevox/releases/tag/0.20.0-nix6839-macos-arm64~~

## 関連 Issue
close: #348
~~VOICEVOXをApple Silicon macOSでネイティブに動作させるという根本的な目的は達成しましたし、Universal2アプリをリリースするには大変な労力がかかると予想されるため、このイシューをクローズしても良いと思います。どう思いますか？~~

## その他
~~すべて完成しましたが、voicevox_engineが0.20.0をリリースするのを待たなければならないので、今はドラフトです。~~

### 他のコミットに関する説明
- [アクションのmacOSビルドでアドホック署名](https://github.com/VOICEVOX/voicevox/commit/900f0032d95b78494f244a23c4d7eaf1ed9d26f1):
	Apple Siliconでネイティブに動作するアプリはコード署名がないと動作しないため、アドホック署名を追加しました。
- [macOSの.appファイルが正しい構造を持つように修正](https://github.com/VOICEVOX/voicevox/commit/030b772f6d549aeebac0a94bbac1a0330b28b39b):
	次の部分を修正しました
	> Contents/MacOSフォルダには実行ファイルのみが存在するべきですが、
その他のファイルも含まれていたため、正しい構造ではなく、
コード署名が失敗しました。
- [preview](https://github.com/VOICEVOX/voicevox/commit/b7705fb19c45dc440e9d700203afb67059320de3):
	これは一時的にビルドを動作させるためのコミットです。後で削除する予定です。