### PR TITLE
Refactor: v-for1つでノートを描画する形に変更し、ダブルクリック判定処理を無くす

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -47,6 +47,7 @@
           : notes"
         :key="note.id"
         :note
+        :nowPreviewing
         :previewLyric="previewLyrics.get(note.id) || null"
         @barMousedown="onNoteBarMouseDown($event, note)"
         @barDoubleClick="onNoteBarDoubleClick($event, note)"

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -1313,79 +1313,81 @@ registerHotkeyWithCleanup({
 
 const contextMenu = ref<InstanceType<typeof ContextMenu>>();
 
-const contextMenuData = ref<ContextMenuItemData[]>([
-  {
-    type: "button",
-    label: "コピー",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+const contextMenuData = computed<ContextMenuItemData[]>(() => {
+  return [
+    {
+      type: "button",
+      label: "コピー",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+      },
+      disabled: !isNoteSelected.value,
+      disableWhenUiLocked: true,
     },
-    disabled: !isNoteSelected.value,
-    disableWhenUiLocked: true,
-  },
-  {
-    type: "button",
-    label: "切り取り",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+    {
+      type: "button",
+      label: "切り取り",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+      },
+      disabled: !isNoteSelected.value,
+      disableWhenUiLocked: true,
     },
-    disabled: !isNoteSelected.value,
-    disableWhenUiLocked: true,
-  },
-  {
-    type: "button",
-    label: "貼り付け",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COMMAND_PASTE_NOTES_FROM_CLIPBOARD");
+    {
+      type: "button",
+      label: "貼り付け",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COMMAND_PASTE_NOTES_FROM_CLIPBOARD");
+      },
+      disableWhenUiLocked: true,
     },
-    disableWhenUiLocked: true,
-  },
-  { type: "separator" },
-  {
-    type: "button",
-    label: "すべて選択",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("SELECT_ALL_NOTES");
+    { type: "separator" },
+    {
+      type: "button",
+      label: "すべて選択",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("SELECT_ALL_NOTES");
+      },
+      disableWhenUiLocked: true,
     },
-    disableWhenUiLocked: true,
-  },
-  {
-    type: "button",
-    label: "選択解除",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("DESELECT_ALL_NOTES");
+    {
+      type: "button",
+      label: "選択解除",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("DESELECT_ALL_NOTES");
+      },
+      disabled: !isNoteSelected.value,
+      disableWhenUiLocked: true,
     },
-    disabled: !isNoteSelected.value,
-    disableWhenUiLocked: true,
-  },
-  { type: "separator" },
-  {
-    type: "button",
-    label: "クオンタイズ",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
+    { type: "separator" },
+    {
+      type: "button",
+      label: "クオンタイズ",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
+      },
+      disabled: !isNoteSelected.value,
+      disableWhenUiLocked: true,
     },
-    disabled: !isNoteSelected.value,
-    disableWhenUiLocked: true,
-  },
-  { type: "separator" },
-  {
-    type: "button",
-    label: "削除",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
+    { type: "separator" },
+    {
+      type: "button",
+      label: "削除",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
+      },
+      disabled: !isNoteSelected.value,
+      disableWhenUiLocked: true,
     },
-    disabled: !isNoteSelected.value,
-    disableWhenUiLocked: true,
-  },
-]);
+  ];
+});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -220,9 +220,30 @@ const notesIncludingPreviewNotes = computed(() => {
     const previewNoteIds = new Set(previewNotes.value.map((value) => value.id));
     return previewNotes.value
       .concat(notes.value.filter((value) => !previewNoteIds.has(value.id)))
-      .sort((a, b) => a.position - b.position);
+      .sort((a, b) => {
+        const aIsSelectedOrPreview =
+          state.selectedNoteIds.has(a.id) || previewNoteIds.has(a.id);
+        const bIsSelectedOrPreview =
+          state.selectedNoteIds.has(b.id) || previewNoteIds.has(b.id);
+        if (aIsSelectedOrPreview === bIsSelectedOrPreview) {
+          return a.position - b.position;
+        } else {
+          // 「プレビュー中か選択中のノート」が「選択されていないノート」より
+          // 手前に表示されるようにする
+          return aIsSelectedOrPreview ? 1 : -1;
+        }
+      });
   } else {
-    return notes.value;
+    return [...notes.value].sort((a, b) => {
+      const aIsSelected = state.selectedNoteIds.has(a.id);
+      const bIsSelected = state.selectedNoteIds.has(b.id);
+      if (aIsSelected === bIsSelected) {
+        return a.position - b.position;
+      } else {
+        // 「選択中のノート」が「選択されていないノート」より手前に表示されるようにする
+        return aIsSelected ? 1 : -1;
+      }
+    });
   }
 });
 

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -52,7 +52,6 @@
         @barMousedown="onNoteBarMouseDown($event, note)"
         @leftEdgeMousedown="onNoteLeftEdgeMouseDown($event, note)"
         @rightEdgeMousedown="onNoteRightEdgeMouseDown($event, note)"
-        @lyricMouseDown="onNoteLyricMouseDown($event, note)"
         @lyricInput="onNoteLyricInput($event, note)"
         @lyricBlur="onNoteLyricBlur()"
       />
@@ -67,7 +66,6 @@
         @barMousedown="onNoteBarMouseDown($event, note)"
         @leftEdgeMousedown="onNoteLeftEdgeMouseDown($event, note)"
         @rightEdgeMousedown="onNoteRightEdgeMouseDown($event, note)"
-        @lyricMouseDown="onNoteLyricMouseDown($event, note)"
         @lyricInput="onNoteLyricInput($event, note)"
         @lyricBlur="onNoteLyricBlur()"
       />
@@ -890,21 +888,6 @@ const onNoteRightEdgeMouseDown = (event: MouseEvent, note: Note) => {
   if (mouseButton === "LEFT_BUTTON") {
     startPreview(event, "RESIZE_NOTE_RIGHT", note);
   } else if (!state.selectedNoteIds.has(note.id)) {
-    selectOnlyThis(note);
-  }
-};
-
-const onNoteLyricMouseDown = (event: MouseEvent, note: Note) => {
-  if (editTarget.value !== "NOTE" || !isSelfEventTarget(event)) {
-    return;
-  }
-  const mouseButton = getButton(event);
-  // ダブルクリック用の処理を行う
-  if (mouseButton === "LEFT_BUTTON") {
-    mouseDownAreaInfo = new NoteAreaInfo(note.id);
-  }
-
-  if (!state.selectedNoteIds.has(note.id)) {
     selectOnlyThis(note);
   }
 };

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -41,28 +41,14 @@
           transform: `translateX(${guideLineX}px)`,
         }"
       ></div>
-      <!-- TODO: 1つのv-forで全てのノートを描画できるようにする -->
       <!-- undefinedだと警告が出るのでnullを渡す -->
       <SequencerNote
-        v-for="note in unselectedNotes"
+        v-for="note in editTarget === 'NOTE'
+          ? notesIncludingPreviewNotes
+          : notes"
         :key="note.id"
         :note
         :previewLyric="previewLyrics.get(note.id) || null"
-        :isSelected="false"
-        @barMousedown="onNoteBarMouseDown($event, note)"
-        @leftEdgeMousedown="onNoteLeftEdgeMouseDown($event, note)"
-        @rightEdgeMousedown="onNoteRightEdgeMouseDown($event, note)"
-        @lyricInput="onNoteLyricInput($event, note)"
-        @lyricBlur="onNoteLyricBlur()"
-      />
-      <SequencerNote
-        v-for="note in editTarget === 'NOTE' && nowPreviewing
-          ? previewNotes
-          : selectedNotes"
-        :key="note.id"
-        :note
-        :previewLyric="previewLyrics.get(note.id) || null"
-        :isSelected="true"
         @barMousedown="onNoteBarMouseDown($event, note)"
         @leftEdgeMousedown="onNoteLeftEdgeMouseDown($event, note)"
         @rightEdgeMousedown="onNoteRightEdgeMouseDown($event, note)"
@@ -227,13 +213,19 @@ const notes = computed(() => store.getters.SELECTED_TRACK.notes);
 const isNoteSelected = computed(() => {
   return state.selectedNoteIds.size > 0;
 });
-const unselectedNotes = computed(() => {
-  const selectedNoteIds = state.selectedNoteIds;
-  return notes.value.filter((value) => !selectedNoteIds.has(value.id));
-});
 const selectedNotes = computed(() => {
   const selectedNoteIds = state.selectedNoteIds;
   return notes.value.filter((value) => selectedNoteIds.has(value.id));
+});
+const notesIncludingPreviewNotes = computed(() => {
+  if (nowPreviewing.value) {
+    const previewNoteIds = new Set(previewNotes.value.map((value) => value.id));
+    return previewNotes.value
+      .concat(notes.value.filter((value) => !previewNoteIds.has(value.id)))
+      .sort((a, b) => a.position - b.position);
+  } else {
+    return notes.value;
+  }
 });
 
 // 矩形選択

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -60,7 +60,7 @@
         v-if="editingLyricNote != undefined"
         :editingLyricNote
         @lyricInput="onLyricInput"
-        @lyricComfirmed="onLyricComfirmed"
+        @lyricConfirmed="onLyricConfirmed"
       />
     </div>
     <SequencerPitch
@@ -323,7 +323,7 @@ const onLyricInput = (text: string, note: Note) => {
   splitAndUpdatePreview(text, note);
 };
 
-const onLyricComfirmed = (nextNoteId: NoteId | undefined) => {
+const onLyricConfirmed = (nextNoteId: NoteId | undefined) => {
   commitPreviewLyrics();
   store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: nextNoteId });
 };

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -336,7 +336,9 @@ let previewRequestId = 0;
 let previewStartEditTarget: SequencerEditTarget = "NOTE";
 let executePreviewProcess = false;
 // ノート編集のプレビュー
+// プレビュー中に更新（移動やリサイズ等）されるノーツ
 const previewNotes = ref<Note[]>([]);
+// プレビュー中に変更されない（プレビュー前の状態を保持する）ノーツ
 const copiedNotesForPreview = new Map<NoteId, Note>();
 const previewNoteIds = computed(() => {
   return new Set(nowPreviewing.value ? copiedNotesForPreview.keys() : []);

--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -47,6 +47,10 @@ const positionY = computed(() => {
 const lyricInput = ref<HTMLInputElement | null>(null);
 
 const onLyricInputKeyDown = (event: KeyboardEvent) => {
+  // IME変換中のキー入力を無視する
+  if (event.isComposing) {
+    return;
+  }
   // タブキーで次のノート入力に移動
   if (event.key === "Tab") {
     event.preventDefault();
@@ -67,12 +71,8 @@ const onLyricInputKeyDown = (event: KeyboardEvent) => {
     const nextNoteId = notes[index + (event.shiftKey ? -1 : 1)].id;
     emit("lyricConfirmed", nextNoteId);
   }
-  // IME変換確定時のEnterを無視する
-  if (event.key === "Enter" && event.isComposing) {
-    return;
-  }
-  // IME変換でなければ入力を確定
-  if (event.key === "Enter" && !event.isComposing) {
+  // Enterキーで入力を確定
+  if (event.key === "Enter") {
     emit("lyricConfirmed", undefined);
   }
 };
@@ -96,7 +96,7 @@ watch(
       lyricInput.value?.select();
     });
   },
-  { immediate: true }
+  { immediate: true },
 );
 </script>
 

--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -2,7 +2,6 @@
   <!-- TODO: ピッチの上に歌詞入力のinputが表示されるようにする -->
   <input
     ref="lyricInput"
-    v-focus
     :value="editingLyricNote.lyric"
     class="lyric-input"
     :style="{
@@ -17,17 +16,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useStore } from "@/store";
 import { tickToBaseX, noteNumberToBaseY } from "@/sing/viewHelper";
 import { NoteId } from "@/type/preload";
 import { Note } from "@/store/type";
-
-const vFocus = {
-  mounted(el: HTMLInputElement) {
-    el.focus();
-  },
-};
 
 const props = defineProps<{
   editingLyricNote: Note;
@@ -95,17 +88,15 @@ const onLyricInput = (event: Event) => {
   emit("lyricInput", event.target.value, props.editingLyricNote);
 };
 
-onMounted(() => {
-  lyricInput.value?.select();
-});
-
 watch(
   () => props.editingLyricNote,
   () => {
     nextTick(() => {
+      lyricInput.value?.focus();
       lyricInput.value?.select();
     });
   },
+  { immediate: true }
 );
 </script>
 

--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -35,7 +35,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (name: "lyricInput", text: string, note: Note): void;
-  (name: "lyricComfirmed", nextNoteId: NoteId | undefined): void;
+  (name: "lyricConfirmed", nextNoteId: NoteId | undefined): void;
 }>();
 
 const store = useStore();
@@ -72,7 +72,7 @@ const onLyricInputKeyDown = (event: KeyboardEvent) => {
       return;
     }
     const nextNoteId = notes[index + (event.shiftKey ? -1 : 1)].id;
-    emit("lyricComfirmed", nextNoteId);
+    emit("lyricConfirmed", nextNoteId);
   }
   // IME変換確定時のEnterを無視する
   if (event.key === "Enter" && event.isComposing) {
@@ -80,12 +80,12 @@ const onLyricInputKeyDown = (event: KeyboardEvent) => {
   }
   // IME変換でなければ入力を確定
   if (event.key === "Enter" && !event.isComposing) {
-    emit("lyricComfirmed", undefined);
+    emit("lyricConfirmed", undefined);
   }
 };
 
 const onLyricInputBlur = () => {
-  emit("lyricComfirmed", undefined);
+  emit("lyricConfirmed", undefined);
 };
 
 const onLyricInput = (event: Event) => {

--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -1,0 +1,127 @@
+<template>
+  <!-- TODO: ピッチの上に歌詞入力のinputが表示されるようにする -->
+  <input
+    ref="lyricInput"
+    v-focus
+    :value="editingLyricNote.lyric"
+    class="lyric-input"
+    :style="{
+      transform: `translate3d(${positionX}px,${positionY}px,0)`,
+    }"
+    @input="onLyricInput"
+    @mousedown.stop
+    @dblclick.stop
+    @keydown.stop="onLyricInputKeyDown"
+    @blur="onLyricInputBlur"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { useStore } from "@/store";
+import { tickToBaseX, noteNumberToBaseY } from "@/sing/viewHelper";
+import { NoteId } from "@/type/preload";
+import { Note } from "@/store/type";
+
+const vFocus = {
+  mounted(el: HTMLInputElement) {
+    el.focus();
+  },
+};
+
+const props = defineProps<{
+  editingLyricNote: Note;
+}>();
+
+const emit = defineEmits<{
+  (name: "lyricInput", text: string, note: Note): void;
+  (name: "lyricComfirmed", nextNoteId: NoteId | undefined): void;
+}>();
+
+const store = useStore();
+const state = store.state;
+
+const zoomX = computed(() => state.sequencerZoomX);
+const zoomY = computed(() => state.sequencerZoomY);
+const positionX = computed(() => {
+  const noteStartTicks = props.editingLyricNote.position;
+  return tickToBaseX(noteStartTicks, state.tpqn) * zoomX.value;
+});
+const positionY = computed(() => {
+  const noteNumber = props.editingLyricNote.noteNumber;
+  return noteNumberToBaseY(noteNumber + 0.5) * zoomY.value;
+});
+const lyricInput = ref<HTMLInputElement | null>(null);
+
+const onLyricInputKeyDown = (event: KeyboardEvent) => {
+  // タブキーで次のノート入力に移動
+  if (event.key === "Tab") {
+    event.preventDefault();
+    const editingLyricNoteId = props.editingLyricNote.id;
+    const notes = store.getters.SELECTED_TRACK.notes;
+    const index = notes.findIndex((value) => {
+      return value.id === editingLyricNoteId;
+    });
+    if (index === -1) {
+      return;
+    }
+    if (event.shiftKey && index - 1 < 0) {
+      return;
+    }
+    if (!event.shiftKey && index + 1 >= notes.length) {
+      return;
+    }
+    const nextNoteId = notes[index + (event.shiftKey ? -1 : 1)].id;
+    emit("lyricComfirmed", nextNoteId);
+  }
+  // IME変換確定時のEnterを無視する
+  if (event.key === "Enter" && event.isComposing) {
+    return;
+  }
+  // IME変換でなければ入力を確定
+  if (event.key === "Enter" && !event.isComposing) {
+    emit("lyricComfirmed", undefined);
+  }
+};
+
+const onLyricInputBlur = () => {
+  emit("lyricComfirmed", undefined);
+};
+
+const onLyricInput = (event: Event) => {
+  if (!(event.target instanceof HTMLInputElement)) {
+    throw new Error("Invalid event target");
+  }
+  emit("lyricInput", event.target.value, props.editingLyricNote);
+};
+
+onMounted(() => {
+  lyricInput.value?.select();
+});
+
+watch(
+  () => props.editingLyricNote,
+  () => {
+    nextTick(() => {
+      lyricInput.value?.select();
+    });
+  },
+);
+</script>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as vars;
+@use "@/styles/colors" as colors;
+
+.lyric-input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-weight: 700;
+  min-width: 3rem;
+  max-width: 6rem;
+  border: 0;
+  outline: 2px solid lab(80, -22.953, 14.365);
+  border-radius: 4px;
+}
+</style>

--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -28,6 +28,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (name: "lyricInput", text: string, note: Note): void;
+  /** 歌詞が確定したときに呼ばれる。次に歌詞入力を開始すべきノートIDを返す。 */
   (name: "lyricConfirmed", nextNoteId: NoteId | undefined): void;
 }>();
 

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -54,11 +54,7 @@
       @blur="onLyricInputBlur"
     />
     <template v-else>
-      <div
-        class="note-lyric"
-        data-testid="note-lyric"
-        @mousedown="onLyricMouseDown"
-      >
+      <div class="note-lyric" data-testid="note-lyric">
         {{ lyricToDisplay }}
       </div>
       <!-- エラー内容を表示 -->
@@ -123,7 +119,6 @@ const emit = defineEmits<{
   (name: "barMousedown", event: MouseEvent): void;
   (name: "rightEdgeMousedown", event: MouseEvent): void;
   (name: "leftEdgeMousedown", event: MouseEvent): void;
-  (name: "lyricMouseDown", event: MouseEvent): void;
   (name: "lyricInput", text: string): void;
   (name: "lyricBlur"): void;
 }>();
@@ -240,10 +235,6 @@ const onRightEdgeMouseDown = (event: MouseEvent) => {
 
 const onLeftEdgeMouseDown = (event: MouseEvent) => {
   emit("leftEdgeMousedown", event);
-};
-
-const onLyricMouseDown = (event: MouseEvent) => {
-  emit("lyricMouseDown", event);
 };
 
 const onLyricInputKeyDown = (event: KeyboardEvent) => {

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -2,7 +2,7 @@
   <div
     class="note"
     :class="{
-      selected: noteState === 'SELECTED',
+      selected: isSelected,
       'preview-lyric': props.previewLyric != undefined,
       overlapping: hasOverlappingError,
       'invalid-phrase': hasPhraseError,
@@ -95,8 +95,6 @@ import ContextMenu, {
   ContextMenuItemData,
 } from "@/components/Menu/ContextMenu.vue";
 
-type NoteState = "NORMAL" | "SELECTED";
-
 const vFocus = {
   mounted(el: HTMLInputElement) {
     el.focus();
@@ -104,16 +102,10 @@ const vFocus = {
   },
 };
 
-const props = withDefaults(
-  defineProps<{
-    note: Note;
-    isSelected: boolean;
-    previewLyric: string | null;
-  }>(),
-  {
-    isSelected: false,
-  },
-);
+const props = defineProps<{
+  note: Note;
+  previewLyric: string | null;
+}>();
 
 const emit = defineEmits<{
   (name: "barMousedown", event: MouseEvent): void;
@@ -144,11 +136,9 @@ const width = computed(() => {
   const noteEndBaseX = tickToBaseX(noteEndTicks, tpqn.value);
   return (noteEndBaseX - noteStartBaseX) * zoomX.value;
 });
-const noteState = computed((): NoteState => {
-  if (props.isSelected) {
-    return "SELECTED";
-  }
-  return "NORMAL";
+const isSelected = computed(() => {
+  const noteId = props.note.id;
+  return state.selectedNoteIds.has(noteId);
 });
 const editTargetIsNote = computed(() => {
   return state.sequencerEditTarget === "NOTE";
@@ -206,7 +196,7 @@ const contextMenuData = ref<ContextMenuItemData[]>([
   {
     type: "button",
     label: "クオンタイズ",
-    disabled: !props.isSelected,
+    disabled: !isSelected.value,
     onClick: async () => {
       contextMenu.value?.hide();
       await store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -105,6 +105,7 @@ const vFocus = {
 
 const props = defineProps<{
   note: Note;
+  nowPreviewing: boolean;
   previewLyric: string | null;
 }>();
 
@@ -180,6 +181,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
     {
       type: "button",
       label: "コピー",
+      disabled: props.nowPreviewing,
       onClick: async () => {
         contextMenu.value?.hide();
         await store.dispatch("COPY_NOTES_TO_CLIPBOARD");
@@ -189,6 +191,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
     {
       type: "button",
       label: "切り取り",
+      disabled: props.nowPreviewing,
       onClick: async () => {
         contextMenu.value?.hide();
         await store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
@@ -199,7 +202,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
     {
       type: "button",
       label: "クオンタイズ",
-      disabled: !isSelected.value,
+      disabled: props.nowPreviewing || !isSelected.value,
       onClick: async () => {
         contextMenu.value?.hide();
         await store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
@@ -210,6 +213,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
     {
       type: "button",
       label: "削除",
+      disabled: props.nowPreviewing,
       onClick: async () => {
         contextMenu.value?.hide();
         await store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -173,47 +173,49 @@ const showLyricInput = computed(() => {
   return state.editingLyricNoteId === props.note.id;
 });
 const contextMenu = ref<InstanceType<typeof ContextMenu>>();
-const contextMenuData = ref<ContextMenuItemData[]>([
-  {
-    type: "button",
-    label: "コピー",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+const contextMenuData = computed<ContextMenuItemData[]>(() => {
+  return [
+    {
+      type: "button",
+      label: "コピー",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+      },
+      disableWhenUiLocked: true,
     },
-    disableWhenUiLocked: true,
-  },
-  {
-    type: "button",
-    label: "切り取り",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+    {
+      type: "button",
+      label: "切り取り",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+      },
+      disableWhenUiLocked: true,
     },
-    disableWhenUiLocked: true,
-  },
-  { type: "separator" },
-  {
-    type: "button",
-    label: "クオンタイズ",
-    disabled: !isSelected.value,
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
+    { type: "separator" },
+    {
+      type: "button",
+      label: "クオンタイズ",
+      disabled: !isSelected.value,
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
+      },
+      disableWhenUiLocked: true,
     },
-    disableWhenUiLocked: true,
-  },
-  { type: "separator" },
-  {
-    type: "button",
-    label: "削除",
-    onClick: async () => {
-      contextMenu.value?.hide();
-      await store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
+    { type: "separator" },
+    {
+      type: "button",
+      label: "削除",
+      onClick: async () => {
+        contextMenu.value?.hide();
+        await store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
+      },
+      disableWhenUiLocked: true,
     },
-    disableWhenUiLocked: true,
-  },
-]);
+  ];
+});
 
 const onBarMouseDown = (event: MouseEvent) => {
   emit("barMousedown", event);

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -20,6 +20,7 @@
         'cursor-move': editTargetIsNote,
       }"
       @mousedown="onBarMouseDown"
+      @dblclick="onBarDoubleClick"
     >
       <div
         class="note-left-edge"
@@ -109,6 +110,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (name: "barMousedown", event: MouseEvent): void;
+  (name: "barDoubleClick", event: MouseEvent): void;
   (name: "rightEdgeMousedown", event: MouseEvent): void;
   (name: "leftEdgeMousedown", event: MouseEvent): void;
   (name: "lyricInput", text: string): void;
@@ -219,6 +221,10 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
 
 const onBarMouseDown = (event: MouseEvent) => {
   emit("barMousedown", event);
+};
+
+const onBarDoubleClick = (event: MouseEvent) => {
+  emit("barDoubleClick", event);
 };
 
 const onRightEdgeMouseDown = (event: MouseEvent) => {

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -2,8 +2,8 @@
   <div
     class="note"
     :class="{
-      selected: isSelected,
-      'preview-lyric': props.previewLyric != undefined,
+      'selected-or-preview': isSelected || isPreview,
+      'preview-lyric': previewLyric != undefined,
       overlapping: hasOverlappingError,
       'invalid-phrase': hasPhraseError,
       'below-pitch': editTargetIsPitch,
@@ -42,44 +42,30 @@
         :menudata="contextMenuData"
       />
     </div>
-    <!-- TODO: ピッチの上に歌詞入力のinputが表示されるようにする -->
-    <input
-      v-if="showLyricInput"
-      v-focus
-      :value="lyricToDisplay"
-      class="note-lyric-input"
-      @input="onLyricInput"
-      @mousedown.stop
-      @dblclick.stop
-      @keydown.stop="onLyricInputKeyDown"
-      @blur="onLyricInputBlur"
-    />
-    <template v-else>
-      <div class="note-lyric" data-testid="note-lyric">
-        {{ lyricToDisplay }}
-      </div>
-      <!-- エラー内容を表示 -->
-      <QTooltip
-        v-if="hasOverlappingError"
-        anchor="bottom left"
-        self="top left"
-        :offset="[0, 8]"
-        transitionShow=""
-        transitionHide=""
-      >
-        ノートが重なっています
-      </QTooltip>
-      <QTooltip
-        v-if="hasPhraseError"
-        anchor="bottom left"
-        self="top left"
-        :offset="[0, 8]"
-        transitionShow=""
-        transitionHide=""
-      >
-        フレーズが生成できません。歌詞は日本語1文字までです。
-      </QTooltip>
-    </template>
+    <div class="note-lyric" data-testid="note-lyric">
+      {{ lyricToDisplay }}
+    </div>
+    <!-- エラー内容を表示 -->
+    <QTooltip
+      v-if="hasOverlappingError"
+      anchor="bottom left"
+      self="top left"
+      :offset="[0, 8]"
+      transitionShow=""
+      transitionHide=""
+    >
+      ノートが重なっています
+    </QTooltip>
+    <QTooltip
+      v-if="hasPhraseError"
+      anchor="bottom left"
+      self="top left"
+      :offset="[0, 8]"
+      transitionShow=""
+      transitionHide=""
+    >
+      フレーズが生成できません。歌詞は日本語1文字までです。
+    </QTooltip>
   </div>
 </template>
 
@@ -96,16 +82,11 @@ import ContextMenu, {
   ContextMenuItemData,
 } from "@/components/Menu/ContextMenu.vue";
 
-const vFocus = {
-  mounted(el: HTMLInputElement) {
-    el.focus();
-    el.select();
-  },
-};
-
 const props = defineProps<{
   note: Note;
   nowPreviewing: boolean;
+  isSelected: boolean;
+  isPreview: boolean;
   previewLyric: string | null;
 }>();
 
@@ -114,8 +95,6 @@ const emit = defineEmits<{
   (name: "barDoubleClick", event: MouseEvent): void;
   (name: "rightEdgeMousedown", event: MouseEvent): void;
   (name: "leftEdgeMousedown", event: MouseEvent): void;
-  (name: "lyricInput", text: string): void;
-  (name: "lyricBlur"): void;
 }>();
 
 const store = useStore();
@@ -138,10 +117,6 @@ const width = computed(() => {
   const noteStartBaseX = tickToBaseX(noteStartTicks, tpqn.value);
   const noteEndBaseX = tickToBaseX(noteEndTicks, tpqn.value);
   return (noteEndBaseX - noteStartBaseX) * zoomX.value;
-});
-const isSelected = computed(() => {
-  const noteId = props.note.id;
-  return state.selectedNoteIds.has(noteId);
 });
 const editTargetIsNote = computed(() => {
   return state.sequencerEditTarget === "NOTE";
@@ -166,15 +141,11 @@ const hasPhraseError = computed(() => {
 });
 
 // 表示する歌詞。
-// 優先度：入力中の歌詞 > 他ノートの入力中の歌詞 > 渡された（=Storeの）歌詞
-const lyricToDisplay = computed(
-  () => temporaryLyric.value ?? props.previewLyric ?? props.note.lyric,
-);
-// 歌詞入力中の一時的な歌詞
-const temporaryLyric = ref<string | undefined>(undefined);
-const showLyricInput = computed(() => {
-  return state.editingLyricNoteId === props.note.id;
+// 優先度：入力中の歌詞 > 渡された（=Storeの）歌詞
+const lyricToDisplay = computed(() => {
+  return props.previewLyric ?? props.note.lyric;
 });
+
 const contextMenu = ref<InstanceType<typeof ContextMenu>>();
 const contextMenuData = computed<ContextMenuItemData[]>(() => {
   return [
@@ -202,7 +173,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
     {
       type: "button",
       label: "クオンタイズ",
-      disabled: props.nowPreviewing || !isSelected.value,
+      disabled: props.nowPreviewing || !props.isSelected,
       onClick: async () => {
         contextMenu.value?.hide();
         await store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
@@ -238,50 +209,6 @@ const onRightEdgeMouseDown = (event: MouseEvent) => {
 const onLeftEdgeMouseDown = (event: MouseEvent) => {
   emit("leftEdgeMousedown", event);
 };
-
-const onLyricInputKeyDown = (event: KeyboardEvent) => {
-  // タブキーで次のノート入力に移動
-  if (event.key === "Tab") {
-    event.preventDefault();
-    const noteId = props.note.id;
-    const notes = store.getters.SELECTED_TRACK.notes;
-    const index = notes.findIndex((value) => value.id === noteId);
-    if (index === -1) {
-      return;
-    }
-    if (event.shiftKey && index - 1 < 0) {
-      return;
-    }
-    if (!event.shiftKey && index + 1 >= notes.length) {
-      return;
-    }
-    const nextNoteId = notes[index + (event.shiftKey ? -1 : 1)].id;
-    store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: nextNoteId });
-  }
-  // IME変換確定時のEnterを無視する
-  if (event.key === "Enter" && event.isComposing) {
-    return;
-  }
-  // IME変換でなければ入力モードを終了
-  if (event.key === "Enter" && !event.isComposing) {
-    store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: undefined });
-  }
-};
-
-const onLyricInputBlur = () => {
-  if (state.editingLyricNoteId === props.note.id) {
-    store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: undefined });
-  }
-  temporaryLyric.value = undefined;
-  emit("lyricBlur");
-};
-const onLyricInput = (event: Event) => {
-  if (!(event.target instanceof HTMLInputElement)) {
-    throw new Error("Invalid event target");
-  }
-  temporaryLyric.value = event.target.value;
-  emit("lyricInput", temporaryLyric.value);
-};
 </script>
 
 <style scoped lang="scss">
@@ -311,7 +238,7 @@ const onLyricInput = (event: Event) => {
       background-color: lab(80, -22.953, 14.365);
     }
 
-    &.selected {
+    &.selected-or-preview {
       // 色は仮
       .note-bar {
         background-color: lab(95, -22.953, 14.365);
@@ -349,7 +276,7 @@ const onLyricInput = (event: Event) => {
       opacity: 0.6;
     }
 
-    &.selected {
+    &.selected-or-preview {
       .note-bar {
         background-color: rgba(colors.$warning-rgb, 0.5);
         border-color: colors.$warning;

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -331,17 +331,6 @@ const onLeftEdgeMouseDown = (event: MouseEvent) => {
   height: 100%;
 }
 
-.note-lyric-input {
-  position: absolute;
-  bottom: 0;
-  font-weight: 700;
-  min-width: 3rem;
-  max-width: 6rem;
-  border: 0;
-  outline: 2px solid lab(80, -22.953, 14.365);
-  border-radius: 4px;
-}
-
 .cursor-move {
   cursor: move;
 }

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -84,8 +84,11 @@ import ContextMenu, {
 
 const props = defineProps<{
   note: Note;
+  /** どれかのノートがプレビュー中 */
   nowPreviewing: boolean;
+  /** このノートが選択中か */
   isSelected: boolean;
+  /** このノートがプレビュー中か */
   isPreview: boolean;
   previewLyric: string | null;
 }>();

--- a/src/sing/viewHelper.ts
+++ b/src/sing/viewHelper.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { StyleInfo, isMac, NoteId } from "@/type/preload";
+import { StyleInfo, isMac } from "@/type/preload";
 import { calculateHash } from "@/sing/utility";
 
 const BASE_X_PER_QUARTER_NOTE = 120;
@@ -119,68 +119,6 @@ export const getStyleDescription = (style: StyleInfo) => {
   }
   return description.join("・");
 };
-
-interface AreaInfo {
-  readonly id: string;
-}
-
-type ClickInfo<T extends AreaInfo> = {
-  readonly clickCount: number;
-  readonly areaInfo: T;
-};
-
-type DoubleClickInfo<T extends AreaInfo> = {
-  readonly clickInfos: [ClickInfo<T>, ClickInfo<T>];
-};
-
-export class DoubleClickDetector<T extends AreaInfo> {
-  private clickInfos: ClickInfo<T>[] = [];
-
-  recordClick(clickCount: number, areaInfo: T) {
-    if (clickCount === 1) {
-      this.clickInfos = [];
-    }
-    this.clickInfos.push({ clickCount, areaInfo });
-  }
-
-  detect(): DoubleClickInfo<T> | undefined {
-    if (this.clickInfos.length < 2) {
-      return undefined;
-    }
-    const clickInfo1 = this.clickInfos[this.clickInfos.length - 2];
-    const clickInfo2 = this.clickInfos[this.clickInfos.length - 1];
-    if (
-      clickInfo1.clickCount === 1 &&
-      clickInfo2.clickCount === 2 &&
-      clickInfo1.areaInfo.id === clickInfo2.areaInfo.id
-    ) {
-      return { clickInfos: [clickInfo1, clickInfo2] };
-    }
-    return undefined;
-  }
-}
-
-export class NoteAreaInfo implements AreaInfo {
-  readonly type: "note";
-  readonly id: string;
-  readonly noteId: NoteId;
-
-  constructor(noteId: NoteId) {
-    this.type = "note";
-    this.id = `NOTE-${noteId}`;
-    this.noteId = noteId;
-  }
-}
-
-export class GridAreaInfo implements AreaInfo {
-  readonly type: "grid";
-  readonly id: string;
-
-  constructor() {
-    this.type = "grid";
-    this.id = "GRID";
-  }
-}
 
 export type PitchData = {
   readonly ticksArray: number[];

--- a/tests/e2e/browser/song/ソング.spec.ts
+++ b/tests/e2e/browser/song/ソング.spec.ts
@@ -79,7 +79,7 @@ test("ダブルクリックで歌詞を編集できる", async ({ page }) => {
 
   await sequencer.click({ position: { x: 107, y: 171 }, clickCount: 2 }); // ダブルクリック
 
-  await note.getByRole("textbox").fill("あ");
+  await sequencer.locator(".lyric-input").fill("あ");
   await page.keyboard.press("Enter");
   const afterLyric = await getCurrentNoteLyric(note);
   expect(afterLyric).not.toEqual(beforeLyric);


### PR DESCRIPTION
## 内容

v-for1つでノートを描画する形に変更し、ダブルクリック判定処理を無くします。

また、以下も行います。
- `onNoteLyricMouseDown`を削除する
- ScoreSequencerのcontextMenuDataがcomputedになっていなかったので修正
- 編集のプレビュー中はノートの右クリックメニューをdisableにする
- 歌詞入力をコンポーネント化する

## 関連 Issue

ref #2041

## その他

ノート編集時の動作が若干重くなってるかもです…