### PR TITLE
Change: RELOAD_URLで飛ばすページをabout:blankにする

### DIFF
--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -977,7 +977,8 @@ ipcMainHandle("VALIDATE_ENGINE_DIR", (_, { engineDir }) => {
 ipcMainHandle("RELOAD_APP", async (_, { isMultiEngineOffMode }) => {
   win.hide(); // FIXME: ダミーページ表示のほうが良い
 
-  win.reload();
+  // 一旦適当なURLに飛ばしてページをアンロードする
+  await win.loadURL("about:blank");
 
   log.info("Checking ENGINE status before reload app");
   const engineCleanupResult = cleanupEngines();

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -977,8 +977,7 @@ ipcMainHandle("VALIDATE_ENGINE_DIR", (_, { engineDir }) => {
 ipcMainHandle("RELOAD_APP", async (_, { isMultiEngineOffMode }) => {
   win.hide(); // FIXME: ダミーページ表示のほうが良い
 
-  // FIXME: 同じようなURLだとスーパーリロードされないことがあるので一度ダミーページを読み込む
-  await win.loadURL(firstUrl + "dummypage");
+  win.reload();
 
   log.info("Checking ENGINE status before reload app");
   const engineCleanupResult = cleanupEngines();


### PR DESCRIPTION
## 内容

RELOAD_URLで飛ばすページをabout:blankにします。

## 関連 Issue

（なし）

## スクリーンショット・動画など

文脈：こんな感じのエラーがでて再起動しなかったことがあるので
![image](https://github.com/VOICEVOX/voicevox/assets/59691627/01f08958-7246-4b1d-b394-0f4ac07f450f)

## その他

（なし）