### PR TITLE
シング側のポートレート位置を調整する

### DIFF
--- a/src/components/Sing/CharacterPortrait.vue
+++ b/src/components/Sing/CharacterPortrait.vue
@@ -33,24 +33,47 @@ const portraitPath = computed(() => {
 @use "@/styles/variables" as vars;
 @use "@/styles/colors" as colors;
 
+// 表示変数
+$headerMargin: 120px;
+$rightMargin: 24px;
+$portraitMaxWidth: 40vw;
+$portraitMaxHeight: 60vh;
+$portraitMinHeight: 500px;
+
 // 画面右下に固定表示
 // 幅固定、高さ可変、画像のアスペクト比を保持、wrapのwidthに合わせてheightを調整
 // bottom位置はスクロールバーの上に表示
 .character-portrait-wrap {
   opacity: 0.55;
-  overflow: hidden;
+  overflow: visible;
   contain: layout;
   pointer-events: none;
   position: fixed;
+  display: grid;
+  place-items: end;
   bottom: 0;
-  right: 88px;
-  min-width: 200px;
-  max-width: 20vw;
+  right: $rightMargin;
 }
 
 .character-portrait {
-  width: 100%;
-  height: auto;
+  width: auto;
+  height: $portraitMaxHeight;
+  min-height: $portraitMinHeight;
+  max-width: $portraitMaxWidth;
+  overflow: visible;
   backface-visibility: hidden;
+  object-fit: cover;
+  object-position: top center;
+}
+
+// ポートレートサイズが画面サイズを超えた場合、ヘッダーを考慮してポートレートを上部基準で表示させる
+// ヘッダー高さ120px+ポートレート高さ500pxだとする
+@media (max-height: #{calc(#{$portraitMinHeight} + #{$headerMargin})}) {
+  .character-portrait-wrap {
+    top: $headerMargin; // ヘッダーの高さより下に位置させる
+    bottom: auto;
+    height: calc(100vh - #{$headerMargin});
+    place-items: start end;
+  }
 }
 </style>

--- a/src/components/Sing/CharacterPortrait.vue
+++ b/src/components/Sing/CharacterPortrait.vue
@@ -34,11 +34,11 @@ const portraitPath = computed(() => {
 @use "@/styles/colors" as colors;
 
 // 表示変数
-$headerMargin: 120px;
-$rightMargin: 24px;
-$portraitMaxWidth: 40vw;
-$portraitMaxHeight: 60vh;
-$portraitMinHeight: 500px;
+$header-margin: vars.$toolbar-height + vars.$menubar-height + 30px; // 30pxはルーラーの高さ
+$right-margin: 24px;
+$portrait-max-width: 40vw;
+$portrait-max-height: 60vh;
+$portrait-min-height: 500px;
 
 // 画面右下に固定表示
 // 幅固定、高さ可変、画像のアスペクト比を保持、wrapのwidthに合わせてheightを調整
@@ -52,14 +52,14 @@ $portraitMinHeight: 500px;
   display: grid;
   place-items: end;
   bottom: 0;
-  right: $rightMargin;
+  right: $right-margin;
 }
 
 .character-portrait {
   width: auto;
-  height: $portraitMaxHeight;
-  min-height: $portraitMinHeight;
-  max-width: $portraitMaxWidth;
+  height: $portrait-max-height;
+  min-height: $portrait-min-height;
+  max-width: $portrait-max-width;
   overflow: visible;
   backface-visibility: hidden;
   object-fit: cover;
@@ -68,11 +68,11 @@ $portraitMinHeight: 500px;
 
 // ポートレートサイズが画面サイズを超えた場合、ヘッダーを考慮してポートレートを上部基準で表示させる
 // ヘッダー高さ120px+ポートレート高さ500pxだとする
-@media (max-height: #{calc(#{$portraitMinHeight} + #{$headerMargin})}) {
+@media (max-height: #{calc(#{$portrait-min-height} + #{$header-margin})}) {
   .character-portrait-wrap {
-    top: $headerMargin; // ヘッダーの高さより下に位置させる
+    top: $header-margin; // ヘッダーの高さより下に位置させる
     bottom: auto;
-    height: calc(100vh - #{$headerMargin});
+    height: calc(100vh - #{$header-margin});
     place-items: start end;
   }
 }


### PR DESCRIPTION
## 内容

シング側のポートレート位置を調整します

- ポートレート高さ以下の場合に表示位置を頭上基準(下が見切れる形)にする
- 常に画面一定サイズ(高さ60%)まで表示

## 関連 Issue

ref: #2058 

## スクリーンショット・動画など

一般
<img width="1728" alt="スクリーンショット 2024-06-19 9 12 22" src="https://github.com/VOICEVOX/voicevox/assets/9082140/e1f7eb90-4242-4dce-baec-2bcd25379fea">

4K程度
![スクリーンショット 2024-06-19 9 21 23](https://github.com/VOICEVOX/voicevox/assets/9082140/800beecb-1c52-4724-93cf-aa156e172c4d)

高さが狭い
<img width="1185" alt="スクリーンショット 2024-06-19 9 12 38" src="https://github.com/VOICEVOX/voicevox/assets/9082140/c72a75ad-9c16-477e-8722-966b3e116574">

とても小さい
<img width="351" alt="スクリーンショット 2024-06-19 9 15 47" src="https://github.com/VOICEVOX/voicevox/assets/9082140/f4c5b8b1-4525-46a9-a59f-fd53e638ddb2">

## その他
