### PR TITLE
Improve: ノートの重なり検出のアルゴリズムを変える

### DIFF
--- a/src/sing/storeHelper.ts
+++ b/src/sing/storeHelper.ts
@@ -38,97 +38,54 @@ export class FrequentlyUpdatedState<T> {
   }
 }
 
-type NoteInfo = {
-  startTicks: number;
-  endTicks: number;
-  overlappingNoteIds: Set<NoteId>;
-};
+export function getOverlappingNoteIds(notes: Note[]): Set<NoteId> {
+  const events: {
+    type: "start" | "end";
+    noteId: NoteId;
+    tick: number;
+  }[] = notes.flatMap((note) => [
+    {
+      type: "start",
+      noteId: note.id,
+      tick: note.position,
+    },
+    {
+      type: "end",
+      noteId: note.id,
+      tick: note.position + note.duration,
+    },
+  ]);
 
-export type OverlappingNoteInfos = Map<NoteId, NoteInfo>;
-
-export function addNotesToOverlappingNoteInfos(
-  overlappingNoteInfos: OverlappingNoteInfos,
-  notes: Note[],
-): void {
-  for (const note of notes) {
-    overlappingNoteInfos.set(note.id, {
-      startTicks: note.position,
-      endTicks: note.position + note.duration,
-      overlappingNoteIds: new Set(),
-    });
-  }
-  // TODO: 計算量がO(n^2)になっているので、区間木などを使用してO(nlogn)にする
-  for (const note of notes) {
-    const overlappingNoteIds = new Set<NoteId>();
-    for (const [noteId, noteInfo] of overlappingNoteInfos) {
-      if (noteId === note.id) {
-        continue;
-      }
-      if (noteInfo.startTicks >= note.position + note.duration) {
-        continue;
-      }
-      if (noteInfo.endTicks <= note.position) {
-        continue;
-      }
-      overlappingNoteIds.add(noteId);
+  // tickが同じ値の時はノート終了 -> ノート開始の順にソート
+  events.sort((a, b) => {
+    if (a.tick !== b.tick) {
+      return a.tick - b.tick;
     }
-
-    const noteId1 = note.id;
-    const noteInfo1 = overlappingNoteInfos.get(noteId1);
-    if (!noteInfo1) {
-      throw new Error("noteInfo1 is undefined.");
+    if (a.type === "start" && b.type === "end") {
+      return -1;
     }
-    for (const noteId2 of overlappingNoteIds) {
-      const noteInfo2 = overlappingNoteInfos.get(noteId2);
-      if (!noteInfo2) {
-        throw new Error("noteInfo2 is undefined.");
-      }
-      noteInfo2.overlappingNoteIds.add(noteId1);
-      noteInfo1.overlappingNoteIds.add(noteId2);
+    if (a.type === "end" && b.type === "start") {
+      return 1;
     }
-  }
-}
+    return 0;
+  });
 
-export function removeNotesFromOverlappingNoteInfos(
-  overlappingNoteInfos: OverlappingNoteInfos,
-  notes: Note[],
-): void {
-  for (const note of notes) {
-    const noteId1 = note.id;
-    const noteInfo1 = overlappingNoteInfos.get(noteId1);
-    if (!noteInfo1) {
-      throw new Error("noteInfo1 is undefined.");
-    }
-    for (const noteId2 of noteInfo1.overlappingNoteIds) {
-      const noteInfo2 = overlappingNoteInfos.get(noteId2);
-      if (!noteInfo2) {
-        throw new Error("noteInfo2 is undefined.");
-      }
-      noteInfo2.overlappingNoteIds.delete(noteId1);
-      noteInfo1.overlappingNoteIds.delete(noteId2);
-    }
-  }
-  for (const note of notes) {
-    overlappingNoteInfos.delete(note.id);
-  }
-}
-
-export function updateNotesOfOverlappingNoteInfos(
-  overlappingNoteInfos: OverlappingNoteInfos,
-  notes: Note[],
-): void {
-  removeNotesFromOverlappingNoteInfos(overlappingNoteInfos, notes);
-  addNotesToOverlappingNoteInfos(overlappingNoteInfos, notes);
-}
-
-export function getOverlappingNoteIds(
-  currentNoteInfos: OverlappingNoteInfos,
-): Set<NoteId> {
   const overlappingNoteIds = new Set<NoteId>();
-  for (const [noteId, noteInfo] of currentNoteInfos) {
-    if (noteInfo.overlappingNoteIds.size !== 0) {
-      overlappingNoteIds.add(noteId);
+  const currentNotes = new Set<NoteId>();
+
+  for (const event of events) {
+    if (event.type === "start") {
+      if (currentNotes.size === 1) {
+        overlappingNoteIds.add(currentNotes.values().next().value);
+        overlappingNoteIds.add(event.noteId);
+      } else if (currentNotes.size > 1) {
+        overlappingNoteIds.add(event.noteId);
+      }
+      currentNotes.add(event.noteId);
+    } else {
+      currentNotes.delete(event.noteId);
     }
   }
+
   return overlappingNoteIds;
 }

--- a/src/sing/storeHelper.ts
+++ b/src/sing/storeHelper.ts
@@ -62,10 +62,10 @@ export function getOverlappingNoteIds(notes: Note[]): Set<NoteId> {
       return a.tick - b.tick;
     }
     if (a.type === "start" && b.type === "end") {
-      return -1;
+      return 1;
     }
     if (a.type === "end" && b.type === "start") {
-      return 1;
+      return -1;
     }
     return 0;
   });

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -417,17 +417,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
     },
   },
 
-  UPDATE_OVERLAPPING_NOTE_IDS: {
-    mutation(state) {
-      state.overlappingNoteIds = getOverlappingNoteIds(
-        state.tracks[selectedTrackIndex].notes,
-      );
-    },
-    async action({ commit }) {
-      commit("UPDATE_OVERLAPPING_NOTE_IDS");
-    },
-  },
-
   SET_NOTES: {
     mutation(state, { notes }: { notes: Note[] }) {
       // TODO: マルチトラック対応
@@ -435,7 +424,9 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       state.editingLyricNoteId = undefined;
       state.selectedNoteIds.clear();
       state.tracks[selectedTrackIndex].notes = notes;
-      singingStore.mutations.UPDATE_OVERLAPPING_NOTE_IDS(state, undefined);
+      state.overlappingNoteIds = getOverlappingNoteIds(
+        state.tracks[selectedTrackIndex].notes,
+      );
     },
     async action({ commit, dispatch }, { notes }: { notes: Note[] }) {
       if (!isValidNotes(notes)) {
@@ -453,7 +444,9 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const newNotes = [...selectedTrack.notes, ...notes];
       newNotes.sort((a, b) => a.position - b.position);
       selectedTrack.notes = newNotes;
-      singingStore.mutations.UPDATE_OVERLAPPING_NOTE_IDS(state, undefined);
+      state.overlappingNoteIds = getOverlappingNoteIds(
+        state.tracks[selectedTrackIndex].notes,
+      );
     },
   },
 
@@ -467,7 +460,9 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       selectedTrack.notes = selectedTrack.notes
         .map((value) => notesMap.get(value.id) ?? value)
         .sort((a, b) => a.position - b.position);
-      singingStore.mutations.UPDATE_OVERLAPPING_NOTE_IDS(state, undefined);
+      state.overlappingNoteIds = getOverlappingNoteIds(
+        state.tracks[selectedTrackIndex].notes,
+      );
     },
   },
 
@@ -488,7 +483,9 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         return !noteIdsSet.has(value.id);
       });
 
-      singingStore.mutations.UPDATE_OVERLAPPING_NOTE_IDS(state, undefined);
+      state.overlappingNoteIds = getOverlappingNoteIds(
+        state.tracks[selectedTrackIndex].notes,
+      );
     },
   },
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -899,11 +899,6 @@ export type SingingStoreTypes = {
     getter: Set<NoteId>;
   };
 
-  UPDATE_OVERLAPPING_NOTE_IDS: {
-    mutation: undefined;
-    action(): void;
-  };
-
   SET_NOTES: {
     mutation: { notes: Note[] };
     action(payload: { notes: Note[] }): void;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -60,7 +60,6 @@ import {
   NotifyAndNotShowAgainButtonOption,
   LoadingScreenOption,
 } from "@/components/Dialog/Dialog";
-import { OverlappingNoteInfos } from "@/sing/storeHelper";
 import {
   LatestProjectType,
   noteSchema,
@@ -830,7 +829,6 @@ export type SingingStoreState = {
   sequencerEditTarget: SequencerEditTarget;
   selectedNoteIds: Set<NoteId>;
   overlappingNoteIds: Set<NoteId>;
-  overlappingNoteInfos: OverlappingNoteInfos;
   editingLyricNoteId?: NoteId;
   nowPlaying: boolean;
   volume: number;
@@ -899,6 +897,11 @@ export type SingingStoreTypes = {
 
   NOTE_IDS: {
     getter: Set<NoteId>;
+  };
+
+  UPDATE_OVERLAPPING_NOTE_IDS: {
+    mutation: undefined;
+    action(): void;
   };
 
   SET_NOTES: {


### PR DESCRIPTION
## 内容

ノートの重なり検出を高速にします。具体的には`O(n^2)`から`O(2n log 2n + 2n)`くらいになります。

## 関連 Issue

- Discord: [このあたりの会話](https://canary.discord.com/channels/879570910208733277/893889888208977960/1254731758763507722)

## スクリーンショット・動画など

（なし）

## その他

（なし）