### PR TITLE
Vuexでproductionモードを使用可能にし、productionモードで起動する方法を案内

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ VOICEVOX エディタの実行とは別にエンジン API のサーバを立て
 また、エンジン API の宛先エンドポイントを変更する場合は`VITE_DEFAULT_ENGINE_INFOS`内の`host`を変更してください。
 
 ```bash
+# 開発しやすい環境で実行
 npm run electron:serve
+
+# ビルド時に近い環境で実行
+npm run electron:serve -- --mode production
 ```
 
 音声合成エンジンのリポジトリはこちらです <https://github.com/VOICEVOX/voicevox_engine>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -39,6 +39,7 @@ import {
   SpeakerId,
   StyleId,
   Voice,
+  isProduction,
 } from "@/type/preload";
 
 export const storeKey: InjectionKey<
@@ -408,7 +409,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...singingStore.actions,
     ...singingCommandStore.actions,
   },
-  strict: import.meta.env.MODE !== "production",
+  strict: !isProduction,
 });
 
 export const useStore = (): Store<

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -408,7 +408,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...singingStore.actions,
     ...singingCommandStore.actions,
   },
-  strict: process.env.NODE_ENV !== "production",
+  strict: import.meta.env.MODE !== "production",
 });
 
 export const useStore = (): Store<


### PR DESCRIPTION
## 内容

Vuexのstrictモードでコマンドが積み重なるとだんだん重くなってきます。
環境をビルド時に近づけられるよう、productionモードを検知できるようにしました。

ついでに起動する方法をREADMEで案内するようにしました。

## その他

NODE_ENVとモードが別々にあるっぽみ。
https://ja.vitejs.dev/guide/env-and-mode#node-env-%E3%81%A8%E3%83%A2%E3%83%BC%E3%83%88%E3%82%99

これでビルド時、`--mode production`指定時両方でstrictじゃなくなります。
（今まではビルド時のみstrictじゃなくなってた）
