### PR TITLE
ファイルの書き出し時の名前設定にプロジェクトファイル名を含められるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm ci
 
 Windows の場合でもパスの区切り文字は`\`ではなく`/`なのでご注意ください。
 
-また、macOS 向けの`VOICEVOX.app`を利用している場合は`/path/to/VOICEVOX.app/Contents/MacOS/run`を指定してください。
+また、macOS 向けの`VOICEVOX.app`を利用している場合は`/path/to/VOICEVOX.app/Contents/MacOS/vv-engine/run`を指定してください。
 
 Linux の場合は、[Releases](https://github.com/VOICEVOX/voicevox/releases/)から入手できる tar.gz 版に含まれる`run`コマンドを指定してください。
 AppImage 版の場合は`$ /path/to/VOICEVOX.AppImage --appimage-mount`でファイルシステムをマウントできます。

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1200,7 +1200,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   },
 
   DEFAULT_AUDIO_FILE_NAME: {
-    getter: (state) => (audioKey) => {
+    getter: (state, getters) => (audioKey) => {
       const fileNamePattern = state.savingSetting.fileNamePattern;
 
       const index = state.audioKeys.indexOf(audioKey);
@@ -1220,12 +1220,16 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       if (style == undefined) throw new Error("assert style != undefined");
 
       const styleName = style.styleName || DEFAULT_STYLE_NAME;
+
+      const projectName = getters.PROJECT_NAME ?? "";
+
       return buildAudioFileNameFromRawData(fileNamePattern, {
         characterName: character.metas.speakerName,
         index,
         styleName,
         text: audioItem.text,
         date: currentDateString(),
+        projectName,
       });
     },
   },

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -23,6 +23,7 @@ import {
   formatCharacterStyleName,
   TuningTranscription,
   filterCharacterInfosByStyleType,
+  DEFAULT_PROJECT_NAME,
 } from "./utility";
 import { createPartialStore } from "./vuex";
 import { determineNextPresetKey } from "./preset";
@@ -1195,7 +1196,9 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
       const defaultFileBaseName = sanitizeFileName(headTailItemText);
 
-      return defaultFileBaseName === "" ? "Untitled" : defaultFileBaseName;
+      return defaultFileBaseName === ""
+        ? DEFAULT_PROJECT_NAME
+        : defaultFileBaseName;
     },
   },
 
@@ -1220,9 +1223,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       if (style == undefined) throw new Error("assert style != undefined");
 
       const styleName = style.styleName || DEFAULT_STYLE_NAME;
-
-      const projectName = getters.PROJECT_NAME ?? "";
-
+      const projectName = getters.PROJECT_NAME ?? DEFAULT_PROJECT_NAME;
       return buildAudioFileNameFromRawData(fileNamePattern, {
         characterName: character.metas.speakerName,
         index,

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -73,10 +73,18 @@ const applySongProjectToStore = async (
 };
 
 export const projectStore = createPartialStore<ProjectStoreTypes>({
-  PROJECT_NAME: {
+  PROJECT_NAME_WITH_EXT: {
     getter(state) {
       return state.projectFilePath
         ? getBaseName(state.projectFilePath)
+        : undefined;
+    },
+  },
+
+  PROJECT_NAME: {
+    getter(state) {
+      return state.projectFilePath
+        ? getBaseName(state.projectFilePath).replace(".vvproj", "")
         : undefined;
     },
   },

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -22,7 +22,7 @@ import {
   SequencerEditTarget,
   PhraseSourceHash,
 } from "./type";
-import { sanitizeFileName } from "./utility";
+import { DEFAULT_PROJECT_NAME, sanitizeFileName } from "./utility";
 import { EngineId, NoteId, StyleId } from "@/type/preload";
 import { FrameAudioQuery, Note as NoteForRequestToEngine } from "@/openapi";
 import { ResultError, getValueOrThrow } from "@/type/result";
@@ -1895,7 +1895,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         const generateDefaultSongFileName = () => {
           const projectName = getters.PROJECT_NAME;
           if (projectName) {
-            return projectName.split(".")[0] + ".wav";
+            return projectName + ".wav";
           }
 
           const singer = getters.SELECTED_TRACK.singer;
@@ -1915,7 +1915,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             }
           }
 
-          return "Untitled.wav";
+          return `${DEFAULT_PROJECT_NAME}.wav`;
         };
 
         const exportWaveFile = async (): Promise<SaveResultObject> => {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1473,6 +1473,10 @@ export type ProjectStoreState = {
 };
 
 export type ProjectStoreTypes = {
+  PROJECT_NAME_WITH_EXT: {
+    getter: string | undefined;
+  };
+
   PROJECT_NAME: {
     getter: string | undefined;
   };

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import { Platform } from "quasar";
 import * as diff from "fast-array-diff";
-import { store } from "./index";
 import {
   CharacterInfo,
   StyleInfo,
@@ -136,6 +135,7 @@ const DEFAULT_AUDIO_FILE_NAME_VARIABLES = {
   text: "テキストテキストテキスト",
   styleName: DEFAULT_STYLE_NAME,
   date: currentDateString(),
+  projectName: "VOICEVOXプロジェクト",
 };
 
 export function currentDateString(): string {
@@ -145,14 +145,6 @@ export function currentDateString(): string {
   const date = currentDate.getDate().toString().padStart(2, "0");
 
   return `${year}${month}${date}`;
-}
-
-/**
- * 書き出しファイルにプロジェクトファイル名を拡張子を取り除いて追加する
- */
-export function removeExtension(projectNameWithExtension?: string): string {
-  const projectName = projectNameWithExtension?.replace(".vvproj", "") ?? "";
-  return projectName;
 }
 
 function replaceTag(
@@ -352,7 +344,7 @@ export function buildAudioFileNameFromRawData(
   const index = (vars.index + 1).toString().padStart(3, "0");
   const styleName = sanitizeFileName(vars.styleName);
   const date = vars.date;
-  const projectName = removeExtension(store.getters.PROJECT_NAME);
+  const projectName = sanitizeFileName(vars.projectName);
   return replaceTag(pattern, {
     text,
     characterName,

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -11,6 +11,7 @@ import {
 import { AccentPhrase, Mora } from "@/openapi";
 
 export const DEFAULT_STYLE_NAME = "ノーマル";
+export const DEFAULT_PROJECT_NAME = "Untitled";
 
 export const formatCharacterStyleName = (
   characterName: string,
@@ -120,7 +121,7 @@ export const replaceTagIdToTagString = {
   styleName: "スタイル",
   text: "テキスト",
   date: "日付",
-  projectName: "プロジェクトファイル名",
+  projectName: "プロジェクト名",
 };
 const replaceTagStringToTagId: { [tagString: string]: string } = Object.entries(
   replaceTagIdToTagString,

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { Platform } from "quasar";
 import * as diff from "fast-array-diff";
+import { store } from "./index";
 import {
   CharacterInfo,
   StyleInfo,
@@ -120,6 +121,7 @@ export const replaceTagIdToTagString = {
   styleName: "スタイル",
   text: "テキスト",
   date: "日付",
+  projectName: "プロジェクトファイル名",
 };
 const replaceTagStringToTagId: { [tagString: string]: string } = Object.entries(
   replaceTagIdToTagString,
@@ -143,6 +145,14 @@ export function currentDateString(): string {
   const date = currentDate.getDate().toString().padStart(2, "0");
 
   return `${year}${month}${date}`;
+}
+
+/**
+ * 書き出しファイルにプロジェクトファイル名を拡張子を取り除いて追加する
+ */
+export function removeExtension(projectNameWithExtension?: string): string {
+  const projectName = projectNameWithExtension?.replace(".vvproj", "") ?? "";
+  return projectName;
 }
 
 function replaceTag(
@@ -342,12 +352,14 @@ export function buildAudioFileNameFromRawData(
   const index = (vars.index + 1).toString().padStart(3, "0");
   const styleName = sanitizeFileName(vars.styleName);
   const date = vars.date;
+  const projectName = removeExtension(store.getters.PROJECT_NAME);
   return replaceTag(pattern, {
     text,
     characterName,
     index,
     styleName,
     date,
+    projectName,
   });
 }
 

--- a/tests/unit/store/utility.spec.ts
+++ b/tests/unit/store/utility.spec.ts
@@ -251,17 +251,18 @@ describe("isAccentPhrasesTextDifferent", () => {
 
 test("buildAudioFileNameFromRawData", () => {
   const fileNamePattern =
-    "index=$連番$ characterName=$キャラ$ text=$テキスト$ styleName=$スタイル$ date=$日付$";
+    "index=$連番$ characterName=$キャラ$ text=$テキスト$ styleName=$スタイル$ date=$日付$ projectName=$プロジェクトファイル名$";
   const vars = {
     index: 10,
     characterName: "キャラ１",
     text: "テストテキスト",
     styleName: "スタイル１",
     date: "20210801",
+    projectName: "サンプルプロジェクト",
   };
   const result = buildAudioFileNameFromRawData(fileNamePattern, vars);
   expect(result).toBe(
-    "index=011 characterName=キャラ１ text=テストテキスト styleName=スタイル１ date=20210801",
+    "index=011 characterName=キャラ１ text=テストテキスト styleName=スタイル１ date=20210801 projectName=サンプルプロジェクト",
   );
 });
 

--- a/tests/unit/store/utility.spec.ts
+++ b/tests/unit/store/utility.spec.ts
@@ -251,7 +251,7 @@ describe("isAccentPhrasesTextDifferent", () => {
 
 test("buildAudioFileNameFromRawData", () => {
   const fileNamePattern =
-    "index=$連番$ characterName=$キャラ$ text=$テキスト$ styleName=$スタイル$ date=$日付$ projectName=$プロジェクトファイル名$";
+    "index=$連番$ characterName=$キャラ$ text=$テキスト$ styleName=$スタイル$ date=$日付$ projectName=$プロジェクト名$";
   const vars = {
     index: 10,
     characterName: "キャラ１",


### PR DESCRIPTION
## 内容

- 設定で書き出しファイル名パターンにプロジェクトファイル名を設定できるようにしました
  - プロジェクトファイル名がない場合、ある場合のそれぞれに対応させました
  - プロジェクトファイル名がない場合は空文字にしています
- READMEの軽微な修正をしました

## 関連 Issue

close #2075 
close #2136 

## スクリーンショット・動画など

画像1
<img width="1291" alt="スクリーンショット 2024-06-27 13 30 35" src="https://github.com/VOICEVOX/voicevox/assets/40142697/be00df0e-3ff9-47d4-8437-0bb35a411e47">

画像2
<img width="1032" alt="スクリーンショット 2024-06-27 13 31 27" src="https://github.com/VOICEVOX/voicevox/assets/40142697/0f66918b-0720-4304-b73b-5fa10fd8725b">

画像1の書き出しファイル名パターンを使用し、音声を書き出した際、
- 画像2における`001_.wav`はプロジェクトファイル名を設定していない音声ファイル
- 画像2における`001_開発テスト用.wav`、`002_開発テスト用.wav`はプロジェクトファイル名を設定した上で書き出したファイル
となっています。

## その他
