### PR TITLE
Ubuntu 24.04の制約を回避するために--no-sandboxオプションをdesktopファイルのExecエントリに追加

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -405,7 +405,7 @@ DESKTOP_FILE=$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -1)
 chmod +x "${DESKTOP_FILE}"
 
 ESCAPED_APP_DIR=$(echo "$APP_DIR" | sed 's/\//\\\//g')
-sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U/" "${DESKTOP_FILE}" > _
+sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U --no-sandbox/" "${DESKTOP_FILE}" > _
 mv _ "${DESKTOP_FILE}"
 
 mkdir -p "${DESKTOP_ENTRY_INSTALL_DIR}"

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -405,7 +405,7 @@ DESKTOP_FILE=$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -1)
 chmod +x "${DESKTOP_FILE}"
 
 ESCAPED_APP_DIR=$(echo "$APP_DIR" | sed 's/\//\\\//g')
-# --no-sandboxをつけているのはセキュリティが強化されたUbuntu 24.04で動作させるため ref:https://github.com/electron/electron/issues/41066
+#ToDo: --no-sandboxをつけているのはセキュリティが強化されたUbuntu 24.04で動作させるため ref:https://github.com/electron/electron/issues/41066。外せたら外す。
 sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U --no-sandbox/" "${DESKTOP_FILE}" > _
 mv _ "${DESKTOP_FILE}"
 

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -405,6 +405,7 @@ DESKTOP_FILE=$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -1)
 chmod +x "${DESKTOP_FILE}"
 
 ESCAPED_APP_DIR=$(echo "$APP_DIR" | sed 's/\//\\\//g')
+# --no-sandboxをつけているのはセキュリティが強化されたUbuntu 24.04で動作させるため ref:https://github.com/electron/electron/issues/41066
 sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U --no-sandbox/" "${DESKTOP_FILE}" > _
 mv _ "${DESKTOP_FILE}"
 

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -405,7 +405,7 @@ DESKTOP_FILE=$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -1)
 chmod +x "${DESKTOP_FILE}"
 
 ESCAPED_APP_DIR=$(echo "$APP_DIR" | sed 's/\//\\\//g')
-#ToDo: --no-sandboxをつけているのはセキュリティが強化されたUbuntu 24.04で動作させるため ref:https://github.com/electron/electron/issues/41066。外せたら外す。
+# TODO: --no-sandboxをつけているのはセキュリティが強化されたUbuntu 24.04で動作させるため ref:https://github.com/electron/electron/issues/41066。外せたら外す。
 sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U --no-sandbox/" "${DESKTOP_FILE}" > _
 mv _ "${DESKTOP_FILE}"
 


### PR DESCRIPTION
## 内容

Ubuntu 24.04ではそのままでは一般ユーザーがUser NameSpaceを作成できなくなり，プロファイルで許可を出すか--no-sandboxを起動オプションとして渡すかなので，一時的なものとして--no-sandboxを追加します．
%Uの後なのはこうしないとプロジェクトファイルをダブルクリックした際に正常にファイルパスが渡されないのでそれを回避するためです．

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #2071 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
