### PR TITLE
Update: utaformatix-tsを0.3.2に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@gtm-support/vue-gtm": "1.2.3",
         "@quasar/extras": "1.10.10",
-        "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.1",
+        "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.2",
         "async-lock": "1.4.0",
         "dayjs": "1.10.7",
         "electron-log": "5.1.2",
@@ -2201,9 +2201,9 @@
     },
     "node_modules/@sevenc-nanashi/utaformatix-ts": {
       "name": "@jsr/sevenc-nanashi__utaformatix-ts",
-      "version": "0.3.1",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/sevenc-nanashi__utaformatix-ts/0.3.1.tgz",
-      "integrity": "sha512-Pcire1igHaJHHAfEyYiEGzsb7LY/heb4WN6PPIYWG8aaml+iAufw+F974SMrq8GKtVfbQFXQbVI2wL23xdhcKg==",
+      "version": "0.3.2",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/sevenc-nanashi__utaformatix-ts/0.3.2.tgz",
+      "integrity": "sha512-TdCME7wLGNnv7vcTRXZ4IXZpv/7uVUqy1ACIxuZQNg2M9jYk3aA9CSRNHkrrTIAeH4JuDBpONfn9zb9GkXsscg==",
       "dependencies": {
         "jszip": "^3.10.1",
         "utaformatix-data": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@gtm-support/vue-gtm": "1.2.3",
         "@quasar/extras": "1.10.10",
-        "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.0",
+        "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.1",
         "async-lock": "1.4.0",
         "dayjs": "1.10.7",
         "electron-log": "5.1.2",
@@ -2201,9 +2201,9 @@
     },
     "node_modules/@sevenc-nanashi/utaformatix-ts": {
       "name": "@jsr/sevenc-nanashi__utaformatix-ts",
-      "version": "0.3.0",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/sevenc-nanashi__utaformatix-ts/0.3.0.tgz",
-      "integrity": "sha512-D6Y6lkxOawpv3LKSgrTGKLquuzaFvkwNThSGDXT5QBnfk7VE4bFbqJr9JlgjvAdh5sNQVGPku6uMdIdvSDxzAg==",
+      "version": "0.3.1",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/sevenc-nanashi__utaformatix-ts/0.3.1.tgz",
+      "integrity": "sha512-Pcire1igHaJHHAfEyYiEGzsb7LY/heb4WN6PPIYWG8aaml+iAufw+F974SMrq8GKtVfbQFXQbVI2wL23xdhcKg==",
       "dependencies": {
         "jszip": "^3.10.1",
         "utaformatix-data": "^1.1.0"
@@ -2362,7 +2362,9 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@gtm-support/vue-gtm": "1.2.3",
     "@quasar/extras": "1.10.10",
-    "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.1",
+    "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.2",
     "async-lock": "1.4.0",
     "dayjs": "1.10.7",
     "electron-log": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@gtm-support/vue-gtm": "1.2.3",
     "@quasar/extras": "1.10.10",
-    "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.0",
+    "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.1",
     "async-lock": "1.4.0",
     "dayjs": "1.10.7",
     "electron-log": "5.1.2",

--- a/src/components/Dialog/ImportSongProjectDialog.vue
+++ b/src/components/Dialog/ImportSongProjectDialog.vue
@@ -110,6 +110,7 @@ const projectNameToExtensions = [
   ["UtaFormatix", ["ufdata"]],
   ["UTAU", ["ust"]],
   ["VOCALOID", ["vpr", "vsq", "vsqx"]],
+  ["VoiSona", ["tssln"]],
 ] as const satisfies [string, SupportedExtensions[]][];
 
 // ちゃんと全部の拡張子があるかチェック


### PR DESCRIPTION
## 内容

utaformatix-tsを0.3.2に更新します。VoiSonaのプロジェクトを読み込めるようになります。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）