### PR TITLE
fix: chromaticのgithubactionsのエラー直す

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,4 +24,5 @@ jobs:
         uses: chromaui/action@v11
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: "storybook:build"
           exitZeroOnChanges: true


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/pull/2140

でchromaticのアクションズが落ちてしまったので修正です。
ビルドスクリプトがデフォルトと違うかったからなはず。

## その他
