### PR TITLE
[project-redisign-help-dialog] デザインの微調整

### DIFF
--- a/src/components/Base/BaseDocumentView.vue
+++ b/src/components/Base/BaseDocumentView.vue
@@ -5,6 +5,7 @@
 </template>
 
 <style scoped lang="scss">
+@use "@/styles/variables" as vars;
 @use "@/styles/mixin" as mixin;
 @use "@/styles/colors-v2" as colors;
 
@@ -48,8 +49,8 @@
     margin-top: 1rem;
   }
 
-  :deep(ul),
-  :deep(ol) {
+  :deep(div > ul),
+  :deep(div > ol) {
     margin-top: 1rem;
   }
 
@@ -69,7 +70,7 @@
   :deep(img) {
     margin-top: 0.5rem;
     border: 1px solid colors.$border;
-    border-radius: 8px;
+    border-radius: vars.$radius-1;
     vertical-align: middle;
   }
 
@@ -82,16 +83,39 @@
   }
 
   :deep(pre) {
-    padding: 8px;
+    padding: vars.$padding-1;
     margin-top: 1rem;
-    background-color: colors.$background;
-    border-radius: 8px;
+    background-color: colors.$surface;
+    border: 1px solid colors.$border;
+    border-radius: vars.$radius-1;
   }
 
-  :deep(p > code) {
+  :deep(:not(pre) > code) {
     padding: 4px;
-    background-color: colors.$background;
+    background-color: colors.$surface;
+    border: 1px solid colors.$border;
     border-radius: 4px;
+  }
+
+  :deep(details) {
+    padding: vars.$padding-1;
+    background-color: colors.$surface;
+    border: 1px solid colors.$border;
+    border-radius: vars.$radius-1;
+  }
+
+  :deep(summary) {
+    padding: vars.$padding-1;
+    margin: calc(#{vars.$padding-1} * -1);
+    cursor: pointer;
+  }
+
+  :deep(summary::before) {
+    content: "▶ ";
+  }
+
+  :deep(details[open] > summary::before) {
+    content: "▼ ";
   }
 }
 </style>

--- a/src/styles/colors-v2.scss
+++ b/src/styles/colors-v2.scss
@@ -10,10 +10,10 @@ $primitive-red: #d04756;
 
 // ライトテーマの色
 :root[is-dark-theme="false"] {
-  --color-v2-background: #{$primitive-white};
+  --color-v2-background: #{lighten($primitive-primary, 25%)};
   --color-v2-background-drawer: #{rgba(lighten($primitive-primary, 20%), 0.75)};
 
-  --color-v2-surface: #{lighten($primitive-primary, 25%)};
+  --color-v2-surface: #{$primitive-white};
   --color-v2-border: #{rgba($primitive-black, 0.2)};
   --color-v2-selected: #{rgba($primitive-primary, 0.3)};
 


### PR DESCRIPTION
## 内容

HelpDialogのデザインの微調整として、DocumentViewのスタイルの調整と色変数のミスの修正を行います。

- 具体的なDocumentViewのスタイルの調整
  - detailsタグのスタイルの追加
    - ![image](https://github.com/VOICEVOX/voicevox/assets/53995265/e8a461ca-2859-4439-9bf3-853154663b13)
  - 2階層目以降のul,olタグの不要な空白の除去
  - pre要素の見た目調整
  - paddingとborder-radiusをSCSS変数を用いるように変更
