### PR TITLE
feat: IPCメッセージの`sender`を確認する

### DIFF
--- a/src/backend/electron/ipc.ts
+++ b/src/backend/electron/ipc.ts
@@ -40,6 +40,7 @@ export function ipcMainSend(
   return win.webContents.send(channel, ...args);
 }
 
+/** IPCメッセージの送信元を確認する */
 const validateIpcSender = (event: IpcMainInvokeEvent) => {
   let isValid: boolean;
   const senderUrl = new URL(event.senderFrame.url);

--- a/src/backend/electron/ipc.ts
+++ b/src/backend/electron/ipc.ts
@@ -18,6 +18,7 @@ export function ipcMainHandle(
     ...args: unknown[]
   ) => {
     try {
+      validateIpcSender(event);
       return listener(event, ...args);
     } catch (e) {
       log.error(e);
@@ -38,3 +39,19 @@ export function ipcMainSend(
 ): void {
   return win.webContents.send(channel, ...args);
 }
+
+const validateIpcSender = (event: IpcMainInvokeEvent) => {
+  let isValid: boolean;
+  const senderUrl = new URL(event.senderFrame.url);
+  if (process.env.VITE_DEV_SERVER_URL != undefined) {
+    const devServerUrl = new URL(process.env.VITE_DEV_SERVER_URL);
+    isValid = senderUrl.origin === devServerUrl.origin;
+  } else {
+    isValid = senderUrl.protocol === "app:";
+  }
+  if (!isValid) {
+    throw new Error(
+      `不正なURLからのIPCメッセージを検出しました。senderUrl: ${senderUrl.toString()}`,
+    );
+  }
+};


### PR DESCRIPTION
## 内容

Electronのベストプラクティスに基づきセキュリティを強化します。

[17. すべての IPC メッセージの sender を確認する](https://www.electronjs.org/ja/docs/latest/tutorial/security#17-%E3%81%99%E3%81%B9%E3%81%A6%E3%81%AE-ipc-%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E3%81%AE-sender-%E3%82%92%E7%A2%BA%E8%AA%8D%E3%81%99%E3%82%8B)

## その他

開発時は開発サーバーから、製品版ではappプロトコルからであることを確認して意図しないフレームからのIPCを防ぎます。