### PR TITLE
feat: appプロトコルでfetch可能なディレクトリを制限する

### DIFF
--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -3,6 +3,7 @@
 import path from "path";
 
 import fs from "fs";
+import { pathToFileURL } from "url";
 import {
   app,
   protocol,
@@ -428,8 +429,23 @@ async function createWindow() {
   // ソフトウェア起動時はプロトコルを app にする
   if (process.env.VITE_DEV_SERVER_URL == undefined) {
     protocol.handle("app", (request) => {
-      const filePath = path.join(__dirname, new URL(request.url).pathname);
-      return net.fetch(`file://${filePath}`);
+      // 読み取り先のファイルがインストールディレクトリ内であることを確認する
+      const { pathname } = new URL(request.url);
+      const pathToServe = path.resolve(path.join(__dirname, pathname));
+      const relativePath = path.relative(__dirname, pathToServe);
+      const isUnsafe =
+        path.isAbsolute(relativePath) ||
+        relativePath.startsWith(`..${path.sep}`) ||
+        relativePath === ".." ||
+        relativePath === "";
+      if (isUnsafe) {
+        log.error(`Bad Request URL: ${request.url}`);
+        return new Response("bad", {
+          status: 400,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      return net.fetch(pathToFileURL(pathToServe).toString());
     });
   }
 

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -436,8 +436,7 @@ async function createWindow() {
       const relativePath = path.relative(__dirname, pathToServe);
       const isUnsafe =
         path.isAbsolute(relativePath) ||
-        relativePath.startsWith(`..${path.sep}`) ||
-        relativePath === ".." ||
+        relativePath.startsWith("..") ||
         relativePath === "";
       if (isUnsafe) {
         log.error(`Bad Request URL: ${request.url}`);

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -430,6 +430,7 @@ async function createWindow() {
   if (process.env.VITE_DEV_SERVER_URL == undefined) {
     protocol.handle("app", (request) => {
       // 読み取り先のファイルがインストールディレクトリ内であることを確認する
+      // ref: https://www.electronjs.org/ja/docs/latest/api/protocol#protocolhandlescheme-handler
       const { pathname } = new URL(request.url);
       const pathToServe = path.resolve(path.join(__dirname, pathname));
       const relativePath = path.relative(__dirname, pathToServe);


### PR DESCRIPTION
## 内容

Electronのベストプラクティスに基づきセキュリティを強化します。
[18. Avoid usage of the `file://` protocol and prefer usage of custom protocols](https://www.electronjs.org/ja/docs/latest/tutorial/security#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols)

ref: https://www.electronjs.org/ja/docs/latest/api/protocol#protocolhandlescheme-handler

## その他

`app://`プロトコルのファイルパスを制限して意図しないファイルの読み込みを防ぎます。
