### PR TITLE
feat: ウインドウの作成とナビゲーションを無効化する

### DIFF
--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -1022,7 +1022,7 @@ app.on("web-contents-created", (e, contents) => {
     if (protocol.match(/^https?:/)) {
       shell.openExternal(url);
     } else {
-      log.warn(`許可されないリンクです。url: ${url}`);
+      log.error(`許可されないリンクです。url: ${url}`);
     }
     return { action: "deny" };
   });

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -1018,11 +1018,19 @@ ipcMainHandle("READ_FILE", async (_, { filePath }) => {
 app.on("web-contents-created", (e, contents) => {
   // リンククリック時はブラウザを開く
   contents.setWindowOpenHandler(({ url }) => {
-    if (url.match(/^http/)) {
+    const { protocol } = new URL(url);
+    if (protocol.match(/^https?:/)) {
       shell.openExternal(url);
-      return { action: "deny" };
+    } else {
+      log.warn(`許可されないリンクです。url: ${url}`);
     }
-    return { action: "allow" };
+    return { action: "deny" };
+  });
+
+  // ナビゲーションを無効化
+  contents.on("will-navigate", (event) => {
+    log.error(`ナビゲーションは無効化されています。url: ${event.url}`);
+    event.preventDefault();
   });
 });
 


### PR DESCRIPTION
## 内容

Electronのベストプラクティスに基づきセキュリティを強化します。
[13. ナビゲーションを無効化か制限](https://www.electronjs.org/ja/docs/latest/tutorial/security#13-%E3%83%8A%E3%83%93%E3%82%B2%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E7%84%A1%E5%8A%B9%E5%8C%96%E3%81%8B%E5%88%B6%E9%99%90)
[14. 新規ウインドウの作成を無効化か制限](https://www.electronjs.org/ja/docs/latest/tutorial/security#14-%E6%96%B0%E8%A6%8F%E3%82%A6%E3%82%A4%E3%83%B3%E3%83%89%E3%82%A6%E3%81%AE%E4%BD%9C%E6%88%90%E3%82%92%E7%84%A1%E5%8A%B9%E5%8C%96%E3%81%8B%E5%88%B6%E9%99%90)
[15. 信用されないコンテンツで shell.openExternal を使用しない](https://www.electronjs.org/ja/docs/latest/tutorial/security#15-%E4%BF%A1%E7%94%A8%E3%81%95%E3%82%8C%E3%81%AA%E3%81%84%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84%E3%81%A7-shellopenexternal-%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
(部分的)

## その他

ナビゲーションと新規ウインドウ作成は現状することはないはずなので無効化します。

`shell.openExternal`は`http:`か`https:`の場合に実行します。
これは`mailto:`などを拒否してしまう一方で危険なURLでも問答無用で開いてしまいます。