### PR TITLE
fix: プリロードスクリプトを変更した時HMR(自動リロード)が機能しない問題を修正

### DIFF
--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -1029,8 +1029,10 @@ app.on("web-contents-created", (e, contents) => {
 
   // ナビゲーションを無効化
   contents.on("will-navigate", (event) => {
-    log.error(`ナビゲーションは無効化されています。url: ${event.url}`);
-    event.preventDefault();
+    if (contents.getURL() !== event.url) {
+      log.error(`ナビゲーションは無効化されています。url: ${event.url}`);
+      event.preventDefault();
+    }
   });
 });
 

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -1029,6 +1029,7 @@ app.on("web-contents-created", (e, contents) => {
 
   // ナビゲーションを無効化
   contents.on("will-navigate", (event) => {
+    // preloadスクリプト変更時のホットリロードを許容する
     if (contents.getURL() !== event.url) {
       log.error(`ナビゲーションは無効化されています。url: ${event.url}`);
       event.preventDefault();


### PR DESCRIPTION
## 内容

プリロードスクリプトを変更したときに自動的にリロードされなくなってしまっていたのでこれを修正します。

## 関連 Issue

- ref: #2154

## その他

プリロードスクリプトを変更するとナビゲーションが起こるようです。
これを完全に無効化してしまったことが原因です。
URLが変わっていなければナビゲーションを許可することでリロードをできるようにします。