### PR TITLE
fix: tsconfigをViteの推奨する設定に合わせる

### DIFF
--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -35,20 +35,18 @@ export class Store<
 > extends BaseStore<S> {
   constructor(options: StoreOptions<S, G, A, M>) {
     super(options as OriginalStoreOptions<S>);
-    // @ts-expect-error Storeの型を書き換えている影響で未初期化として判定される
     this.actions = dotNotationDispatchProxy(this.dispatch.bind(this));
     this.mutations = dotNotationCommitProxy(
-      // @ts-expect-error Storeの型を書き換えている影響で未初期化として判定される
       this.commit.bind(this) as Commit<M>,
     );
   }
 
-  readonly getters!: G;
+  declare readonly getters: G;
 
   // @ts-expect-error Storeの型を非互換な型で書き換えているためエラー
-  dispatch: Dispatch<A>;
+  declare dispatch: Dispatch<A>;
   // @ts-expect-error Storeの型を非互換な型で書き換えているためエラー
-  commit: Commit<M>;
+  declare commit: Commit<M>;
   /**
    * ドット記法用のActionを直接呼べる。エラーになる場合はdispatchを使う。
    * 詳細 https://github.com/VOICEVOX/voicevox/issues/2088

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "esnext",
     "module": "esnext",
     "strict": true,
     "jsx": "preserve",
+    "jsxImportSource": "vue",
     "importHelpers": true,
     "moduleResolution": "bundler",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "baseUrl": ".",
@@ -16,7 +18,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
+    "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## 内容

tsconfigの内容が若干怪しいものがありましたので修正します。

ref: [Vite | TypeScript コンパイラーオプション](https://ja.vitejs.dev/guide/features.html#typescript-%E3%82%B3%E3%83%B3%E3%83%8F%E3%82%9A%E3%82%A4%E3%83%A9%E3%83%BC%E3%82%AA%E3%83%95%E3%82%9A%E3%82%B7%E3%83%A7%E3%83%B3)
ref: [TypeScript で Vue を使用する | tsconfig.json の構成](https://ja.vuejs.org/guide/typescript/overview.html#configuring-tsconfig-json)

## その他

- `target`
Viteはこれを実質的に無視します。
ここでは制御していないことを明示するために`esnext`に設定します。
設定が必要な場合は`vite.config.mts`を変更する必要があります。
- [`useDefineForClassFields`](https://www.typescriptlang.org/tsconfig/#useDefineForClassFields)
`target`を変更したことによってデフォルト値が`false`から`true`に変更されます。
これにより`src/store/vuex.ts`に変更を加える必要があります。
- `jsxImportSource`
Vueの推奨値。
これを設定する必要は感じませんが`"jsx": "preserve"`が設定されていたのでそれに合わせます。
- `isolatedModules`
Viteは(内部で動作する`esbuild`の制限により)強制的に`true`で動作します。
-  `scripthost`
これは`Windows Script Host`のことです。
ここにあるべきではない設定なので削除します。

Vueは`isolatedModules`のスーパーセットである[`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax)も勧めていますがこれをオンにするとリポジトリ全体のimport文を全面的に書き換える必要が生じますので他のPRとの干渉を考え設定していません。