### PR TITLE
リファクタリング：コマンドのunixMillisecをUUID4にする

### DIFF
--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -136,7 +136,7 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
   LAST_COMMAND_IDS: {
     getter(state) {
       const getLastCommandId = (commands: Command[]): CommandId | null => {
-        if (commands.length > 0) return null;
+        if (commands.length == 0) return null;
         else return commands[commands.length - 1].id;
       };
 

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -9,7 +9,7 @@ import {
   MutationsBase,
   MutationTree,
 } from "@/store/vuex";
-import { EditorType } from "@/type/preload";
+import { CommandId, EditorType } from "@/type/preload";
 
 enablePatches();
 enableMapSet();
@@ -67,7 +67,7 @@ const recordPatches =
       (draft: S) => recipe(draft, payload),
     );
     return {
-      unixMillisec: new Date().getTime(),
+      id: CommandId(crypto.randomUUID()),
       redoPatches: doPatches,
       undoPatches: undoPatches,
     };
@@ -133,30 +133,17 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
     },
   },
 
-  LAST_COMMAND_UNIX_MILLISEC: {
+  LAST_COMMAND_IDS: {
     getter(state) {
-      const getLastCommandUnixMillisec = (
-        commands: Command[],
-      ): number | null => {
-        const lastCommand = commands[commands.length - 1];
-        // 型的にはundefinedにはならないが、lengthが0の場合はundefinedになる
-        return lastCommand ? lastCommand.unixMillisec : null;
+      const getLastCommandId = (commands: Command[]): CommandId | null => {
+        if (commands.length > 0) return null;
+        else return commands[commands.length - 1].id;
       };
 
-      const lastTalkCommandTime = getLastCommandUnixMillisec(
-        state.undoCommands["talk"],
-      );
-      const lastSongCommandTime = getLastCommandUnixMillisec(
-        state.undoCommands["song"],
-      );
-
-      if (lastTalkCommandTime != null && lastSongCommandTime != null) {
-        return Math.max(lastTalkCommandTime, lastSongCommandTime);
-      } else if (lastTalkCommandTime != null) {
-        return lastTalkCommandTime;
-      } else {
-        return lastSongCommandTime;
-      }
+      return {
+        talk: getLastCommandId(state.undoCommands["talk"]),
+        song: getLastCommandId(state.undoCommands["song"]),
+      };
     },
   },
 

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -213,7 +213,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           await applySongProjectToStore(dispatch, parsedProjectData.song);
 
           commit("SET_PROJECT_FILEPATH", { filePath });
-          context.commit("RESET_SAVED_LAST_COMMAND_IDS");
+          commit("RESET_SAVED_LAST_COMMAND_IDS");
           commit("CLEAR_COMMANDS");
           return true;
         } catch (err) {

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_TPQN,
 } from "@/sing/domain";
 import { EditorType } from "@/type/preload";
+import { IsEqual } from "@/type/utility";
 
 export const projectStoreState: ProjectStoreState = {
   savedLastCommandIds: { talk: null, song: null },
@@ -373,13 +374,11 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
 
   IS_EDITED: {
     getter(state, getters) {
-      if (
-        Object.keys(state.savedLastCommandIds) !=
-        Object.keys(getters.LAST_COMMAND_IDS)
-      )
-        throw new Error(
-          "Object.keys(state.savedLastCommandIds) != Object.keys(getters.LAST_COMMAND_IDS)",
-        );
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _: IsEqual<
+        typeof state.savedLastCommandIds,
+        typeof getters.LAST_COMMAND_IDS
+      > = true;
       return Object.keys(state.savedLastCommandIds).some((_editor) => {
         const editor = _editor as EditorType;
         return (

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1708,7 +1708,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         await dispatch("SET_TIME_SIGNATURES", { timeSignatures });
         await dispatch("SET_NOTES", { notes });
 
-        commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);
+        context.commit("RESET_SAVED_LAST_COMMAND_IDS");
         commit("CLEAR_COMMANDS");
         dispatch("RENDER");
       },
@@ -1751,7 +1751,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           startFrame: 0,
         });
 
-        commit("SET_SAVED_LAST_COMMAND_UNIX_MILLISEC", null);
+        context.commit("RESET_SAVED_LAST_COMMAND_IDS");
         commit("CLEAR_COMMANDS");
         dispatch("RENDER");
       },

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1751,7 +1751,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           startFrame: 0,
         });
 
-        context.commit("RESET_SAVED_LAST_COMMAND_IDS");
+        commit("RESET_SAVED_LAST_COMMAND_IDS");
         commit("CLEAR_COMMANDS");
         dispatch("RENDER");
       },

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1708,7 +1708,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         await dispatch("SET_TIME_SIGNATURES", { timeSignatures });
         await dispatch("SET_NOTES", { notes });
 
-        context.commit("RESET_SAVED_LAST_COMMAND_IDS");
+        commit("RESET_SAVED_LAST_COMMAND_IDS");
         commit("CLEAR_COMMANDS");
         dispatch("RENDER");
       },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -52,6 +52,7 @@ import {
   RootMiscSettingType,
   EditorType,
   NoteId,
+  CommandId,
 } from "@/type/preload";
 import { IEngineConnectorFactory } from "@/infrastructures/EngineConnector";
 import {
@@ -94,7 +95,7 @@ export type FetchAudioResult = {
 };
 
 export type Command = {
-  unixMillisec: number;
+  id: CommandId;
   undoPatches: Patch[];
   redoPatches: Patch[];
 };
@@ -1233,8 +1234,8 @@ export type CommandStoreTypes = {
     action(payload: { editor: EditorType }): void;
   };
 
-  LAST_COMMAND_UNIX_MILLISEC: {
-    getter: number | null;
+  LAST_COMMAND_IDS: {
+    getter: Record<EditorType, CommandId | null>;
   };
 
   CLEAR_COMMANDS: {
@@ -1469,7 +1470,7 @@ export type IndexStoreTypes = {
 
 export type ProjectStoreState = {
   projectFilePath?: string;
-  savedLastCommandUnixMillisec: number | null;
+  savedLastCommandIds: Record<EditorType, CommandId | null>;
 };
 
 export type ProjectStoreTypes = {
@@ -1511,8 +1512,12 @@ export type ProjectStoreTypes = {
     getter: boolean;
   };
 
-  SET_SAVED_LAST_COMMAND_UNIX_MILLISEC: {
-    mutation: number | null;
+  SET_SAVED_LAST_COMMAND_IDS: {
+    mutation: Record<EditorType, CommandId | null>;
+  };
+
+  RESET_SAVED_LAST_COMMAND_IDS: {
+    mutation: void;
   };
 };
 

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -69,6 +69,10 @@ export const noteIdSchema = z.string().brand<"NoteId">();
 export type NoteId = z.infer<typeof noteIdSchema>;
 export const NoteId = (id: string): NoteId => noteIdSchema.parse(id);
 
+export const commandIdSchema = z.string().brand<"CommandId">();
+export type CommandId = z.infer<typeof commandIdSchema>;
+export const CommandId = (id: string): CommandId => commandIdSchema.parse(id);
+
 // 共通のアクション名
 export const actionPostfixSelectNthCharacter = "番目のキャラクターを選択";
 


### PR DESCRIPTION
## 内容

プロジェクトを編集したかどうかの判定に、コマンドごとに`unixMillisec`を持たせていました。
特に問題ないのですが、時刻よりも ユニークな ID を設定したほうが意図と合うのでそうしてみました。

というよりどちらかというと、コマンドが想定通りかsnapshotテストをしたく、時刻だとモックさせづらかったので他と合わせたいです。
こうしておけば、UUID4をモックにすることでID系もsnapshotテストできるようになって嬉しいです。

## その他
