### PR TITLE
vuexのstoreの呼び出しをリテラル引数からDot記法へ: command.ts, preset.ts, engine.ts, project.ts, audio.ts

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1,6 +1,9 @@
 import path from "path";
 import Encoding from "encoding-japanese";
-import { createUILockAction, withProgress } from "./ui";
+import {
+  createDotNotationUILockAction as createUILockAction,
+  withProgressDotNotation as withProgress,
+} from "./ui";
 import {
   AudioItem,
   SaveResultObject,
@@ -25,7 +28,7 @@ import {
   filterCharacterInfosByStyleType,
   DEFAULT_PROJECT_NAME,
 } from "./utility";
-import { createPartialStore } from "./vuex";
+import { createDotNotationPartialStore as createPartialStore } from "./vuex";
 import { determineNextPresetKey } from "./preset";
 import {
   fetchAudioFromAudioItem,
@@ -269,8 +272,8 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
    */
   LOAD_CHARACTER: {
     action: createUILockAction(
-      async ({ commit, dispatch, state }, { engineId }) => {
-        const instance = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
+      async ({ mutations, actions, state }, { engineId }) => {
+        const instance = await actions.INSTANTIATE_ENGINE_CONNECTOR({
           engineId,
         });
 
@@ -420,7 +423,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
         const characterInfos = await Promise.all(characterInfoPromises);
 
-        commit("SET_CHARACTER_INFOS", { engineId, characterInfos });
+        mutations.SET_CHARACTER_INFOS({ engineId, characterInfos });
       },
     ),
   },
@@ -438,7 +441,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   },
 
   LOAD_MORPHABLE_TARGETS: {
-    async action({ state, dispatch, commit }, { engineId, baseStyleId }) {
+    async action({ state, actions, mutations }, { engineId, baseStyleId }) {
       if (!state.engineManifests[engineId].supportedFeatures?.synthesisMorphing)
         return;
 
@@ -446,7 +449,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
       const rawMorphableTargets = (
         await (
-          await dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId })
+          await actions.INSTANTIATE_ENGINE_CONNECTOR({ engineId })
         ).invoke("morphableTargetsMorphableTargetsPost")({
           requestBody: [baseStyleId],
         })
@@ -472,7 +475,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         }),
       );
 
-      commit("SET_MORPHABLE_TARGETS", {
+      mutations.SET_MORPHABLE_TARGETS({
         engineId,
         baseStyleId,
         morphableTargets,
@@ -548,24 +551,26 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     /**
      * AudioItemに設定される話者（スタイルID）に対してエンジン側の初期化を行い、即座に音声合成ができるようにする。
      */
-    async action({ commit, dispatch }, { engineId, audioKeys, styleId }) {
-      const isInitialized = await dispatch("IS_INITIALIZED_ENGINE_SPEAKER", {
+    async action({ mutations, actions }, { engineId, audioKeys, styleId }) {
+      const isInitialized = await actions.IS_INITIALIZED_ENGINE_SPEAKER({
         engineId,
         styleId,
       });
       if (isInitialized) return;
 
-      commit("SET_AUDIO_KEYS_WITH_INITIALIZING_SPEAKER", {
+      mutations.SET_AUDIO_KEYS_WITH_INITIALIZING_SPEAKER({
         audioKeys,
       });
-      await dispatch("INITIALIZE_ENGINE_SPEAKER", {
-        engineId,
-        styleId,
-      }).finally(() => {
-        commit("SET_AUDIO_KEYS_WITH_INITIALIZING_SPEAKER", {
-          audioKeys: [],
+      await actions
+        .INITIALIZE_ENGINE_SPEAKER({
+          engineId,
+          styleId,
+        })
+        .finally(() => {
+          mutations.SET_AUDIO_KEYS_WITH_INITIALIZING_SPEAKER({
+            audioKeys: [],
+          });
         });
-      });
     },
   },
 
@@ -579,10 +584,10 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     mutation(state, { audioKey }: { audioKey?: AudioKey }) {
       state._activeAudioKey = audioKey;
     },
-    action({ commit, dispatch }, { audioKey }: { audioKey?: AudioKey }) {
-      commit("SET_ACTIVE_AUDIO_KEY", { audioKey });
+    action({ mutations, actions }, { audioKey }: { audioKey?: AudioKey }) {
+      mutations.SET_ACTIVE_AUDIO_KEY({ audioKey });
       // reset audio play start point
-      dispatch("SET_AUDIO_PLAY_START_POINT", { startPoint: undefined });
+      actions.SET_AUDIO_PLAY_START_POINT({ startPoint: undefined });
     },
   },
 
@@ -591,7 +596,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       state._selectedAudioKeys = audioKeys;
     },
     action(
-      { state, commit, getters },
+      { state, mutations, getters },
       { audioKeys }: { audioKeys?: AudioKey[] },
     ) {
       const uniqueAudioKeys = new Set(audioKeys);
@@ -604,7 +609,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       const sortedAudioKeys = state.audioKeys.filter((audioKey) =>
         uniqueAudioKeys.has(audioKey),
       );
-      commit("SET_SELECTED_AUDIO_KEYS", { audioKeys: sortedAudioKeys });
+      mutations.SET_SELECTED_AUDIO_KEYS({ audioKeys: sortedAudioKeys });
     },
   },
 
@@ -612,8 +617,8 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
     mutation(state, { startPoint }: { startPoint?: number }) {
       state._audioPlayStartPoint = startPoint;
     },
-    action({ commit }, { startPoint }: { startPoint?: number }) {
-      commit("SET_AUDIO_PLAY_START_POINT", { startPoint });
+    action({ mutations }, { startPoint }: { startPoint?: number }) {
+      mutations.SET_AUDIO_PLAY_START_POINT({ startPoint });
     },
   },
 
@@ -637,7 +642,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   GENERATE_AUDIO_ITEM: {
     async action(
-      { state, getters, dispatch },
+      { state, getters, actions },
       payload: {
         text?: string;
         voice?: Voice;
@@ -684,9 +689,9 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       };
 
       const query = getters.IS_ENGINE_READY(voice.engineId)
-        ? await dispatch("FETCH_AUDIO_QUERY", fetchQueryParams).catch(
-            () => undefined,
-          )
+        ? await actions
+            .FETCH_AUDIO_QUERY(fetchQueryParams)
+            .catch(() => undefined)
         : undefined;
 
       const newAudioItem: AudioItem = { text, voice };
@@ -742,14 +747,14 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   REGISTER_AUDIO_ITEM: {
     async action(
-      { commit },
+      { mutations },
       {
         audioItem,
         prevAudioKey,
       }: { audioItem: AudioItem; prevAudioKey?: AudioKey },
     ) {
       const audioKey = generateAudioKey();
-      commit("INSERT_AUDIO_ITEM", { audioItem, audioKey, prevAudioKey });
+      mutations.INSERT_AUDIO_ITEM({ audioItem, audioKey, prevAudioKey });
       return audioKey;
     },
   },
@@ -820,9 +825,9 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   },
 
   REMOVE_ALL_AUDIO_ITEM: {
-    action({ commit, state }) {
+    action({ mutations, state }) {
       for (const audioKey of [...state.audioKeys]) {
-        commit("REMOVE_AUDIO_ITEM", { audioKey });
+        mutations.REMOVE_AUDIO_ITEM({ audioKey });
       }
     },
   },
@@ -943,25 +948,26 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       state.audioItems[audioKey].query = audioQuery;
     },
     action(
-      { commit },
+      { mutations },
       payload: { audioKey: AudioKey; audioQuery: AudioQuery },
     ) {
-      commit("SET_AUDIO_QUERY", payload);
+      mutations.SET_AUDIO_QUERY(payload);
     },
   },
 
   FETCH_AUDIO_QUERY: {
     action(
-      { dispatch },
+      { actions },
       {
         text,
         engineId,
         styleId,
       }: { text: string; engineId: EngineId; styleId: StyleId },
     ) {
-      return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineId,
-      })
+      return actions
+        .INSTANTIATE_ENGINE_CONNECTOR({
+          engineId,
+        })
         .then((instance) =>
           instance.invoke("audioQueryAudioQueryPost")({
             text,
@@ -1000,7 +1006,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   FETCH_ACCENT_PHRASES: {
     action(
-      { dispatch },
+      { actions },
       {
         text,
         engineId,
@@ -1013,9 +1019,10 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         isKana?: boolean;
       },
     ) {
-      return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineId,
-      })
+      return actions
+        .INSTANTIATE_ENGINE_CONNECTOR({
+          engineId,
+        })
         .then((instance) =>
           instance.invoke("accentPhrasesAccentPhrasesPost")({
             text,
@@ -1124,7 +1131,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   FETCH_MORA_DATA: {
     action(
-      { dispatch },
+      { actions },
       {
         accentPhrases,
         engineId,
@@ -1135,9 +1142,10 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         styleId: StyleId;
       },
     ) {
-      return dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
-        engineId,
-      })
+      return actions
+        .INSTANTIATE_ENGINE_CONNECTOR({
+          engineId,
+        })
         .then((instance) =>
           instance.invoke("moraDataMoraDataPost")({
             accentPhrase: accentPhrases,
@@ -1158,7 +1166,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   FETCH_AND_COPY_MORA_DATA: {
     async action(
-      { dispatch },
+      { actions },
       {
         accentPhrases,
         engineId,
@@ -1171,14 +1179,12 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         copyIndexes: number[];
       },
     ) {
-      const fetchedAccentPhrases: AccentPhrase[] = await dispatch(
-        "FETCH_MORA_DATA",
-        {
+      const fetchedAccentPhrases: AccentPhrase[] =
+        await actions.FETCH_MORA_DATA({
           accentPhrases,
           engineId,
           styleId,
-        },
-      );
+        });
       for (const index of copyIndexes) {
         accentPhrases[index] = fetchedAccentPhrases[index];
       }
@@ -1271,13 +1277,13 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   FETCH_AUDIO: {
     async action(
-      { dispatch, state },
+      { actions, state },
       { audioKey, ...options }: { audioKey: AudioKey; cacheOnly?: boolean },
     ) {
       const audioItem: AudioItem = JSON.parse(
         JSON.stringify(state.audioItems[audioKey]),
       );
-      return dispatch("FETCH_AUDIO_FROM_AUDIO_ITEM", {
+      return actions.FETCH_AUDIO_FROM_AUDIO_ITEM({
         audioItem,
         ...options,
       });
@@ -1287,10 +1293,10 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   FETCH_AUDIO_FROM_AUDIO_ITEM: {
     action: createUILockAction(
       async (
-        { dispatch, state },
+        { actions, state },
         options: { audioItem: AudioItem; cacheOnly?: boolean },
       ) => {
-        const instance = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
+        const instance = await actions.INSTANTIATE_ENGINE_CONNECTOR({
           engineId: options.audioItem.voice.engineId,
         });
         return fetchAudioFromAudioItem(state, instance, options);
@@ -1301,14 +1307,14 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   CONNECT_AUDIO: {
     action: createUILockAction(
       async (
-        { dispatch, state },
+        { actions, state },
         { encodedBlobs }: { encodedBlobs: string[] },
       ) => {
         const engineId: EngineId | undefined = state.engineIds[0]; // TODO: 複数エンジン対応, 暫定的に音声結合機能は0番目のエンジンのみを使用する
         if (engineId == undefined)
           throw new Error(`No such engine registered: index == 0`);
 
-        const instance = await dispatch("INSTANTIATE_ENGINE_CONNECTOR", {
+        const instance = await actions.INSTANTIATE_ENGINE_CONNECTOR({
           engineId,
         });
         try {
@@ -1326,7 +1332,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   GENERATE_AND_SAVE_AUDIO: {
     action: createUILockAction(
       async (
-        { state, getters, dispatch },
+        { state, getters, actions },
         {
           audioKey,
           filePath,
@@ -1358,7 +1364,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
         let fetchAudioResult: FetchAudioResult;
         try {
-          fetchAudioResult = await dispatch("FETCH_AUDIO", { audioKey });
+          fetchAudioResult = await actions.FETCH_AUDIO({ audioKey });
         } catch (e) {
           const errorMessage = handlePossiblyNotMorphableError(e);
           return {
@@ -1428,7 +1434,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   MULTI_GENERATE_AND_SAVE_AUDIO: {
     action: createUILockAction(
       async (
-        { state, getters, dispatch },
+        { state, getters, actions },
         {
           audioKeys,
           dirPath,
@@ -1453,13 +1459,15 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
           const promises = audioKeys.map((audioKey) => {
             const name = getters.DEFAULT_AUDIO_FILE_NAME(audioKey);
-            return dispatch("GENERATE_AND_SAVE_AUDIO", {
-              audioKey,
-              filePath: path.join(_dirPath, name),
-            }).then((value) => {
-              callback?.(++finishedCount);
-              return value;
-            });
+            return actions
+              .GENERATE_AND_SAVE_AUDIO({
+                audioKey,
+                filePath: path.join(_dirPath, name),
+              })
+              .then((value) => {
+                callback?.(++finishedCount);
+                return value;
+              });
           });
           return Promise.all(promises);
         }
@@ -1470,7 +1478,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   GENERATE_AND_CONNECT_AND_SAVE_AUDIO: {
     action: createUILockAction(
       async (
-        { state, getters, dispatch },
+        { state, getters, actions },
         {
           filePath,
           callback,
@@ -1529,7 +1537,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         for (const audioKey of state.audioKeys) {
           let fetchAudioResult: FetchAudioResult;
           try {
-            fetchAudioResult = await dispatch("FETCH_AUDIO", { audioKey });
+            fetchAudioResult = await actions.FETCH_AUDIO({ audioKey });
           } catch (e) {
             const errorMessage = handlePossiblyNotMorphableError(e);
             return {
@@ -1564,7 +1572,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           );
         }
 
-        const connectedWav = await dispatch("CONNECT_AUDIO", {
+        const connectedWav = await actions.CONNECT_AUDIO({
           encodedBlobs,
         });
         if (!connectedWav) {
@@ -1705,29 +1713,29 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   PLAY_AUDIO: {
     action: createUILockAction(
-      async ({ commit, dispatch }, { audioKey }: { audioKey: AudioKey }) => {
-        await dispatch("STOP_AUDIO");
+      async ({ mutations, actions }, { audioKey }: { audioKey: AudioKey }) => {
+        await actions.STOP_AUDIO();
 
         // 音声用意
         let fetchAudioResult: FetchAudioResult;
-        commit("SET_AUDIO_NOW_GENERATING", {
+        mutations.SET_AUDIO_NOW_GENERATING({
           audioKey,
           nowGenerating: true,
         });
         try {
           fetchAudioResult = await withProgress(
-            dispatch("FETCH_AUDIO", { audioKey }),
-            dispatch,
+            actions.FETCH_AUDIO({ audioKey }),
+            actions,
           );
         } finally {
-          commit("SET_AUDIO_NOW_GENERATING", {
+          mutations.SET_AUDIO_NOW_GENERATING({
             audioKey,
             nowGenerating: false,
           });
         }
 
         const { blob } = fetchAudioResult;
-        return dispatch("PLAY_AUDIO_BLOB", {
+        return actions.PLAY_AUDIO_BLOB({
           audioBlob: blob,
           audioKey,
         });
@@ -1738,14 +1746,14 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   PLAY_AUDIO_BLOB: {
     action: createUILockAction(
       async (
-        { getters, commit, dispatch },
+        { getters, mutations, actions },
         { audioBlob, audioKey }: { audioBlob: Blob; audioKey?: AudioKey },
       ) => {
-        commit("SET_AUDIO_SOURCE", { audioBlob });
+        mutations.SET_AUDIO_SOURCE({ audioBlob });
         let offset: number | undefined;
         // 途中再生用の処理
         if (audioKey) {
-          const accentPhraseOffsets = await dispatch("GET_AUDIO_PLAY_OFFSETS", {
+          const accentPhraseOffsets = await actions.GET_AUDIO_PLAY_OFFSETS({
             audioKey,
           });
           if (accentPhraseOffsets.length === 0)
@@ -1758,7 +1766,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
           offset = startTime + 10e-6;
         }
 
-        return dispatch("PLAY_AUDIO_PLAYER", { offset, audioKey });
+        return actions.PLAY_AUDIO_PLAYER({ offset, audioKey });
       },
     ),
   },
@@ -1780,50 +1788,52 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
   },
 
   PLAY_CONTINUOUSLY_AUDIO: {
-    action: createUILockAction(async ({ state, getters, commit, dispatch }) => {
-      const currentAudioKey = state._activeAudioKey;
-      const currentAudioPlayStartPoint = getters.AUDIO_PLAY_START_POINT;
+    action: createUILockAction(
+      async ({ state, getters, mutations, actions }) => {
+        const currentAudioKey = state._activeAudioKey;
+        const currentAudioPlayStartPoint = getters.AUDIO_PLAY_START_POINT;
 
-      let index = 0;
-      if (currentAudioKey != undefined) {
-        index = state.audioKeys.findIndex((v) => v === currentAudioKey);
-      }
+        let index = 0;
+        if (currentAudioKey != undefined) {
+          index = state.audioKeys.findIndex((v) => v === currentAudioKey);
+        }
 
-      const player = new ContinuousPlayer(state.audioKeys.slice(index), {
-        generateAudio: ({ audioKey }) =>
-          dispatch("FETCH_AUDIO", { audioKey }).then((result) => result.blob),
-        playAudioBlob: ({ audioBlob, audioKey }) =>
-          dispatch("PLAY_AUDIO_BLOB", { audioBlob, audioKey }),
-      });
-      player.addEventListener("playstart", (e) => {
-        commit("SET_ACTIVE_AUDIO_KEY", { audioKey: e.audioKey });
-      });
-      player.addEventListener("waitstart", (e) => {
-        dispatch("START_PROGRESS");
-        commit("SET_ACTIVE_AUDIO_KEY", { audioKey: e.audioKey });
-        commit("SET_AUDIO_NOW_GENERATING", {
-          audioKey: e.audioKey,
-          nowGenerating: true,
+        const player = new ContinuousPlayer(state.audioKeys.slice(index), {
+          generateAudio: ({ audioKey }) =>
+            actions.FETCH_AUDIO({ audioKey }).then((result) => result.blob),
+          playAudioBlob: ({ audioBlob, audioKey }) =>
+            actions.PLAY_AUDIO_BLOB({ audioBlob, audioKey }),
         });
-      });
-      player.addEventListener("waitend", (e) => {
-        dispatch("RESET_PROGRESS");
-        commit("SET_AUDIO_NOW_GENERATING", {
-          audioKey: e.audioKey,
-          nowGenerating: false,
+        player.addEventListener("playstart", (e) => {
+          mutations.SET_ACTIVE_AUDIO_KEY({ audioKey: e.audioKey });
         });
-      });
+        player.addEventListener("waitstart", (e) => {
+          actions.START_PROGRESS();
+          mutations.SET_ACTIVE_AUDIO_KEY({ audioKey: e.audioKey });
+          mutations.SET_AUDIO_NOW_GENERATING({
+            audioKey: e.audioKey,
+            nowGenerating: true,
+          });
+        });
+        player.addEventListener("waitend", (e) => {
+          actions.RESET_PROGRESS();
+          mutations.SET_AUDIO_NOW_GENERATING({
+            audioKey: e.audioKey,
+            nowGenerating: false,
+          });
+        });
 
-      commit("SET_NOW_PLAYING_CONTINUOUSLY", { nowPlaying: true });
+        mutations.SET_NOW_PLAYING_CONTINUOUSLY({ nowPlaying: true });
 
-      await player.playUntilComplete();
+        await player.playUntilComplete();
 
-      commit("SET_ACTIVE_AUDIO_KEY", { audioKey: currentAudioKey });
-      commit("SET_AUDIO_PLAY_START_POINT", {
-        startPoint: currentAudioPlayStartPoint,
-      });
-      commit("SET_NOW_PLAYING_CONTINUOUSLY", { nowPlaying: false });
-    }),
+        mutations.SET_ACTIVE_AUDIO_KEY({ audioKey: currentAudioKey });
+        mutations.SET_AUDIO_PLAY_START_POINT({
+          startPoint: currentAudioPlayStartPoint,
+        });
+        mutations.SET_NOW_PLAYING_CONTINUOUSLY({ nowPlaying: false });
+      },
+    ),
   },
 });
 
@@ -1843,7 +1853,7 @@ export const audioCommandStore = transformCommandStore(
         audioStore.mutations.INSERT_AUDIO_ITEM(draft, payload);
       },
       async action(
-        { commit },
+        { mutations },
         {
           audioItem,
           prevAudioKey,
@@ -1853,7 +1863,7 @@ export const audioCommandStore = transformCommandStore(
         },
       ) {
         const audioKey = generateAudioKey();
-        commit("COMMAND_REGISTER_AUDIO_ITEM", {
+        mutations.COMMAND_REGISTER_AUDIO_ITEM({
           audioItem,
           audioKey,
           prevAudioKey,
@@ -1868,8 +1878,8 @@ export const audioCommandStore = transformCommandStore(
           audioStore.mutations.REMOVE_AUDIO_ITEM(draft, { audioKey });
         }
       },
-      action({ commit }, payload: { audioKeys: AudioKey[] }) {
-        commit("COMMAND_MULTI_REMOVE_AUDIO_ITEM", payload);
+      action({ mutations }, payload: { audioKeys: AudioKey[] }) {
+        mutations.COMMAND_MULTI_REMOVE_AUDIO_ITEM(payload);
       },
     },
 
@@ -1877,8 +1887,8 @@ export const audioCommandStore = transformCommandStore(
       mutation(draft, payload: { audioKeys: AudioKey[] }) {
         audioStore.mutations.SET_AUDIO_KEYS(draft, payload);
       },
-      action({ commit }, payload: { audioKeys: AudioKey[] }) {
-        commit("COMMAND_SET_AUDIO_KEYS", payload);
+      action({ mutations }, payload: { audioKeys: AudioKey[] }) {
+        mutations.COMMAND_SET_AUDIO_KEYS(payload);
       },
     },
 
@@ -1886,8 +1896,8 @@ export const audioCommandStore = transformCommandStore(
       /**
        * 読みを変えずにテキストだけを変える
        */
-      action({ commit }, payload: { audioKey: AudioKey; text: string }) {
-        commit("COMMAND_CHANGE_AUDIO_TEXT", {
+      action({ mutations }, payload: { audioKey: AudioKey; text: string }) {
+        mutations.COMMAND_CHANGE_AUDIO_TEXT({
           audioKey: payload.audioKey,
           text: payload.text,
           update: "Text",
@@ -1924,7 +1934,7 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       async action(
-        { state, commit, dispatch },
+        { state, mutations, actions },
         { audioKey, text }: { audioKey: AudioKey; text: string },
       ) {
         const engineId = state.audioItems[audioKey].voice.engineId;
@@ -1937,14 +1947,12 @@ export const audioCommandStore = transformCommandStore(
 
         try {
           if (query != undefined) {
-            const accentPhrases: AccentPhrase[] = await dispatch(
-              "FETCH_ACCENT_PHRASES",
-              {
+            const accentPhrases: AccentPhrase[] =
+              await actions.FETCH_ACCENT_PHRASES({
                 text: skippedText,
                 engineId,
                 styleId,
-              },
-            );
+              });
 
             // 読みの内容が変わっていなければテキストだけ変更
             const isSameText = !isAccentPhrasesTextDifferent(
@@ -1966,19 +1974,19 @@ export const audioCommandStore = transformCommandStore(
                 newAccentPhrases = mergedDiff;
               }
             }
-            commit("COMMAND_CHANGE_AUDIO_TEXT", {
+            mutations.COMMAND_CHANGE_AUDIO_TEXT({
               audioKey,
               text,
               update: "AccentPhrases",
               accentPhrases: newAccentPhrases,
             });
           } else {
-            const newAudioQuery = await dispatch("FETCH_AUDIO_QUERY", {
+            const newAudioQuery = await actions.FETCH_AUDIO_QUERY({
               text,
               engineId,
               styleId,
             });
-            commit("COMMAND_CHANGE_AUDIO_TEXT", {
+            mutations.COMMAND_CHANGE_AUDIO_TEXT({
               audioKey,
               text,
               update: "AudioQuery",
@@ -1986,7 +1994,7 @@ export const audioCommandStore = transformCommandStore(
             });
           }
         } catch (error) {
-          commit("COMMAND_CHANGE_AUDIO_TEXT", {
+          mutations.COMMAND_CHANGE_AUDIO_TEXT({
             audioKey,
             text,
             update: "Text",
@@ -2058,12 +2066,12 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       async action(
-        { state, dispatch, commit },
+        { state, actions, mutations },
         { audioKeys, voice }: { audioKeys: AudioKey[]; voice: Voice },
       ) {
         const engineId = voice.engineId;
         const styleId = voice.styleId;
-        await dispatch("SETUP_SPEAKER", { audioKeys, engineId, styleId });
+        await actions.SETUP_SPEAKER({ audioKeys, engineId, styleId });
         const errors: Record<AudioKey, unknown> = {};
         const changes: Record<
           AudioKey,
@@ -2084,7 +2092,7 @@ export const audioCommandStore = transformCommandStore(
           try {
             const audioItem = state.audioItems[audioKey];
             if (audioItem.query == undefined) {
-              const query: AudioQuery = await dispatch("FETCH_AUDIO_QUERY", {
+              const query: AudioQuery = await actions.FETCH_AUDIO_QUERY({
                 text: audioItem.text,
                 engineId: voice.engineId,
                 styleId: voice.styleId,
@@ -2094,14 +2102,12 @@ export const audioCommandStore = transformCommandStore(
                 query,
               };
             } else {
-              const newAccentPhrases: AccentPhrase[] = await dispatch(
-                "FETCH_MORA_DATA",
-                {
+              const newAccentPhrases: AccentPhrase[] =
+                await actions.FETCH_MORA_DATA({
                   accentPhrases: audioItem.query.accentPhrases,
                   engineId: voice.engineId,
                   styleId: voice.styleId,
-                },
-              );
+                });
 
               changes[audioKey] = {
                 update: "AccentPhrases",
@@ -2116,7 +2122,7 @@ export const audioCommandStore = transformCommandStore(
           }
         }
 
-        commit("COMMAND_MULTI_CHANGE_VOICE", {
+        mutations.COMMAND_MULTI_CHANGE_VOICE({
           voice,
           changes,
         });
@@ -2145,7 +2151,7 @@ export const audioCommandStore = transformCommandStore(
         });
       },
       async action(
-        { state, dispatch, commit },
+        { state, actions, mutations },
         {
           audioKey,
           accentPhraseIndex,
@@ -2163,22 +2169,20 @@ export const audioCommandStore = transformCommandStore(
             const engineId = state.audioItems[audioKey].voice.engineId;
             const styleId = state.audioItems[audioKey].voice.styleId;
 
-            const resultAccentPhrases: AccentPhrase[] = await dispatch(
-              "FETCH_AND_COPY_MORA_DATA",
-              {
+            const resultAccentPhrases: AccentPhrase[] =
+              await actions.FETCH_AND_COPY_MORA_DATA({
                 accentPhrases: newAccentPhrases,
                 engineId,
                 styleId,
                 copyIndexes: [accentPhraseIndex],
-              },
-            );
+              });
 
-            commit("COMMAND_CHANGE_ACCENT", {
+            mutations.COMMAND_CHANGE_ACCENT({
               audioKey,
               accentPhrases: resultAccentPhrases,
             });
           } catch (error) {
-            commit("COMMAND_CHANGE_ACCENT", {
+            mutations.COMMAND_CHANGE_ACCENT({
               audioKey,
               accentPhrases: newAccentPhrases,
             });
@@ -2199,7 +2203,7 @@ export const audioCommandStore = transformCommandStore(
         audioStore.mutations.SET_ACCENT_PHRASES(draft, payload);
       },
       async action(
-        { state, dispatch, commit },
+        { state, actions, mutations },
         payload: {
           audioKey: AudioKey;
           accentPhraseIndex: number;
@@ -2287,21 +2291,19 @@ export const audioCommandStore = transformCommandStore(
         }
 
         try {
-          const resultAccentPhrases: AccentPhrase[] = await dispatch(
-            "FETCH_AND_COPY_MORA_DATA",
-            {
+          const resultAccentPhrases: AccentPhrase[] =
+            await actions.FETCH_AND_COPY_MORA_DATA({
               accentPhrases: newAccentPhrases,
               engineId,
               styleId,
               copyIndexes: changeIndexes,
-            },
-          );
-          commit("COMMAND_CHANGE_ACCENT_PHRASE_SPLIT", {
+            });
+          mutations.COMMAND_CHANGE_ACCENT_PHRASE_SPLIT({
             audioKey,
             accentPhrases: resultAccentPhrases,
           });
         } catch (error) {
-          commit("COMMAND_CHANGE_ACCENT_PHRASE_SPLIT", {
+          mutations.COMMAND_CHANGE_ACCENT_PHRASE_SPLIT({
             audioKey,
             accentPhrases: newAccentPhrases,
           });
@@ -2312,7 +2314,7 @@ export const audioCommandStore = transformCommandStore(
 
     COMMAND_DELETE_ACCENT_PHRASE: {
       async action(
-        { state, commit },
+        { state, mutations },
         {
           audioKey,
           accentPhraseIndex,
@@ -2332,7 +2334,7 @@ export const audioCommandStore = transformCommandStore(
         ];
 
         // 自動再調整は行わない
-        commit("COMMAND_CHANGE_SINGLE_ACCENT_PHRASE", {
+        mutations.COMMAND_CHANGE_SINGLE_ACCENT_PHRASE({
           audioKey,
           accentPhrases: newAccentPhrases,
         });
@@ -2350,7 +2352,7 @@ export const audioCommandStore = transformCommandStore(
         audioStore.mutations.SET_ACCENT_PHRASES(draft, payload);
       },
       async action(
-        { state, dispatch, commit },
+        { state, actions, mutations },
         {
           audioKey,
           newPronunciation,
@@ -2384,23 +2386,25 @@ export const audioCommandStore = transformCommandStore(
 
           // accent phraseの生成をリクエスト
           // 判別できない読み仮名が混じっていた場合400エラーが帰るのでfallback
-          newAccentPhrasesSegment = await dispatch("FETCH_ACCENT_PHRASES", {
-            text: pureKatakanaWithAccent,
-            engineId,
-            styleId,
-            isKana: true,
-          }).catch(
-            // fallback
-            () =>
-              dispatch("FETCH_ACCENT_PHRASES", {
-                text: newPronunciation,
-                engineId,
-                styleId,
-                isKana: false,
-              }),
-          );
+          newAccentPhrasesSegment = await actions
+            .FETCH_ACCENT_PHRASES({
+              text: pureKatakanaWithAccent,
+              engineId,
+              styleId,
+              isKana: true,
+            })
+            .catch(
+              // fallback
+              () =>
+                actions.FETCH_ACCENT_PHRASES({
+                  text: newPronunciation,
+                  engineId,
+                  styleId,
+                  isKana: false,
+                }),
+            );
         } else {
-          newAccentPhrasesSegment = await dispatch("FETCH_ACCENT_PHRASES", {
+          newAccentPhrasesSegment = await actions.FETCH_ACCENT_PHRASES({
             text: newPronunciation,
             engineId,
             styleId,
@@ -2434,21 +2438,19 @@ export const audioCommandStore = transformCommandStore(
         );
 
         try {
-          const resultAccentPhrases: AccentPhrase[] = await dispatch(
-            "FETCH_AND_COPY_MORA_DATA",
-            {
+          const resultAccentPhrases: AccentPhrase[] =
+            await actions.FETCH_AND_COPY_MORA_DATA({
               accentPhrases: newAccentPhrases,
               engineId,
               styleId,
               copyIndexes,
-            },
-          );
-          commit("COMMAND_CHANGE_SINGLE_ACCENT_PHRASE", {
+            });
+          mutations.COMMAND_CHANGE_SINGLE_ACCENT_PHRASE({
             audioKey,
             accentPhrases: resultAccentPhrases,
           });
         } catch (error) {
-          commit("COMMAND_CHANGE_SINGLE_ACCENT_PHRASE", {
+          mutations.COMMAND_CHANGE_SINGLE_ACCENT_PHRASE({
             audioKey,
             accentPhrases: newAccentPhrases,
           });
@@ -2457,7 +2459,7 @@ export const audioCommandStore = transformCommandStore(
     },
 
     COMMAND_MULTI_RESET_MORA_PITCH_AND_LENGTH: {
-      async action({ state, dispatch, commit }, { audioKeys }) {
+      async action({ state, actions, mutations }, { audioKeys }) {
         for (const audioKey of audioKeys) {
           const engineId = state.audioItems[audioKey].voice.engineId;
           const styleId = state.audioItems[audioKey].voice.styleId;
@@ -2465,13 +2467,13 @@ export const audioCommandStore = transformCommandStore(
           const query = state.audioItems[audioKey].query;
           if (query == undefined) throw new Error("assert query != undefined");
 
-          const newAccentPhrases = await dispatch("FETCH_MORA_DATA", {
+          const newAccentPhrases = await actions.FETCH_MORA_DATA({
             accentPhrases: query.accentPhrases,
             engineId,
             styleId,
           });
 
-          commit("COMMAND_CHANGE_ACCENT", {
+          mutations.COMMAND_CHANGE_ACCENT({
             audioKey,
             accentPhrases: newAccentPhrases,
           });
@@ -2481,7 +2483,7 @@ export const audioCommandStore = transformCommandStore(
 
     COMMAND_RESET_SELECTED_MORA_PITCH_AND_LENGTH: {
       async action(
-        { state, dispatch, commit },
+        { state, actions, mutations },
         { audioKey, accentPhraseIndex },
       ) {
         const engineId = state.audioItems[audioKey].voice.engineId;
@@ -2490,14 +2492,14 @@ export const audioCommandStore = transformCommandStore(
         const query = state.audioItems[audioKey].query;
         if (query == undefined) throw new Error("query == undefined");
 
-        const newAccentPhrases = await dispatch("FETCH_AND_COPY_MORA_DATA", {
+        const newAccentPhrases = await actions.FETCH_AND_COPY_MORA_DATA({
           accentPhrases: [...query.accentPhrases],
           engineId,
           styleId,
           copyIndexes: [accentPhraseIndex],
         });
 
-        commit("COMMAND_CHANGE_ACCENT", {
+        mutations.COMMAND_CHANGE_ACCENT({
           audioKey,
           accentPhrases: newAccentPhrases,
         });
@@ -2518,7 +2520,7 @@ export const audioCommandStore = transformCommandStore(
         audioStore.mutations.SET_AUDIO_MORA_DATA(draft, payload);
       },
       action(
-        { commit },
+        { mutations },
         payload: {
           audioKey: AudioKey;
           accentPhraseIndex: number;
@@ -2527,7 +2529,7 @@ export const audioCommandStore = transformCommandStore(
           type: MoraDataType;
         },
       ) {
-        commit("COMMAND_SET_AUDIO_MORA_DATA", payload);
+        mutations.COMMAND_SET_AUDIO_MORA_DATA(payload);
       },
     },
 
@@ -2615,7 +2617,7 @@ export const audioCommandStore = transformCommandStore(
         });
       },
       action(
-        { commit },
+        { mutations },
         payload: {
           audioKey: AudioKey;
           accentPhraseIndex: number;
@@ -2624,7 +2626,7 @@ export const audioCommandStore = transformCommandStore(
           type: MoraDataType;
         },
       ) {
-        commit("COMMAND_SET_AUDIO_MORA_DATA_ACCENT_PHRASE", payload);
+        mutations.COMMAND_SET_AUDIO_MORA_DATA_ACCENT_PHRASE(payload);
       },
     },
 
@@ -2638,10 +2640,10 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       action(
-        { commit },
+        { mutations },
         payload: { audioKeys: AudioKey[]; speedScale: number },
       ) {
-        commit("COMMAND_MULTI_SET_AUDIO_SPEED_SCALE", payload);
+        mutations.COMMAND_MULTI_SET_AUDIO_SPEED_SCALE(payload);
       },
     },
 
@@ -2655,10 +2657,10 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       action(
-        { commit },
+        { mutations },
         payload: { audioKeys: AudioKey[]; pitchScale: number },
       ) {
-        commit("COMMAND_MULTI_SET_AUDIO_PITCH_SCALE", payload);
+        mutations.COMMAND_MULTI_SET_AUDIO_PITCH_SCALE(payload);
       },
     },
 
@@ -2675,10 +2677,10 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       action(
-        { commit },
+        { mutations },
         payload: { audioKeys: AudioKey[]; intonationScale: number },
       ) {
-        commit("COMMAND_MULTI_SET_AUDIO_INTONATION_SCALE", payload);
+        mutations.COMMAND_MULTI_SET_AUDIO_INTONATION_SCALE(payload);
       },
     },
 
@@ -2692,10 +2694,10 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       action(
-        { commit },
+        { mutations },
         payload: { audioKeys: AudioKey[]; volumeScale: number },
       ) {
-        commit("COMMAND_MULTI_SET_AUDIO_VOLUME_SCALE", payload);
+        mutations.COMMAND_MULTI_SET_AUDIO_VOLUME_SCALE(payload);
       },
     },
 
@@ -2712,10 +2714,10 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       action(
-        { commit },
+        { mutations },
         payload: { audioKeys: AudioKey[]; prePhonemeLength: number },
       ) {
-        commit("COMMAND_MULTI_SET_AUDIO_PRE_PHONEME_LENGTH", payload);
+        mutations.COMMAND_MULTI_SET_AUDIO_PRE_PHONEME_LENGTH(payload);
       },
     },
 
@@ -2732,10 +2734,10 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       action(
-        { commit },
+        { mutations },
         payload: { audioKeys: AudioKey[]; postPhonemeLength: number },
       ) {
-        commit("COMMAND_MULTI_SET_AUDIO_POST_PHONEME_LENGTH", payload);
+        mutations.COMMAND_MULTI_SET_AUDIO_POST_PHONEME_LENGTH(payload);
       },
     },
 
@@ -2755,13 +2757,13 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       action(
-        { commit },
+        { mutations },
         payload: {
           audioKeys: AudioKey[];
           morphingInfo: MorphingInfo | undefined;
         },
       ) {
-        commit("COMMAND_MULTI_SET_MORPHING_INFO", payload);
+        mutations.COMMAND_MULTI_SET_MORPHING_INFO(payload);
       },
     },
 
@@ -2782,13 +2784,13 @@ export const audioCommandStore = transformCommandStore(
         }
       },
       action(
-        { commit },
+        { mutations },
         {
           audioKeys,
           presetKey,
         }: { audioKeys: AudioKey[]; presetKey: PresetKey | undefined },
       ) {
-        commit("COMMAND_MULTI_SET_AUDIO_PRESET", { audioKeys, presetKey });
+        mutations.COMMAND_MULTI_SET_AUDIO_PRESET({ audioKeys, presetKey });
       },
     },
 
@@ -2798,8 +2800,8 @@ export const audioCommandStore = transformCommandStore(
           audioStore.mutations.APPLY_AUDIO_PRESET(draft, { audioKey });
         }
       },
-      action({ commit }, payload: { audioKeys: AudioKey[] }) {
-        commit("COMMAND_MULTI_APPLY_AUDIO_PRESET", payload);
+      action({ mutations }, payload: { audioKeys: AudioKey[] }) {
+        mutations.COMMAND_MULTI_APPLY_AUDIO_PRESET(payload);
       },
     },
 
@@ -2812,8 +2814,8 @@ export const audioCommandStore = transformCommandStore(
           audioStore.mutations.APPLY_AUDIO_PRESET(draft, { audioKey });
         }
       },
-      action({ commit }, payload: { presetKey: PresetKey }) {
-        commit("COMMAND_FULLY_APPLY_AUDIO_PRESET", payload);
+      action({ mutations }, payload: { presetKey: PresetKey }) {
+        mutations.COMMAND_FULLY_APPLY_AUDIO_PRESET(payload);
       },
     },
 
@@ -2833,7 +2835,7 @@ export const audioCommandStore = transformCommandStore(
       },
       action: createUILockAction(
         async (
-          { state, commit, dispatch, getters },
+          { state, mutations, actions, getters },
           { filePath }: { filePath?: string },
         ) => {
           if (!filePath) {
@@ -2867,7 +2869,7 @@ export const audioCommandStore = transformCommandStore(
             baseAudioItem?.voice,
           )) {
             audioItems.push(
-              await dispatch("GENERATE_AUDIO_ITEM", {
+              await actions.GENERATE_AUDIO_ITEM({
                 text,
                 voice,
                 baseAudioItem,
@@ -2878,7 +2880,7 @@ export const audioCommandStore = transformCommandStore(
             audioItem,
             audioKey: generateAudioKey(),
           }));
-          commit("COMMAND_IMPORT_FROM_FILE", {
+          mutations.COMMAND_IMPORT_FROM_FILE({
             audioKeyItemPairs,
           });
         },
@@ -2903,7 +2905,7 @@ export const audioCommandStore = transformCommandStore(
       },
       action: createUILockAction(
         async (
-          { state, commit, dispatch },
+          { state, mutations, actions },
           {
             prevAudioKey,
             texts,
@@ -2925,7 +2927,7 @@ export const audioCommandStore = transformCommandStore(
 
           for (const text of texts.filter((value) => value != "")) {
             const audioKey = generateAudioKey();
-            const audioItem = await dispatch("GENERATE_AUDIO_ITEM", {
+            const audioItem = await actions.GENERATE_AUDIO_ITEM({
               text,
               voice,
               baseAudioItem,
@@ -2937,7 +2939,7 @@ export const audioCommandStore = transformCommandStore(
             });
           }
           const audioKeys = audioKeyItemPairs.map((value) => value.audioKey);
-          commit("COMMAND_PUT_TEXTS", {
+          mutations.COMMAND_PUT_TEXTS({
             prevAudioKey,
             audioKeyItemPairs,
           });

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -4,7 +4,7 @@ import { enablePatches, enableMapSet, Immer } from "immer";
 import { Command, CommandStoreState, CommandStoreTypes, State } from "./type";
 import { applyPatches } from "@/store/immerPatchUtility";
 import {
-  createPartialStore,
+  createDotNotationPartialStore as createPartialStore,
   Mutation,
   MutationsBase,
   MutationTree,
@@ -106,12 +106,12 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
         applyPatches(state, command.undoPatches);
       }
     },
-    action({ commit, dispatch }, { editor }: { editor: EditorType }) {
-      commit("UNDO", { editor });
+    action({ mutations, actions }, { editor }: { editor: EditorType }) {
+      mutations.UNDO({ editor });
       if (editor === "song") {
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
-        commit("DESELECT_ALL_NOTES");
-        dispatch("RENDER");
+        mutations.DESELECT_ALL_NOTES();
+        actions.RENDER();
       }
     },
   },
@@ -124,12 +124,12 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
         applyPatches(state, command.redoPatches);
       }
     },
-    action({ commit, dispatch }, { editor }: { editor: EditorType }) {
-      commit("REDO", { editor });
+    action({ mutations, actions }, { editor }: { editor: EditorType }) {
+      mutations.REDO({ editor });
       if (editor === "song") {
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
-        commit("DESELECT_ALL_NOTES");
-        dispatch("RENDER");
+        mutations.DESELECT_ALL_NOTES();
+        actions.RENDER();
       }
     },
   },

--- a/src/store/preset.ts
+++ b/src/store/preset.ts
@@ -1,4 +1,4 @@
-import { createPartialStore } from "./vuex";
+import { createDotNotationPartialStore as createPartialStore } from "./vuex";
 import { uuid4 } from "@/helpers/random";
 import { PresetStoreState, PresetStoreTypes, State } from "@/store/type";
 import { Preset, PresetKey, Voice, VoiceId } from "@/type/preload";
@@ -106,11 +106,11 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
 
   SET_DEFAULT_PRESET_MAP: {
     action(
-      { commit },
+      { mutations },
       { defaultPresetKeys }: { defaultPresetKeys: Record<VoiceId, PresetKey> },
     ) {
       window.backend.setSetting("defaultPresetKeys", defaultPresetKeys);
-      commit("SET_DEFAULT_PRESET_MAP", { defaultPresetKeys });
+      mutations.SET_DEFAULT_PRESET_MAP({ defaultPresetKeys });
     },
     mutation(
       state,
@@ -121,14 +121,14 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
   },
 
   HYDRATE_PRESET_STORE: {
-    async action({ commit }) {
+    async action({ mutations }) {
       const defaultPresetKeys = (await window.backend.getSetting(
         "defaultPresetKeys",
         // z.BRAND型のRecordはPartialになる仕様なのでasで型を変換
         // TODO: 将来的にzodのバージョンを上げてasを消す https://github.com/colinhacks/zod/pull/2097
       )) as Record<VoiceId, PresetKey>;
 
-      commit("SET_DEFAULT_PRESET_MAP", {
+      mutations.SET_DEFAULT_PRESET_MAP({
         defaultPresetKeys,
       });
 
@@ -139,20 +139,20 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
         presetConfig.keys == undefined
       )
         return;
-      commit("SET_PRESET_ITEMS", {
+      mutations.SET_PRESET_ITEMS({
         // z.BRAND型のRecordはPartialになる仕様なのでasで型を変換
         // TODO: 将来的にzodのバージョンを上げてasを消す https://github.com/colinhacks/zod/pull/2097
         presetItems: presetConfig.items as Record<PresetKey, Preset>,
       });
-      commit("SET_PRESET_KEYS", {
+      mutations.SET_PRESET_KEYS({
         presetKeys: presetConfig.keys,
       });
     },
   },
 
   SAVE_PRESET_ORDER: {
-    action({ state, dispatch }, { presetKeys }: { presetKeys: PresetKey[] }) {
-      return dispatch("SAVE_PRESET_CONFIG", {
+    action({ state, actions }, { presetKeys }: { presetKeys: PresetKey[] }) {
+      return actions.SAVE_PRESET_CONFIG({
         presetItems: state.presetItems,
         presetKeys,
       });
@@ -171,12 +171,12 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
         items: JSON.parse(JSON.stringify(presetItems)),
         keys: JSON.parse(JSON.stringify(presetKeys)),
       });
-      context.commit("SET_PRESET_ITEMS", {
+      context.mutations.SET_PRESET_ITEMS({
         // z.BRAND型のRecordはPartialになる仕様なのでasで型を変換
         // TODO: 将来的にzodのバージョンを上げてasを消す https://github.com/colinhacks/zod/pull/2097
         presetItems: result.items as Record<PresetKey, Preset>,
       });
-      context.commit("SET_PRESET_KEYS", { presetKeys: result.keys });
+      context.mutations.SET_PRESET_KEYS({ presetKeys: result.keys });
     },
   },
 
@@ -189,7 +189,7 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
       };
       const newPresetKeys = [newKey, ...context.state.presetKeys];
 
-      await context.dispatch("SAVE_PRESET_CONFIG", {
+      await context.actions.SAVE_PRESET_CONFIG({
         presetItems: newPresetItems,
         presetKeys: newPresetKeys,
       });
@@ -199,7 +199,7 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
   },
 
   CREATE_ALL_DEFAULT_PRESET: {
-    async action({ state, dispatch, getters }) {
+    async action({ state, actions, getters }) {
       const voices = getters.GET_ALL_VOICES("talk");
 
       for (const voice of voices) {
@@ -221,9 +221,9 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
           prePhonemeLength: 0.1,
           postPhonemeLength: 0.1,
         };
-        const newPresetKey = await dispatch("ADD_PRESET", { presetData });
+        const newPresetKey = await actions.ADD_PRESET({ presetData });
 
-        await dispatch("SET_DEFAULT_PRESET_MAP", {
+        await actions.SET_DEFAULT_PRESET_MAP({
           defaultPresetKeys: {
             ...state.defaultPresetKeys,
             [voiceId]: newPresetKey,
@@ -246,7 +246,7 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
         ? [...context.state.presetKeys]
         : [presetKey, ...context.state.presetKeys];
 
-      await context.dispatch("SAVE_PRESET_CONFIG", {
+      await context.actions.SAVE_PRESET_CONFIG({
         presetItems: newPresetItems,
         presetKeys: newPresetKeys,
       });
@@ -261,7 +261,7 @@ export const presetStore = createPartialStore<PresetStoreTypes>({
       // Filter the `presetKey` properties from presetItems.
       const { [presetKey]: _, ...newPresetItems } = context.state.presetItems;
 
-      await context.dispatch("SAVE_PRESET_CONFIG", {
+      await context.actions.SAVE_PRESET_CONFIG({
         presetItems: newPresetItems,
         presetKeys: newPresetKeys,
       });

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,6 +1,9 @@
 import { getBaseName } from "./utility";
-import { createPartialStore, Dispatch } from "./vuex";
-import { createUILockAction } from "@/store/ui";
+import {
+  createDotNotationPartialStore as createPartialStore,
+  DotNotationDispatch,
+} from "./vuex";
+import { createDotNotationUILockAction as createUILockAction } from "@/store/ui";
 import {
   AllActions,
   AudioItem,
@@ -27,10 +30,10 @@ export const projectStoreState: ProjectStoreState = {
 };
 
 const applyTalkProjectToStore = async (
-  dispatch: Dispatch<AllActions>,
+  actions: DotNotationDispatch<AllActions>,
   talkProject: LatestProjectType["talk"],
 ) => {
-  await dispatch("REMOVE_ALL_AUDIO_ITEM");
+  await actions.REMOVE_ALL_AUDIO_ITEM();
 
   const { audioItems, audioKeys } = talkProject;
 
@@ -41,7 +44,7 @@ const applyTalkProjectToStore = async (
     // valueがundefinedにならないことを検証したあとであれば、
     // このif文に引っかかることはないはずである
     if (audioItem == undefined) throw new Error("audioItem == undefined");
-    prevAudioKey = await dispatch("REGISTER_AUDIO_ITEM", {
+    prevAudioKey = await actions.REGISTER_AUDIO_ITEM({
       prevAudioKey,
       audioItem,
     });
@@ -49,26 +52,26 @@ const applyTalkProjectToStore = async (
 };
 
 const applySongProjectToStore = async (
-  dispatch: Dispatch<AllActions>,
+  actions: DotNotationDispatch<AllActions>,
   songProject: LatestProjectType["song"],
 ) => {
   const { tpqn, tempos, timeSignatures, tracks } = songProject;
   // TODO: マルチトラック対応
-  await dispatch("SET_SINGER", {
+  await actions.SET_SINGER({
     singer: tracks[0].singer,
   });
-  await dispatch("SET_KEY_RANGE_ADJUSTMENT", {
+  await actions.SET_KEY_RANGE_ADJUSTMENT({
     keyRangeAdjustment: tracks[0].keyRangeAdjustment,
   });
-  await dispatch("SET_VOLUME_RANGE_ADJUSTMENT", {
+  await actions.SET_VOLUME_RANGE_ADJUSTMENT({
     volumeRangeAdjustment: tracks[0].volumeRangeAdjustment,
   });
-  await dispatch("SET_TPQN", { tpqn });
-  await dispatch("SET_TEMPOS", { tempos });
-  await dispatch("SET_TIME_SIGNATURES", { timeSignatures });
-  await dispatch("SET_NOTES", { notes: tracks[0].notes });
-  await dispatch("CLEAR_PITCH_EDIT_DATA"); // FIXME: SET_PITCH_EDIT_DATAがセッターになれば不要
-  await dispatch("SET_PITCH_EDIT_DATA", {
+  await actions.SET_TPQN({ tpqn });
+  await actions.SET_TEMPOS({ tempos });
+  await actions.SET_TIME_SIGNATURES({ timeSignatures });
+  await actions.SET_NOTES({ notes: tracks[0].notes });
+  await actions.CLEAR_PITCH_EDIT_DATA(); // FIXME: SET_PITCH_EDIT_DATAがセッターになれば不要
+  await actions.SET_PITCH_EDIT_DATA({
     data: tracks[0].pitchEditData,
     startFrame: 0,
   });
@@ -101,47 +104,43 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
     action: createUILockAction(
       async (context, { confirm }: { confirm?: boolean }) => {
         if (confirm !== false && context.getters.IS_EDITED) {
-          const result = await context.dispatch(
-            "SAVE_OR_DISCARD_PROJECT_FILE",
-            {},
-          );
+          const result = await context.actions.SAVE_OR_DISCARD_PROJECT_FILE({});
           if (result == "canceled") {
             return;
           }
         }
 
         // トークプロジェクトの初期化
-        await context.dispatch("REMOVE_ALL_AUDIO_ITEM");
+        await context.actions.REMOVE_ALL_AUDIO_ITEM();
 
-        const audioItem: AudioItem = await context.dispatch(
-          "GENERATE_AUDIO_ITEM",
+        const audioItem: AudioItem = await context.actions.GENERATE_AUDIO_ITEM(
           {},
         );
-        await context.dispatch("REGISTER_AUDIO_ITEM", {
+        await context.actions.REGISTER_AUDIO_ITEM({
           audioItem,
         });
 
         // ソングプロジェクトの初期化
-        await context.dispatch("SET_TPQN", { tpqn: DEFAULT_TPQN });
-        await context.dispatch("SET_TEMPOS", {
+        await context.actions.SET_TPQN({ tpqn: DEFAULT_TPQN });
+        await context.actions.SET_TEMPOS({
           tempos: [createDefaultTempo(0)],
         });
-        await context.dispatch("SET_TIME_SIGNATURES", {
+        await context.actions.SET_TIME_SIGNATURES({
           timeSignatures: [createDefaultTimeSignature(1)],
         });
-        await context.dispatch("SET_NOTES", { notes: [] });
-        await context.dispatch("SET_SINGER", { withRelated: true });
-        await context.dispatch("CLEAR_PITCH_EDIT_DATA");
+        await context.actions.SET_NOTES({ notes: [] });
+        await context.actions.SET_SINGER({ withRelated: true });
+        await context.actions.CLEAR_PITCH_EDIT_DATA();
 
-        context.commit("SET_PROJECT_FILEPATH", { filePath: undefined });
-        context.commit("RESET_SAVED_LAST_COMMAND_IDS");
-        context.commit("CLEAR_COMMANDS");
+        context.mutations.SET_PROJECT_FILEPATH({ filePath: undefined });
+        context.mutations.RESET_SAVED_LAST_COMMAND_IDS();
+        context.mutations.CLEAR_COMMANDS();
       },
     ),
   },
 
   PARSE_PROJECT_FILE: {
-    async action({ dispatch, getters }, { projectJson }) {
+    async action({ actions, getters }, { projectJson }) {
       const projectData = JSON.parse(projectJson);
 
       const characterInfos = getters.USER_ORDERED_CHARACTER_INFOS("talk");
@@ -149,7 +148,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
         throw new Error("characterInfos == undefined");
 
       const parsedProjectData = await migrateProjectFileObject(projectData, {
-        fetchMoraData: (payload) => dispatch("FETCH_MORA_DATA", payload),
+        fetchMoraData: (payload) => actions.FETCH_MORA_DATA(payload),
         voices: characterInfos.flatMap((characterInfo) =>
           characterInfo.metas.styles.map((style) => ({
             engineId: style.engineId,
@@ -170,7 +169,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
      */
     action: createUILockAction(
       async (
-        { dispatch, commit, getters },
+        { actions, mutations, getters },
         { filePath, confirm }: { filePath?: string; confirm?: boolean },
       ) => {
         if (!filePath) {
@@ -190,17 +189,17 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             .readFile({ filePath })
             .then(getValueOrThrow);
 
-          await dispatch("APPEND_RECENTLY_USED_PROJECT", {
+          await actions.APPEND_RECENTLY_USED_PROJECT({
             filePath,
           });
 
           const text = new TextDecoder("utf-8").decode(buf).trim();
-          const parsedProjectData = await dispatch("PARSE_PROJECT_FILE", {
+          const parsedProjectData = await actions.PARSE_PROJECT_FILE({
             projectJson: text,
           });
 
           if (confirm !== false && getters.IS_EDITED) {
-            const result = await dispatch("SAVE_OR_DISCARD_PROJECT_FILE", {
+            const result = await actions.SAVE_OR_DISCARD_PROJECT_FILE({
               additionalMessage:
                 "プロジェクトをロードすると現在のプロジェクトは破棄されます。",
             });
@@ -209,12 +208,12 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             }
           }
 
-          await applyTalkProjectToStore(dispatch, parsedProjectData.talk);
-          await applySongProjectToStore(dispatch, parsedProjectData.song);
+          await applyTalkProjectToStore(actions, parsedProjectData.talk);
+          await applySongProjectToStore(actions, parsedProjectData.song);
 
-          commit("SET_PROJECT_FILEPATH", { filePath });
-          commit("RESET_SAVED_LAST_COMMAND_IDS");
-          commit("CLEAR_COMMANDS");
+          mutations.SET_PROJECT_FILEPATH({ filePath });
+          mutations.RESET_SAVED_LAST_COMMAND_IDS();
+          mutations.CLEAR_COMMANDS();
           return true;
         } catch (err) {
           window.backend.logError(err);
@@ -279,7 +278,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             });
           }
 
-          await context.dispatch("APPEND_RECENTLY_USED_PROJECT", {
+          await context.actions.APPEND_RECENTLY_USED_PROJECT({
             filePath,
           });
           const appInfos = await window.backend.getAppInfos();
@@ -314,9 +313,8 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
               buffer: buf,
             })
             .then(getValueOrThrow);
-          context.commit("SET_PROJECT_FILEPATH", { filePath });
-          context.commit(
-            "SET_SAVED_LAST_COMMAND_IDS",
+          context.mutations.SET_PROJECT_FILEPATH({ filePath });
+          context.mutations.SET_SAVED_LAST_COMMAND_IDS(
             context.getters.LAST_COMMAND_IDS,
           );
           return true;
@@ -344,7 +342,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
    * 保存に失敗した場合はキャンセル扱いになる。
    */
   SAVE_OR_DISCARD_PROJECT_FILE: {
-    action: createUILockAction(async ({ dispatch }, { additionalMessage }) => {
+    action: createUILockAction(async ({ actions }, { additionalMessage }) => {
       let message = "プロジェクトの変更が保存されていません。";
       if (additionalMessage) {
         message += "\n" + additionalMessage;
@@ -360,7 +358,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
         defaultId: 2,
       });
       if (result == 0) {
-        const saved = await dispatch("SAVE_PROJECT_FILE", {
+        const saved = await actions.SAVE_PROJECT_FILE({
           overwrite: true,
         });
         return saved ? "saved" : "canceled";


### PR DESCRIPTION
## 内容
+ https://github.com/VOICEVOX/voicevox/pull/2099
+ https://github.com/VOICEVOX/voicevox/pull/2170
の続きです。

store内における関数の呼び出しにおいて、dispatch("ACTION1", payloads) のような引数におけるリテラル指定から actions.ACTION(payload) のようにdot記法によるアクセスに変更します。


+ store/command.ts
+ store/preset.ts
+ store/engine.ts
+ store/project.ts
+ store/audio.ts
を変更しています。

storeの残りのsinging.tsはコンフリクトが多そうなので色々終わってからにしようと思います。

## 関連 Issue

+ https://github.com/VOICEVOX/voicevox/issues/2088

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

dispatch
actions

actions\([\s\n]*"([A-Z_]*)",?
actions.$1(

commit
mutations

mutations\([\s\n]*"([A-Z_]*)",?
mutations.$1(
の順に置換してその後眼力チェックしています。