### PR TITLE
ソング：REGISTER_TRACKをINSERT_TRACKに変更

### DIFF
--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1163,9 +1163,17 @@ export type SingingStoreTypes = {
     action(): { trackId: TrackId; track: Track };
   };
 
-  REGISTER_TRACK: {
-    mutation: { trackId: TrackId; track: Track };
-    action(payload: { trackId: TrackId; track: Track }): void;
+  INSERT_TRACK: {
+    mutation: {
+      trackId: TrackId;
+      track: Track;
+      prevTrackId: TrackId | undefined;
+    };
+    action(payload: {
+      trackId: TrackId;
+      track: Track;
+      prevTrackId: TrackId | undefined;
+    }): void;
   };
 
   DELETE_TRACK: {

--- a/tests/unit/store/command.spec.ts
+++ b/tests/unit/store/command.spec.ts
@@ -1,13 +1,12 @@
-import { toRaw } from "vue";
 import { store } from "@/store";
 import { AudioKey } from "@/type/preload";
 import { resetMockMode, uuid4 } from "@/helpers/random";
+import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 
-const initialState = structuredClone(toRaw(store.state));
+const initialState = cloneWithUnwrapProxy(store.state);
 beforeEach(() => {
-  store.replaceState(initialState);
-
   resetMockMode();
+  store.replaceState(initialState);
 });
 
 test("コマンド実行で履歴が作られる", async () => {

--- a/tests/unit/store/command.spec.ts
+++ b/tests/unit/store/command.spec.ts
@@ -5,8 +5,9 @@ import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 
 const initialState = cloneWithUnwrapProxy(store.state);
 beforeEach(() => {
-  resetMockMode();
   store.replaceState(initialState);
+
+  resetMockMode();
 });
 
 test("コマンド実行で履歴が作られる", async () => {

--- a/tests/unit/store/singing.spec.ts
+++ b/tests/unit/store/singing.spec.ts
@@ -1,0 +1,34 @@
+import { store } from "@/store";
+import { TrackId } from "@/type/preload";
+import { resetMockMode, uuid4 } from "@/helpers/random";
+import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
+import { createDefaultTrack } from "@/sing/domain";
+
+const initialState = cloneWithUnwrapProxy(store.state);
+beforeEach(() => {
+  resetMockMode();
+  store.replaceState(initialState);
+});
+
+test("INSERT_TRACK", () => {
+  const dummyTrack = createDefaultTrack();
+
+  // 最後尾に追加
+  // NOTE: 最初から１つトラックが登録されている
+  const trackId1 = TrackId(uuid4());
+  store.commit("INSERT_TRACK", {
+    trackId: trackId1,
+    track: dummyTrack,
+    prevTrackId: undefined,
+  });
+  expect(store.state.trackOrder.slice(1)).toEqual([trackId1]);
+
+  // 途中に追加
+  const trackId2 = TrackId(uuid4());
+  store.commit("INSERT_TRACK", {
+    trackId: trackId2,
+    track: dummyTrack,
+    prevTrackId: store.state.trackOrder[0],
+  });
+  expect(store.state.trackOrder.slice(1)).toEqual([trackId2, trackId1]);
+});

--- a/tests/unit/store/singing.spec.ts
+++ b/tests/unit/store/singing.spec.ts
@@ -6,8 +6,9 @@ import { createDefaultTrack } from "@/sing/domain";
 
 const initialState = cloneWithUnwrapProxy(store.state);
 beforeEach(() => {
-  resetMockMode();
   store.replaceState(initialState);
+
+  resetMockMode();
 });
 
 test("INSERT_TRACK", () => {


### PR DESCRIPTION
## 内容

REGISTER_TRACKは実質的に最後尾にトラックを追加する（add/appendする）挙動をしていました。
トラックリストの途中に挿入する時に不便なので`INSERT_TRACK`に変更します。

トラックをコピペする時とかは挿入された方が便利なので、基本的にこっちの方が使い勝手が良いと思います。

`prevTrackId`の後ろにトラックを追加します。prevTrackId=undefinedの場合は今まで通り最後尾に追加します。
このプルリクエスト自体は挙動変更がないはず。

ちなみにUX考えると、最後尾に追加したいことはほとんどないはず。（トークの経験上）

## 関連 Issue

ref: https://github.com/VOICEVOX/voicevox/issues/2182#issuecomment-2258729695


## その他

ついでになんとなくテストも追加してみました。