### PR TITLE
fix: ソロ全解除をして再生すると、全解除前のように聞こえるバグの修正

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -520,15 +520,13 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       state.timeSignatures = timeSignatures;
     },
     async action(
-      { commit, dispatch },
+      { commit },
       { timeSignatures }: { timeSignatures: TimeSignature[] },
     ) {
       if (!isValidTimeSignatures(timeSignatures)) {
         throw new Error("The time signatures are invalid.");
       }
       commit("SET_TIME_SIGNATURES", { timeSignatures });
-
-      dispatch("RENDER");
     },
   },
 
@@ -2505,13 +2503,11 @@ export const singingCommandStore = transformCommandStore(
         singingStore.mutations.SET_TIME_SIGNATURE(draft, { timeSignature });
       },
       // 拍子を設定する。既に同じ位置に拍子が存在する場合は置き換える。
-      action({ commit, dispatch }, { timeSignature }) {
+      action({ commit }, { timeSignature }) {
         if (!isValidTimeSignature(timeSignature)) {
           throw new Error("The time signature is invalid.");
         }
         commit("COMMAND_SET_TIME_SIGNATURE", { timeSignature });
-
-        dispatch("RENDER");
       },
     },
     COMMAND_REMOVE_TIME_SIGNATURE: {
@@ -2519,7 +2515,7 @@ export const singingCommandStore = transformCommandStore(
         singingStore.mutations.REMOVE_TIME_SIGNATURE(draft, { measureNumber });
       },
       // 拍子を削除する。先頭の拍子の場合はデフォルトの拍子に置き換える。
-      action({ state, commit, dispatch }, { measureNumber }) {
+      action({ state, commit }, { measureNumber }) {
         const exists = state.timeSignatures.some((value) => {
           return value.measureNumber === measureNumber;
         });
@@ -2527,8 +2523,6 @@ export const singingCommandStore = transformCommandStore(
           throw new Error("The time signature does not exist.");
         }
         commit("COMMAND_REMOVE_TIME_SIGNATURE", { measureNumber });
-
-        dispatch("RENDER");
       },
     },
     COMMAND_ADD_NOTES: {

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2365,8 +2365,10 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         track.solo = false;
       }
     },
-    action({ commit }) {
+    action({ commit, dispatch }) {
       commit("UNSOLO_ALL_TRACKS");
+
+      dispatch("RENDER");
     },
   },
 
@@ -2503,11 +2505,13 @@ export const singingCommandStore = transformCommandStore(
         singingStore.mutations.SET_TIME_SIGNATURE(draft, { timeSignature });
       },
       // 拍子を設定する。既に同じ位置に拍子が存在する場合は置き換える。
-      action({ commit }, { timeSignature }: { timeSignature: TimeSignature }) {
+      action({ commit, dispatch }, { timeSignature }) {
         if (!isValidTimeSignature(timeSignature)) {
           throw new Error("The time signature is invalid.");
         }
         commit("COMMAND_SET_TIME_SIGNATURE", { timeSignature });
+
+        dispatch("RENDER");
       },
     },
     COMMAND_REMOVE_TIME_SIGNATURE: {
@@ -2515,7 +2519,7 @@ export const singingCommandStore = transformCommandStore(
         singingStore.mutations.REMOVE_TIME_SIGNATURE(draft, { measureNumber });
       },
       // 拍子を削除する。先頭の拍子の場合はデフォルトの拍子に置き換える。
-      action({ state, commit }, { measureNumber }: { measureNumber: number }) {
+      action({ state, commit, dispatch }, { measureNumber }) {
         const exists = state.timeSignatures.some((value) => {
           return value.measureNumber === measureNumber;
         });
@@ -2523,6 +2527,8 @@ export const singingCommandStore = transformCommandStore(
           throw new Error("The time signature does not exist.");
         }
         commit("COMMAND_REMOVE_TIME_SIGNATURE", { measureNumber });
+
+        dispatch("RENDER");
       },
     },
     COMMAND_ADD_NOTES: {
@@ -2738,8 +2744,10 @@ export const singingCommandStore = transformCommandStore(
       mutation(draft) {
         singingStore.mutations.UNSOLO_ALL_TRACKS(draft, undefined);
       },
-      action({ commit }) {
+      action({ commit, dispatch }) {
         commit("COMMAND_UNSOLO_ALL_TRACKS");
+
+        dispatch("RENDER");
       },
     },
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2503,7 +2503,7 @@ export const singingCommandStore = transformCommandStore(
         singingStore.mutations.SET_TIME_SIGNATURE(draft, { timeSignature });
       },
       // 拍子を設定する。既に同じ位置に拍子が存在する場合は置き換える。
-      action({ commit }, { timeSignature }) {
+      action({ commit }, { timeSignature }: { timeSignature: TimeSignature }) {
         if (!isValidTimeSignature(timeSignature)) {
           throw new Error("The time signature is invalid.");
         }
@@ -2515,7 +2515,7 @@ export const singingCommandStore = transformCommandStore(
         singingStore.mutations.REMOVE_TIME_SIGNATURE(draft, { measureNumber });
       },
       // 拍子を削除する。先頭の拍子の場合はデフォルトの拍子に置き換える。
-      action({ state, commit }, { measureNumber }) {
+      action({ state, commit }, { measureNumber }: { measureNumber: number }) {
         const exists = state.timeSignatures.some((value) => {
           return value.measureNumber === measureNumber;
         });


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/2194

の修正プルリクエストです。

ついでに全singing.tsのactionを検査して、RENDERが必要そうなやつを点検してみました。
`TIME_SIGNATURE`周りでRENDERが呼ばれてないやつはいくつかあったんですか、これ多分いりますよね･･･？
ということでついでに入れときました。
（`COMMAND_`の方にだけRENDERがなかった）

## 関連 Issue

close #2194 

## その他

点検してた感じ、多分これ使わないだろうなっていうactionがいっぱいありました。
コマンド以外ありえないコマンドじゃない関数とか。
呼び間違いがいつか起こりそうだ、消してもいいかもしれない。
