### PR TITLE
fix: トラック名が保存されないバグの修正

### DIFF
--- a/src/components/Sing/SideBar/TrackItem.vue
+++ b/src/components/Sing/SideBar/TrackItem.vue
@@ -214,11 +214,13 @@ watchEffect(() => {
 
 const updateTrackName = () => {
   if (temporaryTrackName.value === track.value.name) return;
+
+  // 空のトラック名だと空欄のようになってしまうので許容しない
   if (temporaryTrackName.value === "") {
-    // NOTE: ↑これの意味を聞く
     temporaryTrackName.value = track.value.name;
     return;
   }
+
   store.dispatch("COMMAND_SET_TRACK_NAME", {
     trackId: props.trackId,
     name: temporaryTrackName.value,

--- a/src/components/Sing/SideBar/TrackItem.vue
+++ b/src/components/Sing/SideBar/TrackItem.vue
@@ -215,12 +215,13 @@ watchEffect(() => {
 const updateTrackName = () => {
   if (temporaryTrackName.value === track.value.name) return;
   if (temporaryTrackName.value === "") {
+    // NOTE: ↑これの意味を聞く
     temporaryTrackName.value = track.value.name;
     return;
   }
   store.dispatch("COMMAND_SET_TRACK_NAME", {
     trackId: props.trackId,
-    name: track.value.name,
+    name: temporaryTrackName.value,
   });
 };
 


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/2198

の解決プルリクエストです。

バッファ変数を作っていて、そのバッファ変数が変わった時にstoreの方に変わった方の値を投げないといけないのですが、storeの方の値を投げていたのが原因でした。
なのでバッファ変数（＝表示される値）だけ変わっていて、保存されていなかった感じでした。


## 関連 Issue

fix #2198 


## その他

これ気づけなかったの申し訳ないですねぇ･･･。
バッファ変数作ってちょっと特殊だったから、テストを書いても良かったのかもしれない。けどまあ･･･。

1回実行チェックしておくべきだったかもしれない。
