### PR TITLE
ツールバーのカスタマイズダイアログのリデザイン

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1,6 +1,6 @@
 <template>
   <ErrorBoundary>
-    <TooltipProvider>
+    <TooltipProvider disableHoverableContent>
       <MenuBar
         v-if="openedEditor != undefined"
         :fileSubMenuData="subMenuData.fileSubMenuData.value"

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1,27 +1,30 @@
 <template>
   <ErrorBoundary>
-    <MenuBar
-      v-if="openedEditor != undefined"
-      :fileSubMenuData="subMenuData.fileSubMenuData.value"
-      :editSubMenuData="subMenuData.editSubMenuData.value"
-      :editor="openedEditor"
-    />
-    <KeepAlive>
-      <Component
-        :is="openedEditor == 'talk' ? TalkEditor : SingEditor"
+    <TooltipProvider>
+      <MenuBar
         v-if="openedEditor != undefined"
-        :key="openedEditor"
-        :isEnginesReady
-        :isProjectFileLoaded
+        :fileSubMenuData="subMenuData.fileSubMenuData.value"
+        :editSubMenuData="subMenuData.editSubMenuData.value"
+        :editor="openedEditor"
       />
-    </KeepAlive>
-    <AllDialog :isEnginesReady />
+      <KeepAlive>
+        <Component
+          :is="openedEditor == 'talk' ? TalkEditor : SingEditor"
+          v-if="openedEditor != undefined"
+          :key="openedEditor"
+          :isEnginesReady
+          :isProjectFileLoaded
+        />
+      </KeepAlive>
+      <AllDialog :isEnginesReady />
+    </TooltipProvider>
   </ErrorBoundary>
 </template>
 
 <script setup lang="ts">
 import { watch, onMounted, ref, computed, toRaw } from "vue";
 import { useGtm } from "@gtm-support/vue-gtm";
+import { TooltipProvider } from "radix-vue";
 import TalkEditor from "@/components/Talk/TalkEditor.vue";
 import SingEditor from "@/components/Sing/SingEditor.vue";
 import { EngineId } from "@/type/preload";

--- a/src/components/Base/BaseListItem.vue
+++ b/src/components/Base/BaseListItem.vue
@@ -2,6 +2,7 @@
   <button
     class="listitem"
     :class="selected && 'selected'"
+    role="listitem"
     @click="(payload) => $emit('click', payload)"
   >
     <div class="indicator"></div>

--- a/src/components/Base/BaseRowCard.vue
+++ b/src/components/Base/BaseRowCard.vue
@@ -2,6 +2,7 @@
   <button
     class="row-card"
     :class="{ clickable: clickable }"
+    role="listitem"
     @click="(payload) => $emit('click', payload)"
   >
     <div class="text">

--- a/src/components/Base/BaseRowCard.vue
+++ b/src/components/Base/BaseRowCard.vue
@@ -32,7 +32,8 @@ defineEmits<{
 @use "@/styles/v2/colors" as colors;
 
 .row-card {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
   text-align: unset;
   align-items: center;
   border: 1px solid colors.$border;

--- a/src/components/Base/BaseSwitch.vue
+++ b/src/components/Base/BaseSwitch.vue
@@ -11,7 +11,7 @@
 import { SwitchRoot, SwitchThumb } from "radix-vue";
 
 defineProps<{
-  id: string;
+  id?: string;
   offLabel?: string;
   onLabel?: string;
 }>();

--- a/src/components/Base/BaseSwitch.vue
+++ b/src/components/Base/BaseSwitch.vue
@@ -42,6 +42,7 @@ const checked = defineModel<boolean>("checked", { required: true });
 
   &:focus-visible {
     @include mixin.on-focus;
+    outline-offset: 2px;
   }
 
   &[data-state="checked"] {

--- a/src/components/Base/BaseSwitch.vue
+++ b/src/components/Base/BaseSwitch.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="root">
+    <div class="label">{{ checked ? onLabel : offLabel }}</div>
+    <SwitchRoot :id v-model:checked="checked" class="SwitchRoot">
+      <SwitchThumb class="SwitchThumb" />
+    </SwitchRoot>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SwitchRoot, SwitchThumb } from "radix-vue";
+
+defineProps<{
+  id: string;
+  offLabel?: string;
+  onLabel?: string;
+}>();
+
+const checked = defineModel<boolean>("checked", { required: true });
+</script>
+
+<style scoped lang="scss">
+@use "@/styles/v2/variables" as vars;
+@use "@/styles/v2/mixin" as mixin;
+@use "@/styles/v2/colors" as colors;
+
+.root {
+  display: flex;
+  align-items: center;
+  gap: vars.$gap-1;
+}
+
+:deep(.SwitchRoot) {
+  cursor: pointer;
+  width: 40px;
+  padding: 1px;
+  height: vars.$size-indicator;
+  background-color: colors.$border;
+  border: 1px solid colors.$border;
+  border-radius: 9999px;
+  position: relative;
+
+  &:focus-visible {
+    @include mixin.on-focus;
+  }
+
+  &[data-state="checked"] {
+    background-color: colors.$primary;
+  }
+}
+
+.SwitchThumb {
+  display: block;
+  width: 20px;
+  height: 20px;
+  background-color: white;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: transform vars.$transition-duration;
+  will-change: transform;
+}
+
+.SwitchThumb[data-state="checked"] {
+  transform: translateX(16px);
+}
+
+.label {
+  color: colors.$display;
+}
+</style>

--- a/src/components/Base/BaseTooltip.vue
+++ b/src/components/Base/BaseTooltip.vue
@@ -1,0 +1,76 @@
+<template>
+  <TooltipRoot>
+    <TooltipTrigger asChild>
+      <slot />
+    </TooltipTrigger>
+    <TooltipPortal>
+      <Transition>
+        <TooltipContent
+          class="TooltipContent"
+          :sideOffset="4"
+          avoidCollisions
+          :collisionPadding="8"
+        >
+          {{ label }}
+          <TooltipArrow class="TooltipArrow" />
+        </TooltipContent>
+      </Transition>
+    </TooltipPortal>
+  </TooltipRoot>
+</template>
+
+<script setup lang="ts">
+import {
+  TooltipArrow,
+  TooltipContent,
+  TooltipPortal,
+  TooltipRoot,
+  TooltipTrigger,
+} from "radix-vue";
+
+defineProps<{
+  label: string;
+}>();
+</script>
+
+<style scoped lang="scss">
+@use "@/styles/v2/variables" as vars;
+@use "@/styles/v2/mixin" as mixin;
+@use "@/styles/v2/colors" as colors;
+
+[data-radix-popper-content-wrapper] {
+  z-index: 9999 !important;
+}
+
+:deep(.TooltipContent) {
+  display: flex;
+  align-items: center;
+  border-radius: vars.$radius-1;
+  height: 32px;
+  padding: 0 8px;
+  color: colors.$display;
+  background-color: colors.$background;
+  border: 1px solid colors.$border;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  user-select: none;
+  transform-origin: var(--radix-tooltip-content-transform-origin);
+  will-change: transform, opacity;
+}
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity vars.$transition-duration;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+
+:deep(.TooltipArrow) {
+  fill: colors.$background;
+  stroke: colors.$border;
+  paint-order: stroke;
+  stroke-width: 2px;
+}
+</style>

--- a/src/components/Base/BaseTooltip.vue
+++ b/src/components/Base/BaseTooltip.vue
@@ -35,11 +35,10 @@ defineProps<{
 
 <style scoped lang="scss">
 @use "@/styles/v2/variables" as vars;
-@use "@/styles/v2/mixin" as mixin;
 @use "@/styles/v2/colors" as colors;
 
 [data-radix-popper-content-wrapper] {
-  z-index: 9999 !important;
+  z-index: vars.$z-index-tooltip !important;
 }
 
 :deep(.TooltipContent) {

--- a/src/components/Base/BaseTooltip.vue
+++ b/src/components/Base/BaseTooltip.vue
@@ -53,8 +53,6 @@ defineProps<{
   border: 1px solid colors.$border;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   user-select: none;
-  transform-origin: var(--radix-tooltip-content-transform-origin);
-  will-change: transform, opacity;
 }
 
 .v-enter-active,

--- a/src/components/Base/BaseTooltip.vue
+++ b/src/components/Base/BaseTooltip.vue
@@ -69,8 +69,7 @@ defineProps<{
 
 :deep(.TooltipArrow) {
   fill: colors.$background;
-  stroke: colors.$border;
-  paint-order: stroke;
-  stroke-width: 2px;
+  margin-top: -1px;
+  filter: drop-shadow(0 1px 0px colors.$border);
 }
 </style>

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -82,6 +82,7 @@
                     :title="getToolbarButtonName(key)"
                     :description="desc"
                     clickable
+                    tabindex="-1"
                     @click="toggleToolbarButtons(key)"
                   >
                     <BaseSwitch

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -145,7 +145,7 @@ window.backend.getDefaultToolbarSetting().then((setting) => {
   defaultSetting.push(...setting);
 });
 
-const toggleToolbarButtons = (key) => {
+const toggleToolbarButtons = (key: ToolbarButtonTagType) => {
   if (toolbarButtons.value.includes(key)) {
     toolbarButtons.value.splice(toolbarButtons.value.indexOf(key), 1);
   } else {

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -53,28 +53,18 @@
               <template
                 #item="{ element: button }: { element: ToolbarButtonTagType }"
               >
-                <QBtn
-                  unelevated
-                  color="toolbar-button"
-                  textColor="toolbar-button-display"
-                  :class="
-                    (button === 'EMPTY' ? ' radio-space' : ' radio') +
-                    ' text-no-wrap text-bold q-mr-sm'
-                  "
-                >
-                  {{ getToolbarButtonName(button) }}
-                  <QTooltip
-                    :delay="800"
-                    anchor="center right"
-                    self="center left"
-                    transitionShow="jump-right"
-                    transitionHide="jump-left"
-                    :style="{
-                      display: toolbarButtonDragging ? 'none' : 'block',
-                    }"
-                    >{{ usableButtonsDesc[button] }}</QTooltip
-                  >
-                </QBtn>
+                <div :class="button === 'EMPTY' ? 'radio-space' : 'radio'">
+                  <BaseTooltip :label="usableButtonsDesc[button]">
+                    <QBtn
+                      unelevated
+                      color="toolbar-button"
+                      textColor="toolbar-button-display"
+                      class="text-no-wrap text-bold"
+                    >
+                      {{ getToolbarButtonName(button) }}
+                    </QBtn>
+                  </BaseTooltip>
+                </div>
               </template>
             </Draggable>
             <div class="preview-toolbar-drag-hint">
@@ -117,6 +107,7 @@ import Draggable from "vuedraggable";
 import BaseSwitch from "@/components/Base/BaseSwitch.vue";
 import BaseScrollArea from "@/components/Base/BaseScrollArea.vue";
 import BaseRowCard from "@/components/Base/BaseRowCard.vue";
+import BaseTooltip from "@/components/Base/BaseTooltip.vue";
 import { useStore } from "@/store";
 import { ToolbarButtonTagType, ToolbarSettingType } from "@/type/preload";
 import { getToolbarButtonName } from "@/store/utility";
@@ -280,6 +271,7 @@ const finishOrNotDialog = async () => {
 .preview-toolbar > div:not(.preview-toolbar-drag-hint) {
   width: 100%;
   display: inline-flex;
+  gap: 8px;
 }
 
 .preview-toolbar-drag-hint {
@@ -288,15 +280,19 @@ const finishOrNotDialog = async () => {
 }
 
 .radio {
-  &:hover {
-    cursor: grab;
+  & > .q-btn:hover {
+    cursor: grab !important;
   }
 }
 
 .radio-space {
   @extend .radio;
   flex-grow: 1;
-  color: transparent;
+
+  & > .q-btn {
+    color: transparent;
+    width: 100%;
+  }
 }
 
 .title {

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -86,7 +86,6 @@
                     @click="toggleToolbarButtons(key)"
                   >
                     <BaseSwitch
-                      :id="key"
                       :checked="toolbarButtons.includes(key)"
                       onLabel="表示する"
                       offLabel="表示しない"

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -43,68 +43,68 @@
           </QToolbar>
         </QHeader>
         <QPage>
-          <QCard flat square class="preview-card">
-            <QToolbar class="bg-toolbar preview-toolbar">
-              <Draggable
-                v-model="toolbarButtons"
-                :itemKey="toolbarButtonKey"
-                @start="toolbarButtonDragging = true"
-                @end="toolbarButtonDragging = false"
+          <QToolbar class="bg-toolbar preview-toolbar">
+            <Draggable
+              v-model="toolbarButtons"
+              :itemKey="toolbarButtonKey"
+              @start="toolbarButtonDragging = true"
+              @end="toolbarButtonDragging = false"
+            >
+              <template
+                #item="{ element: button }: { element: ToolbarButtonTagType }"
               >
-                <template
-                  #item="{ element: button }: { element: ToolbarButtonTagType }"
+                <QBtn
+                  unelevated
+                  color="toolbar-button"
+                  textColor="toolbar-button-display"
+                  :class="
+                    (button === 'EMPTY' ? ' radio-space' : ' radio') +
+                    ' text-no-wrap text-bold q-mr-sm'
+                  "
                 >
-                  <QBtn
-                    unelevated
-                    color="toolbar-button"
-                    textColor="toolbar-button-display"
-                    :class="
-                      (button === 'EMPTY' ? ' radio-space' : ' radio') +
-                      ' text-no-wrap text-bold q-mr-sm'
-                    "
+                  {{ getToolbarButtonName(button) }}
+                  <QTooltip
+                    :delay="800"
+                    anchor="center right"
+                    self="center left"
+                    transitionShow="jump-right"
+                    transitionHide="jump-left"
+                    :style="{
+                      display: toolbarButtonDragging ? 'none' : 'block',
+                    }"
+                    >{{ usableButtonsDesc[button] }}</QTooltip
                   >
-                    {{ getToolbarButtonName(button) }}
-                    <QTooltip
-                      :delay="800"
-                      anchor="center right"
-                      self="center left"
-                      transitionShow="jump-right"
-                      transitionHide="jump-left"
-                      :style="{
-                        display: toolbarButtonDragging ? 'none' : 'block',
-                      }"
-                      >{{ usableButtonsDesc[button] }}</QTooltip
-                    >
-                  </QBtn>
-                </template>
-              </Draggable>
-              <div class="preview-toolbar-drag-hint">
-                ドラッグでボタンの並びを変更できます。
+                </QBtn>
+              </template>
+            </Draggable>
+            <div class="preview-toolbar-drag-hint">
+              ドラッグでボタンの並びを変更できます。
+            </div>
+          </QToolbar>
+          <div class="container">
+            <BaseScrollArea>
+              <div class="inner">
+                <h1 class="title">表示するボタン</h1>
+                <div class="list">
+                  <BaseRowCard
+                    v-for="(desc, key) in usableButtonsDesc"
+                    :key
+                    :title="getToolbarButtonName(key)"
+                    :description="desc"
+                    clickable
+                    @click="toggleToolbarButtons(key)"
+                  >
+                    <BaseSwitch
+                      :id="key"
+                      :checked="toolbarButtons.includes(key)"
+                      onLabel="表示する"
+                      offLabel="表示しない"
+                    />
+                  </BaseRowCard>
+                </div>
               </div>
-            </QToolbar>
-
-            <QCardActions>
-              <div class="text-h5">表示するボタンの選択</div>
-            </QCardActions>
-            <QCardActions class="no-padding">
-              <QList class="usable-button-list bg-surface">
-                <QItem
-                  v-for="(desc, key) in usableButtonsDesc"
-                  :key
-                  v-ripple
-                  tag="label"
-                >
-                  <QItemSection>
-                    <QItemLabel>{{ getToolbarButtonName(key) }}</QItemLabel>
-                    <QItemLabel caption>{{ desc }}</QItemLabel>
-                  </QItemSection>
-                  <QItemSection avatar>
-                    <QToggle v-model="toolbarButtons" :val="key" />
-                  </QItemSection>
-                </QItem>
-              </QList>
-            </QCardActions>
-          </QCard>
+            </BaseScrollArea>
+          </div>
         </QPage>
       </QPageContainer>
     </QLayout>
@@ -114,6 +114,9 @@
 <script setup lang="ts">
 import { computed, ref, watch, Ref } from "vue";
 import Draggable from "vuedraggable";
+import BaseSwitch from "@/components/Base/BaseSwitch.vue";
+import BaseScrollArea from "@/components/Base/BaseScrollArea.vue";
+import BaseRowCard from "@/components/Base/BaseRowCard.vue";
 import { useStore } from "@/store";
 import { ToolbarButtonTagType, ToolbarSettingType } from "@/type/preload";
 import { getToolbarButtonName } from "@/store/utility";
@@ -150,6 +153,14 @@ const defaultSetting: ToolbarSettingType = [];
 window.backend.getDefaultToolbarSetting().then((setting) => {
   defaultSetting.push(...setting);
 });
+
+const toggleToolbarButtons = (key) => {
+  if (toolbarButtons.value.includes(key)) {
+    toolbarButtons.value.splice(toolbarButtons.value.indexOf(key), 1);
+  } else {
+    toolbarButtons.value.push(key);
+  }
+};
 
 const usableButtonsDesc: Record<ToolbarButtonTagType, string> = {
   PLAY_CONTINUOUSLY:
@@ -246,7 +257,9 @@ const finishOrNotDialog = async () => {
 
 <style lang="scss" scoped>
 @use "@/styles/variables" as vars;
-@use "@/styles/colors" as colors;
+@use "@/styles/v2/variables" as newvars;
+@use "@/styles/v2/mixin" as mixin;
+@use "@/styles/v2/colors" as colors;
 
 .tool-bar-custom-dialog .q-layout-container :deep(.absolute-full) {
   right: 0 !important;
@@ -274,23 +287,6 @@ const finishOrNotDialog = async () => {
   padding-bottom: 8px;
 }
 
-.preview-card {
-  width: 100%;
-  min-width: 460px;
-  background: var(--color-background);
-}
-
-.usable-button-list {
-  // menubar-height + toolbar-height * 2(main+preview) + window-border-width
-  // 52(preview part buttons) * 2 + 46(select part title) + 22(preview part hint)
-  height: calc(
-    100vh - #{vars.$menubar-height + (vars.$toolbar-height) +
-      vars.$window-border-width + 52px + 46px + 22px}
-  );
-  width: 100%;
-  overflow-y: scroll;
-}
-
 .radio {
   &:hover {
     cursor: grab;
@@ -301,5 +297,31 @@ const finishOrNotDialog = async () => {
   @extend .radio;
   flex-grow: 1;
   color: transparent;
+}
+
+.title {
+  @include mixin.headline-1;
+}
+
+.container {
+  // TODO: 親コンポーネントからheightを取得できないため一時的にcalcを使用、HelpDialogの構造を再設計後100%に変更する
+  // height: 100%;
+  height: calc(100vh - 164px);
+  background-color: colors.$background;
+}
+
+.inner {
+  margin: auto;
+  max-width: 960px;
+  padding: newvars.$padding-2;
+  display: flex;
+  flex-direction: column;
+  gap: newvars.$gap-1;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: newvars.$gap-1;
 }
 </style>

--- a/src/styles/v2/variables.scss
+++ b/src/styles/v2/variables.scss
@@ -22,3 +22,5 @@ $radius-1: var(--radius-basis);
 $radius-2: calc(var(--radius-basis) * 2);
 
 $transition-duration: 100ms;
+
+$z-index-tooltip: 9999;


### PR DESCRIPTION
## 内容

ツールバーのカスタマイズダイアログを新デザインに変更します。具体的に以下のことを行います。

- BaseSwitch, BaseTooltipコンポーネントを追加
- 表示するボタンのリスト部分のコンポーネントを置き換え
  - （ヘッダー部分はHelpDialogと同様置き換えていません）
- ヘッダーボタンのツールチップを置き換え
- Tooltipの振る舞いをグローバルに制御するためのTooltipProviderコンポーネントをApp.vueに追加

## 関連 Issue

ref voicevox/voicevox_project#40

## スクリーンショット・動画など

![image](https://github.com/user-attachments/assets/e2e5a665-389b-4ab1-ad3f-8dd7799b4729)
