### PR TITLE
読み方&アクセント辞典: click イベントハンドラで `editWord()`  / `deleteWord()` の前に `selectWord(key)` を実行する。

### DIFF
--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -90,7 +90,10 @@
                       dense
                       round
                       icon="edit"
-                      @click.stop="editWord"
+                      @click.stop="
+                        selectWord(key);
+                        editWord();
+                      "
                     >
                       <QTooltip :delay="500">編集</QTooltip>
                     </QBtn>
@@ -100,7 +103,10 @@
                       dense
                       round
                       icon="delete_outline"
-                      @click.stop="deleteWord"
+                      @click.stop="
+                        selectWord(key);
+                        deleteWord();
+                      "
                     >
                       <QTooltip :delay="500">削除</QTooltip>
                     </QBtn>


### PR DESCRIPTION
## 内容


関連 issue で報告された不具合の解消

選択せずホバーで「編集」「削除」ボタンが表出された場合のために、そのボタンの click イベントハンドラで `editWord()`  / `deleteWord()` の前に `selectWord(key)` を実行する。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #2196 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
