### PR TITLE
docs: READMEのエンジンのパスについてもう少し詳しく案内

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,7 @@ VOICEVOXには、下記のような貢献の仕方があります。
 ### 2. 開発環境の構築
 
 - 必須ツール
+
   - [Node.js](https://nodejs.org/en/download/releases/)\
     [こちら](https://github.com/VOICEVOX/voicevox/blob/main/.node-version)に記載されているバージョンのインストーラを入手し、インストールします。
 
@@ -135,7 +136,7 @@ VITE_DEFAULT_ENGINE_INFOS=`[
         "uuid": "074fc39e-678b-4c13-8916-ffca8d505d1d",
         "name": "VOICEVOX Engine",
         "executionEnabled": true,
-        "executionFilePath": "vv-engine/run.exe",
+        "executionFilePath": "C:/Users/(ユーザー名)/AppData/Local/Programs/VOICEVOX/vv-engine/run.exe",
         "executionArgs": [],
         "host": "http://127.0.0.1:50021"
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,6 @@ VOICEVOXには、下記のような貢献の仕方があります。
 ### 2. 開発環境の構築
 
 - 必須ツール
-
   - [Node.js](https://nodejs.org/en/download/releases/)\
     [こちら](https://github.com/VOICEVOX/voicevox/blob/main/.node-version)に記載されているバージョンのインストーラを入手し、インストールします。
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ npm ci
 `.env.production`をコピーして`.env`を作成し、`VITE_DEFAULT_ENGINE_INFOS`内の`executionFilePath`に
 [製品版 VOICEVOX](https://voicevox.hiroshiba.jp/) 内の`vv-engine/run.exe`を指定すれば動きます。
 
-Windows でインストール先を変更していない場合は`C:/Users/(ユーザー名)/AppData/Local/Programs/VOICEVOX/vv-engine/run.exe`です。  
+Windows でインストール先を変更していない場合は`C:/Users/(ユーザー名)/AppData/Local/Programs/VOICEVOX/vv-engine/run.exe`を指定してください。  
 パスの区切り文字は`\`ではなく`/`なのでご注意ください。
 
 macOS 向けの`VOICEVOX.app`を利用している場合は`/path/to/VOICEVOX.app/Contents/MacOS/vv-engine/run`を指定してください。
 
-Linux の場合は、[Releases](https://github.com/VOICEVOX/voicevox/releases/)から入手できる tar.gz 版に含まれる`run`コマンドを指定してください。
+Linux の場合は、[Releases](https://github.com/VOICEVOX/voicevox/releases/)から入手できる tar.gz 版に含まれる`vv-engine/run`コマンドを指定してください。
 AppImage 版の場合は`$ /path/to/VOICEVOX.AppImage --appimage-mount`でファイルシステムをマウントできます。
 
 VOICEVOX エディタの実行とは別にエンジン API のサーバを立てている場合は`executionFilePath`を指定する必要はありませんが、
@@ -67,6 +67,8 @@ VOICEVOX エディタの実行とは別にエンジン API のサーバを立て
 これは製品版 VOICEVOX を起動している場合もあてはまります。
 
 エンジン API の宛先エンドポイントを変更する場合は`VITE_DEFAULT_ENGINE_INFOS`内の`host`を変更してください。
+
+### Electron の実行
 
 ```bash
 # 開発しやすい環境で実行

--- a/README.md
+++ b/README.md
@@ -49,21 +49,24 @@ npm ci
 
 ## 実行
 
-`.env.production`をコピーして`.env`を作成し、`VITE_DEFAULT_ENGINE_INFOS`内の`executionFilePath`に`voicevox_engine`のパスを指定します。
+### エンジンの準備
 
-[製品版 VOICEVOX](https://voicevox.hiroshiba.jp/) のディレクトリのパスを指定すれば動きます。
+`.env.production`をコピーして`.env`を作成し、`VITE_DEFAULT_ENGINE_INFOS`内の`executionFilePath`に
+[製品版 VOICEVOX](https://voicevox.hiroshiba.jp/) 内の`vv-engine/run.exe`を指定すれば動きます。
 
-Windows の場合でもパスの区切り文字は`\`ではなく`/`なのでご注意ください。
+Windows でインストール先を変更していない場合は`C:/Users/(ユーザー名)/AppData/Local/Programs/VOICEVOX/vv-engine/run.exe`です。  
+パスの区切り文字は`\`ではなく`/`なのでご注意ください。
 
-また、macOS 向けの`VOICEVOX.app`を利用している場合は`/path/to/VOICEVOX.app/Contents/MacOS/vv-engine/run`を指定してください。
+macOS 向けの`VOICEVOX.app`を利用している場合は`/path/to/VOICEVOX.app/Contents/MacOS/vv-engine/run`を指定してください。
 
 Linux の場合は、[Releases](https://github.com/VOICEVOX/voicevox/releases/)から入手できる tar.gz 版に含まれる`run`コマンドを指定してください。
 AppImage 版の場合は`$ /path/to/VOICEVOX.AppImage --appimage-mount`でファイルシステムをマウントできます。
 
-VOICEVOX エディタの実行とは別にエンジン API のサーバを立てている場合は`executionFilePath`を指定する必要はありません。
+VOICEVOX エディタの実行とは別にエンジン API のサーバを立てている場合は`executionFilePath`を指定する必要はありませんが、
+代わりに`executionEnabled`を`false`にしてください。
 これは製品版 VOICEVOX を起動している場合もあてはまります。
 
-また、エンジン API の宛先エンドポイントを変更する場合は`VITE_DEFAULT_ENGINE_INFOS`内の`host`を変更してください。
+エンジン API の宛先エンドポイントを変更する場合は`VITE_DEFAULT_ENGINE_INFOS`内の`host`を変更してください。
 
 ```bash
 # 開発しやすい環境で実行


### PR DESCRIPTION
## 内容

READMEのエンジンのパスについての案内がかなり古くなっていたので変更しました。
ついでに多分貢献者向けの案内も一部意図と違ってそうだったので変更してみました。

## その他

何か説明が若干不格好だけど･･･。

