### PR TITLE
Update: utaformatixを0.4.0に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@gtm-support/vue-gtm": "1.2.3",
         "@quasar/extras": "1.10.10",
-        "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.2",
+        "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.4.0",
         "async-lock": "1.4.0",
         "dayjs": "1.10.7",
         "electron-log": "5.1.2",
@@ -5197,10 +5197,11 @@
     },
     "node_modules/@sevenc-nanashi/utaformatix-ts": {
       "name": "@jsr/sevenc-nanashi__utaformatix-ts",
-      "version": "0.3.2",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/sevenc-nanashi__utaformatix-ts/0.3.2.tgz",
-      "integrity": "sha512-TdCME7wLGNnv7vcTRXZ4IXZpv/7uVUqy1ACIxuZQNg2M9jYk3aA9CSRNHkrrTIAeH4JuDBpONfn9zb9GkXsscg==",
+      "version": "0.4.0",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/sevenc-nanashi__utaformatix-ts/0.4.0.tgz",
+      "integrity": "sha512-/rI7ZOy51LjOP+OwWclbuJ6K7gRTs9s2DHGrxBgJ1ho4TeE9LpFgNyQReKwsznLAgleAvJWJbW3a2MMAoNHeGA==",
       "dependencies": {
+        "defu": "^6.1.4",
         "jszip": "^3.10.1",
         "utaformatix-data": "^1.1.0"
       }
@@ -11206,8 +11207,7 @@
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@gtm-support/vue-gtm": "1.2.3",
     "@quasar/extras": "1.10.10",
-    "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.3.2",
+    "@sevenc-nanashi/utaformatix-ts": "npm:@jsr/sevenc-nanashi__utaformatix-ts@0.4.0",
     "async-lock": "1.4.0",
     "dayjs": "1.10.7",
     "electron-log": "5.1.2",


### PR DESCRIPTION
## 内容

utaformatix-tsを更新します。

## 関連 Issue

- ref: https://x.com/okep_s/status/1819590460119413131
- ref: https://github.com/sdercolin/utaformatix3/pull/183
- ref: #2204 

## スクリーンショット・動画など

（なし）

## その他

もうそろそろ色々アプデしてもいい時期かも