### PR TITLE
シング: 正式なカラーとスタイルを定義する

### DIFF
--- a/public/themes/dark.json
+++ b/public/themes/dark.json
@@ -13,12 +13,6 @@
     "warning": "#F27483",
     "text-splitter-hover": "#394152",
     "active-point-focus": "#292F38",
-    "active-point-hover": "#272A2F",
-    "sequencer-whitekey-cell": "#393939",
-    "sequencer-blackkey-cell": "#2D2D2D",
-    "sequencer-main-divider": "#121212",
-    "sequencer-sub-divider": "#2C2C2C",
-    "sequencer-white-key": "#EEEEEE",
-    "sequencer-black-key": "#555555"
+    "active-point-hover": "#272A2F"
   }
 }

--- a/public/themes/default.json
+++ b/public/themes/default.json
@@ -13,12 +13,6 @@
     "warning": "#C10015",
     "text-splitter-hover": "#CCDDFF",
     "active-point-focus": "#E0EAFF",
-    "active-point-hover": "#EEF3FF",
-    "sequencer-whitekey-cell": "#F5F7F5",
-    "sequencer-blackkey-cell": "#EAECEA",
-    "sequencer-main-divider": "#B0B0B0",
-    "sequencer-sub-divider": "#CECECE",
-    "sequencer-white-key": "#FFFFFF",
-    "sequencer-black-key": "#333333"
+    "active-point-hover": "#EEF3FF"
   }
 }

--- a/src/components/Sing/CharacterMenuButton/CharacterSelectMenu.vue
+++ b/src/components/Sing/CharacterMenuButton/CharacterSelectMenu.vue
@@ -139,7 +139,7 @@ const reassignSubMenuOpen = debounce((idx: number) => {
   subMenuOpenFlags.value = arr;
 }, 100);
 
-const changeStyleId = (speakerUuid: SpeakerId, styleId: StyleId) => {
+const changeStyleId = async (speakerUuid: SpeakerId, styleId: StyleId) => {
   const engineId = store.state.engineIds.find((_engineId) =>
     (store.state.characterInfos[_engineId] ?? []).some(
       (characterInfo) =>
@@ -152,7 +152,7 @@ const changeStyleId = (speakerUuid: SpeakerId, styleId: StyleId) => {
       `No engineId for target character style (speakerUuid == ${speakerUuid}, styleId == ${styleId})`,
     );
 
-  store.dispatch("COMMAND_SET_SINGER", {
+  await store.dispatch("COMMAND_SET_SINGER", {
     trackId: props.trackId,
     singer: { engineId, styleId },
     withRelated: true,

--- a/src/components/Sing/CharacterMenuButton/CharacterSelectMenu.vue
+++ b/src/components/Sing/CharacterMenuButton/CharacterSelectMenu.vue
@@ -152,7 +152,7 @@ const changeStyleId = (speakerUuid: SpeakerId, styleId: StyleId) => {
       `No engineId for target character style (speakerUuid == ${speakerUuid}, styleId == ${styleId})`,
     );
 
-  void store.dispatch("COMMAND_SET_SINGER", {
+  store.dispatch("COMMAND_SET_SINGER", {
     trackId: props.trackId,
     singer: { engineId, styleId },
     withRelated: true,

--- a/src/components/Sing/CharacterMenuButton/MenuButton.vue
+++ b/src/components/Sing/CharacterMenuButton/MenuButton.vue
@@ -38,3 +38,34 @@ const selectedSinger = computed(() => {
   return store.getters.SELECTED_TRACK.singer;
 });
 </script>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as vars;
+@use "@/styles/colors" as colors;
+
+.character-menu {
+  .q-menu {
+    :deep(.q-menu__container) {
+      border-radius: 1.25rem;
+    }
+  }
+  .q-item {
+    color: var(--scheme-color-on-surface);
+  }
+  .q-btn-group {
+    > .q-btn:first-child > :deep(.q-btn__content) {
+      justify-content: flex-start;
+    }
+    > div:last-child:hover {
+      background-color: rgba(var(--scheme-color-secondary-rgb), 0.1);
+    }
+  }
+  .engine-icon {
+    position: absolute;
+    width: 13px;
+    height: 13px;
+    bottom: -6px;
+    right: -6px;
+  }
+}
+</style>

--- a/src/components/Sing/CharacterMenuButton/SelectedCharacter.vue
+++ b/src/components/Sing/CharacterMenuButton/SelectedCharacter.vue
@@ -1,27 +1,23 @@
 <template>
   <div v-if="props.showSkeleton" class="selected-character">
-    <QSkeleton class="character-avatar" type="QAvatar" size="52px" />
+    <QSkeleton class="character-avatar" type="QAvatar" size="40px" />
     <div class="character-info">
       <QSkeleton
         class="character-name skeleton"
         type="rect"
-        width="65px"
-        height="15px"
+        width="64px"
+        height="16px"
       />
       <QSkeleton
         class="character-style"
         type="rect"
         width="110px"
-        height="12px"
+        height="8px"
       />
     </div>
   </div>
   <div v-else class="selected-character">
-    <QAvatar
-      v-if="selectedStyleIconPath"
-      class="character-avatar"
-      size="3.5rem"
-    >
+    <QAvatar v-if="selectedStyleIconPath" class="character-avatar">
       <img :src="selectedStyleIconPath" class="character-avatar-icon" />
     </QAvatar>
     <div class="character-info">
@@ -83,12 +79,32 @@ const selectedStyleIconPath = computed(() => {
 @use "@/styles/colors" as colors;
 
 .selected-character {
+  border: 1px solid var(--scheme-color-outline-variant);
+  border-radius: 4px 0 0 4px;
   align-items: center;
   display: flex;
-  padding: 0.25rem 0.5rem 0.25rem 0.25rem;
+  padding: 0 8px 0 4px;
   position: relative;
+  height: 40px;
+  font-smooth: antialiased;
+
+  &:hover {
+    border-color: var(--scheme-color-outline);
+    background: rgba(var(--scheme-color-secondary-container-rgb), 0.1);
+  }
+
+  &:focus {
+    border-color: var(--scheme-color-primary);
+  }
+
+  .character-avatar {
+    background: var(--scheme-color-background);
+    width: 36px;
+    height: 36px;
+  }
 
   .character-avatar-icon {
+    border: 1px solid var(--scheme-color-outline-variant);
     display: block;
     height: 100%;
     object-fit: cover;
@@ -99,33 +115,41 @@ const selectedStyleIconPath = computed(() => {
     align-items: start;
     display: flex;
     flex-direction: column;
-    margin-left: 0.5rem;
+    margin-left: 8px;
     text-align: left;
     justify-content: center;
     white-space: nowrap;
+    font-optical-sizing: auto;
   }
+
   .character-name {
-    font-size: 0.875rem;
-    font-weight: bold;
-    line-height: 1rem;
-    padding-top: 0.5rem;
+    color: var(--scheme-color-on-surface);
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+    padding-top: 12px;
+    margin-bottom: 0;
+    font-optical-sizing: auto;
 
     &.skeleton {
-      margin-top: 0.4rem;
-      margin-bottom: 0.2rem;
+      margin-top: 0;
+      margin-bottom: 0;
     }
   }
 
   .character-style {
-    color: rgba(colors.$display-rgb, 0.6);
-    font-size: 0.75rem;
-    font-weight: bold;
-    line-height: 1rem;
+    color: var(--scheme-color-on-surface-variant);
+    font-size: 9px;
+    transform: translateY(-5px);
+    font-weight: 400;
+    line-height: 16px;
+    margin-bottom: 8px;
   }
 
   .character-menu-dropdown-icon {
-    color: rgba(colors.$display-rgb, 0.8);
-    margin-left: 0.25rem;
+    display: none;
+    color: var(--scheme-color-on-surface-variant);
+    margin-left: 4px;
   }
 }
 </style>

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -28,8 +28,6 @@
       @scroll="onScroll"
       @contextmenu.prevent
     >
-      <!-- キャラクター全身 -->
-      <CharacterPortrait />
       <!-- グリッド -->
       <SequencerGrid />
       <div
@@ -40,7 +38,7 @@
           transform: `translateX(${guideLineX}px)`,
         }"
       ></div>
-
+      <CharacterPortrait />
       <!-- undefinedだと警告が出るのでnullを渡す -->
       <!-- TODO: ちゃんとしたトラックIDを渡す -->
       <SequencerShadowNote
@@ -137,6 +135,7 @@
       :max="ZOOM_X_MAX"
       :step="ZOOM_X_STEP"
       class="zoom-x-slider"
+      trackSize="3px"
       @update:modelValue="setZoomX"
     />
     <QSlider
@@ -147,6 +146,7 @@
       vertical
       reverse
       class="zoom-y-slider"
+      trackSize="3px"
       @update:modelValue="setZoomY"
     />
     <ContextMenu
@@ -154,6 +154,7 @@
       ref="contextMenu"
       :menudata="contextMenuData"
     />
+    <div class="character-selecter"></div>
   </div>
 </template>
 
@@ -378,7 +379,7 @@ const onLyricInput = (text: string, note: Note) => {
 
 const onLyricConfirmed = (nextNoteId: NoteId | undefined) => {
   commitPreviewLyrics();
-  void store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: nextNoteId });
+  store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: nextNoteId });
 };
 
 // プレビュー
@@ -733,9 +734,9 @@ const getYInBorderBox = (clientY: number, element: HTMLElement) => {
 };
 
 const selectOnlyThis = (note: Note) => {
-  void store.dispatch("DESELECT_ALL_NOTES");
-  void store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
-  void store.dispatch("PLAY_PREVIEW_SOUND", {
+  store.dispatch("DESELECT_ALL_NOTES");
+  store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
+  store.dispatch("PLAY_PREVIEW_SOUND", {
     noteNumber: note.noteNumber,
     duration: PREVIEW_SOUND_DURATION,
   });
@@ -781,7 +782,7 @@ const startPreview = (event: MouseEvent, mode: PreviewMode, note?: Note) => {
         noteNumber: cursorNoteNumber,
         lyric: getDoremiFromNoteNumber(cursorNoteNumber),
       };
-      void store.dispatch("DESELECT_ALL_NOTES");
+      store.dispatch("DESELECT_ALL_NOTES");
       copiedNotes.push(note);
     } else {
       if (!note) {
@@ -804,9 +805,9 @@ const startPreview = (event: MouseEvent, mode: PreviewMode, note?: Note) => {
             noteIdsToSelect.push(noteId);
           }
         }
-        void store.dispatch("SELECT_NOTES", { noteIds: noteIdsToSelect });
+        store.dispatch("SELECT_NOTES", { noteIds: noteIdsToSelect });
       } else if (isOnCommandOrCtrlKeyDown(event)) {
-        void store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
+        store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
       } else if (!selectedNoteIds.value.has(note.id)) {
         selectOnlyThis(note);
       }
@@ -867,21 +868,21 @@ const endPreview = () => {
 
     if (edited) {
       if (previewMode === "ADD_NOTE") {
-        void store.dispatch("COMMAND_ADD_NOTES", {
+        store.dispatch("COMMAND_ADD_NOTES", {
           notes: previewNotes.value,
           trackId: selectedTrackId.value,
         });
-        void store.dispatch("SELECT_NOTES", {
+        store.dispatch("SELECT_NOTES", {
           noteIds: previewNotes.value.map((value) => value.id),
         });
       } else {
-        void store.dispatch("COMMAND_UPDATE_NOTES", {
+        store.dispatch("COMMAND_UPDATE_NOTES", {
           notes: previewNotes.value,
           trackId: selectedTrackId.value,
         });
       }
       if (previewNotes.value.length === 1) {
-        void store.dispatch("PLAY_PREVIEW_SOUND", {
+        store.dispatch("PLAY_PREVIEW_SOUND", {
           noteNumber: previewNotes.value[0].noteNumber,
           duration: PREVIEW_SOUND_DURATION,
         });
@@ -904,14 +905,14 @@ const endPreview = () => {
         applyGaussianFilter(data, 0.7);
         data = data.map((value) => Math.exp(value));
 
-        void store.dispatch("COMMAND_SET_PITCH_EDIT_DATA", {
+        store.dispatch("COMMAND_SET_PITCH_EDIT_DATA", {
           pitchArray: data,
           startFrame: previewPitchEdit.value.startFrame,
           trackId: selectedTrackId.value,
         });
       }
     } else if (previewPitchEditType === "erase") {
-      void store.dispatch("COMMAND_ERASE_PITCH_EDIT_DATA", {
+      store.dispatch("COMMAND_ERASE_PITCH_EDIT_DATA", {
         startFrame: previewPitchEdit.value.startFrame,
         frameLength: previewPitchEdit.value.frameLength,
         trackId: selectedTrackId.value,
@@ -944,7 +945,7 @@ const onNoteBarDoubleClick = (event: MouseEvent, note: Note) => {
   }
   const mouseButton = getButton(event);
   if (mouseButton === "LEFT_BUTTON" && note.id !== state.editingLyricNoteId) {
-    void store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: note.id });
+    store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: note.id });
   }
 };
 
@@ -988,7 +989,7 @@ const onMouseDown = (event: MouseEvent) => {
         startPreview(event, "ADD_NOTE");
       }
     } else {
-      void store.dispatch("DESELECT_ALL_NOTES");
+      store.dispatch("DESELECT_ALL_NOTES");
     }
   } else if (editTarget.value === "PITCH") {
     if (mouseButton === "LEFT_BUTTON") {
@@ -1076,9 +1077,9 @@ const rectSelect = (additive: boolean) => {
     }
   }
   if (!additive) {
-    void store.dispatch("DESELECT_ALL_NOTES");
+    store.dispatch("DESELECT_ALL_NOTES");
   }
-  void store.dispatch("SELECT_NOTES", { noteIds: noteIdsToSelect });
+  store.dispatch("SELECT_NOTES", { noteIds: noteIdsToSelect });
 };
 
 const onMouseEnter = () => {
@@ -1099,13 +1100,13 @@ const handleNotesArrowUp = () => {
   if (editedNotes.some((note) => note.noteNumber > 127)) {
     return;
   }
-  void store.dispatch("COMMAND_UPDATE_NOTES", {
+  store.dispatch("COMMAND_UPDATE_NOTES", {
     notes: editedNotes,
     trackId: selectedTrackId.value,
   });
 
   if (editedNotes.length === 1) {
-    void store.dispatch("PLAY_PREVIEW_SOUND", {
+    store.dispatch("PLAY_PREVIEW_SOUND", {
       noteNumber: editedNotes[0].noteNumber,
       duration: PREVIEW_SOUND_DURATION,
     });
@@ -1121,13 +1122,13 @@ const handleNotesArrowDown = () => {
   if (editedNotes.some((note) => note.noteNumber < 0)) {
     return;
   }
-  void store.dispatch("COMMAND_UPDATE_NOTES", {
+  store.dispatch("COMMAND_UPDATE_NOTES", {
     notes: editedNotes,
     trackId: selectedTrackId.value,
   });
 
   if (editedNotes.length === 1) {
-    void store.dispatch("PLAY_PREVIEW_SOUND", {
+    store.dispatch("PLAY_PREVIEW_SOUND", {
       noteNumber: editedNotes[0].noteNumber,
       duration: PREVIEW_SOUND_DURATION,
     });
@@ -1144,7 +1145,7 @@ const handleNotesArrowRight = () => {
     // TODO: 例外処理は`UPDATE_NOTES`内に移す？
     return;
   }
-  void store.dispatch("COMMAND_UPDATE_NOTES", {
+  store.dispatch("COMMAND_UPDATE_NOTES", {
     notes: editedNotes,
     trackId: selectedTrackId.value,
   });
@@ -1162,7 +1163,7 @@ const handleNotesArrowLeft = () => {
   ) {
     return;
   }
-  void store.dispatch("COMMAND_UPDATE_NOTES", {
+  store.dispatch("COMMAND_UPDATE_NOTES", {
     notes: editedNotes,
     trackId: selectedTrackId.value,
   });
@@ -1173,7 +1174,7 @@ const handleNotesBackspaceOrDelete = () => {
     // TODO: 例外処理は`COMMAND_REMOVE_SELECTED_NOTES`内に移す？
     return;
   }
-  void store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
+  store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
 };
 
 const handleKeydown = (event: KeyboardEvent) => {
@@ -1201,7 +1202,7 @@ const handleKeydown = (event: KeyboardEvent) => {
       handleNotesBackspaceOrDelete();
       break;
     case "Escape":
-      void store.dispatch("DESELECT_ALL_NOTES");
+      store.dispatch("DESELECT_ALL_NOTES");
       break;
   }
 };
@@ -1222,7 +1223,7 @@ const setZoomX = (value: number | null) => {
   const scrollTop = sequencerBodyElement.scrollTop;
   const clientWidth = sequencerBodyElement.clientWidth;
 
-  void store.dispatch("SET_ZOOM_X", { zoomX: newZoomX }).then(() => {
+  store.dispatch("SET_ZOOM_X", { zoomX: newZoomX }).then(() => {
     const centerBaseX = (scrollLeft + clientWidth / 2) / oldZoomX;
     const newScrollLeft = centerBaseX * newZoomX - clientWidth / 2;
     sequencerBodyElement.scrollTo(newScrollLeft, scrollTop);
@@ -1245,7 +1246,7 @@ const setZoomY = (value: number | null) => {
   const scrollTop = sequencerBodyElement.scrollTop;
   const clientHeight = sequencerBodyElement.clientHeight;
 
-  void store.dispatch("SET_ZOOM_Y", { zoomY: newZoomY }).then(() => {
+  store.dispatch("SET_ZOOM_Y", { zoomY: newZoomY }).then(() => {
     const centerBaseY = (scrollTop + clientHeight / 2) / oldZoomY;
     const newScrollTop = centerBaseY * newZoomY - clientHeight / 2;
     sequencerBodyElement.scrollTo(scrollLeft, newScrollTop);
@@ -1272,7 +1273,7 @@ const onWheel = (event: WheelEvent) => {
     const scrollTop = sequencerBodyElement.scrollTop;
     guideLineX.value = 0; // 補助線がはみ出さないように位置を一旦0にする
 
-    void store.dispatch("SET_ZOOM_X", { zoomX: newZoomX }).then(() => {
+    store.dispatch("SET_ZOOM_X", { zoomX: newZoomX }).then(() => {
       const cursorBaseX = (scrollLeft + cursorX.value) / oldZoomX;
       const newScrollLeft = cursorBaseX * newZoomX - cursorX.value;
       sequencerBodyElement.scrollTo(newScrollLeft, scrollTop);
@@ -1356,14 +1357,14 @@ onActivated(() => {
     yToScroll = scrollY.value;
   }
   // 実際にスクロールする
-  void nextTick(() => {
+  nextTick(() => {
     sequencerBodyElement.scrollTo(xToScroll, yToScroll);
   });
 });
 
 // リスナー登録
 onActivated(() => {
-  void store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
     listener: playheadPositionChangeListener,
   });
 
@@ -1372,7 +1373,7 @@ onActivated(() => {
 
 // リスナー解除
 onDeactivated(() => {
-  void store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
     listener: playheadPositionChangeListener,
   });
 
@@ -1393,7 +1394,7 @@ registerHotkeyWithCleanup({
     if (selectedNoteIds.value.size === 0) {
       return;
     }
-    void store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+    store.dispatch("COPY_NOTES_TO_CLIPBOARD");
   },
 });
 
@@ -1407,7 +1408,7 @@ registerHotkeyWithCleanup({
     if (selectedNoteIds.value.size === 0) {
       return;
     }
-    void store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+    store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
   },
 });
 
@@ -1418,7 +1419,7 @@ registerHotkeyWithCleanup({
     if (nowPreviewing.value) {
       return;
     }
-    void store.dispatch("COMMAND_PASTE_NOTES_FROM_CLIPBOARD");
+    store.dispatch("COMMAND_PASTE_NOTES_FROM_CLIPBOARD");
   },
 });
 
@@ -1429,7 +1430,7 @@ registerHotkeyWithCleanup({
     if (nowPreviewing.value) {
       return;
     }
-    void store.dispatch("SELECT_ALL_NOTES_IN_TRACK", {
+    store.dispatch("SELECT_ALL_NOTES_IN_TRACK", {
       trackId: selectedTrackId.value,
     });
   },
@@ -1523,16 +1524,15 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
 .score-sequencer {
   backface-visibility: hidden;
   display: grid;
-  grid-template-rows: 30px 1fr;
+  grid-template-rows: 40px 1fr;
   grid-template-columns: 48px 1fr;
 }
 
 .sequencer-corner {
   grid-row: 1;
   grid-column: 1;
-  background: colors.$background;
-  border-top: 1px solid colors.$sequencer-sub-divider;
-  border-bottom: 1px solid colors.$sequencer-sub-divider;
+  background: var(--scheme-color-sing-ruler-surface);
+  border-radius: 8px 0 0 0;
 }
 
 .sequencer-ruler {
@@ -1557,12 +1557,51 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
   }
 }
 
+.sequencer-grid {
+  display: block;
+  pointer-events: none;
+}
+
+.sequencer-grid-cell {
+  display: block;
+  stroke: var(--scheme-color-surface-variant);
+  stroke-width: 1;
+}
+
+.sequencer-grid-octave-cell {
+  stroke: var(--scheme-color-outline);
+}
+
+.sequencer-grid-octave-line {
+  backface-visibility: hidden;
+  stroke: var(--scheme-color-outline);
+}
+
+.sequencer-grid-cell-white {
+  fill: var(--scheme-color-background);
+}
+
+.sequencer-grid-cell-black {
+  fill: var(--scheme-color-surface-variant);
+}
+
+.sequencer-grid-measure-line {
+  backface-visibility: hidden;
+  stroke: var(--scheme-color-outline);
+}
+
+.sequencer-grid-beat-line {
+  backface-visibility: hidden;
+  stroke: var(--scheme-color-outline);
+  opacity: 0.6;
+}
+
 .sequencer-guideline {
   position: absolute;
   top: 0;
-  left: -1px;
-  width: 2px;
-  background: hsl(130, 35%, 82%);
+  left: -0.5px;
+  width: 1px;
+  background: var(--scheme-color-secondary-container);
   pointer-events: none;
 }
 
@@ -1590,18 +1629,18 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
 .sequencer-playhead {
   position: absolute;
   top: 0;
-  left: -1px;
+  left: 0px;
   width: 2px;
   height: 100%;
-  background: rgba(colors.$display-rgb, 0.6);
+  background: var(--scheme-color-inverse-surface);
   will-change: transform;
 }
 
 .rect-select-preview {
   pointer-events: none;
   position: absolute;
-  border: 2px solid rgba(colors.$primary-rgb, 0.5);
-  background: rgba(colors.$primary-rgb, 0.25);
+  border: 1px dashed var(--scheme-color-secondary);
+  background: oklch(from var(--scheme-color-secondary) l c h / 0.1);
 }
 
 .cursor-draw {
@@ -1615,6 +1654,15 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
   bottom: 16px;
   right: 32px;
   width: 80px;
+
+  :deep(.q-slider__track) {
+    background: var(--scheme-color-outline-variant);
+    color: var(--scheme-color-secondary);
+  }
+
+  :deep(.q-slider__thumb) {
+    color: var(--scheme-color-secondary);
+  }
 }
 
 .zoom-y-slider {
@@ -1622,5 +1670,14 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
   bottom: 40px;
   right: 16px;
   height: 80px;
+
+  :deep(.q-slider__track) {
+    background: var(--scheme-color-outline-variant);
+    color: var(--scheme-color-secondary);
+  }
+
+  :deep(.q-slider__thumb) {
+    color: var(--scheme-color-secondary);
+  }
 }
 </style>

--- a/src/components/Sing/SequencerKeys.vue
+++ b/src/components/Sing/SequencerKeys.vue
@@ -136,29 +136,29 @@ const noteNumberOfKeyBeingPressed = ref<number | undefined>();
 const sequencerKeys = ref<HTMLElement | null>(null);
 let resizeObserver: ResizeObserver | undefined;
 
-const onMouseDown = (noteNumber: number) => {
+const onMouseDown = async (noteNumber: number) => {
   noteNumberOfKeyBeingPressed.value = noteNumber;
-  store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
+  await store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
 };
 
-const onMouseUp = () => {
+const onMouseUp = async () => {
   if (noteNumberOfKeyBeingPressed.value != undefined) {
     const noteNumber = noteNumberOfKeyBeingPressed.value;
     noteNumberOfKeyBeingPressed.value = undefined;
-    store.dispatch("STOP_PREVIEW_SOUND", { noteNumber });
+    await store.dispatch("STOP_PREVIEW_SOUND", { noteNumber });
   }
 };
 
-const onMouseEnter = (noteNumber: number) => {
+const onMouseEnter = async (noteNumber: number) => {
   if (
     noteNumberOfKeyBeingPressed.value != undefined &&
     noteNumberOfKeyBeingPressed.value !== noteNumber
   ) {
-    store.dispatch("STOP_PREVIEW_SOUND", {
+    await store.dispatch("STOP_PREVIEW_SOUND", {
       noteNumber: noteNumberOfKeyBeingPressed.value,
     });
     noteNumberOfKeyBeingPressed.value = noteNumber;
-    store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
+    await store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
   }
 };
 

--- a/src/components/Sing/SequencerKeys.vue
+++ b/src/components/Sing/SequencerKeys.vue
@@ -1,6 +1,11 @@
 <template>
   <div ref="sequencerKeys" class="sequencer-keys">
-    <svg xmlns="http://www.w3.org/2000/svg" :width :height>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width
+      :height
+      shape-rendering="crispEdges"
+    >
       <g
         v-for="(whiteKeyInfo, index) in whiteKeyInfos"
         :key="index"
@@ -8,8 +13,8 @@
         @mouseenter="onMouseEnter(whiteKeyInfo.noteNumber)"
       >
         <rect
-          :x="whiteKeyRects[index].x - 0.5"
-          :y="whiteKeyRects[index].y + 0.5 - offset"
+          :x="whiteKeyRects[index].x"
+          :y="whiteKeyRects[index].y - offset"
           :width="whiteKeyRects[index].width"
           :height="whiteKeyRects[index].height"
           :title="whiteKeyInfo.name"
@@ -18,6 +23,20 @@
               ? 'white-key-being-pressed'
               : 'white-key'
           "
+        />
+        <line
+          :x1="whiteKeyRects[index].x"
+          :y1="whiteKeyRects[index].y - offset"
+          :x2="whiteKeyRects[index].x"
+          :y2="whiteKeyRects[index].y + whiteKeyRects[index].height - offset"
+          class="key-border"
+        />
+        <line
+          :x1="whiteKeyRects[index].x"
+          :y1="whiteKeyRects[index].y + whiteKeyRects[index].height - offset"
+          :x2="whiteKeyRects[index].x + whiteKeyRects[index].width"
+          :y2="whiteKeyRects[index].y + whiteKeyRects[index].height - offset"
+          class="key-border"
         />
         <text
           v-if="whiteKeyInfo.pitch === 'C'"
@@ -32,9 +51,9 @@
       <rect
         v-for="(blackKeyInfo, index) in blackKeyInfos"
         :key="index"
-        :x="blackKeyRects[index].x - 0.5"
-        :y="blackKeyRects[index].y + 0.5 - offset"
-        :width="blackKeyRects[index].width"
+        :x="blackKeyRects[index].x - 2"
+        :y="blackKeyRects[index].y - offset"
+        :width="blackKeyRects[index].width + 2"
         :height="blackKeyRects[index].height"
         rx="2"
         ry="2"
@@ -93,21 +112,22 @@ const whiteKeyRects = computed(() => {
     const isLast = index === array.length - 1;
     const nextValue = isLast ? keyBaseHeight * 128 : array[index + 1];
     return {
-      x: -2,
-      y: Math.floor(value * zoomY.value),
-      width: width.value + 2,
+      x: 0,
+      y: Math.round(value * zoomY.value),
+      width: width.value,
       height:
-        Math.floor(nextValue * zoomY.value) - Math.floor(value * zoomY.value),
+        Math.round(nextValue * zoomY.value) - Math.round(value * zoomY.value),
     };
   });
 });
+
 const blackKeyRects = computed(() => {
   return blackKeyBasePositions.map((value) => {
     return {
-      x: -2,
-      y: Math.floor(value * zoomY.value),
-      width: props.blackKeyWidth + 2,
-      height: Math.floor(keyBaseHeight * zoomY.value),
+      x: 0,
+      y: Math.round(value * zoomY.value),
+      width: props.blackKeyWidth,
+      height: Math.round(keyBaseHeight * zoomY.value),
     };
   });
 });
@@ -118,14 +138,14 @@ let resizeObserver: ResizeObserver | undefined;
 
 const onMouseDown = (noteNumber: number) => {
   noteNumberOfKeyBeingPressed.value = noteNumber;
-  void store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
+  store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
 };
 
 const onMouseUp = () => {
   if (noteNumberOfKeyBeingPressed.value != undefined) {
     const noteNumber = noteNumberOfKeyBeingPressed.value;
     noteNumberOfKeyBeingPressed.value = undefined;
-    void store.dispatch("STOP_PREVIEW_SOUND", { noteNumber });
+    store.dispatch("STOP_PREVIEW_SOUND", { noteNumber });
   }
 };
 
@@ -134,11 +154,11 @@ const onMouseEnter = (noteNumber: number) => {
     noteNumberOfKeyBeingPressed.value != undefined &&
     noteNumberOfKeyBeingPressed.value !== noteNumber
   ) {
-    void store.dispatch("STOP_PREVIEW_SOUND", {
+    store.dispatch("STOP_PREVIEW_SOUND", {
       noteNumber: noteNumberOfKeyBeingPressed.value,
     });
     noteNumberOfKeyBeingPressed.value = noteNumber;
-    void store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
+    store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
   }
 };
 
@@ -172,32 +192,35 @@ onUnmounted(() => {
 <style scoped lang="scss">
 @use "@/styles/variables" as vars;
 @use "@/styles/colors" as colors;
-
 .sequencer-keys {
   backface-visibility: hidden;
-  background: colors.$background;
+  background: var(--scheme-color-background);
   overflow: hidden;
 }
 
 .white-key {
-  fill: colors.$sequencer-white-key;
-  stroke: colors.$sequencer-main-divider;
+  fill: var(--scheme-color-sing-piano-key-white);
 }
 
 .white-key-being-pressed {
-  fill: colors.$primary;
-  stroke: colors.$primary;
+  fill: var(--scheme-color-secondary-fixed);
 }
 
 .black-key {
-  fill: colors.$sequencer-black-key;
+  fill: var(--scheme-color-sing-piano-key-black);
 }
 
 .black-key-being-pressed {
-  fill: colors.$primary;
+  fill: var(--scheme-color-secondary-fixed);
+}
+
+.key-border {
+  stroke: var(--scheme-color-outline-variant);
+  stroke-width: 1px;
 }
 
 .pitchname {
-  fill: colors.$sequencer-black-key;
+  font-weight: 500;
+  fill: var(--scheme-color-sing-piano-key-black);
 }
 </style>

--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -1,18 +1,21 @@
 <template>
-  <!-- TODO: ピッチの上に歌詞入力のinputが表示されるようにする -->
-  <input
-    ref="lyricInput"
-    :value="editingLyricNote.lyric"
-    class="lyric-input"
+  <div
+    class="lyric-input-container"
     :style="{
       transform: `translate3d(${positionX}px,${positionY}px,0)`,
     }"
-    @input="onLyricInput"
-    @mousedown.stop
-    @dblclick.stop
-    @keydown.stop="onLyricInputKeyDown"
-    @blur="onLyricInputBlur"
-  />
+  >
+    <input
+      ref="lyricInput"
+      :value="editingLyricNote.lyric"
+      class="lyric-input"
+      @input="onLyricInput"
+      @mousedown.stop
+      @dblclick.stop
+      @keydown.stop="onLyricInputKeyDown"
+      @blur="onLyricInputBlur"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -86,13 +89,14 @@ const onLyricInput = (event: Event) => {
   if (!(event.target instanceof HTMLInputElement)) {
     throw new Error("Invalid event target");
   }
-  emit("lyricInput", event.target.value, props.editingLyricNote);
+  const newValue = event.target.value;
+  emit("lyricInput", newValue, props.editingLyricNote);
 };
 
 watch(
-  () => props.editingLyricNote,
+  () => props.editingLyricNote.lyric,
   () => {
-    void nextTick(() => {
+    nextTick(() => {
       lyricInput.value?.focus();
       lyricInput.value?.select();
     });
@@ -105,15 +109,28 @@ watch(
 @use "@/styles/variables" as vars;
 @use "@/styles/colors" as colors;
 
-.lyric-input {
+.lyric-input-container {
   position: absolute;
-  top: 0;
-  left: 0;
-  font-weight: 700;
-  min-width: 3rem;
-  max-width: 6rem;
-  border: 0;
-  outline: 2px solid lab(80, -22.953, 14.365);
+  top: -2px;
+  left: -2px;
+}
+
+.lyric-input {
+  display: inline-block;
+  font-weight: 500;
+  font-size: 16px;
+  box-sizing: border-box;
+  background-color: oklch(from var(--scheme-color-background) l c h / 0.88);
+  backdrop-filter: blur(1px);
+  color: var(--scheme-color-on-surface);
+  outline-offset: 1px;
+  border: 1px solid var(--scheme-color-inverse-surface);
+  box-shadow:
+    oklch(from var(--scheme-color-scrim) l c h / 0.19) 0px 8px 20px,
+    oklch(from var(--scheme-color-scrim) l c h / 0.23) 0px 6px 6px;
+  outline: 0;
   border-radius: 4px;
+  padding: 0 4px;
+  width: 10ch;
 }
 </style>

--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -95,8 +95,8 @@ const onLyricInput = (event: Event) => {
 
 watch(
   () => props.editingLyricNote.lyric,
-  () => {
-    nextTick(() => {
+  async () => {
+    await nextTick(() => {
       lyricInput.value?.focus();
       lyricInput.value?.select();
     });

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -2,7 +2,8 @@
   <div
     class="note"
     :class="{
-      'selected-or-preview': isSelected || isPreview,
+      selected: isSelected,
+      preview: isPreview,
       'preview-lyric': previewLyric != undefined,
       overlapping: hasOverlappingError,
       'invalid-phrase': hasPhraseError,
@@ -22,27 +23,34 @@
       @mousedown="onBarMouseDown"
       @dblclick="onBarDoubleClick"
     >
-      <div
-        class="note-left-edge"
-        :class="{
-          'cursor-ew-resize': editTargetIsNote,
-        }"
-        @mousedown="onLeftEdgeMouseDown"
-      ></div>
-      <div
-        class="note-right-edge"
-        :class="{
-          'cursor-ew-resize': editTargetIsNote,
-        }"
-        @mousedown="onRightEdgeMouseDown"
-      ></div>
       <ContextMenu
         v-if="editTargetIsNote"
         ref="contextMenu"
         :menudata="contextMenuData"
       />
     </div>
-    <div class="note-lyric" data-testid="note-lyric">
+    <div
+      class="note-left-edge"
+      :class="{
+        'cursor-ew-resize': editTargetIsNote,
+      }"
+      @mousedown="onLeftEdgeMouseDown"
+    ></div>
+    <div
+      class="note-right-edge"
+      :class="{
+        'cursor-ew-resize': editTargetIsNote,
+      }"
+      @mousedown="onRightEdgeMouseDown"
+    ></div>
+    <div
+      class="note-lyric"
+      data-testid="note-lyric"
+      :style="{
+        fontSize: `${height > 16 ? 16 : height - 2}px`,
+        lineHeight: `${height}px`,
+      }"
+    >
       {{ lyricToDisplay }}
     </div>
     <!-- エラー内容を表示 -->
@@ -223,115 +231,185 @@ const onLeftEdgeMouseDown = (event: MouseEvent) => {
   top: 0;
   left: 0;
 
-  &.below-pitch {
+  .note-lyric {
+    border-radius: 4px;
+    position: fixed;
+    left: 2px;
+    bottom: 0;
+    color: var(--scheme-color-sing-on-note-bar-container);
+    font-size: 16px;
+    font-weight: 400;
+    letter-spacing: -0.1em;
+    white-space: nowrap;
+    pointer-events: none;
+    background: transparent;
+    text-shadow:
+      -1px -1px 0 var(--scheme-color-sing-note-bar-container),
+      1px -1px 0 var(--scheme-color-sing-note-bar-container),
+      -1px 1px 0 var(--scheme-color-sing-note-bar-container),
+      1px 1px 0 var(--scheme-color-sing-note-bar-container),
+      0 -1px 0 var(--scheme-color-sing-note-bar-container),
+      0 1px 0 var(--scheme-color-sing-note-bar-container),
+      -1px 0 0 var(--scheme-color-sing-note-bar-container),
+      1px 0 0 var(--scheme-color-sing-note-bar-container);
+    // アンチエイリアス
+    -webkit-font-smoothing: subpixel-antialiased;
+  }
+
+  .note-bar {
+    box-sizing: border-box;
+    position: absolute;
+    width: calc(100% + 1px);
+    height: 100%;
+    background-color: var(--scheme-color-sing-note-bar-container);
+    border: 1px solid var(--scheme-color-sing-note-bar-border);
+    border-radius: 4px;
+  }
+
+  .note-left-edge {
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-radius: 4px 0 0 4px;
+    width: 25%;
+    min-width: 4px;
+    max-width: 8px;
+    height: 100%;
+    &:hover {
+      background-color: var(--scheme-color-sing-note-bar-border);
+    }
+  }
+
+  .note-right-edge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    border-radius: 0 4px 4px 0;
+    width: 25%;
+    min-width: 4px;
+    max-width: 8px;
+    height: 100%;
+
+    &:hover {
+      background-color: var(--scheme-color-sing-note-bar-border);
+    }
+  }
+
+  &.selected {
     .note-bar {
-      background-color: rgba(colors.$primary-rgb, 0.18);
-      border-color: hsl(130, 35%, 78%);
+      background-color: var(--scheme-color-sing-note-bar-selected-container);
+      border-color: var(--scheme-color-sing-note-bar-selected-border);
+      outline: 1px solid var(--scheme-color-sing-note-bar-selected-outline);
+      outline-offset: 1px;
     }
-  }
 
-  &:not(.below-pitch) {
+    .note-lyric {
+      color: var(--scheme-color-sing-on-note-bar-selected-container);
+      text-shadow:
+        -1px -1px 0 var(--scheme-color-sing-note-bar-selected-container),
+        1px -1px 0 var(--scheme-color-sing-note-bar-selected-container),
+        -1px 1px 0 var(--scheme-color-sing-note-bar-selected-container),
+        1px 1px 0 var(--scheme-color-sing-note-bar-selected-container),
+        0 -1px 0 var(--scheme-color-sing-note-bar-selected-container),
+        0 1px 0 var(--scheme-color-sing-note-bar-selected-container),
+        -1px 0 0 var(--scheme-color-sing-note-bar-selected-container),
+        1px 0 0 var(--scheme-color-sing-note-bar-selected-container);
+    }
+
+    .note-right-edge:hover,
     .note-left-edge:hover {
-      // FIXME: hoverだとカーソル位置によって適用されないので、プレビュー中に明示的にクラス指定する
-      background-color: lab(80 -22.953 14.365);
-    }
-
-    .note-right-edge:hover {
-      // FIXME: hoverだとカーソル位置によって適用されないので、プレビュー中に明示的にクラス指定する
-      background-color: lab(80 -22.953 14.365);
-    }
-
-    &.selected-or-preview {
-      // 色は仮
-      .note-bar {
-        background-color: lab(95 -22.953 14.365);
-        border-color: lab(65 -22.953 14.365);
-        outline: solid 2px lab(70 -22.953 14.365);
-      }
+      background-color: var(--scheme-color-sing-note-bar-selected-border);
     }
   }
-  // TODO：もっといい見た目を考える
+
   &.preview-lyric {
     .note-bar {
-      background-color: lab(90, -22.953, 14.365);
-      border-color: lab(75, -22.953, 14.365);
-      outline: solid 2px lab(80, -22.953, 14.365);
+      background-color: var(--scheme-color-sing-note-bar-preview-container);
+      border-color: var(--scheme-color-sing-note-bar-preview-border);
+      outline-color: var(--scheme-color-sing-note-bar-preview-outline);
     }
 
     .note-lyric {
       opacity: 0.38;
-    }
-
-    &.below-pitch {
-      .note-bar {
-        background-color: rgba(hsl(130, 100%, 50%), 0.18);
-      }
+      text-shadow:
+        -1px -1px 0 var(--scheme-color-sing-note-bar-preview-container),
+        1px -1px 0 var(--scheme-color-sing-note-bar-preview-container),
+        -1px 1px 0 var(--scheme-color-sing-note-bar-preview-container),
+        1px 1px 0 var(--scheme-color-sing-note-bar-preview-container),
+        0 -1px 0 var(--scheme-color-sing-note-bar-preview-container),
+        0 1px 0 var(--scheme-color-sing-note-bar-preview-container),
+        -1px 0 0 var(--scheme-color-sing-note-bar-preview-container),
+        1px 0 0 var(--scheme-color-sing-note-bar-preview-container);
     }
   }
 
   &.overlapping,
   &.invalid-phrase {
     .note-bar {
-      background-color: rgba(colors.$warning-rgb, 0.5);
+      background-color: var(--scheme-color-surface-variant);
+      border-color: var(--scheme-color-error);
+      outline-color: var(--scheme-color-error-container);
+    }
+
+    .note-right-edge:hover,
+    .note-left-edge:hover {
+      background-color: var(--scheme-color-error);
     }
 
     .note-lyric {
-      opacity: 0.6;
+      color: var(--scheme-color-on-error-container);
+      opacity: 0.38;
+      text-shadow: none;
     }
 
-    &.selected-or-preview {
+    &.selected,
+    &:active {
       .note-bar {
-        background-color: rgba(colors.$warning-rgb, 0.5);
-        border-color: colors.$warning;
-        outline: 2px solid rgba(colors.$warning-rgb, 0.3);
+        background-color: var(--scheme-color-error-container);
+        border-color: var(--scheme-color-error);
+        outline-color: var(--scheme-color-error);
+      }
+
+      .note-lyric {
+        color: var(--scheme-color-on-error-container);
+        text-shadow: none;
       }
     }
   }
-}
 
-.note-lyric {
-  position: absolute;
-  left: 0.125rem;
-  bottom: 0;
-  min-width: 2rem;
-  padding: 0;
-  background: transparent;
-  color: #121212;
-  font-size: 1rem;
-  font-weight: 700;
-  text-shadow:
-    -1px -1px 0 #fff,
-    1px -1px 0 #fff,
-    -1px 1px 0 #fff,
-    1px 1px 0 #fff;
-  white-space: nowrap;
-  pointer-events: none;
-}
+  &.below-pitch {
+    .note-bar {
+      background-color: var(--scheme-color-surface-variant);
+      border-color: var(--scheme-color-outline-variant);
+      outline: none;
+      opacity: 0.8;
+    }
 
-.note-bar {
-  box-sizing: border-box;
-  position: absolute;
-  width: calc(100% + 1px);
-  height: 100%;
-  background-color: colors.$primary;
-  border: 1px solid rgba(colors.$background-rgb, 0.5);
-  border-radius: 4px;
-}
+    .note-lyric {
+      color: var(--scheme-color-on-surface);
+      opacity: 0.8;
+      text-shadow: none;
+    }
 
-.note-left-edge {
-  position: absolute;
-  top: 0;
-  left: -1px;
-  width: 5px;
-  height: 100%;
-}
+    .note-right-edge:hover,
+    .note-left-edge:hover {
+      background-color: transparent;
+    }
 
-.note-right-edge {
-  position: absolute;
-  top: 0;
-  right: -1px;
-  width: 5px;
-  height: 100%;
+    &.overlapping,
+    &.invalid-phrase {
+      .note-bar {
+        background: var(--scheme-color-surface-variant);
+        border-color: var(--scheme-color-error);
+        outline: none;
+      }
+
+      .note-lyric {
+        color: var(--scheme-color-error);
+        text-shadow: none;
+      }
+    }
+  }
 }
 
 .cursor-move {

--- a/src/components/Sing/SequencerPhraseIndicator.vue
+++ b/src/components/Sing/SequencerPhraseIndicator.vue
@@ -44,13 +44,52 @@ const className = computed(() => {
 }
 
 .waiting-to-be-rendered {
+  background-color: color-mix(
+    in oklch,
+    var(--scheme-color-secondary-fixed-dim) 70%,
+    var(--scheme-color-background)
+  );
+  /*
   @include tint-if-in-other-track(
     "background-color",
     color-mix(in srgb, colors.$primary 80%, colors.$background)
-  );
+  ); */
 }
 
 .now-rendering {
+  border: 1px solid --scheme-color-primary-fixed-dim;
+  background-color: var(--scheme-color-background);
+  background-size: 28px 28px;
+  background-image: linear-gradient(
+    -45deg,
+    var(--scheme-color-primary-fixed-dim) 25%,
+    color-mix(
+        in oklch,
+        var(--scheme-color-primary-fixed-dim) 36%,
+        var(--scheme-color-background)
+      )
+      25%,
+    color-mix(
+        in oklch,
+        var(--scheme-color-primary-fixed-dim) 36%,
+        var(--scheme-color-background)
+      )
+      50%,
+    var(--scheme-color-primary-fixed-dim) 50%,
+    var(--scheme-color-primary-fixed-dim) 75%,
+    color-mix(
+        in oklch,
+        var(--scheme-color-primary-fixed-dim) 36%,
+        var(--scheme-color-background)
+      )
+      75%,
+    color-mix(
+        in oklch,
+        var(--scheme-color-primary-fixed-dim) 36%,
+        var(--scheme-color-background)
+      )
+      100%
+  );
   background-color: colors.$background;
   background-size: 28px 28px;
   &.is-in-selected-track {
@@ -94,7 +133,11 @@ const className = computed(() => {
 }
 
 .could-not-render {
-  @include tint-if-in-other-track("background-color", colors.$warning);
+  background-color: var(--scheme-color-error);
+  @include tint-if-in-other-track(
+    "background-color",
+    var(--scheme-color-error)
+  );
 }
 
 .playable {

--- a/src/components/Sing/SequencerRuler.vue
+++ b/src/components/Sing/SequencerRuler.vue
@@ -142,8 +142,8 @@ const playheadX = computed(() => {
   return Math.floor(baseX * zoomX.value);
 });
 
-const onClick = (event: MouseEvent) => {
-  store.dispatch("DESELECT_ALL_NOTES");
+const onClick = async (event: MouseEvent) => {
+  await store.dispatch("DESELECT_ALL_NOTES");
 
   const sequencerRulerElement = sequencerRuler.value;
   if (!sequencerRulerElement) {
@@ -151,7 +151,7 @@ const onClick = (event: MouseEvent) => {
   }
   const baseX = (props.offset + event.offsetX) / zoomX.value;
   const ticks = baseXToTick(baseX, tpqn.value);
-  store.dispatch("SET_PLAYHEAD_POSITION", { position: ticks });
+  await store.dispatch("SET_PLAYHEAD_POSITION", { position: ticks });
 };
 
 const sequencerRuler = ref<HTMLElement | null>(null);
@@ -161,7 +161,7 @@ const playheadPositionChangeListener = (position: number) => {
   playheadTicks.value = position;
 };
 
-onMounted(() => {
+onMounted(async () => {
   const sequencerRulerElement = sequencerRuler.value;
   if (!sequencerRulerElement) {
     throw new Error("sequencerRulerElement is null.");
@@ -179,15 +179,15 @@ onMounted(() => {
   });
   resizeObserver.observe(sequencerRulerElement);
 
-  store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  await store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
     listener: playheadPositionChangeListener,
   });
 });
 
-onUnmounted(() => {
+onUnmounted(async () => {
   resizeObserver?.disconnect();
 
-  store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  await store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
     listener: playheadPositionChangeListener,
   });
 });

--- a/src/components/Sing/SequencerShadowNote.vue
+++ b/src/components/Sing/SequencerShadowNote.vue
@@ -60,13 +60,14 @@ const width = computed(() => {
   pointer-events: none;
 
   .shadow-line {
+    border-radius: 1px;
     position: absolute;
     top: 50%;
     left: 0;
     width: 100%;
     height: 2px;
     transform: translateY(-50%);
-    background-color: colors.$sequencer-main-divider;
+    background-color: var(--scheme-color-sing-shadow-note);
   }
 }
 </style>

--- a/src/components/Sing/ToolBar/EditTargetSwicher.vue
+++ b/src/components/Sing/ToolBar/EditTargetSwicher.vue
@@ -1,37 +1,44 @@
-<!--
-  ノートやピッチなどの編集対象を切り替えるボタン
--->
-
 <template>
-  <QBtnToggle
-    dense
-    unelevated
-    toggleColor="primary"
-    :modelValue="editTarget"
-    toggleTextColor="display-on-primary"
-    class="edit-target-switcher q-mr-sm"
-    :options="[
-      {
-        icon: 'piano',
-        value: 'NOTE',
-        slot: 'NOTE',
-      },
-      {
-        icon: 'show_chart',
-        value: 'PITCH',
-        slot: 'PITCH',
-      },
-    ]"
-    @update:modelValue="changeEditTarget"
-    ><template #NOTE
-      ><QTooltip :delay="500" anchor="bottom middle">ノート編集</QTooltip>
-    </template>
-    <template #PITCH>
-      <QTooltip :delay="500" anchor="bottom middle"
-        >ピッチ編集<br />{{ !isMac ? "Ctrl" : "Cmd" }}+クリックで消去</QTooltip
+  <QBtnGroup flat class="edit-target-switcher">
+    <!-- ノート -->
+    <QBtn
+      dense
+      unelevated
+      class="segment-switch"
+      :class="{ active: editTarget === 'NOTE' }"
+      @click="changeEditTarget('NOTE')"
+      @keydown="handleKeyDown"
+    >
+      <QIcon name="piano" size="24px" />
+      <QTooltip
+        :delay="500"
+        anchor="bottom middle"
+        transitionShow=""
+        transitionHide=""
       >
-    </template>
-  </QBtnToggle>
+        ノート編集
+      </QTooltip>
+    </QBtn>
+
+    <!-- ピッチ -->
+    <QBtn
+      dense
+      unelevated
+      class="segment-switch"
+      :class="{ active: editTarget === 'PITCH' }"
+      @click="changeEditTarget('PITCH')"
+    >
+      <QIcon name="timeline" size="24px" />
+      <QTooltip
+        :delay="500"
+        anchor="bottom middle"
+        transitionShow=""
+        transitionSide=""
+      >
+        ピッチ編集<br />{{ !isMac ? "Ctrl" : "Cmd" }}+クリックで消去
+      </QTooltip>
+    </QBtn>
+  </QBtnGroup>
 </template>
 
 <script setup lang="ts">
@@ -42,24 +49,32 @@ defineProps<{
   editTarget: SequencerEditTarget;
   changeEditTarget: (editTarget: SequencerEditTarget) => void;
 }>();
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (event.key === " " || event.key === "Spacebar") {
+    event.preventDefault();
+  }
+};
 </script>
 
-<style lang="scss" scoped>
-.edit-target-switcher :deep(.q-btn-item) {
-  position: relative;
+<style scoped lang="scss">
+.edit-target-switcher {
+  background: var(--scheme-color-surface-container-lowest);
+  //border: 1px solid var(--scheme-color-outline-variant);
+  box-sizing: border-box;
+  padding: 3px;
+  height: 40px;
+  border-radius: 20px;
+}
 
-  &.bg-primary {
-    // borderがないと切り換え時に1px動くのでそれを防ぐ
-    border: 1px solid var(--color-primary);
-  }
-  &:not(.bg-primary) {
-    border: 1px solid rgba(var(--color-display-rgb), 0.3);
-    &:first-child {
-      border-right: 0;
-    }
-    &:last-child {
-      border-left: 0;
-    }
+.segment-switch {
+  color: var(--scheme-color-on-secondary-container);
+  height: 34px;
+  min-width: 34px;
+  border-radius: 17px !important;
+
+  &.active {
+    background: var(--scheme-color-surface-container-highest);
+    color: var(--scheme-color-on-secondary-container);
   }
 }
 </style>

--- a/src/components/Sing/ToolBar/ToolBar.vue
+++ b/src/components/Sing/ToolBar/ToolBar.vue
@@ -11,63 +11,85 @@
         @click="toggleSidebar"
       />
       <CharacterMenuButton />
-      <QInput
-        type="number"
-        :modelValue="keyRangeAdjustmentInputBuffer"
-        label="音域調整"
-        dense
-        hideBottomSpace
-        class="key-range-adjustment"
-        @update:modelValue="setKeyRangeAdjustmentInputBuffer"
-        @change="setKeyRangeAdjustment"
-      />
-      <QInput
-        type="number"
-        :modelValue="volumeRangeAdjustmentInputBuffer"
-        label="声量調整"
-        dense
-        hideBottomSpace
-        class="volume-range-adjustment"
-        @update:modelValue="setVolumeRangeAdjustmentInputBuffer"
-        @change="setVolumeRangeAdjustment"
-      />
+      <div class="sing-adjustment">
+        <QInput
+          type="number"
+          dense
+          :modelValue="keyRangeAdjustmentInputBuffer"
+          label="音域"
+          hideBottomSpace
+          unelevated
+          class="key-range-adjustment"
+          @update:modelValue="setKeyRangeAdjustmentInputBuffer"
+          @change="setKeyRangeAdjustment"
+        />
+        <QInput
+          type="number"
+          dense
+          :modelValue="volumeRangeAdjustmentInputBuffer"
+          label="声量"
+          hideBottomSpace
+          unelevated
+          class="volume-range-adjustment"
+          @update:modelValue="setVolumeRangeAdjustmentInputBuffer"
+          @change="setVolumeRangeAdjustment"
+        />
+      </div>
       <QInput
         type="number"
         :modelValue="bpmInputBuffer"
-        label="テンポ"
         dense
         hideBottomSpace
+        outlined
+        unelevated
+        label="BPM"
         class="sing-tempo"
+        padding="0"
         @update:modelValue="setBpmInputBuffer"
         @change="setTempo"
+      />
+      <QField
+        hideBottomSpace
+        dense
+        class="sing-time-signature-field"
+        label="拍子"
+        stackLabel
+        outlined
       >
-        <template #prepend>
-          <QIcon name="music_note" size="xs" class="sing-tempo-icon" />
+        <template #control>
+          <div class="sing-beats">
+            <QSelect
+              :modelValue="timeSignatures[0].beats"
+              :options="beatsOptions"
+              hideBottomSpace
+              hideDropdownIcon
+              dense
+              userInputs
+              unelevated
+              optionsDense
+              transitionShow="none"
+              transitionHide="none"
+              class="sing-time-signature beats"
+              @update:modelValue="setBeats"
+            />
+            <div class="sing-beats-separator">/</div>
+            <QSelect
+              :modelValue="timeSignatures[0].beatType"
+              :options="beatTypeOptions"
+              hideBottomSpace
+              hideDropdownIcon
+              dense
+              userInputs
+              unelevated
+              optionsDense
+              transitionShow="none"
+              transitionHide="none"
+              class="sing-time-signature beat-type"
+              @update:modelValue="setBeatType"
+            />
+          </div>
         </template>
-      </QInput>
-      <div class="sing-beats">
-        <QInput
-          type="number"
-          :modelValue="beatsInputBuffer"
-          label="拍子"
-          dense
-          hideBottomSpace
-          class="sing-time-signature"
-          @update:modelValue="setBeatsInputBuffer"
-          @change="setTimeSignature"
-        />
-        <div class="sing-beats-separator">/</div>
-        <QInput
-          type="number"
-          :modelValue="beatTypeInputBuffer"
-          label=""
-          dense
-          hideBottomSpace
-          class="sing-time-signature"
-          @update:modelValue="setBeatTypeInputBuffer"
-          @change="setTimeSignature"
-        />
-      </div>
+      </QField>
     </div>
     <!-- player -->
     <div class="sing-player">
@@ -81,14 +103,14 @@
       <QBtn
         v-if="!nowPlaying"
         round
-        class="sing-playback-button"
+        class="sing-playback-button sing-playback-play"
         icon="play_arrow"
         @click="play"
       />
       <QBtn
         v-else
         round
-        class="sing-playback-button"
+        class="sing-playback-button sing-playback-stop"
         icon="stop"
         @click="stop"
       />
@@ -106,31 +128,33 @@
         flat
         dense
         round
-        icon="undo"
         class="sing-undo-button"
         :disable="!canUndo"
         @click="undo"
-      />
+      >
+        <QIcon name="undo" size="24px" />
+      </QBtn>
       <QBtn
         flat
         dense
         round
-        icon="redo"
         class="sing-redo-button"
         :disable="!canRedo"
         @click="redo"
-      />
+      >
+        <QIcon name="redo" size="24px" />
+      </QBtn>
       <QIcon name="volume_up" size="xs" class="sing-volume-icon" />
-      <QSlider v-model.number="volume" class="sing-volume" />
+      <QSlider v-model.number="volume" trackSize="2px" class="sing-volume" />
       <QSelect
         v-model="snapTypeSelectModel"
         :options="snapTypeSelectOptions"
-        outlined
-        color="primary"
         dense
-        textColor="display-on-primary"
+        outlined
         hideBottomSpace
         optionsDense
+        hideDropdownIcon
+        unelevated
         label="スナップ"
         transitionShow="none"
         transitionHide="none"
@@ -202,21 +226,21 @@ registerHotkeyWithCleanup({
 });
 
 const undo = () => {
-  void store.dispatch("UNDO", { editor });
+  store.dispatch("UNDO", { editor });
 };
 const redo = () => {
-  void store.dispatch("REDO", { editor });
+  store.dispatch("REDO", { editor });
 };
 
 const editTarget = computed(() => store.state.sequencerEditTarget);
 
 const changeEditTarget = (editTarget: SequencerEditTarget) => {
-  void store.dispatch("SET_EDIT_TARGET", { editTarget });
+  store.dispatch("SET_EDIT_TARGET", { editTarget });
 };
 
 const isSidebarOpen = computed(() => store.state.isSongSidebarOpen);
 const toggleSidebar = () => {
-  void store.dispatch("SET_SONG_SIDEBAR_OPEN", {
+  store.dispatch("SET_SONG_SIDEBAR_OPEN", {
     isSongSidebarOpen: !isSidebarOpen.value,
   });
 };
@@ -230,6 +254,20 @@ const volumeRangeAdjustment = computed(
   () => store.getters.SELECTED_TRACK.volumeRangeAdjustment,
 );
 const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
+
+const beatsOptions = computed(() => {
+  return Array.from({ length: 32 }, (_, i) => ({
+    label: (i + 1).toString(),
+    value: i + 1,
+  }));
+});
+
+const beatTypeOptions = computed(() => {
+  return [2, 4, 8, 16, 32].map((beatType) => ({
+    label: beatType.toString(),
+    value: beatType,
+  }));
+});
 
 const bpmInputBuffer = ref(120);
 const beatsInputBuffer = ref(4);
@@ -278,20 +316,30 @@ const setBpmInputBuffer = (bpmStr: string | number | null) => {
   bpmInputBuffer.value = bpmValue;
 };
 
-const setBeatsInputBuffer = (beatsStr: string | number | null) => {
-  const beatsValue = Number(beatsStr);
-  if (!isValidBeats(beatsValue)) {
+const setBeats = (beats: { label: string; value: number }) => {
+  if (!isValidBeats(beats.value)) {
     return;
   }
-  beatsInputBuffer.value = beatsValue;
+  store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
+    timeSignature: {
+      measureNumber: 1,
+      beats: beats.value,
+      beatType: timeSignatures.value[0].beatType,
+    },
+  });
 };
 
-const setBeatTypeInputBuffer = (beatTypeStr: string | number | null) => {
-  const beatTypeValue = Number(beatTypeStr);
-  if (!isValidBeatType(beatTypeValue)) {
+const setBeatType = (beatType: { label: string; value: number }) => {
+  if (!isValidBeatType(beatType.value)) {
     return;
   }
-  beatTypeInputBuffer.value = beatTypeValue;
+  store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
+    timeSignature: {
+      measureNumber: 1,
+      beats: timeSignatures.value[0].beats,
+      beatType: beatType.value,
+    },
+  });
 };
 
 const setKeyRangeAdjustmentInputBuffer = (
@@ -316,7 +364,7 @@ const setVolumeRangeAdjustmentInputBuffer = (
 
 const setTempo = () => {
   const bpm = bpmInputBuffer.value;
-  void store.dispatch("COMMAND_SET_TEMPO", {
+  store.dispatch("COMMAND_SET_TEMPO", {
     tempo: {
       position: 0,
       bpm,
@@ -324,21 +372,9 @@ const setTempo = () => {
   });
 };
 
-const setTimeSignature = () => {
-  const beats = beatsInputBuffer.value;
-  const beatType = beatTypeInputBuffer.value;
-  void store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
-    timeSignature: {
-      measureNumber: 1,
-      beats,
-      beatType,
-    },
-  });
-};
-
 const setKeyRangeAdjustment = () => {
   const keyRangeAdjustment = keyRangeAdjustmentInputBuffer.value;
-  void store.dispatch("COMMAND_SET_KEY_RANGE_ADJUSTMENT", {
+  store.dispatch("COMMAND_SET_KEY_RANGE_ADJUSTMENT", {
     keyRangeAdjustment,
     trackId: selectedTrackId.value,
   });
@@ -346,7 +382,7 @@ const setKeyRangeAdjustment = () => {
 
 const setVolumeRangeAdjustment = () => {
   const volumeRangeAdjustment = volumeRangeAdjustmentInputBuffer.value;
-  void store.dispatch("COMMAND_SET_VOLUME_RANGE_ADJUSTMENT", {
+  store.dispatch("COMMAND_SET_VOLUME_RANGE_ADJUSTMENT", {
     volumeRangeAdjustment,
     trackId: selectedTrackId.value,
   });
@@ -379,15 +415,15 @@ const playHeadPositionMilliSecStr = computed(() => {
 const nowPlaying = computed(() => store.state.nowPlaying);
 
 const play = () => {
-  void store.dispatch("SING_PLAY_AUDIO");
+  store.dispatch("SING_PLAY_AUDIO");
 };
 
 const stop = () => {
-  void store.dispatch("SING_STOP_AUDIO");
+  store.dispatch("SING_STOP_AUDIO");
 };
 
 const goToZero = () => {
-  void store.dispatch("SET_PLAYHEAD_POSITION", { position: 0 });
+  store.dispatch("SET_PLAYHEAD_POSITION", { position: 0 });
 };
 
 const volume = computed({
@@ -395,7 +431,7 @@ const volume = computed({
     return store.state.volume * 100;
   },
   set(value: number) {
-    void store.dispatch("SET_VOLUME", { volume: value / 100 });
+    store.dispatch("SET_VOLUME", { volume: value / 100 });
   },
 });
 
@@ -427,7 +463,7 @@ const snapTypeSelectModel = computed({
     );
   },
   set(value) {
-    void store.dispatch("SET_SNAP_TYPE", {
+    store.dispatch("SET_SNAP_TYPE", {
       snapType: value.snapType,
     });
   },
@@ -438,42 +474,93 @@ const playheadPositionChangeListener = (position: number) => {
 };
 
 onMounted(() => {
-  void store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
     listener: playheadPositionChangeListener,
   });
 });
 
 onUnmounted(() => {
-  void store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
     listener: playheadPositionChangeListener,
   });
 });
 </script>
 
 <style scoped lang="scss">
-@use "@/styles/variables" as vars;
+@use "@/styles/v2/variables" as vars;
 @use "@/styles/colors" as colors;
 
-.q-input {
-  :deep(.q-field__control::before) {
-    border-color: rgba(colors.$display-rgb, 0.3);
+// フィールドデフォルト
+:deep(.q-field__native) {
+  color: var(--scheme-color-on-surface);
+  text-align: center;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+/* QInput のアウトラインをoutline-variantにする */
+:deep(.q-input .q-field__control:before, .q-select .q-field__control:before) {
+  border: 1px solid var(--scheme-color-outline-variant);
+}
+
+:deep(.q-field--outlined .q-field__control) {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+// ラベルのフォントサイズを小さくする()
+:deep(.q-input .q-field__label, .q-select .q-field__label) {
+  font-size: 12px;
+  color: var(--scheme-color-on-surface-variant);
+}
+
+// type:number
+:deep(.q-field__native[type="number"]) {
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    cursor: pointer;
+  }
+
+  // スピンボタンのホバー状態
+  &:hover::-webkit-inner-spin-button,
+  &:hover::-webkit-outer-spin-button {
+    background: var(--scheme-color-surface-container-highest);
+  }
+
+  // スピンボタンのアクティブ状態
+  &:active::-webkit-inner-spin-button,
+  &:active::-webkit-outer-spin-button {
+    background: var(--scheme-color-surface-container-low);
   }
 }
 
-.q-select {
-  :deep(.q-field__control::before) {
-    border-color: rgba(colors.$display-rgb, 0.3);
-  }
+:deep(
+    .q-input .q-field__control:hover:before,
+    .q-select .q-field__control:hover:before
+  ) {
+  border: 1px solid var(--scheme-color-outline);
+}
+
+// オプションメニュー全体の背景色
+:deep(.q-menu) {
+  background: var(--scheme-color-surface-container);
+}
+
+// TODO: アクティブ色が効かないので修正したい
+:deep(.q-menu .q-item--active) {
+  //background-color: var(--scheme-color-secondary-container);
+  color: var(--scheme-color-primary);
 }
 
 .sing-toolbar {
-  background: colors.$sing-toolbar;
+  background: var(--scheme-color-sing-toolbar-container);
   align-items: center;
   display: flex;
   justify-content: space-between;
-  min-height: 56px;
-  padding: 0 8px 0 0;
+  min-height: 64px;
+  padding: 8px 8px 8px 0;
   width: 100%;
+  letter-spacing: 0.01em;
 }
 
 .sing-configs {
@@ -489,50 +576,146 @@ onUnmounted(() => {
   flex: 1;
 }
 
+.sing-adjustment {
+  height: 40px;
+  border: 1px solid var(--scheme-color-outline-variant);
+  border-left: 0;
+  border-radius: 0 4px 4px 0;
+  padding: 0 0 0 8px;
+  display: flex;
+  align-items: center;
+}
+
 .key-range-adjustment {
-  margin-left: 16px;
-  margin-right: 4px;
-  width: 50px;
+  margin-right: 0px;
+  width: 40px;
+
+  :deep(.q-field__control) {
+    height: 40px;
+
+    &:before {
+      border: 1px solid transparent;
+    }
+
+    &:hover:before {
+      border-color: transparent;
+      border-bottom: 1px solid var(--scheme-color-outline);
+    }
+  }
 }
 
 .volume-range-adjustment {
-  margin-left: 4px;
-  margin-right: 4px;
-  width: 50px;
+  width: 40px;
+
+  :deep(.q-field__control) {
+    padding: 0 2px;
+    height: 40px;
+
+    &:before {
+      border: 1px solid transparent;
+    }
+
+    &:hover:before {
+      border-color: transparent;
+      border-bottom: 1px solid var(--scheme-color-outline);
+    }
+  }
 }
 
 .sing-tempo {
-  margin-left: 8px;
+  margin-left: 16px;
   margin-right: 4px;
-  width: 72px;
+  width: 60px;
 }
 
-.sing-tempo-icon {
-  color: rgba(colors.$display-rgb, 0.6);
-  padding-right: 0px;
-  position: relative;
-  top: 4px;
-  left: 0;
+.sing-time-signature-field {
+  height: 40px;
+
+  :deep(.q-field__control) {
+    height: 40px;
+    padding: 0 2px;
+  }
+
+  :deep(.q-field__label) {
+    font-size: 9px;
+    top: 2px;
+    margin-left: 6px;
+    transform: translateY(0) !important;
+    color: var(--scheme-color-on-surface-variant);
+    opacity: 0.9;
+  }
+
+  :deep(.q-field__native) {
+    padding-top: 4px;
+  }
+
+  :deep(.q-field__control:before) {
+    border-color: var(--scheme-color-outline-variant);
+  }
+
+  :deep(.q-field__control:hover:before) {
+    border-color: var(--scheme-color-outline);
+  }
+}
+
+.sing-time-signature.beats {
+  :deep(.q-field__control) {
+    padding: 0 4px 0 8px;
+  }
+}
+
+.sing-time-signature.beat-type {
+  :deep(.q-field__control) {
+    padding: 0 8px 0 4px;
+  }
 }
 
 .sing-beats {
-  align-items: center;
   display: flex;
-  margin-left: 8px;
-  position: relative;
+  align-items: center;
+  height: 40px;
+  margin-top: -14px;
+
+  &:deep(.q-field__control:before) {
+    border: 1px solid transparent;
+  }
+
+  &:deep(.q-field__control) {
+    background: transparent;
+    padding: 0 4px;
+  }
+
+  &:deep(.q-field__control:hover:before) {
+    border-color: transparent;
+  }
 }
 
-.sing-time-signature {
-  margin: 0;
-  position: relative;
-  width: 32px;
-}
 .sing-beats-separator {
-  color: rgba(colors.$display-rgb, 0.6);
-  position: relative;
-  top: 5px;
-  margin-right: 8px;
+  font-weight: 500;
+  color: var(--scheme-color-on-surface-variant);
   pointer-events: none;
+  transform: translateY(6px);
+  opacity: 0.56;
+}
+
+.sing-transport-button {
+  color: var(--scheme-color-on-surface-variant);
+}
+
+.sing-playback-button {
+  background: var(--scheme-color-sing-playback-button-container);
+  color: var(--scheme-color-sing-on-playback-button-container);
+  &:before {
+    box-shadow: none;
+  }
+
+  &.sing-playback-play .q-btn__wrapper .q-icon {
+    transform: translateX(-0.5px);
+  }
+
+  &.sing-playback-stop .q-btn__wrapper .q-icon {
+    transform: translateX(-0.5px);
+  }
 }
 
 .sing-playhead-position {
@@ -541,14 +724,14 @@ onUnmounted(() => {
   font-size: 28px;
   font-weight: 700;
   margin-left: 16px;
-  color: colors.$display;
+  color: var(--scheme-color-on-surface);
 }
 
 .sing-playhead-position-millisec {
   font-size: 16px;
   font-weight: 700;
   margin: 10px 0 0 2px;
-  color: rgba(colors.$display-rgb, 0.73);
+  color: var(--scheme-color-on-surface);
 }
 
 .sing-controls {
@@ -558,26 +741,71 @@ onUnmounted(() => {
   flex: 1;
 }
 
+.sing-undo-button {
+  margin-left: 24px;
+}
+
 .sing-undo-button,
 .sing-redo-button {
+  color: var(--scheme-color-on-surface-variant);
+  width: 40px;
+  height: 40px;
   &.disabled {
-    opacity: 0.4 !important;
+    opacity: 0.38 !important;
   }
 }
 .sing-redo-button {
-  margin-right: 16px;
+  margin-right: 8px;
 }
 
 .sing-volume-icon {
   margin-right: 8px;
   opacity: 0.6;
+
+  :deep {
+    color: var(--scheme-color-on-surface-variant);
+  }
 }
+
 .sing-volume {
   margin-right: 16px;
   width: 72px;
+
+  :deep(.q-slider__track) {
+    background: var(--scheme-color-outline-variant);
+    color: var(--scheme-color-secondary);
+  }
+
+  :deep(.q-slider__thumb) {
+    color: var(--scheme-color-secondary);
+  }
+
+  &:hover {
+    :deep(.q-slider__track) {
+      color: var(--scheme-color-primary);
+    }
+    :deep(.q-slider__thumb) {
+      color: var(--scheme-color-primary);
+    }
+  }
 }
 
 .sing-snap {
-  min-width: 104px;
+  min-width: 72px;
+  height: 40px;
+
+  &:deep(.q-field__control:before) {
+    height: 40px;
+    border: 1px solid var(--scheme-color-outline-variant);
+  }
+
+  :deep(.q-field__control:hover:before) {
+    border-color: var(--scheme-color-outline);
+  }
+
+  :deep(.q-field__label) {
+    font-size: 12px;
+    color: var(--scheme-color-on-surface-variant);
+  }
 }
 </style>

--- a/src/components/Sing/ToolBar/ToolBar.vue
+++ b/src/components/Sing/ToolBar/ToolBar.vue
@@ -197,18 +197,18 @@ const { registerHotkeyWithCleanup } = useHotkeyManager();
 registerHotkeyWithCleanup({
   editor,
   name: "元に戻す",
-  callback: () => {
+  callback: async () => {
     if (!uiLocked.value && canUndo.value) {
-      undo();
+      await undo();
     }
   },
 });
 registerHotkeyWithCleanup({
   editor,
   name: "やり直す",
-  callback: () => {
+  callback: async () => {
     if (!uiLocked.value && canRedo.value) {
-      redo();
+      await redo();
     }
   },
 });
@@ -216,31 +216,31 @@ registerHotkeyWithCleanup({
 registerHotkeyWithCleanup({
   editor,
   name: "再生/停止",
-  callback: () => {
+  callback: async () => {
     if (nowPlaying.value) {
-      stop();
+      await stop();
     } else {
-      play();
+      await play();
     }
   },
 });
 
-const undo = () => {
-  store.dispatch("UNDO", { editor });
+const undo = async () => {
+  await store.dispatch("UNDO", { editor });
 };
-const redo = () => {
-  store.dispatch("REDO", { editor });
+const redo = async () => {
+  await store.dispatch("REDO", { editor });
 };
 
 const editTarget = computed(() => store.state.sequencerEditTarget);
 
-const changeEditTarget = (editTarget: SequencerEditTarget) => {
-  store.dispatch("SET_EDIT_TARGET", { editTarget });
+const changeEditTarget = async (editTarget: SequencerEditTarget) => {
+  await store.dispatch("SET_EDIT_TARGET", { editTarget });
 };
 
 const isSidebarOpen = computed(() => store.state.isSongSidebarOpen);
-const toggleSidebar = () => {
-  store.dispatch("SET_SONG_SIDEBAR_OPEN", {
+const toggleSidebar = async () => {
+  await store.dispatch("SET_SONG_SIDEBAR_OPEN", {
     isSongSidebarOpen: !isSidebarOpen.value,
   });
 };
@@ -316,11 +316,11 @@ const setBpmInputBuffer = (bpmStr: string | number | null) => {
   bpmInputBuffer.value = bpmValue;
 };
 
-const setBeats = (beats: { label: string; value: number }) => {
+const setBeats = async (beats: { label: string; value: number }) => {
   if (!isValidBeats(beats.value)) {
     return;
   }
-  store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
+  await store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
     timeSignature: {
       measureNumber: 1,
       beats: beats.value,
@@ -329,11 +329,11 @@ const setBeats = (beats: { label: string; value: number }) => {
   });
 };
 
-const setBeatType = (beatType: { label: string; value: number }) => {
+const setBeatType = async (beatType: { label: string; value: number }) => {
   if (!isValidBeatType(beatType.value)) {
     return;
   }
-  store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
+  await store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
     timeSignature: {
       measureNumber: 1,
       beats: timeSignatures.value[0].beats,
@@ -362,9 +362,9 @@ const setVolumeRangeAdjustmentInputBuffer = (
   volumeRangeAdjustmentInputBuffer.value = volumeRangeAdjustmentValue;
 };
 
-const setTempo = () => {
+const setTempo = async () => {
   const bpm = bpmInputBuffer.value;
-  store.dispatch("COMMAND_SET_TEMPO", {
+  await store.dispatch("COMMAND_SET_TEMPO", {
     tempo: {
       position: 0,
       bpm,
@@ -372,17 +372,17 @@ const setTempo = () => {
   });
 };
 
-const setKeyRangeAdjustment = () => {
+const setKeyRangeAdjustment = async () => {
   const keyRangeAdjustment = keyRangeAdjustmentInputBuffer.value;
-  store.dispatch("COMMAND_SET_KEY_RANGE_ADJUSTMENT", {
+  await store.dispatch("COMMAND_SET_KEY_RANGE_ADJUSTMENT", {
     keyRangeAdjustment,
     trackId: selectedTrackId.value,
   });
 };
 
-const setVolumeRangeAdjustment = () => {
+const setVolumeRangeAdjustment = async () => {
   const volumeRangeAdjustment = volumeRangeAdjustmentInputBuffer.value;
-  store.dispatch("COMMAND_SET_VOLUME_RANGE_ADJUSTMENT", {
+  await store.dispatch("COMMAND_SET_VOLUME_RANGE_ADJUSTMENT", {
     volumeRangeAdjustment,
     trackId: selectedTrackId.value,
   });
@@ -414,24 +414,24 @@ const playHeadPositionMilliSecStr = computed(() => {
 
 const nowPlaying = computed(() => store.state.nowPlaying);
 
-const play = () => {
-  store.dispatch("SING_PLAY_AUDIO");
+const play = async () => {
+  await store.dispatch("SING_PLAY_AUDIO");
 };
 
-const stop = () => {
-  store.dispatch("SING_STOP_AUDIO");
+const stop = async () => {
+  await store.dispatch("SING_STOP_AUDIO");
 };
 
-const goToZero = () => {
-  store.dispatch("SET_PLAYHEAD_POSITION", { position: 0 });
+const goToZero = async () => {
+  await store.dispatch("SET_PLAYHEAD_POSITION", { position: 0 });
 };
 
 const volume = computed({
   get() {
     return store.state.volume * 100;
   },
-  set(value: number) {
-    store.dispatch("SET_VOLUME", { volume: value / 100 });
+  async set(value: number) {
+    await store.dispatch("SET_VOLUME", { volume: value / 100 });
   },
 });
 
@@ -462,8 +462,8 @@ const snapTypeSelectModel = computed({
       selectOptions[0]
     );
   },
-  set(value) {
-    store.dispatch("SET_SNAP_TYPE", {
+  async set(value) {
+    await store.dispatch("SET_SNAP_TYPE", {
       snapType: value.snapType,
     });
   },
@@ -473,14 +473,14 @@ const playheadPositionChangeListener = (position: number) => {
   playheadTicks.value = position;
 };
 
-onMounted(() => {
-  store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+onMounted(async () => {
+  await store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
     listener: playheadPositionChangeListener,
   });
 });
 
-onUnmounted(() => {
-  store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+onUnmounted(async () => {
+  await store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
     listener: playheadPositionChangeListener,
   });
 });

--- a/src/components/Sing/ToolBar/ToolBar.vue
+++ b/src/components/Sing/ToolBar/ToolBar.vue
@@ -558,7 +558,7 @@ onUnmounted(async () => {
   display: flex;
   justify-content: space-between;
   min-height: 64px;
-  padding: 8px 8px 8px 0;
+  padding: 8px 12px;
   width: 100%;
   letter-spacing: 0.01em;
 }

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -2,6 +2,7 @@
 @use './colors' as colors;
 @use './v2/variables' as vars-v2;
 @use './v2/colors' as colors-v2;
+@use './v2/sing-colors' as sing-colors;
 @import "./fonts";
 
 // 優先度を強引に上げる

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -7,6 +7,13 @@
 
 @font-face {
   font-family: "Unhinted Rounded M+ 1p";
+  src: url("../fonts/unhinted-rounded-mplus-1p-medium.woff2");
+
+  font-weight: medium;
+}
+
+@font-face {
+  font-family: "Unhinted Rounded M+ 1p";
   src: url("../fonts/unhinted-rounded-mplus-1p-bold.woff2");
 
   font-weight: bold;

--- a/src/styles/v2/sing-colors.scss
+++ b/src/styles/v2/sing-colors.scss
@@ -29,7 +29,7 @@ color: var(--scheme-color-on-primary);
 */
 :root {
   // 基準彩度
-  --primary-c: 0.099;
+  --primary-c: 0.108;
   --secondary-c: calc(var(--primary-c) / 3); // 0.036
   --tertiary-c: var(--primary-c);
   --error-c: 0.21;

--- a/src/styles/v2/sing-colors.scss
+++ b/src/styles/v2/sing-colors.scss
@@ -1,0 +1,545 @@
+/*
+
+## 利用
+
+background-color: var(--scheme-color-primary);
+color: var(--scheme-color-on-primary);
+
+## カスタマイズサンプル
+
+50%明度プライマリ:
+  color: oklch(var(--lr-50) var(--primary-c) var(--primary-h));
+
+50%明度プライマリ(相対)
+  color: oklch(from var(--primary-key) l calc(var(--lr-50)));
+
+ロールカラー定義(on-primaryを相対)
+  --on-primary-dark: oklch(var(--lr-10) var(--primary-c) var(--primary-h));
+
+エイリアス
+  --sing-piano-key-white-dark: oklch(var(--lr-70) var(--neutral-c) var(--neutral-h));
+
+プライマリと色調を揃えた新カラー(色相が150度異なる紫)
+  color: oklch(from var(--primary-key) l calc(var(--lr-70)) c h calc(var(--primary-c) + 150 % 360)));
+
+*/
+
+/* 
+カラースキーム計算基準
+*/
+:root {
+  // 基準彩度
+  --primary-c: 0.099;
+  --secondary-c: calc(var(--primary-c) / 3); // 0.036
+  --tertiary-c: var(--primary-c);
+  --error-c: 0.21;
+  --neutral-c: 0;
+  --neutral-variant-c: 0.003;
+  --link-c: 0.21;
+
+  // 基準色相
+  --primary-h: 149.64;
+  --secondary-h: var(--primary-h);
+  --tertiary-h: calc(var(--primary-h) - 60);
+  --error-h: 19.64;
+  --neutral-h: var(--primary-h);
+  --neutral-variant-h: var(--primary-h);
+  --link-h: 256;
+
+  // キーカラー(60%明度)
+  --primary-key: oklch(var(--lr-60) var(--primary-c) var(--primary-h));
+  --secondary-key: oklch(var(--lr-60) var(--secondary-c) var(--secondary-h));
+  --tertiary-key: oklch(var(--lr-60) var(--tertiary-c) var(--tertiary-h));
+  --error-key: oklch(var(--lr-60) var(--error-c) var(--error-h));
+  --neutral-key: oklch(var(--lr-60) var(--neutral-c) var(--neutral-h));
+  --neutral-variant-key: oklch(var(--lr-60) var(--neutral-variant-c) var(--neutral-variant-h));
+  --link-key: oklch(var(--lr-60) var(--link-c) var(--link-h));
+}
+
+/* 
+明度LUT
+OKLCHのL値を相対明度に補正した値
+eg: 50%: --lr-50
+*/
+:root {
+  --lr-0: 0.00000;
+  --lr-1: 0.03257;
+  --lr-2: 0.05321;
+  --lr-3: 0.07049;
+  --lr-4: 0.08600;
+  --lr-5: 0.10036;
+  --lr-6: 0.11391;
+  --lr-7: 0.12686;
+  --lr-8: 0.13934;
+  --lr-9: 0.15143;
+  --lr-10: 0.16321;
+  --lr-11: 0.17472;
+  --lr-12: 0.18600;
+  --lr-13: 0.19708;
+  --lr-14: 0.20799;
+  --lr-15: 0.21875;
+  --lr-16: 0.22937;
+  --lr-17: 0.23988;
+  --lr-18: 0.25027;
+  --lr-19: 0.26056;
+  --lr-20: 0.27077;
+  --lr-21: 0.28089;
+  --lr-22: 0.29093;
+  --lr-23: 0.30091;
+  --lr-24: 0.31082;
+  --lr-25: 0.32068;
+  --lr-26: 0.33047;
+  --lr-27: 0.34022;
+  --lr-28: 0.34992;
+  --lr-29: 0.35957;
+  --lr-30: 0.36919;
+  --lr-31: 0.37876;
+  --lr-32: 0.38829;
+  --lr-33: 0.39779;
+  --lr-34: 0.40726;
+  --lr-35: 0.41670;
+  --lr-36: 0.42611;
+  --lr-37: 0.43548;
+  --lr-38: 0.44484;
+  --lr-39: 0.45416;
+  --lr-40: 0.46347;
+  --lr-41: 0.47275;
+  --lr-42: 0.48201;
+  --lr-43: 0.49125;
+  --lr-44: 0.50047;
+  --lr-45: 0.50967;
+  --lr-46: 0.51885;
+  --lr-47: 0.52802;
+  --lr-48: 0.53716;
+  --lr-49: 0.54630;
+  --lr-50: 0.55541;
+  --lr-51: 0.56452;
+  --lr-52: 0.57361;
+  --lr-53: 0.58268;
+  --lr-54: 0.59175;
+  --lr-55: 0.60080;
+  --lr-56: 0.60983;
+  --lr-57: 0.61886;
+  --lr-58: 0.62788;
+  --lr-59: 0.63688;
+  --lr-60: 0.64588;
+  --lr-61: 0.65486;
+  --lr-62: 0.66384;
+  --lr-63: 0.67280;
+  --lr-64: 0.68176;
+  --lr-65: 0.69071;
+  --lr-66: 0.69965;
+  --lr-67: 0.70858;
+  --lr-68: 0.71750;
+  --lr-69: 0.72642;
+  --lr-70: 0.73533;
+  --lr-71: 0.74423;
+  --lr-72: 0.75312;
+  --lr-73: 0.76201;
+  --lr-74: 0.77089;
+  --lr-75: 0.77977;
+  --lr-76: 0.78864;
+  --lr-77: 0.79750;
+  --lr-78: 0.80636;
+  --lr-79: 0.81521;
+  --lr-80: 0.82405;
+  --lr-81: 0.83289;
+  --lr-82: 0.84173;
+  --lr-83: 0.85056;
+  --lr-84: 0.85938;
+  --lr-85: 0.86820;
+  --lr-86: 0.87702;
+  --lr-87: 0.88583;
+  --lr-88: 0.89463;
+  --lr-89: 0.90344;
+  --lr-90: 0.91223;
+  --lr-91: 0.92103;
+  --lr-92: 0.92982;
+  --lr-93: 0.93860;
+  --lr-94: 0.94738;
+  --lr-95: 0.95616;
+  --lr-96: 0.96494;
+  --lr-97: 0.97371;
+  --lr-98: 0.98248;
+  --lr-99: 0.99124;
+  --lr-100: 1;
+};
+
+/* 
+OKLCHでのカラースキーム
+*/
+/*
+ライトテーマ
+*/
+:root[is-dark-theme="false"] {
+  --scheme-color-primary: oklch(var(--lr-40) var(--primary-c) var(--primary-h));
+  --scheme-color-on-primary: oklch(var(--lr-100) var(--primary-c) var(--primary-h));
+  --scheme-color-primary-container: oklch(var(--lr-90) var(--primary-c) var(--primary-h));
+  --scheme-color-on-primary-container: oklch(var(--lr-10) var(--primary-c) var(--primary-h));
+  --scheme-color-primary-fixed: oklch(var(--lr-90) var(--primary-c) var(--primary-h));
+  --scheme-color-primary-fixed-dim: oklch(var(--lr-80) var(--primary-c) var(--primary-h));
+  --scheme-color-on-primary-fixed: oklch(var(--lr-10) var(--primary-c) var(--primary-h));
+  --scheme-color-on-primary-fixed-variant: oklch(var(--lr-30) var(--primary-c) var(--primary-h));
+
+  --scheme-color-secondary: oklch(var(--lr-40) var(--secondary-c) var(--secondary-h));
+  --scheme-color-on-secondary: oklch(var(--lr-100) var(--secondary-c) var(--secondary-h));
+  --scheme-color-secondary-container: oklch(var(--lr-90) var(--secondary-c) var(--secondary-h));
+  --scheme-color-on-secondary-container: oklch(var(--lr-10) var(--secondary-c) var(--secondary-h));
+  --scheme-color-secondary-fixed: oklch(var(--lr-90) var(--secondary-c) var(--secondary-h));
+  --scheme-color-secondary-fixed-dim: oklch(var(--lr-80) var(--secondary-c) var(--secondary-h));
+  --scheme-color-on-secondary-fixed: oklch(var(--lr-10) var(--secondary-c) var(--secondary-h));
+  --scheme-color-on-secondary-fixed-variant: oklch(var(--lr-30) var(--secondary-c) var(--secondary-h));
+
+  --scheme-color-tertiary: oklch(var(--lr-40) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-on-tertiary: oklch(var(--lr-100) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-tertiary-container: oklch(var(--lr-90) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-on-tertiary-container: oklch(var(--lr-10) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-tertiary-fixed: oklch(var(--lr-90) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-tertiary-fixed-dim: oklch(var(--lr-80) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-on-tertiary-fixed: oklch(var(--lr-10) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-on-tertiary-fixed-variant: oklch(var(--lr-30) var(--tertiary-c) var(--tertiary-h));
+
+  --scheme-color-error: oklch(var(--lr-40) var(--error-c) var(--error-h));
+  --scheme-color-on-error: oklch(var(--lr-100) var(--error-c) var(--error-h));
+  --scheme-color-error-container: oklch(var(--lr-90) var(--error-c) var(--error-h));
+  --scheme-color-on-error-container: oklch(var(--lr-10) var(--error-c) var(--error-h));
+
+  --scheme-color-background: oklch(var(--lr-99) var(--neutral-c) var(--neutral-h));
+  --scheme-color-on-background: oklch(var(--lr-10) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface: oklch(var(--lr-99) var(--neutral-c) var(--neutral-h));
+  --scheme-color-on-surface: oklch(var(--lr-10) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-variant: oklch(var(--lr-90) var(--neutral-variant-c) var(--neutral-variant-h));
+  --scheme-color-on-surface-variant: oklch(var(--lr-30) var(--neutral-variant-c) var(--neutral-variant-h));
+  --scheme-color-outline: oklch(var(--lr-50) var(--neutral-variant-c) var(--neutral-variant-h));
+  --scheme-color-outline-variant: oklch(var(--lr-80) var(--neutral-variant-c) var(--neutral-variant-h));
+
+  --scheme-color-shadow: oklch(var(--lr-0) var(--neutral-c) var(--neutral-h));
+  --scheme-color-scrim: oklch(var(--lr-0) var(--neutral-c) var(--neutral-h));
+  --scheme-color-inverse-surface: oklch(var(--lr-20) var(--neutral-c) var(--neutral-h));
+  --scheme-color-inverse-on-surface: oklch(var(--lr-95) var(--neutral-c) var(--neutral-h));
+  --scheme-color-inverse-primary: oklch(var(--lr-80) var(--primary-c) var(--primary-h));
+
+  --scheme-color-surface-dim: oklch(var(--lr-87) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-bright: oklch(var(--lr-98) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container-lowest: oklch(var(--lr-90) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container-low: oklch(var(--lr-92) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container: oklch(var(--lr-94) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container-high: oklch(var(--lr-96) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container-highest: oklch(var(--lr-100) var(--neutral-c) var(--neutral-h));
+
+  /* カスタムカラー */
+  --scheme-color-link: oklch(var(--lr-40) var(--link-c) var(--link-h));
+  --scheme-color-on-link: oklch(var(--lr-100) var(--link-c) var(--link-h));
+  --scheme-color-link-container: oklch(var(--lr-90) var(--link-c) var(--link-h));
+  --scheme-color-on-link-container: oklch(var(--lr-10) var(--link-c) var(--link-h));
+
+  /* ソング用エイリアスカラー */
+  --scheme-color-sing-toolbar-container: oklch(var(--lr-99) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-playback-button-container: oklch(var(--lr-80) var(--primary-c) var(--primary-h));
+  --scheme-color-sing-on-playback-button-container: oklch(var(--lr-10) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-grid-cell-white: oklch(var(--lr-100) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-grid-cell-black: oklch(var(--lr-96) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-grid-measure-line: oklch(var(--lr-75) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-grid-beat-line: oklch(var(--lr-90) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-grid-vertical-line: oklch(var(--lr-96) var(--neutral-c) var(--neutral-h));
+
+  --scheme-color-sing-grid-octave-line: oklch(var(--lr-88) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-grid-horizontal-line: oklch(var(--lr-96) var(--neutral-c) var(--neutral-h));
+
+  --scheme-color-sing-ruler-surface: oklch(var(--lr-90) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-ruler-measure-line: oklch(var(--lr-65) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-ruler-beat-line: oklch(var(--lr-75) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-piano-key-white: oklch(var(--lr-99) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-piano-key-black: oklch(var(--lr-45) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-note-bar-container: oklch(var(--lr-88) var(--secondary-c) var(--secondary-h));
+  --scheme-color-sing-on-note-bar-container: oklch(var(--lr-10) var(--secondary-c) var(--secondary-h));
+  --scheme-color-sing-note-bar-border: oklch(var(--lr-60) var(--secondary-c) var(--secondary-h));
+  
+  --scheme-color-sing-note-bar-selected-container: oklch(var(--lr-96) var(--primary-c) var(--primary-h));
+  --scheme-color-sing-on-note-bar-selected-container: oklch(var(--lr-10) var(--primary-c) var(--primary-h));
+  --scheme-color-sing-note-bar-selected-border: oklch(var(--lr-60) var(--primary-c) var(--primary-h));
+  --scheme-color-sing-note-bar-selected-outline: oklch(var(--lr-80) var(--primary-c) var(--primary-h));
+  
+  --scheme-color-sing-note-bar-preview-container: oklch(var(--lr-88) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-sing-on-note-bar-preview-container: oklch(var(--lr-10) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-sing-note-bar-preview-border: oklch(var(--lr-60) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-sing-note-bar-preview-outline: oklch(var(--lr-80) var(--tertiary-c) var(--tertiary-h));
+  
+  --scheme-color-sing-shadow-note: oklch(var(--lr-88) var(--neutral-variant-c) var(--neutral-variant-h));
+}
+
+/* ダークテーマ */
+:root[is-dark-theme="true"] {
+  --scheme-color-primary: oklch(var(--lr-80) var(--primary-c) var(--primary-h));
+  --scheme-color-on-primary: oklch(var(--lr-20) var(--primary-c) var(--primary-h));
+  --scheme-color-primary-container: oklch(var(--lr-30) var(--primary-c) var(--primary-h));
+  --scheme-color-on-primary-container: oklch(var(--lr-90) var(--primary-c) var(--primary-h));
+  --scheme-color-primary-fixed: oklch(var(--lr-90) var(--primary-c) var(--primary-h));
+  --scheme-color-primary-fixed-dim: oklch(var(--lr-80) var(--primary-c) var(--primary-h));
+  --scheme-color-on-primary-fixed: oklch(var(--lr-10) var(--primary-c) var(--primary-h));
+  --scheme-color-on-primary-fixed-variant: oklch(var(--lr-30) var(--primary-c) var(--primary-h));
+
+  --scheme-color-secondary: oklch(var(--lr-80) var(--secondary-c) var(--secondary-h));
+  --scheme-color-on-secondary: oklch(var(--lr-20) var(--secondary-c) var(--secondary-h));
+  --scheme-color-secondary-container: oklch(var(--lr-30) var(--secondary-c) var(--secondary-h));
+  --scheme-color-on-secondary-container: oklch(var(--lr-90) var(--secondary-c) var(--secondary-h));
+  --scheme-color-secondary-fixed: oklch(var(--lr-90) var(--secondary-c) var(--secondary-h));
+  --scheme-color-secondary-fixed-dim: oklch(var(--lr-80) var(--secondary-c) var(--secondary-h));
+  --scheme-color-on-secondary-fixed: oklch(var(--lr-10) var(--secondary-c) var(--secondary-h));
+  --scheme-color-on-secondary-fixed-variant: oklch(var(--lr-30) var(--secondary-c) var(--secondary-h));
+
+  --scheme-color-tertiary: oklch(var(--lr-80) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-on-tertiary: oklch(var(--lr-20) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-tertiary-container: oklch(var(--lr-30) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-on-tertiary-container: oklch(var(--lr-90) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-tertiary-fixed: oklch(var(--lr-90) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-tertiary-fixed-dim: oklch(var(--lr-80) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-on-tertiary-fixed: oklch(var(--lr-10) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-on-tertiary-fixed-variant: oklch(var(--lr-30) var(--tertiary-c) var(--tertiary-h));
+
+  --scheme-color-error: oklch(var(--lr-80) var(--error-c) var(--error-h));
+  --scheme-color-on-error: oklch(var(--lr-20) var(--error-c) var(--error-h));
+  --scheme-color-error-container: oklch(var(--lr-30) var(--error-c) var(--error-h));
+  --scheme-color-on-error-container: oklch(var(--lr-90) var(--error-c) var(--error-h));
+
+  --scheme-color-shadow: oklch(var(--lr-0) var(--neutral-c) var(--neutral-h));
+  --scheme-color-scrim: oklch(var(--lr-0) var(--neutral-c) var(--neutral-h));
+  --scheme-color-inverse-surface: oklch(var(--lr-90) var(--neutral-c) var(--neutral-h));
+  --scheme-color-inverse-on-surface: oklch(var(--lr-20) var(--neutral-c) var(--neutral-h));
+  --scheme-color-inverse-primary: oklch(var(--lr-40) var(--primary-c) var(--primary-h));
+
+  --scheme-color-background: oklch(var(--lr-10) var(--neutral-c) var(--neutral-h));
+  --scheme-color-on-background: oklch(var(--lr-90) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface: oklch(var(--lr-10) var(--neutral-c) var(--neutral-h));
+  --scheme-color-on-surface: oklch(var(--lr-90) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-variant: oklch(var(--lr-30) var(--neutral-variant-c) var(--neutral-variant-h));
+  --scheme-color-on-surface-variant: oklch(var(--lr-80) var(--neutral-variant-c) var(--neutral-variant-h));
+  --scheme-color-outline: oklch(var(--lr-60) var(--neutral-variant-c) var(--neutral-variant-h));
+  --scheme-color-outline-variant: oklch(var(--lr-30) var(--neutral-variant-c) var(--neutral-variant-h));
+
+  --scheme-color-surface-dim: oklch(var(--lr-6) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-bright: oklch(var(--lr-24) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container-lowest: oklch(var(--lr-4) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container-low: oklch(var(--lr-10) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container: oklch(var(--lr-12) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container-high: oklch(var(--lr-17) var(--neutral-c) var(--neutral-h));
+  --scheme-color-surface-container-highest: oklch(var(--lr-22) var(--neutral-c) var(--neutral-h));
+
+  /* カスタムカラー */
+  --scheme-color-link: oklch(var(--lr-80) var(--link-c) var(--link-h));
+  --scheme-color-on-link: oklch(var(--lr-20) var(--link-c) var(--link-h));
+  --scheme-color-link-container: oklch(var(--lr-30) var(--link-c) var(--link-h));
+  --scheme-color-on-link-container: oklch(var(--lr-90) var(--link-c) var(--link-h));
+
+  /* ソング用エイリアスカラー */
+  --scheme-color-sing-toolbar-container: oklch(var(--lr-19) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-playback-button-container: oklch(var(--lr-70) var(--primary-c) var(--primary-h));
+  --scheme-color-sing-on-playback-button-container: oklch(var(--lr-10) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-grid-cell-white: oklch(var(--lr-20) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-grid-cell-black: oklch(var(--lr-15) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-grid-measure-line: oklch(var(--lr-40) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-grid-beat-line: oklch(var(--lr-4) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-grid-vertical-line: oklch(var(--lr-15) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-grid-octave-line: oklch(var(--lr-30) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-grid-horizontal-line: oklch(var(--lr-15) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-ruler-surface: oklch(var(--lr-30) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-ruler-measure-line: oklch(var(--lr-60) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-ruler-beat-line: oklch(var(--lr-50) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-piano-key-white: oklch(var(--lr-70) var(--neutral-c) var(--neutral-h));
+  --scheme-color-sing-piano-key-black: oklch(var(--lr-20) var(--neutral-c) var(--neutral-h));
+  
+  --scheme-color-sing-note-bar-container: oklch(var(--lr-70) var(--secondary-c) var(--secondary-h));
+  --scheme-color-sing-on-note-bar-container: oklch(var(--lr-10) var(--secondary-c) var(--secondary-h));
+  --scheme-color-sing-note-bar-border: oklch(var(--lr-85) var(--secondary-c) var(--secondary-h));
+  
+  --scheme-color-sing-note-bar-selected-container: oklch(var(--lr-80) var(--primary-c) var(--primary-h));
+  --scheme-color-sing-on-note-bar-selected-container: oklch(var(--lr-10) var(--primary-c) var(--primary-h));
+  --scheme-color-sing-note-bar-selected-border: oklch(var(--lr-95) var(--primary-c) var(--primary-h));
+  --scheme-color-sing-note-bar-selected-outline: oklch(var(--lr-60) var(--primary-c) var(--primary-h));
+  
+  --scheme-color-sing-note-bar-preview-container: oklch(var(--lr-70) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-sing-on-note-bar-preview-container: oklch(var(--lr-10) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-sing-note-bar-preview-border: oklch(var(--lr-85) var(--tertiary-c) var(--tertiary-h));
+  --scheme-color-sing-note-bar-preview-outline: oklch(var(--lr-60) var(--tertiary-c) var(--tertiary-h));
+  
+  --scheme-color-sing-shadow-note: oklch(var(--lr-50) var(--neutral-variant-c) var(--neutral-variant-h));
+};
+
+/*
+フォールバック
+*/
+
+@supports not (color: oklch(0% 0 0)) {
+  :root[is-dark-theme="false"] {
+    --scheme-color-primary: #29683a;
+    --scheme-color-on-primary: #fff;
+    --scheme-color-primary-container: #b3f5bf;
+    --scheme-color-on-primary-container: #001500;
+    --scheme-color-primary-fixed: #b3f5bf;
+    --scheme-color-primary-fixed-dim: #97d8a3;
+    --scheme-color-on-primary-fixed: #001500;
+    --scheme-color-on-primary-fixed-variant: #054d20;
+    --scheme-color-secondary: #4c5e4f;
+    --scheme-color-on-secondary: #fff;
+    --scheme-color-secondary-container: #d3e9d7;
+    --scheme-color-on-secondary-container: #041206;
+    --scheme-color-secondary-fixed: #d3e9d7;
+    --scheme-color-secondary-fixed-dim: #b7ccba;
+    --scheme-color-on-secondary-fixed: #041206;
+    --scheme-color-on-secondary-fixed-variant: #334536;
+    --scheme-color-tertiary: #725400;
+    --scheme-color-on-tertiary: #fff;
+    --scheme-color-tertiary-container: #ffdc4d;
+    --scheme-color-on-tertiary-container: #170c00;
+    --scheme-color-tertiary-fixed: #ffdc4d;
+    --scheme-color-tertiary-fixed-dim: #f5bd00;
+    --scheme-color-on-tertiary-fixed: #170c00;
+    --scheme-color-on-tertiary-fixed-variant: #533c00;
+    --scheme-color-error: #ad0026;
+    --scheme-color-on-error: #fff;
+    --scheme-color-error-container: #ffd1d0;
+    --scheme-color-on-error-container: #280001;
+    --scheme-color-background: #fcfcfc;
+    --scheme-color-on-background: #0e0e0e;
+    --scheme-color-surface: #fcfcfc;
+    --scheme-color-on-surface: #0e0e0e;
+    --scheme-color-surface-variant: #e1e2e1;
+    --scheme-color-on-surface-variant: #3e403f;
+    --scheme-color-outline: #727472;
+    --scheme-color-outline-variant: #c4c6c4;
+    --scheme-color-shadow: #000;
+    --scheme-color-scrim: #000;
+    --scheme-color-inverse-surface: #272727;
+    --scheme-color-inverse-on-surface: #f0f0f0;
+    --scheme-color-inverse-primary: #97d8a3;
+    --scheme-color-surface-dim: #d9d9d9;
+    --scheme-color-surface-bright: #f9f9f9;
+    --scheme-color-surface-container-lowest: #dcdcdc;
+    --scheme-color-surface-container-low: #e2e2e2;
+    --scheme-color-surface-container: #f0f0f0;
+    --scheme-color-surface-container-high: #f6f6f6;
+    --scheme-color-surface-container-highest: #fff;
+    --scheme-color-link: #0052bf;
+    --scheme-color-on-link: #fff;
+    --scheme-color-link-container: #c7e5ff;
+    --scheme-color-on-link-container: #000042;
+    --scheme-color-sing-toolbar-container: #fcfcfc;
+    --scheme-color-sing-playback-button-container: #97d8a3;
+    --scheme-color-sing-on-playback-button-container: #0e0e0e;
+    --scheme-color-sing-grid-cell-white: #fff;
+    --scheme-color-sing-grid-cell-black: #f3f3f3;
+    --scheme-color-sing-grid-vertical-line: #f3f3f3;
+    --scheme-color-sing-grid-horizontal-line: #f3f3f3;
+    --scheme-color-sing-grid-measure-line: #b7b7b7;
+    --scheme-color-sing-grid-beat-line: #e2e2e2;
+    --scheme-color-sing-grid-octave-line: #dcdcdc;
+    --scheme-color-sing-ruler-surface: #e2e2e2;
+    --scheme-color-sing-ruler-measure-line: #9b9b9b;
+    --scheme-color-sing-ruler-beat-line: #b7b7b7;
+    --scheme-color-sing-piano-key-white: #fcfcfc;
+    --scheme-color-sing-piano-key-black: #666;
+    --scheme-color-sing-note-bar-container: #cee3d1;
+    --scheme-color-sing-on-note-bar-container: #041206;
+    --scheme-color-sing-note-bar-outline: #809483;
+    --scheme-color-sing-note-bar-selected-container: #c6ffd1;
+    --scheme-color-sing-on-note-bar-selected-container: #001500;
+    --scheme-color-sing-note-bar-selected-outline: #609f6d;
+    --scheme-color-sing-note-bar-selected-outline-outer: #97d8a3;
+    --scheme-color-sing-note-bar-preview-container: #ffd400;
+    --scheme-color-sing-on-note-bar-preview-container: #170c00;
+    --scheme-color-sing-note-bar-preview-outline: #b28700;
+    --scheme-color-sing-note-bar-preview-outline-outer: #f5bd00;
+    --scheme-color-sing-shadow-note: #dbdddb;
+  }
+  
+  :root[is-dark-theme="true"] {
+    --scheme-color-primary: #97d8a3;
+    --scheme-color-on-primary: #003306;
+    --scheme-color-primary-container: #054d20;
+    --scheme-color-on-primary-container: #b3f5bf;
+    --scheme-color-primary-fixed: #b3f5bf;
+    --scheme-color-primary-fixed-dim: #97d8a3;
+    --scheme-color-on-primary-fixed: #001500;
+    --scheme-color-on-primary-fixed-variant: #054d20;
+    --scheme-color-secondary: #b7ccba;
+    --scheme-color-on-secondary: #1b2b1e;
+    --scheme-color-secondary-container: #334536;
+    --scheme-color-on-secondary-container: #d3e9d7;
+    --scheme-color-secondary-fixed: #d3e9d7;
+    --scheme-color-secondary-fixed-dim: #b7ccba;
+    --scheme-color-on-secondary-fixed: #041206;
+    --scheme-color-on-secondary-fixed-variant: #334536;
+    --scheme-color-tertiary: #f5bd00;
+    --scheme-color-on-tertiary: #352400;
+    --scheme-color-tertiary-container: #533c00;
+    --scheme-color-on-tertiary-container: #ffdc4d;
+    --scheme-color-tertiary-fixed: #ffdc4d;
+    --scheme-color-tertiary-fixed-dim: #f5bd00;
+    --scheme-color-on-tertiary-fixed: #170c00;
+    --scheme-color-on-tertiary-fixed-variant: #533c00;
+    --scheme-color-error: #ffa4a5;
+    --scheme-color-on-error: #550009;
+    --scheme-color-error-container: #810017;
+    --scheme-color-on-error-container: #ffd1d0;
+    --scheme-color-background: #0e0e0e;
+    --scheme-color-on-background: #e2e2e2;
+    --scheme-color-surface: #0e0e0e;
+    --scheme-color-on-surface: #e2e2e2;
+    --scheme-color-surface-variant: #3e403f;
+    --scheme-color-on-surface-variant: #c4c6c4;
+    --scheme-color-outline: #8d8e8d;
+    --scheme-color-outline-variant: #3e403f;
+    --scheme-color-shadow: #000;
+    --scheme-color-scrim: #000;
+    --scheme-color-inverse-surface: #e2e2e2;
+    --scheme-color-inverse-on-surface: #272727;
+    --scheme-color-inverse-primary: #29683a;
+    --scheme-color-surface-dim: #050505;
+    --scheme-color-surface-bright: #303030;
+    --scheme-color-surface-container-lowest: #020202;
+    --scheme-color-surface-container-low: #0e0e0e;
+    --scheme-color-surface-container: #131313;
+    --scheme-color-surface-container-high: #1f1f1f;
+    --scheme-color-surface-container-highest: #2b2b2b;
+    --scheme-color-link: #95c8ff;
+    --scheme-color-on-link: #001d6b;
+    --scheme-color-link-container: #003699;
+    --scheme-color-on-link-container: #c7e5ff;
+    --scheme-color-sing-toolbar-container: #1f1f1f;
+    --scheme-color-sing-playback-button-container: #7bbb88;
+    --scheme-color-sing-on-playback-button-container: #0e0e0e;
+    --scheme-color-sing-grid-cell-white: #272727;
+    --scheme-color-sing-grid-cell-black: #1a1a1a;
+    --scheme-color-sing-grid-vertical-line: #1a1a1a;
+    --scheme-color-sing-grid-horizontal-line: #1a1a1a;
+    --scheme-color-sing-grid-measure-line: #595959;
+    --scheme-color-sing-grid-beat-line: #020202;
+    --scheme-color-sing-grid-octave-line: #3f3f3f;
+    --scheme-color-sing-ruler-surface: #3f3f3f;
+    --scheme-color-sing-ruler-measure-line: #8e8e8e;
+    --scheme-color-sing-ruler-beat-line: #666;
+    --scheme-color-sing-piano-key-white: #a9a9a9;
+    --scheme-color-sing-piano-key-black: #272727;
+    --scheme-color-sing-note-bar-container: #9bb09e;
+    --scheme-color-sing-on-note-bar-container: #041206;
+    --scheme-color-sing-note-bar-outline: #c5dac8;
+    --scheme-color-sing-note-bar-selected-container: #97d8a3;
+    --scheme-color-sing-on-note-bar-selected-container: #001500;
+    --scheme-color-sing-note-bar-selected-outline: #c1ffcd;
+    --scheme-color-sing-note-bar-selected-outline-outer: #609f6d;
+    --scheme-color-sing-note-bar-preview-container: #d3a200;
+    --scheme-color-sing-on-note-bar-preview-container: #170c00;
+    --scheme-color-sing-note-bar-preview-outline: #ffcb00;
+    --scheme-color-sing-note-bar-preview-outline-outer: #b28700;
+    --scheme-color-sing-shadow-note: #a8aaa8;
+  }
+}

--- a/src/styles/v2/variables.scss
+++ b/src/styles/v2/variables.scss
@@ -3,6 +3,24 @@
   --padding-basis: 8px;
   --gap-basis: 8px;
   --radius-basis: 8px;
+
+  --font-regular: 400;
+  --font-medium: 500;
+  --font-bold: 700;
+
+  --input-m-size: calc(var(--size-basis) * 5);
+  --input-l-size: calc(var(--size-basis) * 7);
+
+  --label-l-size: calc(var(--size-basis) * 1.75);
+  --label-m-size: calc(var(--size-basis) * 1.5);
+  --label-s-size: calc(var(--size-basis) * 1.25);
+
+  --border-width-basis: 1px;
+
+  --opacity-medium: 0.87;
+  --opacity-low: 0.6;
+  --opacity-separator: 0.5;
+  --opacity-disabled: 0.38;
 }
 
 $size-scrollbar: calc(var(--size-basis) * 1.5);

--- a/tests/e2e/browser/song/ソング.spec.ts
+++ b/tests/e2e/browser/song/ソング.spec.ts
@@ -72,15 +72,33 @@ test("ダブルクリックで歌詞を編集できる", async ({ page }) => {
   const getCurrentNoteLyric = async (note: Locator) =>
     await note.getByTestId("note-lyric").textContent();
 
+  // ノートを追加し、表示されるまで待つ
   await sequencer.click({ position: { x: 107, y: 171 } });
+  await page.waitForSelector(".note");
 
-  const note = sequencer.locator(".note");
+  // ノートの歌詞を取得
+  const note = sequencer.locator(".note").first();
   const beforeLyric = await getCurrentNoteLyric(note);
 
-  await sequencer.click({ position: { x: 107, y: 171 }, clickCount: 2 }); // ダブルクリック
+  // ノートをダブルクリックし、入力フィールドが表示されるまで待つ
+  await note.dblclick();
+  await page.waitForSelector(".lyric-input");
 
-  await sequencer.locator(".lyric-input").fill("あ");
-  await page.keyboard.press("Enter");
+  // 歌詞を入力し、Enterキーを押す
+  const lyricInput = sequencer.locator(".lyric-input");
+  await lyricInput.fill("あ");
+  await lyricInput.press("Enter");
+
+  // 変更が反映されるまで待つ
+  await page.waitForFunction((beforeLyric) => {
+    const lyricElement = document.querySelector(
+      '.note [data-testid="note-lyric"]',
+    );
+    return lyricElement && lyricElement.textContent !== beforeLyric;
+  }, beforeLyric);
+
+  // 歌詞が変更されたことを確認
   const afterLyric = await getCurrentNoteLyric(note);
   expect(afterLyric).not.toEqual(beforeLyric);
+  expect(afterLyric).toEqual("あ");
 });


### PR DESCRIPTION
## 内容

シング機能において正式なカラーを定義し、スタイルを調整することでユーザーの使い勝手を向上させます。
一定程度のアクセシビリティ対応を含みます。

- OKLCHベースで色を定義
- RGB(HEX)フォールバックあり
- ほぼMaterialDesign3準拠

※ 動的なテーマ生成+テーマエディタ機能のサブセットとなります

## 関連 Issue

ref #1810
close #1810

## スクリーンショット・動画など

<img width="1312" alt="スクリーンショット 2024-08-14 5 19 46" src="https://github.com/user-attachments/assets/afc2b715-f543-4635-8331-26b44c523db4">
<img width="1312" alt="スクリーンショット 2024-08-14 5 20 31" src="https://github.com/user-attachments/assets/5a78f193-2df3-43f3-8e98-0f6fe9d039c2">

## その他

スタイルにおいての変数の使用については、すりあわせができればと思います。