### PR TITLE
fix: --retry-all-errorsの未対応をなくす

### DIFF
--- a/.github/actions/download-engine/action.yml
+++ b/.github/actions/download-engine/action.yml
@@ -66,7 +66,7 @@ runs:
         cat $TEMPDIR/target.json | jq -er '[.assets[] | select(.name | contains("'$TARGET'") and endswith(".7z.txt"))][0]' > $TEMPDIR/assets_txt.json
         LIST_URL=$(cat $TEMPDIR/assets_txt.json | jq -er '.browser_download_url')
         echo "7z.txt url: $LIST_URL"
-        echo $LIST_URL | xargs curl -sSL --retry 3 --retry-delay 5 --retry-all-errors > $TEMPDIR/download_name.txt
+        echo $LIST_URL | xargs curl -sSL --retry 3 --retry-delay 5 > $TEMPDIR/download_name.txt
         echo "Files to download:"
         cat $TEMPDIR/download_name.txt | sed -e 's|^|- |'
 
@@ -74,7 +74,7 @@ runs:
         for i in $(cat $TEMPDIR/download_name.txt); do
           URL=$(cat $TEMPDIR/target.json | jq -er "[.assets[] | select(.name == \"$i\")][0].browser_download_url")
           echo "Download url: $URL, dest: $TEMPDIR/$i"
-          curl -sSL $URL --retry 3 --retry-delay 5 --retry-all-errors -o $TEMPDIR/$i &
+          curl -sSL $URL --retry 3 --retry-delay 5 -o $TEMPDIR/$i &
         done
         for job in `jobs -p`; do
           wait $job

--- a/build/codesign_setup.bash
+++ b/build/codesign_setup.bash
@@ -32,7 +32,7 @@ fi
 
 # eSignerCKAのセットアップ
 if [ ! -d "$ESIGNERCKA_INSTALL_DIR" ]; then
-    curl -LO --retry 3 --retry-delay 5 --retry-all-errors \
+    curl -LO --retry 3 --retry-delay 5 \
         "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.6/SSL.COM-eSigner-CKA_1.0.6.zip"
     unzip -o SSL.COM-eSigner-CKA_1.0.6.zip
     mv *eSigner*CKA_*.exe eSigner_CKA_Installer.exe


### PR DESCRIPTION
## 内容

curlの`--retry-all-errors`引数はubuntu-20.04でだけ使えなかったっぽいことがわかったので無くしました。

ちなみにこの引数はサーバー側が400エラーになったり500エラーになった場合でもリトライする仕組みです。
それ以外のエラーはちゃんとリトライされるはず。

## その他
