### PR TITLE
テキスト未選択時にコンテキストメニューヘッダーを非表示にする

### DIFF
--- a/src/components/Talk/AudioCell.vue
+++ b/src/components/Talk/AudioCell.vue
@@ -634,6 +634,7 @@ const readyForContextMenu = () => {
     isRangeSelected.value = false;
     getMenuItemButton("切り取り").disabled = true;
     getMenuItemButton("コピー").disabled = true;
+    contextMenuHeader.value = "";
   } else {
     isRangeSelected.value = true;
     getMenuItemButton("切り取り").disabled = false;


### PR DESCRIPTION
## 内容

- トークエディタ画面で右クリックメニューを使用する際、テキスト未選択時にコンテキストメニューヘッダー上で過去に選択したテキストが表示されるバグを解消

## 関連 Issue

https://github.com/VOICEVOX/voicevox/pull/2156#issuecomment-2282126084

## スクリーンショット・動画など

### 修正前

https://github.com/user-attachments/assets/189e2e9b-512b-4855-bd3f-fc4b2d7d920b

### 修正後

https://github.com/user-attachments/assets/54b37d19-9f73-483a-be0b-98ca369b265f

## その他
