### PR TITLE
ソング：水平方向のズームの上限と下限を変更

### DIFF
--- a/src/sing/viewHelper.ts
+++ b/src/sing/viewHelper.ts
@@ -5,8 +5,8 @@ import { calculateHash } from "@/sing/utility";
 const BASE_X_PER_QUARTER_NOTE = 120;
 const BASE_Y_PER_SEMITONE = 30;
 
-export const ZOOM_X_MIN = 0.2;
-export const ZOOM_X_MAX = 1;
+export const ZOOM_X_MIN = 0.15;
+export const ZOOM_X_MAX = 2;
 export const ZOOM_X_STEP = 0.05;
 export const ZOOM_Y_MIN = 0.5;
 export const ZOOM_Y_MAX = 1.5;


### PR DESCRIPTION
## 内容

ピッチを描きやすくするため、水平方向のズームの上限を1から2に変更します。
ついでに、広い範囲を見れるようにするために、下限も0.2から0.15に変更します。

## その他