### PR TITLE
辞書のリセットボタンの挙動を修正する

### DIFF
--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -241,7 +241,7 @@
                 textColor="display"
                 class="text-no-wrap text-bold q-mr-sm"
                 :disable="uiLocked || !isWordChanged"
-                @click="resetWord"
+                @click="resetWord(selectedId)"
                 >リセット</QBtn
               >
               <QBtn
@@ -602,13 +602,17 @@ const deleteWord = async () => {
     toInitialState();
   }
 };
-const resetWord = async () => {
+const resetWord = async (id: string) => {
   const result = await store.dispatch("SHOW_WARNING_DIALOG", {
     title: "単語の変更をリセットしますか？",
     message: "単語の変更は破棄されてリセットされます。",
     actionName: "リセット",
   });
   if (result === "OK") {
+    selectedId.value = id;
+    surface.value = userDict.value[id].surface;
+    void setYomi(userDict.value[id].yomi, true);
+    wordPriority.value = userDict.value[id].priority;
     toWordEditingState();
   }
 };


### PR DESCRIPTION
## 内容

- 読み方&アクセント辞書の編集画面におけるリセットボタンの挙動を修正

## 関連 Issue

close #2229 

## スクリーンショット・動画など

https://github.com/user-attachments/assets/9803ed84-f370-4861-89c6-e597de745643

## その他
