### PR TITLE
refactor: definePropsのimportは不要らしいので削除

### DIFF
--- a/src/components/Dialog/HotkeyRecordingDialog.vue
+++ b/src/components/Dialog/HotkeyRecordingDialog.vue
@@ -82,7 +82,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineProps, defineEmits } from "vue";
+import { computed } from "vue";
 import { HotkeyCombination } from "@/type/preload";
 
 const props = defineProps<{


### PR DESCRIPTION
## 内容

このようなwarningが出ていたので、該当箇所を削除してみました。

```log
[@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported.
[@vue/compiler-sfc] `defineEmits` is a compiler macro and no longer needs to be imported.
```


## その他
