### PR TITLE
ソング：フレーズのレンダリング処理をリファクタリング

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -360,7 +360,7 @@ const phraseInfosInOtherTracks = computed(() => {
 
 const ctrlKey = useCommandOrControlKey();
 const editTarget = computed(() => state.sequencerEditTarget);
-const editFrameRate = computed(() => state.editFrameRate);
+const editorFrameRate = computed(() => state.editorFrameRate);
 const scrollBarWidth = ref(12);
 const sequencerBody = ref<HTMLElement | null>(null);
 
@@ -601,7 +601,7 @@ const previewDrawPitch = () => {
   if (previewPitchEdit.value.type !== "draw") {
     throw new Error("previewPitchEdit.value.type is not draw.");
   }
-  const frameRate = editFrameRate.value;
+  const frameRate = editorFrameRate.value;
   const cursorBaseX = (scrollX.value + cursorX.value) / zoomX.value;
   const cursorBaseY = (scrollY.value + cursorY.value) / zoomY.value;
   const cursorTicks = baseXToTick(cursorBaseX, tpqn.value);
@@ -675,7 +675,7 @@ const previewErasePitch = () => {
   if (previewPitchEdit.value.type !== "erase") {
     throw new Error("previewPitchEdit.value.type is not erase.");
   }
-  const frameRate = editFrameRate.value;
+  const frameRate = editorFrameRate.value;
   const cursorBaseX = (scrollX.value + cursorX.value) / zoomX.value;
   const cursorTicks = baseXToTick(cursorBaseX, tpqn.value);
   const cursorSeconds = tickToSecond(cursorTicks, tempos.value, tpqn.value);
@@ -827,7 +827,7 @@ const startPreview = (event: MouseEvent, mode: PreviewMode, note?: Note) => {
   } else if (editTarget.value === "PITCH") {
     // 編集ターゲットがピッチのときの処理
 
-    const frameRate = editFrameRate.value;
+    const frameRate = editorFrameRate.value;
     const cursorTicks = baseXToTick(cursorBaseX, tpqn.value);
     const cursorSeconds = tickToSecond(cursorTicks, tempos.value, tpqn.value);
     const cursorFrame = Math.round(cursorSeconds * frameRate);

--- a/src/components/Sing/SequencerPhraseIndicator.vue
+++ b/src/components/Sing/SequencerPhraseIndicator.vue
@@ -6,15 +6,16 @@
 import { computed } from "vue";
 import { useStore } from "@/store";
 import { getOrThrow } from "@/helpers/mapHelper";
-import { PhraseSourceHash, PhraseState } from "@/store/type";
+import { PhraseKey, PhraseState } from "@/store/type";
 
 const props = defineProps<{
-  phraseKey: PhraseSourceHash;
+  phraseKey: PhraseKey;
   isInSelectedTrack: boolean;
 }>();
 
 const store = useStore();
 const classNames: Record<PhraseState, string> = {
+  SINGER_IS_NOT_SET: "singer-is-not-set",
   WAITING_TO_BE_RENDERED: "waiting-to-be-rendered",
   NOW_RENDERING: "now-rendering",
   COULD_NOT_RENDER: "could-not-render",
@@ -41,6 +42,10 @@ const className = computed(() => {
   &:not(.is-in-selected-track) {
     #{$property}: tint($color);
   }
+}
+
+.singer-is-not-set {
+  visibility: hidden;
 }
 
 .waiting-to-be-rendered {

--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -56,7 +56,7 @@ const pitchEditData = computed(() => {
 });
 const previewPitchEdit = computed(() => props.previewPitchEdit);
 const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
-const editFrameRate = computed(() => store.state.editFrameRate);
+const editorFrameRate = computed(() => store.state.editorFrameRate);
 const singingGuidesInSelectedTrack = computed(() => {
   const singingGuides: {
     query: EditorFrameAudioQuery;
@@ -263,7 +263,7 @@ const setPitchDataToPitchLine = async (
 
 const generateOriginalPitchData = () => {
   const unvoicedPhonemes = UNVOICED_PHONEMES;
-  const frameRate = editFrameRate.value; // f0（元のピッチ）は編集フレームレートで表示する
+  const frameRate = editorFrameRate.value; // f0（元のピッチ）はエディターのフレームレートで表示する
 
   // 選択中のトラックで使われている歌い方のf0を結合してピッチデータを生成する
   const tempData = [];
@@ -316,7 +316,7 @@ const generateOriginalPitchData = () => {
 };
 
 const generatePitchEditData = () => {
-  const frameRate = editFrameRate.value;
+  const frameRate = editorFrameRate.value;
 
   const tempData = [...pitchEditData.value];
   // プレビュー中のピッチ編集があれば、適用する

--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -30,7 +30,7 @@ import { ExhaustiveError } from "@/type/utility";
 import { createLogger } from "@/domain/frontend/log";
 import { getLast } from "@/sing/utility";
 import { getOrThrow } from "@/helpers/mapHelper";
-import { FrameAudioQuery } from "@/openapi";
+import { EditorFrameAudioQuery } from "@/store/type";
 
 type PitchLine = {
   readonly color: Color;
@@ -59,8 +59,7 @@ const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
 const editFrameRate = computed(() => store.state.editFrameRate);
 const singingGuidesInSelectedTrack = computed(() => {
   const singingGuides: {
-    query: FrameAudioQuery;
-    frameRate: number;
+    query: EditorFrameAudioQuery;
     startTime: number;
   }[] = [];
   for (const phrase of store.state.phrases.values()) {
@@ -70,16 +69,10 @@ const singingGuidesInSelectedTrack = computed(() => {
     if (phrase.queryKey == undefined) {
       continue;
     }
-    const track = store.state.tracks.get(phrase.trackId);
-    if (track == undefined || track.singer == undefined) {
-      continue;
-    }
     const phraseQuery = getOrThrow(store.state.phraseQueries, phrase.queryKey);
-    const engineManifest = store.state.engineManifests[track.singer.engineId];
     singingGuides.push({
       startTime: phrase.startTime,
       query: phraseQuery,
-      frameRate: engineManifest.frameRate,
     });
   }
   return singingGuides;
@@ -276,7 +269,7 @@ const generateOriginalPitchData = () => {
   const tempData = [];
   for (const singingGuide of singingGuidesInSelectedTrack.value) {
     // TODO: 補間を行うようにする
-    if (singingGuide.frameRate !== frameRate) {
+    if (singingGuide.query.frameRate !== frameRate) {
       throw new Error(
         "The frame rate between the singing guide and the edit does not match.",
       );

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -4,17 +4,12 @@ import {
   Note,
   Phrase,
   PhraseSource,
-  SingingGuide,
-  SingingGuideSource,
-  SingingVoiceSource,
   Tempo,
   TimeSignature,
-  phraseSourceHashSchema,
+  PhraseKey,
   Track,
-  singingGuideSourceHashSchema,
-  singingVoiceSourceHashSchema,
 } from "@/store/type";
-import { FramePhoneme } from "@/openapi";
+import { FrameAudioQuery, FramePhoneme } from "@/openapi";
 import { TrackId } from "@/type/preload";
 
 const BEAT_TYPES = [2, 4, 8, 16];
@@ -379,23 +374,9 @@ export function isValidPitchEditData(pitchEditData: number[]) {
   );
 }
 
-export const calculatePhraseSourceHash = async (phraseSource: PhraseSource) => {
+export const calculatePhraseKey = async (phraseSource: PhraseSource) => {
   const hash = await calculateHash(phraseSource);
-  return phraseSourceHashSchema.parse(hash);
-};
-
-export const calculateSingingGuideSourceHash = async (
-  singingGuideSource: SingingGuideSource,
-) => {
-  const hash = await calculateHash(singingGuideSource);
-  return singingGuideSourceHashSchema.parse(hash);
-};
-
-export const calculateSingingVoiceSourceHash = async (
-  singingVoiceSource: SingingVoiceSource,
-) => {
-  const hash = await calculateHash(singingVoiceSource);
-  return singingVoiceSourceHashSchema.parse(hash);
+  return PhraseKey(hash);
 };
 
 export function getStartTicksOfPhrase(phrase: Phrase) {
@@ -469,7 +450,11 @@ export function convertToFramePhonemes(phonemes: FramePhoneme[]) {
 }
 
 export function applyPitchEdit(
-  singingGuide: SingingGuide,
+  singingGuide: {
+    query: FrameAudioQuery;
+    frameRate: number;
+    startTime: number;
+  },
   pitchEditData: number[],
   editFrameRate: number,
 ) {

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -293,7 +293,7 @@ export const DEFAULT_BEAT_TYPE = 4;
 export const SEQUENCER_MIN_NUM_MEASURES = 32;
 
 // マルチエンジン対応のために将来的に廃止予定で、利用は非推奨
-export const DEPRECATED_DEFAULT_EDIT_FRAME_RATE = 93.75;
+export const DEPRECATED_DEFAULT_EDITOR_FRAME_RATE = 93.75;
 
 export const VALUE_INDICATING_NO_DATA = -1;
 
@@ -454,13 +454,13 @@ export function applyPitchEdit(
   phraseQuery: EditorFrameAudioQuery,
   phraseStartTime: number,
   pitchEditData: number[],
-  editFrameRate: number,
+  editorFrameRate: number,
 ) {
-  // フレーズのクエリのフレームレートと編集フレームレートが一致しない場合はエラー
+  // フレーズのクエリのフレームレートとエディターのフレームレートが一致しない場合はエラー
   // TODO: 補間するようにする
-  if (phraseQuery.frameRate !== editFrameRate) {
+  if (phraseQuery.frameRate !== editorFrameRate) {
     throw new Error(
-      "The frame rate between the phrase query and the edit data does not match.",
+      "The frame rate between the phrase query and the editor does not match.",
     );
   }
   const unvoicedPhonemes = UNVOICED_PHONEMES;

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -16,11 +16,7 @@ import {
   EditorFrameAudioQueryKey,
   EditorFrameAudioQuery,
 } from "@/store/type";
-import {
-  FrameAudioQuery,
-  FramePhoneme,
-  Note as NoteForRequestToEngine,
-} from "@/openapi";
+import { FramePhoneme, Note as NoteForRequestToEngine } from "@/openapi";
 import { applyPitchEdit, decibelToLinear, tickToSecond } from "@/sing/domain";
 import { calculateHash, linearInterpolation } from "@/sing/utility";
 import { EngineId, StyleId, TrackId } from "@/type/preload";
@@ -235,17 +231,18 @@ type ExternalDependencies = Readonly<{
 
   fetchQuery: (
     engineId: EngineId,
+    engineFrameRate: number,
     notes: NoteForRequestToEngine[],
-  ) => Promise<FrameAudioQuery>;
+  ) => Promise<EditorFrameAudioQuery>;
   fetchSingFrameVolume: (
     notes: NoteForRequestToEngine[],
-    query: FrameAudioQuery,
+    query: EditorFrameAudioQuery,
     engineId: EngineId,
     styleId: StyleId,
   ) => Promise<SingingVolume>;
   synthesizeSingingVoice: (
     singer: Singer,
-    query: FrameAudioQuery,
+    query: EditorFrameAudioQuery,
   ) => Promise<SingingVoice>;
 }>;
 
@@ -351,11 +348,12 @@ const generateQuery = async (
 
   const query = await externalDependencies.fetchQuery(
     querySource.engineId,
+    querySource.engineFrameRate,
     notesForRequestToEngine,
   );
 
   shiftPitch(query.f0, querySource.keyRangeAdjustment);
-  return { ...query, frameRate: querySource.engineFrameRate };
+  return query;
 };
 
 const queryGenerationStage: BaseStage = {

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -172,7 +172,7 @@ type Snapshot = Readonly<{
   tempos: Tempo[];
   tracks: Map<TrackId, Track>;
   engineFrameRates: Map<EngineId, number>;
-  editFrameRate: number;
+  editorFrameRate: number;
 }>;
 
 /**
@@ -437,7 +437,7 @@ const generateSingingVolumeSource = (context: Context): SingingVolumeSource => {
     clonedQuery,
     phrase.startTime,
     track.pitchEditData,
-    context.snapshot.editFrameRate,
+    context.snapshot.editorFrameRate,
   );
   return {
     engineId: track.singer.engineId,
@@ -599,7 +599,7 @@ const generateSingingVoiceSource = (context: Context): SingingVoiceSource => {
     clonedQuery,
     phrase.startTime,
     track.pitchEditData,
-    context.snapshot.editFrameRate,
+    context.snapshot.editorFrameRate,
   );
   clonedQuery.volume = clonedSingingVolume;
   return {

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -686,6 +686,10 @@ const singingVoiceSynthesisStage: BaseStage = {
 
 // フレーズレンダラー
 
+/**
+ * フレーズレンダラー。
+ * 各フレーズごとに、ステージを進めながらレンダリング処理を行う。
+ */
 export type PhraseRenderer = Readonly<{
   /**
    * 一番最初のステージのIDを返す。

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -301,7 +301,7 @@ type QuerySource = Readonly<{
 }>;
 
 const generateQuerySource = (context: Context): QuerySource => {
-  const phrases = context.externalDependencies.phrases;
+  const { phrases } = context.externalDependencies;
 
   const track = getOrThrow(context.snapshot.tracks, context.trackId);
   if (track.singer == undefined) {
@@ -355,7 +355,7 @@ const generateQuery = async (
 const queryGenerationStage: BaseStage = {
   id: "queryGeneration",
   shouldBeExecuted: async (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
+    const { phrases } = context.externalDependencies;
 
     const track = getOrThrow(context.snapshot.tracks, context.trackId);
     if (track.singer == undefined) {
@@ -368,8 +368,7 @@ const queryGenerationStage: BaseStage = {
     return phraseQueryKey == undefined || phraseQueryKey !== queryKey;
   },
   deleteExecutionResult: (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
-    const phraseQueries = context.externalDependencies.phraseQueries;
+    const { phrases, phraseQueries } = context.externalDependencies;
 
     const phrase = phrases.get(context.phraseKey);
     const phraseQueryKey = phrase.queryKey.get();
@@ -379,9 +378,7 @@ const queryGenerationStage: BaseStage = {
     }
   },
   execute: async (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
-    const phraseQueries = context.externalDependencies.phraseQueries;
-    const queryCache = context.externalDependencies.queryCache;
+    const { phrases, phraseQueries, queryCache } = context.externalDependencies;
 
     const querySource = generateQuerySource(context);
     const queryKey = await calculateQueryKey(querySource);
@@ -424,8 +421,7 @@ type SingingVolumeSource = Readonly<{
 }>;
 
 const generateSingingVolumeSource = (context: Context): SingingVolumeSource => {
-  const phrases = context.externalDependencies.phrases;
-  const phraseQueries = context.externalDependencies.phraseQueries;
+  const { phrases, phraseQueries } = context.externalDependencies;
 
   const track = getOrThrow(context.snapshot.tracks, context.trackId);
   if (track.singer == undefined) {
@@ -507,7 +503,7 @@ const generateSingingVolume = async (
 const singingVolumeGenerationStage: BaseStage = {
   id: "singingVolumeGeneration",
   shouldBeExecuted: async (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
+    const { phrases } = context.externalDependencies;
 
     const track = getOrThrow(context.snapshot.tracks, context.trackId);
     if (track.singer == undefined) {
@@ -524,9 +520,7 @@ const singingVolumeGenerationStage: BaseStage = {
     );
   },
   deleteExecutionResult: (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
-    const phraseSingingVolumes =
-      context.externalDependencies.phraseSingingVolumes;
+    const { phrases, phraseSingingVolumes } = context.externalDependencies;
 
     const phrase = phrases.get(context.phraseKey);
     const phraseSingingVolumeKey = phrase.singingVolumeKey.get();
@@ -536,10 +530,8 @@ const singingVolumeGenerationStage: BaseStage = {
     }
   },
   execute: async (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
-    const phraseSingingVolumes =
-      context.externalDependencies.phraseSingingVolumes;
-    const singingVolumeCache = context.externalDependencies.singingVolumeCache;
+    const { phrases, phraseSingingVolumes, singingVolumeCache } =
+      context.externalDependencies;
 
     const singingVolumeSource = generateSingingVolumeSource(context);
     const singingVolumeKey =
@@ -578,10 +570,8 @@ type SingingVoiceSource = Readonly<{
 }>;
 
 const generateSingingVoiceSource = (context: Context): SingingVoiceSource => {
-  const phrases = context.externalDependencies.phrases;
-  const phraseQueries = context.externalDependencies.phraseQueries;
-  const phraseSingingVolumes =
-    context.externalDependencies.phraseSingingVolumes;
+  const { phrases, phraseQueries, phraseSingingVolumes } =
+    context.externalDependencies;
 
   const track = getOrThrow(context.snapshot.tracks, context.trackId);
   if (track.singer == undefined) {
@@ -634,7 +624,7 @@ const synthesizeSingingVoice = async (
 const singingVoiceSynthesisStage: BaseStage = {
   id: "singingVoiceSynthesis",
   shouldBeExecuted: async (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
+    const { phrases } = context.externalDependencies;
 
     const track = getOrThrow(context.snapshot.tracks, context.trackId);
     if (track.singer == undefined) {
@@ -650,9 +640,7 @@ const singingVoiceSynthesisStage: BaseStage = {
     );
   },
   deleteExecutionResult: (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
-    const phraseSingingVoices =
-      context.externalDependencies.phraseSingingVoices;
+    const { phrases, phraseSingingVoices } = context.externalDependencies;
 
     const phrase = phrases.get(context.phraseKey);
     const phraseSingingVoiceKey = phrase.singingVoiceKey.get();
@@ -662,10 +650,8 @@ const singingVoiceSynthesisStage: BaseStage = {
     }
   },
   execute: async (context: Context) => {
-    const phrases = context.externalDependencies.phrases;
-    const phraseSingingVoices =
-      context.externalDependencies.phraseSingingVoices;
-    const singingVoiceCache = context.externalDependencies.singingVoiceCache;
+    const { phrases, phraseSingingVoices, singingVoiceCache } =
+      context.externalDependencies;
 
     const singingVoiceSource = generateSingingVoiceSource(context);
     const singingVoiceKey = await calculateSingingVoiceKey(singingVoiceSource);

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -265,7 +265,8 @@ export type PhraseRenderStageId =
   | "singingVoiceSynthesis";
 
 /**
- * フレーズレンダリングのステージ
+ * フレーズレンダリングのステージのインターフェイス。
+ * フレーズレンダラー内で順に実行される。
  */
 type BaseStage = Readonly<{
   id: PhraseRenderStageId;

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -196,7 +196,7 @@ type Phrase = Readonly<{
 }>;
 
 /**
- * フレーズレンダリングで必要となるキャッシュや関数
+ * フレーズレンダリングで必要となる外部のキャッシュや関数
  */
 type ExternalDependencies = Readonly<{
   queryCache: Map<FrameAudioQueryKey, FrameAudioQuery>;
@@ -746,7 +746,7 @@ const stages: readonly Stage[] = [
 
 /**
  * フレーズレンダラーを作成する。
- * @param externalDependencies レンダリング処理で必要となるキャッシュや関数
+ * @param externalDependencies レンダリング処理で必要となる外部のキャッシュや関数
  * @returns フレーズレンダラー
  */
 export const createPhraseRenderer = (

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -1,0 +1,733 @@
+import {
+  FrameAudioQueryKey,
+  Note,
+  PhraseKey,
+  Singer,
+  SingingVoice,
+  SingingVoiceKey,
+  Tempo,
+  Track,
+  SingingVolumeKey,
+  SingingVolume,
+} from "@/store/type";
+import {
+  FrameAudioQuery,
+  FramePhoneme,
+  Note as NoteForRequestToEngine,
+} from "@/openapi";
+import { applyPitchEdit, decibelToLinear, tickToSecond } from "@/sing/domain";
+import { calculateHash, linearInterpolation } from "@/sing/utility";
+import { EngineId, StyleId, TrackId } from "@/type/preload";
+import { createLogger } from "@/domain/frontend/log";
+import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
+import { getOrThrow } from "@/helpers/mapHelper";
+
+const logger = createLogger("store/singing");
+
+// リクエスト用のノーツ（と休符）を作成する
+const createNotesForRequestToEngine = (
+  firstRestDuration: number,
+  lastRestDurationSeconds: number,
+  notes: Note[],
+  tempos: Tempo[],
+  tpqn: number,
+  frameRate: number,
+) => {
+  const notesForRequestToEngine: NoteForRequestToEngine[] = [];
+
+  // 先頭の休符を変換
+  const firstRestStartSeconds = tickToSecond(
+    notes[0].position - firstRestDuration,
+    tempos,
+    tpqn,
+  );
+  const firstRestStartFrame = Math.round(firstRestStartSeconds * frameRate);
+  const firstRestEndSeconds = tickToSecond(notes[0].position, tempos, tpqn);
+  const firstRestEndFrame = Math.round(firstRestEndSeconds * frameRate);
+  notesForRequestToEngine.push({
+    key: undefined,
+    frameLength: firstRestEndFrame - firstRestStartFrame,
+    lyric: "",
+  });
+
+  // ノートを変換
+  for (const note of notes) {
+    const noteOnSeconds = tickToSecond(note.position, tempos, tpqn);
+    const noteOnFrame = Math.round(noteOnSeconds * frameRate);
+    const noteOffSeconds = tickToSecond(
+      note.position + note.duration,
+      tempos,
+      tpqn,
+    );
+    const noteOffFrame = Math.round(noteOffSeconds * frameRate);
+    notesForRequestToEngine.push({
+      key: note.noteNumber,
+      frameLength: noteOffFrame - noteOnFrame,
+      lyric: note.lyric,
+    });
+  }
+
+  // 末尾に休符を追加
+  const lastRestFrameLength = Math.round(lastRestDurationSeconds * frameRate);
+  notesForRequestToEngine.push({
+    key: undefined,
+    frameLength: lastRestFrameLength,
+    lyric: "",
+  });
+
+  // frameLengthが1以上になるようにする
+  for (let i = 0; i < notesForRequestToEngine.length; i++) {
+    const frameLength = notesForRequestToEngine[i].frameLength;
+    const frameToShift = Math.max(0, 1 - frameLength);
+    notesForRequestToEngine[i].frameLength += frameToShift;
+    if (i < notesForRequestToEngine.length - 1) {
+      notesForRequestToEngine[i + 1].frameLength -= frameToShift;
+    }
+  }
+
+  return notesForRequestToEngine;
+};
+
+const shiftKeyOfNotes = (notes: NoteForRequestToEngine[], keyShift: number) => {
+  for (const note of notes) {
+    if (note.key != undefined) {
+      note.key += keyShift;
+    }
+  }
+};
+
+const getPhonemes = (query: FrameAudioQuery) => {
+  return query.phonemes.map((value) => value.phoneme).join(" ");
+};
+
+const shiftPitch = (f0: number[], pitchShift: number) => {
+  for (let i = 0; i < f0.length; i++) {
+    f0[i] *= Math.pow(2, pitchShift / 12);
+  }
+};
+
+const shiftVolume = (volume: number[], volumeShift: number) => {
+  for (let i = 0; i < volume.length; i++) {
+    volume[i] *= decibelToLinear(volumeShift);
+  }
+};
+
+// 歌とpauの呼吸音が重ならないようにvolumeを制御する
+// fadeOutDurationSecondsが0の場合は即座にvolumeを0にする
+const muteLastPauSection = (
+  volume: number[],
+  phonemes: FramePhoneme[],
+  frameRate: number,
+  fadeOutDurationSeconds: number,
+) => {
+  const lastPhoneme = phonemes.at(-1);
+  if (lastPhoneme == undefined || lastPhoneme.phoneme !== "pau") {
+    throw new Error("No pau exists at the end.");
+  }
+
+  let lastPauStartFrame = 0;
+  for (let i = 0; i < phonemes.length - 1; i++) {
+    lastPauStartFrame += phonemes[i].frameLength;
+  }
+
+  const lastPauFrameLength = lastPhoneme.frameLength;
+  let fadeOutFrameLength = Math.round(fadeOutDurationSeconds * frameRate);
+  fadeOutFrameLength = Math.max(0, fadeOutFrameLength);
+  fadeOutFrameLength = Math.min(lastPauFrameLength, fadeOutFrameLength);
+
+  // フェードアウト処理を行う
+  if (fadeOutFrameLength === 1) {
+    volume[lastPauStartFrame] *= 0.5;
+  } else {
+    for (let i = 0; i < fadeOutFrameLength; i++) {
+      volume[lastPauStartFrame + i] *= linearInterpolation(
+        0,
+        1,
+        fadeOutFrameLength - 1,
+        0,
+        i,
+      );
+    }
+  }
+  // 音量を0にする
+  for (let i = fadeOutFrameLength; i < lastPauFrameLength; i++) {
+    volume[lastPauStartFrame + i] = 0;
+  }
+};
+
+const singingTeacherStyleId = StyleId(6000); // TODO: 設定できるようにする
+const lastRestDurationSeconds = 0.5; // TODO: 設定できるようにする
+const fadeOutDurationSeconds = 0.15; // TODO: 設定できるようにする
+
+type Snapshot = Readonly<{
+  tpqn: number;
+  tempos: Tempo[];
+  tracks: Map<TrackId, Track>;
+  engineFrameRates: Map<EngineId, number>;
+  editFrameRate: number;
+}>;
+
+type Phrase = Readonly<{
+  firstRestDuration: number;
+  notes: Note[];
+  startTime: number;
+  queryKey: {
+    get: () => FrameAudioQueryKey | undefined;
+    set: (value: FrameAudioQueryKey | undefined) => void;
+  };
+  singingVolumeKey: {
+    get: () => SingingVolumeKey | undefined;
+    set: (value: SingingVolumeKey | undefined) => void;
+  };
+  singingVoiceKey: {
+    get: () => SingingVoiceKey | undefined;
+    set: (value: SingingVoiceKey | undefined) => void;
+  };
+}>;
+
+type ExternalDependencies = Readonly<{
+  queryCache: Map<FrameAudioQueryKey, FrameAudioQuery>;
+  singingVolumeCache: Map<SingingVolumeKey, SingingVolume>;
+  singingVoiceCache: Map<SingingVoiceKey, SingingVoice>;
+
+  phrases: {
+    get: (phraseKey: PhraseKey) => Phrase;
+  };
+  phraseQueries: {
+    get: (queryKey: FrameAudioQueryKey) => FrameAudioQuery;
+    set: (queryKey: FrameAudioQueryKey, query: FrameAudioQuery) => void;
+    delete: (queryKey: FrameAudioQueryKey) => void;
+  };
+  phraseSingingVolumes: {
+    get: (singingVolumeKey: SingingVolumeKey) => SingingVolume;
+    set: (
+      singingVolumeKey: SingingVolumeKey,
+      singingVolume: SingingVolume,
+    ) => void;
+    delete: (singingVolumeKey: SingingVolumeKey) => void;
+  };
+  phraseSingingVoices: {
+    set: (singingVoiceKey: SingingVoiceKey, singingVoice: SingingVoice) => void;
+    delete: (singingVoiceKey: SingingVoiceKey) => void;
+  };
+
+  fetchQuery: (
+    engineId: EngineId,
+    notes: NoteForRequestToEngine[],
+  ) => Promise<FrameAudioQuery>;
+  fetchSingFrameVolume: (
+    notes: NoteForRequestToEngine[],
+    query: FrameAudioQuery,
+    engineId: EngineId,
+    styleId: StyleId,
+  ) => Promise<SingingVolume>;
+  synthesizeSingingVoice: (
+    singer: Singer,
+    query: FrameAudioQuery,
+  ) => Promise<SingingVoice>;
+}>;
+
+type Context = Readonly<{
+  snapshot: Snapshot;
+  trackId: TrackId;
+  phraseKey: PhraseKey;
+  externalDependencies: ExternalDependencies;
+}>;
+
+// クエリ生成ステージ
+
+type QuerySource = Readonly<{
+  engineId: EngineId;
+  engineFrameRate: number;
+  tpqn: number;
+  tempos: Tempo[];
+  firstRestDuration: number;
+  notes: Note[];
+  keyRangeAdjustment: number;
+}>;
+
+type QueryGenerationStage = Readonly<{
+  id: "queryGeneration";
+  shouldBeExecuted: (context: Context) => Promise<boolean>;
+  deleteExecutionResult: (context: Context) => void;
+  execute: (context: Context) => Promise<void>;
+}>;
+
+const generateQuerySource = (context: Context): QuerySource => {
+  const phrases = context.externalDependencies.phrases;
+
+  const track = getOrThrow(context.snapshot.tracks, context.trackId);
+  if (track.singer == undefined) {
+    throw new Error("track.singer is undefined.");
+  }
+  const engineFrameRate = getOrThrow(
+    context.snapshot.engineFrameRates,
+    track.singer.engineId,
+  );
+  const phrase = phrases.get(context.phraseKey);
+  return {
+    engineId: track.singer.engineId,
+    engineFrameRate,
+    tpqn: context.snapshot.tpqn,
+    tempos: context.snapshot.tempos,
+    firstRestDuration: phrase.firstRestDuration,
+    notes: phrase.notes,
+    keyRangeAdjustment: track.keyRangeAdjustment,
+  };
+};
+
+const calculateQueryKey = async (querySource: QuerySource) => {
+  const hash = await calculateHash(querySource);
+  return FrameAudioQueryKey(hash);
+};
+
+const generateQuery = async (
+  querySource: QuerySource,
+  externalDependencies: ExternalDependencies,
+) => {
+  const notesForRequestToEngine = createNotesForRequestToEngine(
+    querySource.firstRestDuration,
+    lastRestDurationSeconds,
+    querySource.notes,
+    querySource.tempos,
+    querySource.tpqn,
+    querySource.engineFrameRate,
+  );
+
+  shiftKeyOfNotes(notesForRequestToEngine, -querySource.keyRangeAdjustment);
+
+  const query = await externalDependencies.fetchQuery(
+    querySource.engineId,
+    notesForRequestToEngine,
+  );
+
+  shiftPitch(query.f0, querySource.keyRangeAdjustment);
+  return query;
+};
+
+const queryGenerationStage: QueryGenerationStage = {
+  id: "queryGeneration",
+  shouldBeExecuted: async (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+
+    const track = getOrThrow(context.snapshot.tracks, context.trackId);
+    if (track.singer == undefined) {
+      return false;
+    }
+    const phrase = phrases.get(context.phraseKey);
+    const phraseQueryKey = phrase.queryKey.get();
+    const querySource = generateQuerySource(context);
+    const queryKey = await calculateQueryKey(querySource);
+    return phraseQueryKey == undefined || phraseQueryKey !== queryKey;
+  },
+  deleteExecutionResult: (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+    const phraseQueries = context.externalDependencies.phraseQueries;
+
+    const phrase = phrases.get(context.phraseKey);
+    const phraseQueryKey = phrase.queryKey.get();
+    if (phraseQueryKey != undefined) {
+      phraseQueries.delete(phraseQueryKey);
+      phrase.queryKey.set(undefined);
+    }
+  },
+  execute: async (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+    const phraseQueries = context.externalDependencies.phraseQueries;
+    const queryCache = context.externalDependencies.queryCache;
+
+    const querySource = generateQuerySource(context);
+    const queryKey = await calculateQueryKey(querySource);
+
+    let query = queryCache.get(queryKey);
+    if (query != undefined) {
+      logger.info(`Loaded query from cache.`);
+    } else {
+      query = await generateQuery(querySource, context.externalDependencies);
+      const phonemes = getPhonemes(query);
+      logger.info(`Generated query. phonemes: ${phonemes}`);
+      queryCache.set(queryKey, query);
+    }
+
+    const phrase = phrases.get(context.phraseKey);
+    const phraseQueryKey = phrase.queryKey.get();
+    if (phraseQueryKey != undefined) {
+      phraseQueries.delete(phraseQueryKey);
+    }
+    phraseQueries.set(queryKey, query);
+    phrase.queryKey.set(queryKey);
+  },
+};
+
+// 歌唱ボリューム生成ステージ
+
+type SingingVolumeSource = Readonly<{
+  engineId: EngineId;
+  engineFrameRate: number;
+  tpqn: number;
+  tempos: Tempo[];
+  firstRestDuration: number;
+  notes: Note[];
+  keyRangeAdjustment: number;
+  volumeRangeAdjustment: number;
+  queryForVolumeGeneration: FrameAudioQuery;
+}>;
+
+type SingingVolumeGenerationStage = Readonly<{
+  id: "singingVolumeGeneration";
+  shouldBeExecuted: (context: Context) => Promise<boolean>;
+  deleteExecutionResult: (context: Context) => void;
+  execute: (context: Context) => Promise<void>;
+}>;
+
+const generateSingingVolumeSource = (context: Context): SingingVolumeSource => {
+  const phrases = context.externalDependencies.phrases;
+  const phraseQueries = context.externalDependencies.phraseQueries;
+
+  const track = getOrThrow(context.snapshot.tracks, context.trackId);
+  if (track.singer == undefined) {
+    throw new Error("track.singer is undefined.");
+  }
+  const engineFrameRate = getOrThrow(
+    context.snapshot.engineFrameRates,
+    track.singer.engineId,
+  );
+  const phrase = phrases.get(context.phraseKey);
+  const phraseQueryKey = phrase.queryKey.get();
+  if (phraseQueryKey == undefined) {
+    throw new Error("phraseQueryKey is undefined.");
+  }
+  const query = phraseQueries.get(phraseQueryKey);
+  const clonedQuery = cloneWithUnwrapProxy(query);
+  applyPitchEdit(
+    {
+      query: clonedQuery,
+      startTime: phrase.startTime,
+      frameRate: engineFrameRate,
+    },
+    track.pitchEditData,
+    context.snapshot.editFrameRate,
+  );
+  return {
+    engineId: track.singer.engineId,
+    engineFrameRate,
+    tpqn: context.snapshot.tpqn,
+    tempos: context.snapshot.tempos,
+    firstRestDuration: phrase.firstRestDuration,
+    notes: phrase.notes,
+    keyRangeAdjustment: track.keyRangeAdjustment,
+    volumeRangeAdjustment: track.volumeRangeAdjustment,
+    queryForVolumeGeneration: clonedQuery,
+  };
+};
+
+const calculateSingingVolumeKey = async (
+  singingVolumeSource: SingingVolumeSource,
+) => {
+  const hash = await calculateHash(singingVolumeSource);
+  return SingingVolumeKey(hash);
+};
+
+const generateSingingVolume = async (
+  singingVolumeSource: SingingVolumeSource,
+  externalDependencies: ExternalDependencies,
+) => {
+  const notesForRequestToEngine = createNotesForRequestToEngine(
+    singingVolumeSource.firstRestDuration,
+    lastRestDurationSeconds,
+    singingVolumeSource.notes,
+    singingVolumeSource.tempos,
+    singingVolumeSource.tpqn,
+    singingVolumeSource.engineFrameRate,
+  );
+  const queryForVolumeGeneration = singingVolumeSource.queryForVolumeGeneration;
+
+  shiftKeyOfNotes(
+    notesForRequestToEngine,
+    -singingVolumeSource.keyRangeAdjustment,
+  );
+  shiftPitch(
+    queryForVolumeGeneration.f0,
+    -singingVolumeSource.keyRangeAdjustment,
+  );
+
+  const singingVolume = await externalDependencies.fetchSingFrameVolume(
+    notesForRequestToEngine,
+    queryForVolumeGeneration,
+    singingVolumeSource.engineId,
+    singingTeacherStyleId,
+  );
+
+  shiftVolume(singingVolume, singingVolumeSource.volumeRangeAdjustment);
+
+  // 末尾のpauの区間の音量を0にする
+  muteLastPauSection(
+    singingVolume,
+    queryForVolumeGeneration.phonemes,
+    singingVolumeSource.engineFrameRate,
+    fadeOutDurationSeconds,
+  );
+  return singingVolume;
+};
+
+const singingVolumeGenerationStage: SingingVolumeGenerationStage = {
+  id: "singingVolumeGeneration",
+  shouldBeExecuted: async (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+
+    const track = getOrThrow(context.snapshot.tracks, context.trackId);
+    if (track.singer == undefined) {
+      return false;
+    }
+    const singingVolumeSource = generateSingingVolumeSource(context);
+    const singingVolumeKey =
+      await calculateSingingVolumeKey(singingVolumeSource);
+    const phrase = phrases.get(context.phraseKey);
+    const phraseSingingVolumeKey = phrase.singingVolumeKey.get();
+    return (
+      phraseSingingVolumeKey == undefined ||
+      phraseSingingVolumeKey !== singingVolumeKey
+    );
+  },
+  deleteExecutionResult: (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+    const phraseSingingVolumes =
+      context.externalDependencies.phraseSingingVolumes;
+
+    const phrase = phrases.get(context.phraseKey);
+    const phraseSingingVolumeKey = phrase.singingVolumeKey.get();
+    if (phraseSingingVolumeKey != undefined) {
+      phraseSingingVolumes.delete(phraseSingingVolumeKey);
+      phrase.singingVolumeKey.set(undefined);
+    }
+  },
+  execute: async (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+    const phraseSingingVolumes =
+      context.externalDependencies.phraseSingingVolumes;
+    const singingVolumeCache = context.externalDependencies.singingVolumeCache;
+
+    const singingVolumeSource = generateSingingVolumeSource(context);
+    const singingVolumeKey =
+      await calculateSingingVolumeKey(singingVolumeSource);
+
+    let singingVolume = singingVolumeCache.get(singingVolumeKey);
+    if (singingVolume != undefined) {
+      logger.info(`Loaded singing volume from cache.`);
+    } else {
+      singingVolume = await generateSingingVolume(
+        singingVolumeSource,
+        context.externalDependencies,
+      );
+      logger.info(`Generated singing volume.`);
+      singingVolumeCache.set(singingVolumeKey, singingVolume);
+    }
+
+    const phrase = phrases.get(context.phraseKey);
+    const phraseSingingVolumeKey = phrase.singingVolumeKey.get();
+    if (phraseSingingVolumeKey != undefined) {
+      phraseSingingVolumes.delete(phraseSingingVolumeKey);
+    }
+    phraseSingingVolumes.set(singingVolumeKey, singingVolume);
+    phrase.singingVolumeKey.set(singingVolumeKey);
+  },
+};
+
+// 音声合成ステージ
+
+type SingingVoiceSource = Readonly<{
+  singer: Singer;
+  queryForSingingVoiceSynthesis: FrameAudioQuery;
+}>;
+
+type SingingVoiceSynthesisStage = Readonly<{
+  id: "singingVoiceSynthesis";
+  shouldBeExecuted: (context: Context) => Promise<boolean>;
+  deleteExecutionResult: (context: Context) => void;
+  execute: (context: Context) => Promise<void>;
+}>;
+
+const generateSingingVoiceSource = (context: Context): SingingVoiceSource => {
+  const phrases = context.externalDependencies.phrases;
+  const phraseQueries = context.externalDependencies.phraseQueries;
+  const phraseSingingVolumes =
+    context.externalDependencies.phraseSingingVolumes;
+
+  const track = getOrThrow(context.snapshot.tracks, context.trackId);
+  if (track.singer == undefined) {
+    throw new Error("track.singer is undefined.");
+  }
+  const engineFrameRate = getOrThrow(
+    context.snapshot.engineFrameRates,
+    track.singer.engineId,
+  );
+  const phrase = phrases.get(context.phraseKey);
+  const phraseQueryKey = phrase.queryKey.get();
+  const phraseSingingVolumeKey = phrase.singingVolumeKey.get();
+  if (phraseQueryKey == undefined) {
+    throw new Error("phraseQueryKey is undefined.");
+  }
+  if (phraseSingingVolumeKey == undefined) {
+    throw new Error("phraseSingingVolumeKey is undefined.");
+  }
+  const query = phraseQueries.get(phraseQueryKey);
+  const singingVolume = phraseSingingVolumes.get(phraseSingingVolumeKey);
+  const clonedQuery = cloneWithUnwrapProxy(query);
+  const clonedSingingVolume = cloneWithUnwrapProxy(singingVolume);
+  applyPitchEdit(
+    {
+      query: clonedQuery,
+      startTime: phrase.startTime,
+      frameRate: engineFrameRate,
+    },
+    track.pitchEditData,
+    context.snapshot.editFrameRate,
+  );
+  clonedQuery.volume = clonedSingingVolume;
+  return {
+    singer: track.singer,
+    queryForSingingVoiceSynthesis: clonedQuery,
+  };
+};
+
+const calculateSingingVoiceKey = async (
+  singingVoiceSource: SingingVoiceSource,
+) => {
+  const hash = await calculateHash(singingVoiceSource);
+  return SingingVoiceKey(hash);
+};
+
+const synthesizeSingingVoice = async (
+  singingVoiceSource: SingingVoiceSource,
+  externalDependencies: ExternalDependencies,
+) => {
+  const singingVoice = await externalDependencies.synthesizeSingingVoice(
+    singingVoiceSource.singer,
+    singingVoiceSource.queryForSingingVoiceSynthesis,
+  );
+  return singingVoice;
+};
+
+const singingVoiceSynthesisStage: SingingVoiceSynthesisStage = {
+  id: "singingVoiceSynthesis",
+  shouldBeExecuted: async (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+
+    const track = getOrThrow(context.snapshot.tracks, context.trackId);
+    if (track.singer == undefined) {
+      return false;
+    }
+    const singingVoiceSource = generateSingingVoiceSource(context);
+    const singingVoiceKey = await calculateSingingVoiceKey(singingVoiceSource);
+    const phrase = phrases.get(context.phraseKey);
+    const phraseSingingVoiceKey = phrase.singingVoiceKey.get();
+    return (
+      phraseSingingVoiceKey == undefined ||
+      phraseSingingVoiceKey !== singingVoiceKey
+    );
+  },
+  deleteExecutionResult: (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+    const phraseSingingVoices =
+      context.externalDependencies.phraseSingingVoices;
+
+    const phrase = phrases.get(context.phraseKey);
+    const phraseSingingVoiceKey = phrase.singingVoiceKey.get();
+    if (phraseSingingVoiceKey != undefined) {
+      phraseSingingVoices.delete(phraseSingingVoiceKey);
+      phrase.singingVoiceKey.set(undefined);
+    }
+  },
+  execute: async (context: Context) => {
+    const phrases = context.externalDependencies.phrases;
+    const phraseSingingVoices =
+      context.externalDependencies.phraseSingingVoices;
+    const singingVoiceCache = context.externalDependencies.singingVoiceCache;
+
+    const singingVoiceSource = generateSingingVoiceSource(context);
+    const singingVoiceKey = await calculateSingingVoiceKey(singingVoiceSource);
+
+    let singingVoice = singingVoiceCache.get(singingVoiceKey);
+    if (singingVoice != undefined) {
+      logger.info(`Loaded singing voice from cache.`);
+    } else {
+      singingVoice = await synthesizeSingingVoice(
+        singingVoiceSource,
+        context.externalDependencies,
+      );
+      logger.info(`Generated singing voice.`);
+      singingVoiceCache.set(singingVoiceKey, singingVoice);
+    }
+
+    const phrase = phrases.get(context.phraseKey);
+    const phraseSingingVoiceKey = phrase.singingVoiceKey.get();
+    if (phraseSingingVoiceKey != undefined) {
+      phraseSingingVoices.delete(phraseSingingVoiceKey);
+    }
+    phraseSingingVoices.set(singingVoiceKey, singingVoice);
+    phrase.singingVoiceKey.set(singingVoiceKey);
+  },
+};
+
+// フレーズレンダラー
+
+const stages = [
+  queryGenerationStage,
+  singingVolumeGenerationStage,
+  singingVoiceSynthesisStage,
+] as const;
+
+export type PhraseRenderStageId = (typeof stages)[number]["id"];
+
+export const createPhraseRenderer = (
+  externalDependencies: ExternalDependencies,
+) => {
+  return {
+    getFirstRenderStageId: () => {
+      return stages[0].id;
+    },
+    determineStartStage: async (
+      snapshot: Snapshot,
+      trackId: TrackId,
+      phraseKey: PhraseKey,
+    ) => {
+      const context: Context = {
+        snapshot,
+        trackId,
+        phraseKey,
+        externalDependencies,
+      };
+      for (const stage of stages) {
+        if (await stage.shouldBeExecuted(context)) {
+          return stage.id;
+        }
+      }
+      return undefined;
+    },
+    render: async (
+      snapshot: Snapshot,
+      trackId: TrackId,
+      phraseKey: PhraseKey,
+      startStageId: PhraseRenderStageId,
+    ) => {
+      const context: Context = {
+        snapshot,
+        trackId,
+        phraseKey,
+        externalDependencies,
+      };
+      const startStageIndex = stages.findIndex((value) => {
+        return value.id === startStageId;
+      });
+      if (startStageIndex === -1) {
+        throw new Error("Stage not found.");
+      }
+      for (let i = stages.length - 1; i >= startStageIndex; i--) {
+        stages[i].deleteExecutionResult(context);
+      }
+      for (let i = startStageIndex; i < stages.length; i++) {
+        await stages[i].execute(context);
+      }
+    },
+  } as const;
+};

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -262,7 +262,7 @@ export type PhraseRenderStageId =
 /**
  * フレーズレンダリングのステージ
  */
-type Stage = Readonly<{
+type BaseStage = Readonly<{
   id: PhraseRenderStageId;
 
   /**
@@ -352,7 +352,7 @@ const generateQuery = async (
   return { ...query, frameRate: querySource.engineFrameRate };
 };
 
-const queryGenerationStage: Stage = {
+const queryGenerationStage: BaseStage = {
   id: "queryGeneration",
   shouldBeExecuted: async (context: Context) => {
     const phrases = context.externalDependencies.phrases;
@@ -504,7 +504,7 @@ const generateSingingVolume = async (
   return singingVolume;
 };
 
-const singingVolumeGenerationStage: Stage = {
+const singingVolumeGenerationStage: BaseStage = {
   id: "singingVolumeGeneration",
   shouldBeExecuted: async (context: Context) => {
     const phrases = context.externalDependencies.phrases;
@@ -631,7 +631,7 @@ const synthesizeSingingVoice = async (
   return singingVoice;
 };
 
-const singingVoiceSynthesisStage: Stage = {
+const singingVoiceSynthesisStage: BaseStage = {
   id: "singingVoiceSynthesis",
   shouldBeExecuted: async (context: Context) => {
     const phrases = context.externalDependencies.phrases;
@@ -731,7 +731,7 @@ export type PhraseRenderer = Readonly<{
   ) => Promise<void>;
 }>;
 
-const stages: readonly Stage[] = [
+const stages: readonly BaseStage[] = [
   queryGenerationStage,
   singingVolumeGenerationStage,
   singingVoiceSynthesisStage,

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -1,3 +1,8 @@
+/**
+ * フレーズごとに音声合成するフレーズレンダラーと、それに必要な処理。
+ * レンダリングが必要かどうかの判定やキャッシュの作成も行う。
+ */
+
 import {
   Note,
   PhraseKey,
@@ -682,14 +687,17 @@ const singingVoiceSynthesisStage: BaseStage = {
 
 export type PhraseRenderer = Readonly<{
   /**
-   * レンダリング処理の開始点となる最初のステージのIDを返す。
+   * 一番最初のステージのIDを返す。
+   * 一度もレンダリングを行っていないフレーズは、
+   * この（一番最初の）ステージからレンダリング処理を開始する必要がある。
    * @returns ステージID
    */
   getFirstRenderStageId: () => PhraseRenderStageId;
 
   /**
-   * レンダリングがどのステージから開始されるべきかを判断する。
-   * すべてのステージがスキップ可能な場合、undefinedが返される。
+   * レンダリングが必要なフレーズかどうかを判断し、
+   * レンダリングが必要であればどのステージから開始されるべきかを判断して、そのステージのIDを返す。
+   * レンダリングが必要ない場合、undefinedが返される。
    * @param snapshot スナップショット
    * @param trackId トラックID
    * @param phraseKey フレーズキー
@@ -702,7 +710,7 @@ export type PhraseRenderer = Readonly<{
   ) => Promise<PhraseRenderStageId | undefined>;
 
   /**
-   * 指定されたステージからレンダリング処理を開始する。
+   * 指定されたフレーズのレンダリング処理を、指定されたステージから開始する。
    * レンダリング処理を開始する前に、前回のレンダリング処理結果の削除が行われる。
    * @param snapshot スナップショット
    * @param trackId トラックID

--- a/src/sing/phraseRendering.ts
+++ b/src/sing/phraseRendering.ts
@@ -254,11 +254,16 @@ type Context = Readonly<{
   externalDependencies: ExternalDependencies;
 }>;
 
+export type PhraseRenderStageId =
+  | "queryGeneration"
+  | "singingVolumeGeneration"
+  | "singingVoiceSynthesis";
+
 /**
  * フレーズレンダリングのステージ
  */
 type Stage = Readonly<{
-  id: "queryGeneration" | "singingVolumeGeneration" | "singingVoiceSynthesis";
+  id: PhraseRenderStageId;
 
   /**
    * このステージが実行されるべきかを判定する。
@@ -688,8 +693,6 @@ const singingVoiceSynthesisStage: Stage = {
 };
 
 // フレーズレンダラー
-
-export type PhraseRenderStageId = Stage["id"];
 
 export type PhraseRenderer = Readonly<{
   /**

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1658,7 +1658,10 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         for (const [phraseKey, foundPhrase] of foundPhrases) {
           // 新しいフレーズまたは既存のフレーズの場合
           const existingPhrase = state.phrases.get(phraseKey);
-          const phrase = existingPhrase ?? foundPhrase;
+          const phrase =
+            existingPhrase == undefined
+              ? foundPhrase
+              : cloneWithUnwrapProxy(existingPhrase);
           const track = getOrThrow(snapshot.tracks, phrase.trackId);
           if (track.singer == undefined) {
             phrase.state = "SINGER_IS_NOT_SET";

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -66,7 +66,7 @@ import {
   isValidTimeSignatures,
   isValidTpqn,
   DEFAULT_TPQN,
-  DEPRECATED_DEFAULT_EDIT_FRAME_RATE,
+  DEPRECATED_DEFAULT_EDITOR_FRAME_RATE,
   createDefaultTrack,
   createDefaultTempo,
   createDefaultTimeSignature,
@@ -413,7 +413,7 @@ export const singingStoreState: SingingStoreState = {
    */
   _selectedTrackId: initialTrackId,
 
-  editFrameRate: DEPRECATED_DEFAULT_EDIT_FRAME_RATE,
+  editorFrameRate: DEPRECATED_DEFAULT_EDITOR_FRAME_RATE,
   phrases: new Map(),
   phraseQueries: new Map(),
   phraseSingingVolumes: new Map(),
@@ -1547,7 +1547,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               ],
             ),
           ),
-          editFrameRate: state.editFrameRate,
+          editorFrameRate: state.editorFrameRate,
         } as const;
 
         const phraseRenderer = createPhraseRenderer({

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1555,37 +1555,40 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           singingVolumeCache,
           singingVoiceCache,
           phrases: {
-            get: (phraseKey: PhraseKey) => ({
-              firstRestDuration: getOrThrow(state.phrases, phraseKey)
-                .firstRestDuration,
-              notes: getOrThrow(state.phrases, phraseKey).notes,
-              startTime: getOrThrow(state.phrases, phraseKey).startTime,
-              queryKey: {
-                get: () => getOrThrow(state.phrases, phraseKey).queryKey,
-                set: (value) =>
-                  mutations.SET_QUERY_KEY_TO_PHRASE({
-                    phraseKey,
-                    queryKey: value,
-                  }),
-              },
-              singingVolumeKey: {
-                get: () =>
-                  getOrThrow(state.phrases, phraseKey).singingVolumeKey,
-                set: (value) =>
-                  mutations.SET_SINGING_VOLUME_KEY_TO_PHRASE({
-                    phraseKey,
-                    singingVolumeKey: value,
-                  }),
-              },
-              singingVoiceKey: {
-                get: () => getOrThrow(state.phrases, phraseKey).singingVoiceKey,
-                set: (value) =>
-                  mutations.SET_SINGING_VOICE_KEY_TO_PHRASE({
-                    phraseKey,
-                    singingVoiceKey: value,
-                  }),
-              },
-            }),
+            get: (phraseKey: PhraseKey) => {
+              const phrase = getOrThrow(state.phrases, phraseKey);
+              return {
+                firstRestDuration: phrase.firstRestDuration,
+                notes: phrase.notes,
+                startTime: phrase.startTime,
+                queryKey: {
+                  get: () => getOrThrow(state.phrases, phraseKey).queryKey,
+                  set: (value) =>
+                    mutations.SET_QUERY_KEY_TO_PHRASE({
+                      phraseKey,
+                      queryKey: value,
+                    }),
+                },
+                singingVolumeKey: {
+                  get: () =>
+                    getOrThrow(state.phrases, phraseKey).singingVolumeKey,
+                  set: (value) =>
+                    mutations.SET_SINGING_VOLUME_KEY_TO_PHRASE({
+                      phraseKey,
+                      singingVolumeKey: value,
+                    }),
+                },
+                singingVoiceKey: {
+                  get: () =>
+                    getOrThrow(state.phrases, phraseKey).singingVoiceKey,
+                  set: (value) =>
+                    mutations.SET_SINGING_VOICE_KEY_TO_PHRASE({
+                      phraseKey,
+                      singingVoiceKey: value,
+                    }),
+                },
+              };
+            },
           },
           phraseQueries: {
             get: (queryKey) => getOrThrow(state.phraseQueries, queryKey),

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1527,7 +1527,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
 
         const firstRestMinDurationSeconds = 0.12;
 
-        // レンダリング中に変更される可能性のあるデータをコピーする
+        // レンダリング中に変更される可能性のあるデータのコピー
         const snapshot = {
           tpqn: state.tpqn,
           tempos: cloneWithUnwrapProxy(state.tempos),
@@ -1547,7 +1547,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             ),
           ),
           editFrameRate: state.editFrameRate,
-        };
+        } as const;
 
         const phraseRenderer = createPhraseRenderer({
           queryCache,
@@ -1669,6 +1669,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             if (track.singer == undefined) {
               phrase.state = "SINGER_IS_NOT_SET";
             } else {
+              // どのステージから開始するかを決める
+              // phrase.stateがCOULD_NOT_RENDERだった場合は最初からレンダリングし直す
               const renderStartStageId =
                 phrase.state === "COULD_NOT_RENDER"
                   ? phraseRenderer.getFirstRenderStageId()
@@ -1754,6 +1756,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           });
 
           try {
+            // フレーズのレンダリングを行う
             await phraseRenderer.render(
               snapshot,
               phrase.trackId,

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -19,10 +19,11 @@ import {
   PhraseKey,
   Track,
   SequenceId,
-  FrameAudioQueryKey,
   SingingVolumeKey,
   SingingVolume,
   SingingVoiceKey,
+  EditorFrameAudioQueryKey,
+  EditorFrameAudioQuery,
 } from "./type";
 import { DEFAULT_PROJECT_NAME, sanitizeFileName } from "./utility";
 import {
@@ -247,7 +248,7 @@ const phraseSingingVoices = new Map<SingingVoiceKey, SingingVoice>();
 const sequences = new Map<SequenceId, Sequence & { trackId: TrackId }>();
 const animationTimer = new AnimationTimer();
 
-const queryCache = new Map<FrameAudioQueryKey, FrameAudioQuery>();
+const queryCache = new Map<EditorFrameAudioQueryKey, EditorFrameAudioQuery>();
 const singingVolumeCache = new Map<SingingVolumeKey, SingingVolume>();
 const singingVoiceCache = new Map<SingingVoiceKey, SingingVoice>();
 
@@ -880,7 +881,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         queryKey,
       }: {
         phraseKey: PhraseKey;
-        queryKey: FrameAudioQueryKey | undefined;
+        queryKey: EditorFrameAudioQueryKey | undefined;
       },
     ) {
       const phrase = getOrThrow(state.phrases, phraseKey);
@@ -947,8 +948,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         queryKey,
         query,
       }: {
-        queryKey: FrameAudioQueryKey;
-        query: FrameAudioQuery;
+        queryKey: EditorFrameAudioQueryKey;
+        query: EditorFrameAudioQuery;
       },
     ) {
       state.phraseQueries.set(queryKey, query);
@@ -956,7 +957,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
   },
 
   DELETE_PHRASE_QUERY: {
-    mutation(state, { queryKey }: { queryKey: FrameAudioQueryKey }) {
+    mutation(state, { queryKey }: { queryKey: EditorFrameAudioQueryKey }) {
       state.phraseQueries.delete(queryKey);
     },
   },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -822,7 +822,7 @@ export type SingingStoreState = {
   tracks: Map<TrackId, Track>;
   trackOrder: TrackId[];
   _selectedTrackId: TrackId;
-  editFrameRate: number;
+  editorFrameRate: number;
   phrases: Map<PhraseKey, Phrase>;
   phraseQueries: Map<EditorFrameAudioQueryKey, EditorFrameAudioQuery>;
   phraseSingingVolumes: Map<SingingVolumeKey, SingingVolume>;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -745,6 +745,11 @@ export type PhraseState =
   | "PLAYABLE";
 
 /**
+ * エディタ用のFrameAudioQuery
+ */
+export type EditorFrameAudioQuery = FrameAudioQuery & { frameRate: number };
+
+/**
  * 歌唱ボリューム
  */
 export type SingingVolume = number[];
@@ -754,10 +759,15 @@ export type SingingVolume = number[];
  */
 export type SingingVoice = Blob;
 
-const frameAudioQueryKeySchema = z.string().brand<"FrameAudioQueryKey">();
-export type FrameAudioQueryKey = z.infer<typeof frameAudioQueryKeySchema>;
-export const FrameAudioQueryKey = (id: string): FrameAudioQueryKey =>
-  frameAudioQueryKeySchema.parse(id);
+const editorFrameAudioQueryKeySchema = z
+  .string()
+  .brand<"EditorFrameAudioQueryKey">();
+export type EditorFrameAudioQueryKey = z.infer<
+  typeof editorFrameAudioQueryKeySchema
+>;
+export const EditorFrameAudioQueryKey = (
+  id: string,
+): EditorFrameAudioQueryKey => editorFrameAudioQueryKeySchema.parse(id);
 
 const singingVolumeKeySchema = z.string().brand<"SingingVolumeKey">();
 export type SingingVolumeKey = z.infer<typeof singingVolumeKeySchema>;
@@ -782,7 +792,7 @@ export type Phrase = {
   notes: Note[];
   startTime: number;
   state: PhraseState;
-  queryKey?: FrameAudioQueryKey;
+  queryKey?: EditorFrameAudioQueryKey;
   singingVolumeKey?: SingingVolumeKey;
   singingVoiceKey?: SingingVoiceKey;
   sequenceId?: SequenceId;
@@ -790,7 +800,7 @@ export type Phrase = {
 };
 
 /**
- * フレーズのソース
+ * フレーズの生成に必要なデータ
  */
 export type PhraseSource = {
   firstRestDuration: number;
@@ -814,7 +824,7 @@ export type SingingStoreState = {
   _selectedTrackId: TrackId;
   editFrameRate: number;
   phrases: Map<PhraseKey, Phrase>;
-  phraseQueries: Map<FrameAudioQueryKey, FrameAudioQuery>;
+  phraseQueries: Map<EditorFrameAudioQueryKey, EditorFrameAudioQuery>;
   phraseSingingVolumes: Map<SingingVolumeKey, SingingVolume>;
   sequencerZoomX: number;
   sequencerZoomY: number;
@@ -971,7 +981,7 @@ export type SingingStoreTypes = {
   SET_QUERY_KEY_TO_PHRASE: {
     mutation: {
       phraseKey: PhraseKey;
-      queryKey: FrameAudioQueryKey | undefined;
+      queryKey: EditorFrameAudioQueryKey | undefined;
     };
   };
 
@@ -998,13 +1008,13 @@ export type SingingStoreTypes = {
 
   SET_PHRASE_QUERY: {
     mutation: {
-      queryKey: FrameAudioQueryKey;
-      query: FrameAudioQuery;
+      queryKey: EditorFrameAudioQueryKey;
+      query: EditorFrameAudioQuery;
     };
   };
 
   DELETE_PHRASE_QUERY: {
-    mutation: { queryKey: FrameAudioQueryKey };
+    mutation: { queryKey: EditorFrameAudioQueryKey };
   };
 
   SET_PHRASE_SINGING_VOLUME: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1072,7 +1072,7 @@ export type SingingStoreTypes = {
   FETCH_SING_FRAME_VOLUME: {
     action(palyoad: {
       notes: NoteForRequestToEngine[];
-      frameAudioQuery: FrameAudioQuery;
+      query: EditorFrameAudioQuery;
       engineId: EngineId;
       styleId: StyleId;
     }): Promise<number[]>;

--- a/tests/unit/lib/selectPriorPhrase.spec.ts
+++ b/tests/unit/lib/selectPriorPhrase.spec.ts
@@ -1,11 +1,11 @@
 import { it, expect } from "vitest";
+import { Phrase, PhraseKey, PhraseState } from "@/store/type";
 import {
-  Phrase,
-  PhraseSourceHash,
-  PhraseState,
-  phraseSourceHashSchema,
-} from "@/store/type";
-import { DEFAULT_TPQN, selectPriorPhrase } from "@/sing/domain";
+  DEFAULT_BPM,
+  DEFAULT_TPQN,
+  selectPriorPhrase,
+  tickToSecond,
+} from "@/sing/domain";
 import { NoteId, TrackId } from "@/type/preload";
 import { uuid4 } from "@/helpers/random";
 
@@ -29,30 +29,20 @@ const createPhrase = (
         lyric: "ド",
       },
     ],
+    startTime: tickToSecond(
+      start * DEFAULT_TPQN - firstRestDuration * DEFAULT_TPQN,
+      [{ position: 0, bpm: DEFAULT_BPM }],
+      DEFAULT_TPQN,
+    ),
     state,
   };
 };
-const basePhrases = new Map<PhraseSourceHash, Phrase>([
-  [
-    phraseSourceHashSchema.parse("1"),
-    createPhrase(0, 0, 1, "WAITING_TO_BE_RENDERED"),
-  ],
-  [
-    phraseSourceHashSchema.parse("2"),
-    createPhrase(0, 1, 2, "WAITING_TO_BE_RENDERED"),
-  ],
-  [
-    phraseSourceHashSchema.parse("3"),
-    createPhrase(0, 2, 3, "WAITING_TO_BE_RENDERED"),
-  ],
-  [
-    phraseSourceHashSchema.parse("4"),
-    createPhrase(0, 3, 4, "WAITING_TO_BE_RENDERED"),
-  ],
-  [
-    phraseSourceHashSchema.parse("5"),
-    createPhrase(0, 4, 5, "WAITING_TO_BE_RENDERED"),
-  ],
+const basePhrases = new Map<PhraseKey, Phrase>([
+  [PhraseKey("1"), createPhrase(0, 0, 1, "WAITING_TO_BE_RENDERED")],
+  [PhraseKey("2"), createPhrase(0, 1, 2, "WAITING_TO_BE_RENDERED")],
+  [PhraseKey("3"), createPhrase(0, 2, 3, "WAITING_TO_BE_RENDERED")],
+  [PhraseKey("4"), createPhrase(0, 3, 4, "WAITING_TO_BE_RENDERED")],
+  [PhraseKey("5"), createPhrase(0, 4, 5, "WAITING_TO_BE_RENDERED")],
 ]);
 
 it("しっかり優先順位に従って探している", () => {


### PR DESCRIPTION
## 内容

以下を行います。

- `PhraseRenderer`を追加
- `QueryGenerationStage`を追加
- `SingingVolumeGenerationStage`を追加
- `SingingVoiceSynthesisStage`を追加
- 以下の関数を`phraseRendering.ts`に移動
  - `createNotesForRequestToEngine`
  - `shiftKeyOfNotes`
  - `getPhonemes`
  - `shiftPitch`
  - `shiftVolume`
  - `muteLastPauSection`
- フレーズのレンダリング処理を`PhraseRenderer`を使用して行うように変更
- フレーズの開始時間（`startTime`）を`Phrase`に持たせ、算出をフレーズ生成時に行うように変更
- `PhraseState`に`SINGER_IS_NOT_SET`を追加
- 型を整理

### レンダリングの流れ
1. 重なっているノートを除外
1. `searchPhrases`を実行
1. 新しいフレーズまたは既存のフレーズに対して以下を行う
    1. シンガーが未設定の場合、`state`を`SINGER_IS_NOT_SET`に設定
    1. シンガーが設定されている場合、以下を行う
        1. 新しいフレーズまたは`state`が`COUND_NOT_RENDER`の場合、レンダリング開始ステージを一番最初のステージに設定
        1. 既存のフレーズの場合、適切なレンダリング開始ステージを決定する
        1. `state`を`WAITING_TO_BE_RENDERED`に設定
1. 無くなったフレーズに対して、以下を行う
    1. シーケンスが存在する場合、シーケンスを削除する
1. `state`が`SINGER_IS_NOT_SET`または`WAITING_TO_BE_RENDERED`のフレーズに対して、以下を行う
    1. シーケンスが存在する場合、シーケンスを削除する
    1. ノートシーケンスを生成して登録する
1. `state`が`WAITING_TO_BE_RENDERED`のフレーズに対して以下を行う
    1. フレーズのレンダリングを行う
    1. シーケンスが存在する場合、シーケンスを削除する
    1. オーディオシーケンスを作成して登録する

## 関連 Issue

ref #2247

## その他