### PR TITLE
eslintの観測範囲を`*.ts`へ

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,7 @@ module.exports = {
       },
     },
     {
-      files: ["./*/**/*.ts"],
+      files: ["*.ts"],
       parser: "@typescript-eslint/parser",
       extends: ["plugin:@typescript-eslint/recommended-type-checked"],
       parserOptions: tsEslintOptions,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": [
+    "playwright.config.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     "src/**/*.vue",


### PR DESCRIPTION
## 内容

eslintの対象を`./*/**/`にするとroot直下にある`.`始まりのフォルダ内のものが見えないことに気づきました。

- https://github.com/VOICEVOX/voicevox/pull/2172

特に`*.ts`にしてもエラーにならなかったので、そうしてみるPR作ってみました。

## その他

> tsconfigで*.tsを指定すると大変になりそう

ということだったので、tsconfigはそのままにeslintを変えてみました。
