### PR TITLE
エンジンの管理ダイアログのリデザイン

### DIFF
--- a/src/components/Base/BaseButton.vue
+++ b/src/components/Base/BaseButton.vue
@@ -2,6 +2,7 @@
   <button
     class="button"
     :class="variant ? variant : 'default'"
+    :disabled
     @click="(payload) => $emit('click', payload)"
   >
     <!-- 暫定でq-iconを使用 -->
@@ -14,6 +15,7 @@
 defineProps<{
   label: string;
   icon?: string;
+  disabled?: boolean;
   variant?: "default" | "primary" | "danger";
 }>();
 

--- a/src/components/Base/BaseButton.vue
+++ b/src/components/Base/BaseButton.vue
@@ -33,6 +33,7 @@ defineEmits<{
   display: flex;
   justify-content: space-between;
   align-items: center;
+  text-wrap: nowrap;
   height: vars.$size-control;
   border-radius: vars.$radius-1;
   padding: 0 vars.$padding-2;

--- a/src/components/Base/BaseListItem.vue
+++ b/src/components/Base/BaseListItem.vue
@@ -29,12 +29,12 @@ defineEmits<{
   color: colors.$display;
   cursor: pointer;
   position: relative;
-  height: vars.$size-listitem;
+  min-height: vars.$size-listitem;
   display: flex;
   align-items: center;
   background-color: colors.$clear;
   border: none;
-  padding: 0 vars.$padding-2;
+  padding: vars.$padding-1 vars.$padding-2;
   border-radius: vars.$radius-1;
   transition: background-color vars.$transition-duration;
 

--- a/src/components/Base/BaseNavigationView.stories.ts
+++ b/src/components/Base/BaseNavigationView.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+
+import BaseNavigationView from "./BaseNavigationView.vue";
+import BaseListItem from "./BaseListItem.vue";
+
+const meta: Meta<typeof BaseNavigationView> = {
+  component: BaseNavigationView,
+};
+
+export default meta;
+type Story = StoryObj<typeof BaseNavigationView>;
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { BaseNavigationView, BaseListItem },
+    setup() {
+      return { args };
+    },
+    template: `
+      <BaseNavigationView style="width: 100%; height:480px" v-bind="args">
+        <template #sidebar>
+          <BaseListItem>ListItem</BaseListItem>
+        </template>
+        <div>Content</div>
+      </BaseNavigationView>`,
+  }),
+};

--- a/src/components/Base/BaseNavigationView.vue
+++ b/src/components/Base/BaseNavigationView.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="grid">
+    <div class="sidebar">
+      <BaseScrollArea>
+        <div class="sidebar-inner">
+          <slot name="sidebar" />
+        </div>
+      </BaseScrollArea>
+    </div>
+
+    <main class="content">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import BaseScrollArea from "./BaseScrollArea.vue";
+</script>
+
+<style lang="scss" scoped>
+@use "@/styles/v2/variables" as vars;
+@use "@/styles/v2/colors" as colors;
+
+// TODO: MenuBar+Header分のマージン。Dialogコンポーネント置き換え後削除
+.grid {
+  height: calc(100vh - 90px);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: 100%;
+  backdrop-filter: blur(32px);
+  background-color: colors.$background-drawer;
+}
+
+.sidebar-inner {
+  display: flex;
+  flex-direction: column;
+  padding: vars.$padding-2;
+  width: max-content;
+}
+
+.content {
+  background-color: colors.$background;
+  border-left: 1px solid colors.$border;
+}
+</style>

--- a/src/components/Base/BaseScrollArea.vue
+++ b/src/components/Base/BaseScrollArea.vue
@@ -1,7 +1,9 @@
 <template>
   <ScrollAreaRoot class="ScrollAreaRoot" type="auto">
-    <ScrollAreaViewport class="ScrollAreaViewport">
-      <slot />
+    <ScrollAreaViewport asChild>
+      <div class="ScrollAreaViewport">
+        <slot />
+      </div>
     </ScrollAreaViewport>
     <ScrollAreaScrollbar class="ScrollAreaScrollbar" orientation="horizontal">
       <ScrollAreaThumb class="ScrollAreaThumb">
@@ -37,8 +39,12 @@ import {
   flex-direction: column;
 }
 
-.ScrollAreaViewport {
+:deep([data-radix-scroll-area-viewport]) {
   width: 100%;
+  height: 100%;
+}
+
+:deep(.ScrollAreaViewport) {
   height: 100%;
 }
 

--- a/src/components/Base/BaseScrollArea.vue
+++ b/src/components/Base/BaseScrollArea.vue
@@ -39,6 +39,7 @@ import {
   flex-direction: column;
 }
 
+// 親要素のサイズいっぱいに広げさせるためプライベートなデータ属性を使用
 :deep([data-radix-scroll-area-viewport]) {
   width: 100%;
   height: 100%;

--- a/src/components/Base/BaseTextField.stories.ts
+++ b/src/components/Base/BaseTextField.stories.ts
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+
+import BaseTextField from "./BaseTextField.vue";
+
+const meta: Meta<typeof BaseTextField> = {
+  component: BaseTextField,
+};
+
+export default meta;
+type Story = StoryObj<typeof BaseTextField>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "Placeholder",
+    hasError: false,
+    readonly: false,
+    disabled: false,
+  },
+};
+
+export const HasError: Story = {
+  args: {
+    placeholder: "Placeholder",
+    hasError: true,
+    readonly: false,
+    disabled: false,
+  },
+  render: (args) => ({
+    components: { BaseTextField },
+    setup() {
+      return { args };
+    },
+    template: `
+      <BaseTextField v-bind="args">
+        <template #error>
+          ERROR TEXT
+        </template>
+      </BaseTextField>`,
+  }),
+};

--- a/src/components/Base/BaseTextField.stories.ts
+++ b/src/components/Base/BaseTextField.stories.ts
@@ -9,21 +9,29 @@ const meta: Meta<typeof BaseTextField> = {
 export default meta;
 type Story = StoryObj<typeof BaseTextField>;
 
-export const Default: Story = {
+export const Default: Story = {};
+
+export const Placeholder: Story = {
   args: {
     placeholder: "Placeholder",
-    hasError: false,
-    readonly: false,
-    disabled: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    readonly: true,
   },
 };
 
 export const HasError: Story = {
   args: {
-    placeholder: "Placeholder",
     hasError: true,
-    readonly: false,
-    disabled: false,
   },
   render: (args) => ({
     components: { BaseTextField },

--- a/src/components/Base/BaseTextField.vue
+++ b/src/components/Base/BaseTextField.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="wrapper">
+    <input
+      v-model="model"
+      type="text"
+      class="input"
+      :class="{ error: hasError }"
+      :placeholder
+      :readonly
+      :disabled
+    />
+    <div v-if="hasError" class="error-label">
+      <slot name="error" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  placeholder?: string;
+  hasError?: boolean;
+  readonly?: boolean;
+  disabled?: boolean;
+}>();
+
+const model = defineModel<string>();
+</script>
+
+<style scoped lang="scss">
+@use "@/styles/v2/variables" as vars;
+@use "@/styles/v2/colors" as colors;
+@use "@/styles/v2/mixin" as mixin;
+
+.wrapper {
+  width: 100%;
+}
+
+.input {
+  height: vars.$size-control;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: vars.$gap-1;
+  border: 1px solid colors.$border;
+  border-radius: vars.$radius-1;
+  padding-inline: vars.$padding-1;
+  background-color: colors.$control;
+  color: colors.$display;
+
+  &:focus {
+    @include mixin.on-focus;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+  }
+
+  &::placeholder {
+    color: colors.$display-sub;
+  }
+}
+
+.error {
+  border: 2px solid colors.$display-warning;
+}
+
+.error-label {
+  color: colors.$display-warning;
+}
+</style>

--- a/src/components/Base/BaseTextField.vue
+++ b/src/components/Base/BaseTextField.vue
@@ -8,6 +8,7 @@
       :placeholder
       :readonly
       :disabled
+      @click="(payload) => $emit('click', payload)"
     />
     <div v-if="hasError" class="error-label">
       <slot name="error" />
@@ -21,6 +22,10 @@ defineProps<{
   hasError?: boolean;
   readonly?: boolean;
   disabled?: boolean;
+}>();
+
+defineEmits<{
+  click: [payload: MouseEvent];
 }>();
 
 const model = defineModel<string>();

--- a/src/components/Base/BaseToggleGroup.stories.ts
+++ b/src/components/Base/BaseToggleGroup.stories.ts
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+
+import BaseToggleGroup from "./BaseToggleGroup.vue";
+import BaseToggleGroupItem from "./BaseToggleGroupItem.vue";
+
+const meta: Meta<typeof BaseToggleGroup> = {
+  component: BaseToggleGroup,
+};
+
+export default meta;
+type Story = StoryObj<typeof BaseToggleGroup>;
+
+export const Single: Story = {
+  args: {
+    type: "single",
+  },
+  render: (args) => ({
+    components: { BaseToggleGroup, BaseToggleGroupItem },
+    setup() {
+      return { args };
+    },
+    template: `
+      <BaseToggleGroup v-bind="args">
+        <BaseToggleGroupItem label="A" value="a" />
+        <BaseToggleGroupItem label="B" value="B" />
+        <BaseToggleGroupItem label="C" value="C" />
+      </BaseToggleGroup>`,
+  }),
+};
+
+export const Multiple: Story = {
+  args: {
+    type: "multiple",
+  },
+  render: (args) => ({
+    components: { BaseToggleGroup, BaseToggleGroupItem },
+    setup() {
+      return { args };
+    },
+    template: `
+      <BaseToggleGroup v-bind="args">
+        <BaseToggleGroupItem label="A" value="a" />
+        <BaseToggleGroupItem label="B" value="B" />
+        <BaseToggleGroupItem label="C" value="C" />
+      </BaseToggleGroup>`,
+  }),
+};

--- a/src/components/Base/BaseToggleGroup.vue
+++ b/src/components/Base/BaseToggleGroup.vue
@@ -1,0 +1,44 @@
+<template>
+  <ToggleGroupRoot
+    class="ToggleGroup"
+    :type
+    :modelValue
+    :disabled
+    @update:modelValue="
+      (value) => {
+        if (value != undefined) {
+          $emit('update:modelValue', value);
+        }
+      }
+    "
+  >
+    <slot />
+  </ToggleGroupRoot>
+</template>
+
+<script setup lang="ts">
+import { ToggleGroupRoot } from "radix-vue";
+
+defineProps<{
+  type: "single" | "multiple";
+  modelValue: string | string[];
+  disabled?: boolean;
+}>();
+
+defineEmits<{
+  "update:modelValue": [payload: string | string[]];
+}>();
+</script>
+
+<style scoped lang="scss">
+@use "@/styles/v2/variables" as vars;
+@use "@/styles/v2/colors" as colors;
+@use "@/styles/v2/mixin" as mixin;
+
+.ToggleGroup {
+  display: inline-flex;
+  background-color: var(--mauve-6);
+  border-radius: 4px;
+  box-shadow: 0 2px 10px var(--black-a7);
+}
+</style>

--- a/src/components/Base/BaseToggleGroupItem.vue
+++ b/src/components/Base/BaseToggleGroupItem.vue
@@ -1,0 +1,83 @@
+<template>
+  <ToggleGroupItem :value class="ToggleGroupItem">
+    <QIcon class="check" name="check" />
+    {{ label }}
+  </ToggleGroupItem>
+</template>
+
+<script setup lang="ts">
+import { ToggleGroupItem } from "radix-vue";
+
+defineProps<{
+  label: string;
+  value: string;
+}>();
+</script>
+
+<style scoped lang="scss">
+@use "@/styles/v2/variables" as vars;
+@use "@/styles/v2/colors" as colors;
+@use "@/styles/v2/mixin" as mixin;
+
+.ToggleGroupItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: vars.$size-control;
+  padding: 0 vars.$padding-2;
+  gap: vars.$gap-1;
+  border: 1px solid;
+  transition: background-color vars.$transition-duration;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+
+  &:active:not(:disabled) {
+    box-shadow: 0 0 0 transparent;
+  }
+
+  &:focus-visible {
+    @include mixin.on-focus;
+  }
+
+  &:first-child {
+    border-top-left-radius: vars.$radius-1;
+    border-bottom-left-radius: vars.$radius-1;
+  }
+  &:last-child {
+    border-top-right-radius: vars.$radius-1;
+    border-bottom-right-radius: vars.$radius-1;
+  }
+
+  &[data-state="off"] {
+    color: colors.$display;
+    border-color: colors.$border;
+    background-color: colors.$control;
+
+    &:hover:not(:disabled) {
+      background-color: colors.$control-hovered;
+    }
+
+    &:active:not(:disabled) {
+      background-color: colors.$control-pressed;
+    }
+  }
+
+  &[data-state="on"] {
+    color: colors.$display-oncolor;
+    border-color: colors.$border;
+    background-color: colors.$primary;
+
+    &:hover:not(:disabled) {
+      background-color: colors.$primary-hovered;
+    }
+
+    &:active:not(:disabled) {
+      background-color: colors.$primary-pressed;
+    }
+  }
+}
+
+[data-state="off"] > .check {
+  display: none;
+}
+</style>

--- a/src/components/Base/BaseToggleGroupItem.vue
+++ b/src/components/Base/BaseToggleGroupItem.vue
@@ -24,10 +24,10 @@ defineProps<{
   justify-content: space-between;
   align-items: center;
   height: vars.$size-control;
-  padding: 0 vars.$padding-2;
-  gap: vars.$gap-1;
   border: 1px solid;
-  transition: background-color vars.$transition-duration;
+  transition:
+    background-color vars.$transition-duration,
+    padding vars.$transition-duration;
   cursor: pointer;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 
@@ -49,6 +49,8 @@ defineProps<{
   }
 
   &[data-state="off"] {
+    padding: 0
+      calc(#{vars.$padding-1} + (#{vars.$size-icon} + #{vars.$gap-1}) / 2);
     color: colors.$display;
     border-color: colors.$border;
     background-color: colors.$control;
@@ -63,6 +65,7 @@ defineProps<{
   }
 
   &[data-state="on"] {
+    padding: 0 vars.$padding-1;
     color: colors.$display-oncolor;
     border-color: colors.$border;
     background-color: colors.$primary;
@@ -77,7 +80,20 @@ defineProps<{
   }
 }
 
+.check {
+  width: vars.$size-icon;
+  height: vars.$size-icon;
+  opacity: 1;
+  margin-right: vars.$gap-1;
+  transition:
+    width vars.$transition-duration,
+    margin-right vars.$transition-duration,
+    opacity vars.$transition-duration;
+}
+
 [data-state="off"] > .check {
-  display: none;
+  width: 0;
+  opacity: 0;
+  margin-right: 0;
 }
 </style>

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -132,7 +132,7 @@
                         newEngineDirValidationState != undefined &&
                         newEngineDirValidationState !== 'ok'
                       "
-                      @click="selectVvppFile"
+                      @click="selectEngineDir"
                     >
                       <template #error>
                         {{

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -48,42 +48,40 @@
                 @click="toAddEngineState"
               />
             </div>
-            <div class="list">
-              <template
-                v-for="([type, engineIds], i) in Object.entries(
-                  categorizedEngineIds,
-                )"
-                :key="`engine-list-${i}`"
+            <template
+              v-for="([type, engineIds], i) in Object.entries(
+                categorizedEngineIds,
+              )"
+              :key="`engine-list-${i}`"
+            >
+              <div class="list-label">
+                {{ getEngineTypeName(type) }}
+              </div>
+              <BaseListItem
+                v-for="id in engineIds"
+                :key="id"
+                :selected="selectedId === id"
+                @click="selectEngine(id)"
               >
-                <div class="list-label">
-                  {{ getEngineTypeName(type) }}
+                <img
+                  v-if="engineIcons[id]"
+                  class="listitem-icon"
+                  :src="engineIcons[id]"
+                  :alt="engineInfos[id].name"
+                />
+                <div v-else class="listitem-unknown">?</div>
+                <div class="listitem-content">
+                  {{ engineInfos[id].name }}
+                  <span caption class="listitem-path">
+                    {{
+                      engineManifests[id] != undefined
+                        ? engineManifests[id].brandName
+                        : engineInfos[id].uuid
+                    }}
+                  </span>
                 </div>
-                <BaseListItem
-                  v-for="id in engineIds"
-                  :key="id"
-                  :selected="selectedId === id"
-                  @click="selectEngine(id)"
-                >
-                  <img
-                    v-if="engineIcons[id]"
-                    class="listitem-icon"
-                    :src="engineIcons[id]"
-                    :alt="engineInfos[id].name"
-                  />
-                  <div v-else class="listitem-unknown">?</div>
-                  <div class="listitem-content">
-                    {{ engineInfos[id].name }}
-                    <span caption class="listitem-path">
-                      {{
-                        engineManifests[id] != undefined
-                          ? engineManifests[id].brandName
-                          : engineInfos[id].uuid
-                      }}
-                    </span>
-                  </div>
-                </BaseListItem>
-              </template>
-            </div>
+              </BaseListItem>
+            </template>
           </template>
           <div v-if="isAddingEngine" class="detail">
             <BaseScrollArea>
@@ -93,7 +91,7 @@
                   <BaseToggleGroupItem label="VVPPファイル" value="vvpp" />
                   <BaseToggleGroupItem label="既存エンジン" value="dir" />
                 </BaseToggleGroup>
-                <div v-if="engineLoaderType === 'vvpp'">
+                <section v-if="engineLoaderType === 'vvpp'" class="section">
                   <div>VVPPファイルでエンジンをインストールします。</div>
                   <div class="flex-row">
                     <BaseTextField
@@ -104,6 +102,7 @@
                         newEngineDirValidationState != undefined &&
                         newEngineDirValidationState !== 'ok'
                       "
+                      @click="selectVvppFile"
                     >
                       <template #error>
                         {{
@@ -121,8 +120,8 @@
                       @click="selectVvppFile"
                     />
                   </div>
-                </div>
-                <div v-if="engineLoaderType === 'dir'">
+                </section>
+                <section v-if="engineLoaderType === 'dir'" class="section">
                   <div>PC内にあるエンジンを追加します。</div>
                   <div class="flex-row">
                     <BaseTextField
@@ -133,6 +132,7 @@
                         newEngineDirValidationState != undefined &&
                         newEngineDirValidationState !== 'ok'
                       "
+                      @click="selectVvppFile"
                     >
                       <template #error>
                         {{
@@ -150,7 +150,7 @@
                       @click="selectEngineDir"
                     />
                   </div>
-                </div>
+                </section>
                 <div class="footer">
                   <BaseButton label="キャンセル" @click="toInitialState" />
                   <BaseButton
@@ -178,7 +178,7 @@
                   {{ engineInfos[selectedId].name }}
                 </div>
 
-                <div>
+                <section class="section">
                   <ul>
                     <li>
                       バージョン：{{
@@ -199,8 +199,8 @@
                       <span v-else>（取得に失敗しました）</span>
                     </li>
                   </ul>
-                </div>
-                <div>
+                </section>
+                <section class="section">
                   <div class="headline">機能</div>
                   <ul
                     v-if="
@@ -222,21 +222,23 @@
                     </li>
                   </ul>
                   <span v-else>（取得に失敗しました）</span>
-                </div>
-                <div class="headline">場所</div>
-                <div class="flex-row">
-                  <BaseTextField
-                    v-model="engineDir"
-                    :disabled="uiLocked || !engineInfos[selectedId].path"
-                    readonly
-                  />
-                  <BaseButton
-                    icon="folder_open"
-                    label="フォルダを開く"
-                    :disabled="uiLocked || !engineInfos[selectedId].path"
-                    @click="openSelectedEngineDirectory"
-                  />
-                </div>
+                </section>
+                <section class="section">
+                  <div class="headline">場所</div>
+                  <div class="flex-row">
+                    <BaseTextField
+                      v-model="engineDir"
+                      :disabled="uiLocked || !engineInfos[selectedId].path"
+                      readonly
+                    />
+                    <BaseButton
+                      icon="folder_open"
+                      label="フォルダを開く"
+                      :disabled="uiLocked || !engineInfos[selectedId].path"
+                      @click="openSelectedEngineDirectory"
+                    />
+                  </div>
+                </section>
                 <div class="footer">
                   <BaseButton
                     label="削除"
@@ -688,7 +690,7 @@ const toDialogClosedState = () => {
   display: flex;
   flex-direction: column;
   padding: newvars.$padding-2;
-  gap: newvars.$gap-1;
+  gap: newvars.$gap-2;
 }
 
 .engine-title {
@@ -732,5 +734,15 @@ const toDialogClosedState = () => {
   margin-top: auto;
   display: flex;
   justify-content: flex-end;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: newvars.$gap-1;
+}
+
+:deep(ul) {
+  margin: 0;
 }
 </style>

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -590,8 +590,7 @@ const toDialogClosedState = () => {
 
 <style lang="scss" scoped>
 @use "@/styles/colors" as colors;
-@use "@/styles/variables" as vars;
-@use "@/styles/v2/variables" as newvars;
+@use "@/styles/v2/variables" as vars;
 @use "@/styles/v2/mixin" as mixin;
 @use "@/styles/v2/colors" as newcolors;
 
@@ -602,7 +601,7 @@ const toDialogClosedState = () => {
 
 .list-header {
   display: flex;
-  gap: newvars.$gap-1;
+  gap: vars.$gap-1;
   align-items: center;
   justify-content: space-between;
 }
@@ -612,14 +611,14 @@ const toDialogClosedState = () => {
 }
 
 .listitem-icon {
-  margin-right: newvars.$gap-1;
-  border-radius: newvars.$radius-1;
+  margin-right: vars.$gap-1;
+  border-radius: vars.$radius-1;
   width: 32px;
 }
 
 .listitem-unknown {
-  margin-right: newvars.$gap-1;
-  border-radius: newvars.$radius-1;
+  margin-right: vars.$gap-1;
+  border-radius: vars.$radius-1;
   background-color: colors.$primary;
   display: grid;
   place-content: center;
@@ -677,26 +676,26 @@ const toDialogClosedState = () => {
   min-height: 100%;
   display: flex;
   flex-direction: column;
-  padding: newvars.$padding-2;
-  gap: newvars.$gap-2;
+  padding: vars.$padding-2;
+  gap: vars.$gap-2;
 }
 
 .engine-title {
   display: flex;
   align-items: center;
-  gap: newvars.$gap-1;
+  gap: vars.$gap-1;
 }
 
 .engine-icon {
   width: 40px;
   height: 40px;
-  border-radius: newvars.$radius-1;
+  border-radius: vars.$radius-1;
 }
 
 .engine-unknown {
   width: 40px;
   height: 40px;
-  border-radius: newvars.$radius-1;
+  border-radius: vars.$radius-1;
   background-color: colors.$primary;
   display: grid;
   place-content: center;
@@ -714,11 +713,11 @@ const toDialogClosedState = () => {
 .flex-row {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: newvars.$gap-1;
+  gap: vars.$gap-1;
 }
 
 .footer {
-  gap: newvars.$gap-1;
+  gap: vars.$gap-1;
   margin-top: auto;
   display: flex;
   justify-content: flex-end;
@@ -727,7 +726,7 @@ const toDialogClosedState = () => {
 .section {
   display: flex;
   flex-direction: column;
-  gap: newvars.$gap-1;
+  gap: vars.$gap-1;
 }
 
 :deep(ul) {

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -40,7 +40,7 @@
           <template #sidebar>
             <div v-if="isAddingEngine" class="list-disable-overlay" />
             <div class="list-header">
-              <div class="header-title">エンジン一覧</div>
+              <div class="list-title">エンジン一覧</div>
               <BaseButton
                 label="追加"
                 icon="add"
@@ -595,17 +595,6 @@ const toDialogClosedState = () => {
 @use "@/styles/v2/mixin" as mixin;
 @use "@/styles/v2/colors" as newcolors;
 
-.list-disable-overlay {
-  background-color: rgba($color: #000000, $alpha: 0.4);
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-}
-
-.header-title {
-  @include mixin.headline-2;
-}
-
 .list {
   display: flex;
   flex-direction: column;
@@ -616,6 +605,10 @@ const toDialogClosedState = () => {
   gap: newvars.$gap-1;
   align-items: center;
   justify-content: space-between;
+}
+
+.list-title {
+  @include mixin.headline-2;
 }
 
 .listitem-icon {
@@ -652,16 +645,11 @@ const toDialogClosedState = () => {
   color: newcolors.$display-sub;
 }
 
-.active-engine {
-  background: rgba(colors.$primary-rgb, 0.4);
-}
-
-.engine-list-disable-overlay {
+.list-disable-overlay {
   background-color: rgba($color: #000000, $alpha: 0.4);
-  width: 100%;
-  height: 100%;
   position: absolute;
-  z-index: 10;
+  inset: 0;
+  z-index: 1;
 }
 
 .ui-lock-popup {

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -6,7 +6,7 @@
     transitionHide="jump-down"
     class="setting-dialog transparent-backdrop"
   >
-    <QLayout container view="hHh Lpr fFf" class="bg-background">
+    <QLayout>
       <QPageContainer>
         <QHeader class="q-pa-sm">
           <QToolbar>
@@ -23,320 +23,241 @@
             />
           </QToolbar>
         </QHeader>
-        <QPage class="row">
-          <div v-if="uiLockedState" class="ui-lock-popup">
-            <div class="q-pa-md">
-              <QSpinner color="primary" size="2.5rem" />
-              <div class="q-mt-xs">
-                <template v-if="uiLockedState === 'addingEngine'"
-                  >追加中・・・</template
-                >
-                <template v-if="uiLockedState === 'deletingEngine'"
-                  >削除中・・・</template
-                >
-              </div>
+        <div v-if="uiLockedState" class="ui-lock-popup">
+          <div class="q-pa-md">
+            <QSpinner color="primary" size="2.5rem" />
+            <div class="q-mt-xs">
+              <template v-if="uiLockedState === 'addingEngine'"
+                >追加中・・・</template
+              >
+              <template v-if="uiLockedState === 'deletingEngine'"
+                >削除中・・・</template
+              >
             </div>
           </div>
-          <div class="col-4 engine-list-col">
-            <div v-if="isAddingEngine" class="engine-list-disable-overlay" />
-            <div class="engine-list-header text-no-wrap">
-              <div class="row engine-list-title text-h5">エンジン一覧</div>
-              <div class="row no-wrap">
-                <QBtn
-                  outline
-                  textColor="display"
-                  class="text-no-wrap text-bold col-sm q-ma-sm"
-                  :disable="uiLocked"
-                  @click="toAddEngineState"
-                  >追加</QBtn
-                >
-              </div>
+        </div>
+        <BaseNavigationView>
+          <template #sidebar>
+            <div v-if="isAddingEngine" class="list-disable-overlay" />
+            <div class="list-header">
+              <div class="header-title">エンジン一覧</div>
+              <BaseButton
+                label="追加"
+                icon="add"
+                :disable="uiLocked"
+                @click="toAddEngineState"
+              />
             </div>
-            <QList class="engine-list">
+            <div class="list">
               <template
                 v-for="([type, engineIds], i) in Object.entries(
                   categorizedEngineIds,
                 )"
                 :key="`engine-list-${i}`"
               >
-                <QSeparator v-if="i > 0" spaced />
-                <QItemLabel header> {{ getEngineTypeName(type) }}</QItemLabel>
-                <QItem
+                <div class="list-label">
+                  {{ getEngineTypeName(type) }}
+                </div>
+                <BaseListItem
                   v-for="id in engineIds"
                   :key="id"
-                  v-ripple
-                  tag="label"
-                  clickable
-                  :active="selectedId === id"
-                  activeClass="active-engine"
+                  :selected="selectedId === id"
                   @click="selectEngine(id)"
                 >
-                  <QItemSection avatar>
-                    <QAvatar rounded color="primary">
-                      <img
-                        v-if="engineIcons[id]"
-                        :src="engineIcons[id]"
-                        :alt="engineInfos[id].name"
-                      />
-                      <span v-else class="text-display-on-primary"> ? </span>
-                    </QAvatar>
-                  </QItemSection>
-                  <QItemSection>
-                    <QItemLabel class="text-display">{{
-                      engineInfos[id].name
-                    }}</QItemLabel>
-                    <QItemLabel caption class="engine-path">{{
-                      engineManifests[id] != undefined
-                        ? engineManifests[id].brandName
-                        : engineInfos[id].uuid
-                    }}</QItemLabel>
-                  </QItemSection>
-                </QItem>
+                  <img
+                    v-if="engineIcons[id]"
+                    class="listitem-icon"
+                    :src="engineIcons[id]"
+                    :alt="engineInfos[id].name"
+                  />
+                  <div v-else class="listitem-unknown">?</div>
+                  <div class="listitem-content">
+                    {{ engineInfos[id].name }}
+                    <span caption class="listitem-path">
+                      {{
+                        engineManifests[id] != undefined
+                          ? engineManifests[id].brandName
+                          : engineInfos[id].uuid
+                      }}
+                    </span>
+                  </div>
+                </BaseListItem>
               </template>
-            </QList>
-          </div>
-
-          <!-- 右側のpane -->
-          <div
-            v-if="isAddingEngine"
-            class="col-8 no-wrap text-no-wrap engine-detail"
-          >
-            <div class="q-pl-md q-mt-md">
-              <div class="text-h5 q-ma-sm">エンジンの追加</div>
-
-              <div class="q-ma-sm">
-                <QBtnToggle
-                  v-model="engineLoaderType"
-                  :options="[
-                    { value: 'vvpp', label: 'VVPPファイル' },
-                    { value: 'dir', label: '既存エンジン' },
-                  ]"
-                  color="surface"
-                  unelevated
-                  textColor="display"
-                  toggleColor="primary"
-                  toggleTextColor="display-on-primary"
-                />
-              </div>
             </div>
-
-            <div v-if="engineLoaderType === 'vvpp'" class="no-wrap q-pl-md">
-              <div class="q-ma-sm">
-                VVPPファイルでエンジンをインストールします。
-              </div>
-              <div class="q-ma-sm">
-                <QInput
-                  ref="vvppFilePathInput"
-                  v-model="vvppFilePath"
-                  dense
-                  readonly
-                  placeholder="VVPPファイルの場所"
-                  @click="selectVvppFile"
-                >
-                  <template #append>
-                    <QBtn
-                      square
-                      dense
-                      flat
-                      color="primary"
+          </template>
+          <div v-if="isAddingEngine" class="detail">
+            <BaseScrollArea>
+              <div class="inner">
+                <div class="title">エンジンの追加</div>
+                <BaseToggleGroup v-model="engineLoaderType" type="single">
+                  <BaseToggleGroupItem label="VVPPファイル" value="vvpp" />
+                  <BaseToggleGroupItem label="既存エンジン" value="dir" />
+                </BaseToggleGroup>
+                <div v-if="engineLoaderType === 'vvpp'">
+                  <div>VVPPファイルでエンジンをインストールします。</div>
+                  <div class="flex-row">
+                    <BaseTextField
+                      v-model="vvppFilePath"
+                      placeholder="VVPPファイルの場所"
+                      readonly
+                      :hasError="
+                        newEngineDirValidationState != undefined &&
+                        newEngineDirValidationState !== 'ok'
+                      "
+                    >
+                      <template #error>
+                        {{
+                          newEngineDirValidationState
+                            ? getEngineDirValidationMessage(
+                                newEngineDirValidationState,
+                              )
+                            : undefined
+                        }}
+                      </template>
+                    </BaseTextField>
+                    <BaseButton
+                      label="ファイル選択"
                       icon="folder_open"
                       @click="selectVvppFile"
+                    />
+                  </div>
+                </div>
+                <div v-if="engineLoaderType === 'dir'">
+                  <div>PC内にあるエンジンを追加します。</div>
+                  <div class="flex-row">
+                    <BaseTextField
+                      v-model="newEngineDir"
+                      placeholder="エンジンフォルダの場所"
+                      readonly
+                      :hasError="
+                        newEngineDirValidationState != undefined &&
+                        newEngineDirValidationState !== 'ok'
+                      "
                     >
-                      <QTooltip :delay="500" anchor="bottom left">
-                        ファイル選択
-                      </QTooltip>
-                    </QBtn>
-                  </template>
-                  <template #error>
-                    {{
-                      newEngineDirValidationState
-                        ? getEngineDirValidationMessage(
-                            newEngineDirValidationState,
-                          )
-                        : undefined
-                    }}
-                  </template>
-                </QInput>
-              </div>
-            </div>
-            <div v-if="engineLoaderType === 'dir'" class="no-wrap q-pl-md">
-              <div class="q-ma-sm">PC内にあるエンジンを追加します。</div>
-              <div class="q-ma-sm">
-                <QInput
-                  ref="newEngineDirInput"
-                  v-model="newEngineDir"
-                  dense
-                  readonly
-                  :error="
-                    newEngineDirValidationState != undefined &&
-                    newEngineDirValidationState !== 'ok'
-                  "
-                  placeholder="エンジンフォルダの場所"
-                  @click="selectEngineDir"
-                >
-                  <template #append>
-                    <QBtn
-                      square
-                      dense
-                      flat
-                      color="primary"
+                      <template #error>
+                        {{
+                          newEngineDirValidationState
+                            ? getEngineDirValidationMessage(
+                                newEngineDirValidationState,
+                              )
+                            : undefined
+                        }}
+                      </template>
+                    </BaseTextField>
+                    <BaseButton
+                      label="フォルダ選択"
                       icon="folder_open"
                       @click="selectEngineDir"
+                    />
+                  </div>
+                </div>
+                <div class="footer">
+                  <BaseButton label="キャンセル" @click="toInitialState" />
+                  <BaseButton
+                    label="追加"
+                    icon="add"
+                    variant="primary"
+                    :disabled="!canAddEngine"
+                    @click="addEngine"
+                  />
+                </div>
+              </div>
+            </BaseScrollArea>
+          </div>
+          <div v-else-if="selectedId" class="detail">
+            <BaseScrollArea>
+              <div class="inner">
+                <div class="engine-title title">
+                  <img
+                    v-if="selectedId in engineIcons"
+                    :src="engineIcons[selectedId]"
+                    :alt="engineInfos[selectedId].name"
+                    class="engine-icon"
+                  />
+                  <div v-else class="engine-unknown">?</div>
+                  {{ engineInfos[selectedId].name }}
+                </div>
+
+                <div>
+                  <ul>
+                    <li>
+                      バージョン：{{
+                        engineVersions[selectedId]
+                          ? engineVersions[selectedId]
+                          : "（取得に失敗しました）"
+                      }}
+                    </li>
+                    <li>
+                      URL：
+                      <a
+                        v-if="engineManifests[selectedId]"
+                        :href="engineManifests[selectedId].url"
+                        class="text-display-hyperlink"
+                        target="_blank"
+                        >{{ engineManifests[selectedId].url }}</a
+                      >
+                      <span v-else>（取得に失敗しました）</span>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <div class="headline">機能</div>
+                  <ul
+                    v-if="
+                      engineManifests[selectedId] &&
+                      engineManifests[selectedId].supportedFeatures
+                    "
+                  >
+                    <li
+                      v-for="(value, feature) in engineManifests[selectedId]
+                        .supportedFeatures != null
+                        ? engineManifests[selectedId].supportedFeatures
+                        : null"
+                      :key="feature"
+                      :class="value ? '' : 'text-warning'"
                     >
-                      <QTooltip :delay="500" anchor="bottom left">
-                        フォルダ選択
-                      </QTooltip>
-                    </QBtn>
-                  </template>
-                  <template #error>
-                    {{
-                      newEngineDirValidationState
-                        ? getEngineDirValidationMessage(
-                            newEngineDirValidationState,
-                          )
-                        : undefined
-                    }}
-                  </template>
-                </QInput>
-              </div>
-            </div>
-            <div class="row q-px-md right-pane-buttons">
-              <QSpace />
-
-              <QBtn
-                outline
-                textColor="display"
-                class="text-no-wrap text-bold q-mr-sm"
-                @click="toInitialState"
-                >キャンセル</QBtn
-              >
-              <QBtn
-                outline
-                textColor="display"
-                class="text-no-wrap text-bold q-mr-sm"
-                :disabled="!canAddEngine"
-                @click="addEngine"
-                >追加</QBtn
-              >
-            </div>
-          </div>
-          <div
-            v-else-if="selectedId"
-            class="col-8 no-wrap text-no-wrap engine-detail"
-          >
-            <div class="q-pl-md q-mt-md flex">
-              <img
-                v-if="selectedId in engineIcons"
-                :src="engineIcons[selectedId]"
-                :alt="engineInfos[selectedId].name"
-                class="engine-icon"
-              />
-              <div v-else class="q-mt-sm inline-block">
-                <QAvatar rounded color="primary" size="2rem">
-                  <span class="text-display-on-primary"> ? </span>
-                </QAvatar>
-              </div>
-              <div class="text-h5 q-ma-sm">
-                {{ engineInfos[selectedId].name }}
-              </div>
-            </div>
-
-            <div class="no-wrap q-pl-md">
-              <ul>
-                <li>
-                  バージョン：{{
-                    engineVersions[selectedId]
-                      ? engineVersions[selectedId]
-                      : "（取得に失敗しました）"
-                  }}
-                </li>
-                <li>
-                  URL：
-                  <a
-                    v-if="engineManifests[selectedId]"
-                    :href="engineManifests[selectedId].url"
-                    class="text-display-hyperlink"
-                    target="_blank"
-                    >{{ engineManifests[selectedId].url }}</a
-                  >
+                      {{ getFeatureName(feature) }}：{{
+                        value ? "対応" : "非対応"
+                      }}
+                    </li>
+                  </ul>
                   <span v-else>（取得に失敗しました）</span>
-                </li>
-              </ul>
-            </div>
-            <div class="no-wrap q-pl-md">
-              <div class="text-h6 q-ma-sm">機能</div>
-              <ul
-                v-if="
-                  engineManifests[selectedId] &&
-                  engineManifests[selectedId].supportedFeatures
-                "
-              >
-                <template
-                  v-for="(value, feature) in engineManifests[selectedId]
-                    .supportedFeatures != null
-                    ? engineManifests[selectedId].supportedFeatures
-                    : null"
-                  :key="feature"
-                >
-                  <!-- TODO: vvlib機能がリリースされたらmanageLibraryも表示するようにする -->
-                  <li
-                    v-if="feature != 'manageLibrary'"
-                    :class="value ? '' : 'text-warning'"
-                  >
-                    {{ getFeatureName(feature) }}：{{
-                      value ? "対応" : "非対応"
-                    }}
-                  </li>
-                </template>
-              </ul>
-              <span v-else>（取得に失敗しました）</span>
-            </div>
-            <div class="no-wrap q-pl-md">
-              <div class="text-h6 q-ma-sm">場所</div>
-              <div
-                :class="
-                  'q-ma-sm' + (engineInfos[selectedId].path ? '' : ' disabled')
-                "
-              >
-                <QInput
-                  ref="pathInput"
-                  v-model="engineDir"
-                  disabled
-                  dense
-                  readonly
-                />
+                </div>
+                <div class="headline">場所</div>
+                <div class="flex-row">
+                  <BaseTextField
+                    v-model="engineDir"
+                    :disabled="uiLocked || !engineInfos[selectedId].path"
+                    readonly
+                  />
+                  <BaseButton
+                    icon="folder_open"
+                    label="フォルダを開く"
+                    :disabled="uiLocked || !engineInfos[selectedId].path"
+                    @click="openSelectedEngineDirectory"
+                  />
+                </div>
+                <div class="footer">
+                  <BaseButton
+                    label="削除"
+                    icon="delete_outline"
+                    :disabled="uiLocked || engineInfos[selectedId].isDefault"
+                    variant="danger"
+                    @click="deleteEngine"
+                  />
+                  <BaseButton
+                    label="再起動"
+                    icon="refresh"
+                    :disabled="
+                      uiLocked || engineStates[selectedId] === 'STARTING'
+                    "
+                    @click="restartSelectedEngine"
+                  />
+                </div>
               </div>
-            </div>
-            <div class="row q-px-md right-pane-buttons">
-              <QSpace />
-
-              <QBtn
-                outline
-                textColor="warning"
-                class="text-no-wrap text-bold q-mr-sm"
-                :disable="uiLocked || engineInfos[selectedId].isDefault"
-                @click="deleteEngine"
-                >削除</QBtn
-              >
-              <QBtn
-                outline
-                textColor="display"
-                class="text-no-wrap text-bold q-mr-sm"
-                :disable="uiLocked || !engineInfos[selectedId].path"
-                @click="openSelectedEngineDirectory"
-                >フォルダを開く</QBtn
-              >
-              <QBtn
-                outline
-                textColor="display"
-                class="text-no-wrap text-bold q-mr-sm"
-                :disable="uiLocked || engineStates[selectedId] === 'STARTING'"
-                @click="restartSelectedEngine"
-                >再起動</QBtn
-              >
-            </div>
+            </BaseScrollArea>
           </div>
-        </QPage>
+        </BaseNavigationView>
       </QPageContainer>
     </QLayout>
   </QDialog>
@@ -344,6 +265,13 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import BaseToggleGroup from "../Base/BaseToggleGroup.vue";
+import BaseToggleGroupItem from "../Base/BaseToggleGroupItem.vue";
+import BaseButton from "@/components/Base/BaseButton.vue";
+import BaseListItem from "@/components/Base/BaseListItem.vue";
+import BaseNavigationView from "@/components/Base/BaseNavigationView.vue";
+import BaseTextField from "@/components/Base/BaseTextField.vue";
+import BaseScrollArea from "@/components/Base/BaseScrollArea.vue";
 import { useStore } from "@/store";
 import { EngineDirValidationResult, EngineId } from "@/type/preload";
 import type { SupportedFeatures } from "@/openapi/models/SupportedFeatures";
@@ -661,37 +589,65 @@ const toDialogClosedState = () => {
 <style lang="scss" scoped>
 @use "@/styles/colors" as colors;
 @use "@/styles/variables" as vars;
+@use "@/styles/v2/variables" as newvars;
+@use "@/styles/v2/mixin" as mixin;
+@use "@/styles/v2/colors" as newcolors;
 
-.engine-list-col {
-  border-right: solid 1px colors.$surface;
-  position: relative; // オーバーレイのため
-  overflow-x: hidden;
+.list-disable-overlay {
+  background-color: rgba($color: #000000, $alpha: 0.4);
+  position: absolute;
+  inset: 0;
+  z-index: 1;
 }
 
-.engine-list-header {
-  margin: 1rem;
+.header-title {
+  @include mixin.headline-2;
+}
 
-  gap: 0.5rem;
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.list-header {
+  display: flex;
+  gap: newvars.$gap-1;
   align-items: center;
   justify-content: space-between;
-  .engine-list-title {
-    flex-grow: 1;
-  }
 }
 
-.engine-list {
-  // menubar-height + toolbar-height + window-border-width +
-  // 82(title & buttons) + 30(margin 15x2)
-  height: calc(
-    100vh - #{vars.$menubar-height + vars.$toolbar-height +
-      vars.$window-border-width + 82px + 30px}
-  );
-  width: 100%;
-  overflow-y: auto;
+.listitem-icon {
+  margin-right: newvars.$gap-1;
+  border-radius: newvars.$radius-1;
+  width: 32px;
 }
 
-.engine-path {
+.listitem-unknown {
+  margin-right: newvars.$gap-1;
+  border-radius: newvars.$radius-1;
+  background-color: colors.$primary;
+  display: grid;
+  place-content: center;
+  font-weight: 700;
+  width: 32px;
+  height: 32px;
+}
+
+.listitem-content {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+}
+
+.listitem-path {
+  font-size: 0.75rem;
   overflow-wrap: break-word;
+}
+
+.list-label {
+  padding: 8px 16px;
+  padding-top: 16px;
+  color: newcolors.$display-sub;
 }
 
 .active-engine {
@@ -704,31 +660,6 @@ const toDialogClosedState = () => {
   height: 100%;
   position: absolute;
   z-index: 10;
-}
-
-.engine-detail {
-  display: flex;
-  flex-flow: column;
-  height: calc(
-    100vh - #{vars.$menubar-height + vars.$toolbar-height +
-      vars.$window-border-width}
-  ) !important;
-  overflow: auto;
-}
-
-.right-pane-buttons {
-  padding: 20px;
-
-  display: flex;
-  flex: 1;
-  align-items: flex-end;
-}
-
-.engine-icon {
-  height: 2rem;
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-  border-radius: 5px;
 }
 
 .ui-lock-popup {
@@ -746,5 +677,60 @@ const toDialogClosedState = () => {
     background: colors.$background;
     border-radius: 6px;
   }
+}
+
+.detail {
+  height: 100%;
+}
+
+.inner {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: newvars.$padding-2;
+  gap: newvars.$gap-1;
+}
+
+.engine-title {
+  display: flex;
+  align-items: center;
+  gap: newvars.$gap-1;
+}
+
+.engine-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: newvars.$radius-1;
+}
+
+.engine-unknown {
+  width: 40px;
+  height: 40px;
+  border-radius: newvars.$radius-1;
+  background-color: colors.$primary;
+  display: grid;
+  place-content: center;
+  font-weight: 700;
+}
+
+.title {
+  @include mixin.headline-1;
+}
+
+.headline {
+  @include mixin.headline-2;
+}
+
+.flex-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: newvars.$gap-1;
+}
+
+.footer {
+  gap: newvars.$gap-1;
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
 }
 </style>


### PR DESCRIPTION
## 内容

エンジンの管理ダイアログをリデザインします。具体的に以下を行います。

- 必要なBaseコンポーネント（BaseToggleGroup, BaseNavigationView, BaseTextField）の追加
- 追加したBaseコンポーネントのstoriesファイルを追加
- BaseScrollAreaで親のheightの100%が伝搬できるように変更
  - ダイアログのフッター部の下固定をできるようにするため

## スクリーンショット・動画など

![image](https://github.com/user-attachments/assets/cf357757-ef3f-4f51-b1ee-3f12208bfaee)
![image](https://github.com/user-attachments/assets/96e4c1c7-7a71-4f5d-b1a1-aaef62a07dc1)
