### PR TITLE
refactoring: AltPortInfosの定義場所を移動する

### DIFF
--- a/src/backend/electron/manager/engineManager.ts
+++ b/src/backend/electron/manager/engineManager.ts
@@ -16,6 +16,7 @@ import {
 } from "./portManager";
 
 import {
+  AltPortInfos,
   EngineInfo,
   EngineDirValidationResult,
   MinimumEngineManifestType,
@@ -23,7 +24,6 @@ import {
   minimumEngineManifestSchema,
   envEngineInfoSchema,
 } from "@/type/preload";
-import { AltPortInfos } from "@/store/type";
 import { BaseConfigManager } from "@/backend/common/ConfigManager";
 
 type EngineProcessContainer = {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -55,6 +55,7 @@ import {
   NoteId,
   CommandId,
   TrackId,
+  AltPortInfos,
 } from "@/type/preload";
 import { IEngineConnectorFactory } from "@/infrastructures/EngineConnector";
 import {
@@ -103,9 +104,6 @@ export type Command = {
 };
 
 export type EngineState = "STARTING" | "FAILED_STARTING" | "ERROR" | "READY";
-
-// ポートが塞がれていたときの代替ポート情報
-export type AltPortInfos = Record<EngineId, { from: number; to: number }>;
 
 export type SaveResult =
   | "SUCCESS"

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -11,8 +11,8 @@ import {
   EngineSettingType,
   EngineId,
   MessageBoxReturnValue,
+  AltPortInfos,
 } from "@/type/preload";
-import { AltPortInfos } from "@/store/type";
 import { Result } from "@/type/result";
 
 /**

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { IpcSOData } from "./ipc";
-import { AltPortInfos } from "@/store/type";
 import { Result } from "@/type/result";
 
 export const isProduction = import.meta.env.MODE === "production";
@@ -208,6 +207,9 @@ export const defaultToolbarButtonSetting: ToolbarSettingType = [
   "UNDO",
   "REDO",
 ];
+
+// ポートが塞がれていたときの代替ポート情報
+export type AltPortInfos = Record<EngineId, { from: number; to: number }>;
 
 export interface Sandbox {
   getAppInfos(): Promise<AppInfos>;


### PR DESCRIPTION
## 内容

`AltPortInfos`の定義場所が`@/store/type.ts`になっていて、`@/type/preload.ts`と相互importになってしまっていたので、`@/type/preload.ts`内に移しました。

## その他

とりあえず相互importを解決するために移動してみたけど、どこにあるのがふさわしいのか若干わからない･･･。
少なくとも`store/type.ts`ではないとは思うけど･･･。
