### PR TITLE
refactor: エンジンとVVPP周りの処理の流れを制御するクラスを切り出し

### DIFF
--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -1,0 +1,203 @@
+import log from "electron-log/main";
+import { BrowserWindow, dialog } from "electron";
+
+import EngineInfoManager from "./manager/engineInfoManager";
+import EngineProcessManager from "./manager/engineProcessManager";
+import VvppManager from "./manager/vvppManager";
+import { RuntimeInfoManager } from "./manager/RuntimeInfoManager";
+import { ElectronConfigManager } from "./electronConfig";
+import { EngineId, EngineInfo, engineSettingSchema } from "@/type/preload";
+
+/**
+ * エンジンとVVPP周りの処理の流れを制御するクラス。
+ */
+export class EngineAndVvppController {
+  constructor(
+    private runtimeInfoManager: RuntimeInfoManager,
+    private configManager: ElectronConfigManager,
+    private engineInfoManager: EngineInfoManager,
+    private engineProcessManager: EngineProcessManager,
+    private vvppManager: VvppManager,
+  ) {}
+
+  /**
+   * VVPPエンジンをインストールする。
+   */
+  async installVvppEngine(vvppPath: string) {
+    try {
+      await this.vvppManager.install(vvppPath);
+      return true;
+    } catch (e) {
+      dialog.showErrorBox(
+        "インストールエラー",
+        `${vvppPath} をインストールできませんでした。`,
+      );
+      log.error(`Failed to install ${vvppPath},`, e);
+      return false;
+    }
+  }
+
+  /**
+   * 危険性を案内してからVVPPエンジンをインストールする。
+   * FIXME: こちらで案内せず、GUIでのインストール側に合流させる
+   */
+  async installVvppEngineWithWarning({
+    vvppPath,
+    reloadNeeded,
+    reloadCallback,
+    win,
+  }: {
+    vvppPath: string;
+    reloadNeeded: boolean;
+    reloadCallback?: () => void; // 再読み込みが必要な場合のコールバック
+    win: BrowserWindow; // dialog表示に必要。 FIXME: dialog表示関数をDI可能にし、winを削除する
+  }) {
+    const result = dialog.showMessageBoxSync(win, {
+      type: "warning",
+      title: "エンジン追加の確認",
+      message: `この操作はコンピュータに損害を与える可能性があります。エンジンの配布元が信頼できない場合は追加しないでください。`,
+      buttons: ["追加", "キャンセル"],
+      noLink: true,
+      cancelId: 1,
+    });
+    if (result == 1) {
+      return;
+    }
+
+    await this.installVvppEngine(vvppPath);
+
+    if (reloadNeeded) {
+      void dialog
+        .showMessageBox(win, {
+          type: "info",
+          title: "再読み込みが必要です",
+          message:
+            "VVPPファイルを読み込みました。反映には再読み込みが必要です。今すぐ再読み込みしますか？",
+          buttons: ["再読み込み", "キャンセル"],
+          noLink: true,
+          cancelId: 1,
+        })
+        .then((result) => {
+          if (result.response === 0) {
+            reloadCallback?.();
+          }
+        });
+    }
+  }
+
+  /**
+   * VVPPエンジンをアンインストールする。
+   * 関数を呼んだタイミングでアンインストール処理を途中まで行い、アプリ終了時に完遂する。
+   */
+  async uninstallVvppEngine(engineId: EngineId) {
+    let engineInfo: EngineInfo | undefined = undefined;
+    try {
+      engineInfo = this.engineInfoManager.fetchEngineInfo(engineId);
+      if (!engineInfo) {
+        throw new Error(
+          `No such engineInfo registered: engineId == ${engineId}`,
+        );
+      }
+
+      if (!this.vvppManager.canUninstall(engineInfo)) {
+        throw new Error(`Cannot uninstall: engineId == ${engineId}`);
+      }
+
+      // Windows環境だとエンジンを終了してから削除する必要がある。
+      // そのため、アプリの終了時に削除するようにする。
+      this.vvppManager.markWillDelete(engineId);
+      return true;
+    } catch (e) {
+      const engineName = engineInfo?.name ?? engineId;
+      dialog.showErrorBox(
+        "アンインストールエラー",
+        `${engineName} をアンインストールできませんでした。`,
+      );
+      log.error(`Failed to uninstall ${engineId},`, e);
+      return false;
+    }
+  }
+
+  // エンジンの準備と起動
+  async launchEngines() {
+    // エンジンの追加と削除を反映させるためEngineInfoとAltPortInfosを再生成する。
+    this.engineInfoManager.initializeEngineInfosAndAltPortInfo();
+
+    // TODO: デフォルトエンジンの処理をConfigManagerに移してブラウザ版と共通化する
+    const engineInfos = this.engineInfoManager.fetchEngineInfos();
+    const engineSettings = this.configManager.get("engineSettings");
+    for (const engineInfo of engineInfos) {
+      if (!engineSettings[engineInfo.uuid]) {
+        // 空オブジェクトをパースさせることで、デフォルト値を取得する
+        engineSettings[engineInfo.uuid] = engineSettingSchema.parse({});
+      }
+    }
+    this.configManager.set("engineSettings", engineSettings);
+
+    await this.engineProcessManager.runEngineAll();
+    this.runtimeInfoManager.setEngineInfos(engineInfos);
+    await this.runtimeInfoManager.exportFile();
+  }
+
+  /**
+   * エンジンの停止とエンジン終了後処理を行う。
+   * 全処理が完了済みの場合 alreadyCompleted を返す。
+   * そうでない場合は Promise を返す。
+   */
+  cleanupEngines(): Promise<void> | "alreadyCompleted" {
+    const killingProcessPromises = this.engineProcessManager.killEngineAll();
+    const numLivingEngineProcess = Object.entries(
+      killingProcessPromises,
+    ).length;
+
+    // 前処理が完了している場合
+    if (
+      numLivingEngineProcess === 0 &&
+      !this.vvppManager.hasMarkedEngineDirs()
+    ) {
+      return "alreadyCompleted";
+    }
+
+    let numEngineProcessKilled = 0;
+
+    // 非同期的にすべてのエンジンプロセスをキル
+    const waitingKilledPromises: Promise<void>[] = Object.entries(
+      killingProcessPromises,
+    ).map(([engineId, promise]) => {
+      return promise
+        .catch((error) => {
+          // TODO: 各エンジンプロセスキルの失敗をUIに通知する
+          log.error(
+            `ENGINE ${engineId}: Error during killing process: ${error}`,
+          );
+          // エディタを終了するため、エラーが起きてもエンジンプロセスをキルできたとみなす
+        })
+        .finally(() => {
+          numEngineProcessKilled++;
+          log.info(
+            `ENGINE ${engineId}: Process killed. ${numEngineProcessKilled} / ${numLivingEngineProcess} processes killed`,
+          );
+        });
+    });
+
+    // すべてのエンジンプロセスキル処理が完了するまで待機
+    return Promise.all(waitingKilledPromises).then(() => {
+      // エンジン終了後の処理を実行
+      log.info(
+        "All ENGINE process kill operations done. Running post engine kill process",
+      );
+      return this.vvppManager.handleMarkedEngineDirs();
+    });
+  }
+
+  /**
+   * 安全なシャットダウン処理。
+   * この関数内の処理はelectronの終了シーケンスに合わせ、非同期処理が必要かどうかを判定したあとで非同期処理を実行する必要がある。
+   * FIXME: 判定用の関数と非同期処理関数を分離すれば仕様が簡潔になる。
+   */
+  gracefulShutdown() {
+    const engineCleanupResult = this.cleanupEngines();
+    const configSavedResult = this.configManager.ensureSaved();
+    return { engineCleanupResult, configSavedResult };
+  }
+}

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -27,6 +27,7 @@ import configMigration014 from "./configMigration014";
 import { RuntimeInfoManager } from "./manager/RuntimeInfoManager";
 import { registerIpcMainHandle, ipcMainSendProxy, IpcMainHandle } from "./ipc";
 import { getConfigManager } from "./electronConfig";
+import { EngineAndVvppController } from "./engineAndVvppController";
 import { failure, success } from "@/type/result";
 import {
   ContactTextFileName,
@@ -45,7 +46,6 @@ import {
   defaultHotkeySettings,
   isMac,
   defaultToolbarButtonSetting,
-  engineSettingSchema,
   EngineId,
   UpdateInfo,
 } from "@/type/preload";
@@ -200,6 +200,14 @@ const engineProcessManager = new EngineProcessManager({
 });
 const vvppManager = new VvppManager({ vvppEngineDir });
 
+const engineAndVvppController = new EngineAndVvppController(
+  runtimeInfoManager,
+  configManager,
+  engineInfoManager,
+  engineProcessManager,
+  vvppManager,
+);
+
 // エンジンのフォルダを開く
 function openEngineDirectory(engineId: EngineId) {
   const engineDirectory = engineInfoManager.fetchEngineDirectory(engineId);
@@ -207,69 +215,6 @@ function openEngineDirectory(engineId: EngineId) {
   // Windows環境だとスラッシュ区切りのパスが動かない。
   // path.resolveはWindowsだけバックスラッシュ区切りにしてくれるため、path.resolveを挟む。
   void shell.openPath(path.resolve(engineDirectory));
-}
-
-/**
- * VVPPエンジンをインストールする。
- */
-async function installVvppEngine(vvppPath: string) {
-  try {
-    await vvppManager.install(vvppPath);
-    return true;
-  } catch (e) {
-    dialog.showErrorBox(
-      "インストールエラー",
-      `${vvppPath} をインストールできませんでした。`,
-    );
-    log.error(`Failed to install ${vvppPath},`, e);
-    return false;
-  }
-}
-
-/**
- * 危険性を案内してからVVPPエンジンをインストールする。
- * FIXME: こちらで案内せず、GUIでのインストール側に合流させる
- */
-async function installVvppEngineWithWarning({
-  vvppPath,
-  reloadNeeded,
-}: {
-  vvppPath: string;
-  reloadNeeded: boolean;
-}) {
-  const result = dialog.showMessageBoxSync(win, {
-    type: "warning",
-    title: "エンジン追加の確認",
-    message: `この操作はコンピュータに損害を与える可能性があります。エンジンの配布元が信頼できない場合は追加しないでください。`,
-    buttons: ["追加", "キャンセル"],
-    noLink: true,
-    cancelId: 1,
-  });
-  if (result == 1) {
-    return;
-  }
-
-  await installVvppEngine(vvppPath);
-
-  if (reloadNeeded) {
-    void dialog
-      .showMessageBox(win, {
-        type: "info",
-        title: "再読み込みが必要です",
-        message:
-          "VVPPファイルを読み込みました。反映には再読み込みが必要です。今すぐ再読み込みしますか？",
-        buttons: ["再読み込み", "キャンセル"],
-        noLink: true,
-        cancelId: 1,
-      })
-      .then((result) => {
-        if (result.response === 0) {
-          ipcMainSendProxy.CHECK_EDITED_AND_NOT_SAVE(win, {
-            closeOrReload: "reload",
-          });
-        }
-      });
-  }
 }
 
 /**
@@ -288,37 +233,6 @@ function checkMultiEngineEnabled(): boolean {
     });
   }
   return enabled;
-}
-
-/**
- * VVPPエンジンをアンインストールする。
- * 関数を呼んだタイミングでアンインストール処理を途中まで行い、アプリ終了時に完遂する。
- */
-async function uninstallVvppEngine(engineId: EngineId) {
-  let engineInfo: EngineInfo | undefined = undefined;
-  try {
-    engineInfo = engineInfoManager.fetchEngineInfo(engineId);
-    if (!engineInfo) {
-      throw new Error(`No such engineInfo registered: engineId == ${engineId}`);
-    }
-
-    if (!vvppManager.canUninstall(engineInfo)) {
-      throw new Error(`Cannot uninstall: engineId == ${engineId}`);
-    }
-
-    // Windows環境だとエンジンを終了してから削除する必要がある。
-    // そのため、アプリの終了時に削除するようにする。
-    vvppManager.markWillDelete(engineId);
-    return true;
-  } catch (e) {
-    const engineName = engineInfo?.name ?? engineId;
-    dialog.showErrorBox(
-      "アンインストールエラー",
-      `${engineName} をアンインストールできませんでした。`,
-    );
-    log.error(`Failed to uninstall ${engineId},`, e);
-    return false;
-  }
 }
 
 // テーマの読み込み
@@ -523,73 +437,8 @@ async function loadUrl(obj: {
 
 // 開始。その他の準備が完了した後に呼ばれる。
 async function start() {
-  await launchEngines();
+  await engineAndVvppController.launchEngines();
   await createWindow();
-}
-
-// エンジンの準備と起動
-async function launchEngines() {
-  // エンジンの追加と削除を反映させるためEngineInfoとAltPortInfosを再生成する。
-  engineInfoManager.initializeEngineInfosAndAltPortInfo();
-
-  // TODO: デフォルトエンジンの処理をConfigManagerに移してブラウザ版と共通化する
-  const engineInfos = engineInfoManager.fetchEngineInfos();
-  const engineSettings = configManager.get("engineSettings");
-  for (const engineInfo of engineInfos) {
-    if (!engineSettings[engineInfo.uuid]) {
-      // 空オブジェクトをパースさせることで、デフォルト値を取得する
-      engineSettings[engineInfo.uuid] = engineSettingSchema.parse({});
-    }
-  }
-  configManager.set("engineSettings", engineSettings);
-
-  await engineProcessManager.runEngineAll();
-  runtimeInfoManager.setEngineInfos(engineInfos);
-  await runtimeInfoManager.exportFile();
-}
-
-/**
- * エンジンの停止とエンジン終了後処理を行う。
- * 全処理が完了済みの場合 alreadyCompleted を返す。
- * そうでない場合は Promise を返す。
- */
-function cleanupEngines(): Promise<void> | "alreadyCompleted" {
-  const killingProcessPromises = engineProcessManager.killEngineAll();
-  const numLivingEngineProcess = Object.entries(killingProcessPromises).length;
-
-  // 前処理が完了している場合
-  if (numLivingEngineProcess === 0 && !vvppManager.hasMarkedEngineDirs()) {
-    return "alreadyCompleted";
-  }
-
-  let numEngineProcessKilled = 0;
-
-  // 非同期的にすべてのエンジンプロセスをキル
-  const waitingKilledPromises: Promise<void>[] = Object.entries(
-    killingProcessPromises,
-  ).map(([engineId, promise]) => {
-    return promise
-      .catch((error) => {
-        // TODO: 各エンジンプロセスキルの失敗をUIに通知する
-        log.error(`ENGINE ${engineId}: Error during killing process: ${error}`);
-        // エディタを終了するため、エラーが起きてもエンジンプロセスをキルできたとみなす
-      })
-      .finally(() => {
-        numEngineProcessKilled++;
-        log.info(
-          `ENGINE ${engineId}: Process killed. ${numEngineProcessKilled} / ${numLivingEngineProcess} processes killed`,
-        );
-      });
-  });
-
-  // すべてのエンジンプロセスキル処理が完了するまで待機
-  return Promise.all(waitingKilledPromises).then(() => {
-    // エンジン終了後の処理を実行
-    log.info(
-      "All ENGINE process kill operations done. Running post engine kill process",
-    );
-    return vvppManager.handleMarkedEngineDirs();
-  });
 }
 
 const menuTemplateForMac: Electron.MenuItemConstructorOptions[] = [
@@ -1000,11 +849,11 @@ registerIpcMainHandle<IpcMainHandle>({
   },
 
   INSTALL_VVPP_ENGINE: async (_, path: string) => {
-    return await installVvppEngine(path);
+    return await engineAndVvppController.installVvppEngine(path);
   },
 
   UNINSTALL_VVPP_ENGINE: async (_, engineId: EngineId) => {
-    return await uninstallVvppEngine(engineId);
+    return await engineAndVvppController.uninstallVvppEngine(engineId);
   },
 
   VALIDATE_ENGINE_DIR: (_, { engineDir }) => {
@@ -1018,7 +867,7 @@ registerIpcMainHandle<IpcMainHandle>({
     await win.loadURL("about:blank");
 
     log.info("Checking ENGINE status before reload app");
-    const engineCleanupResult = cleanupEngines();
+    const engineCleanupResult = engineAndVvppController.cleanupEngines();
 
     // エンジンの停止とエンジン終了後処理の待機
     if (engineCleanupResult != "alreadyCompleted") {
@@ -1026,7 +875,7 @@ registerIpcMainHandle<IpcMainHandle>({
     }
     log.info("Post engine kill process done. Now reloading app");
 
-    await launchEngines();
+    await engineAndVvppController.launchEngines();
 
     await loadUrl({ isMultiEngineOffMode: !!isMultiEngineOffMode });
     win.show();
@@ -1092,8 +941,8 @@ app.on("before-quit", async (event) => {
   }
 
   log.info("Checking ENGINE status before app quit");
-  const engineCleanupResult = cleanupEngines();
-  const configSavedResult = configManager.ensureSaved();
+  const { engineCleanupResult, configSavedResult } =
+    engineAndVvppController.gracefulShutdown();
 
   // - エンジンの停止
   // - エンジン終了後処理
@@ -1254,9 +1103,10 @@ app.on("ready", async () => {
     log.info(`vvpp file install: ${filePath}`);
     // FIXME: GUI側に合流させる
     if (checkMultiEngineEnabled()) {
-      await installVvppEngineWithWarning({
+      await engineAndVvppController.installVvppEngineWithWarning({
         vvppPath: filePath,
         reloadNeeded: false,
+        win,
       });
     }
   }
@@ -1273,9 +1123,15 @@ app.on("second-instance", async (event, argv, workDir, rawData) => {
     log.info("Second instance launched with vvpp file");
     // FIXME: GUI側に合流させる
     if (checkMultiEngineEnabled()) {
-      await installVvppEngineWithWarning({
+      await engineAndVvppController.installVvppEngineWithWarning({
         vvppPath: data.filePath,
         reloadNeeded: true,
+        reloadCallback: () => {
+          ipcMainSendProxy.CHECK_EDITED_AND_NOT_SAVE(win, {
+            closeOrReload: "reload",
+          });
+        },
+        win,
       });
     }
   } else if (data.filePath.endsWith(".vvproj")) {

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -764,17 +764,8 @@ registerIpcMainHandle<IpcMainHandle>({
     return engineInfoManager.fetchEngineInfos();
   },
 
-  /**
-   * エンジンを再起動する。
-   * エンジンの起動が開始したらresolve、起動が失敗したらreject。
-   */
   RESTART_ENGINE: async (_, { engineId }) => {
-    await engineProcessManager.restartEngine(engineId);
-
-    // ランタイム情報の更新
-    // TODO: setからexportの処理は排他処理にしたほうがより良い
-    runtimeInfoManager.setEngineInfos(engineInfoManager.fetchEngineInfos());
-    await runtimeInfoManager.exportFile();
+    return engineProcessManager.restartEngine(engineId);
   },
 
   OPEN_ENGINE_DIRECTORY: async (_, { engineId }) => {
@@ -839,9 +830,7 @@ registerIpcMainHandle<IpcMainHandle>({
   },
 
   SET_ENGINE_SETTING: async (_, engineId, engineSetting) => {
-    const engineSettings = configManager.get("engineSettings");
-    engineSettings[engineId] = engineSetting;
-    configManager.set(`engineSettings`, engineSettings);
+    engineAndVvppController.updateEngineSetting(engineId, engineSetting);
   },
 
   SET_NATIVE_THEME: (_, source) => {


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/pull/2260#issuecomment-2349275014

の時のコメントにあった、エンジン＆VVPP周りの処理を移動させてみるリファクタリングです。

処理用のクラスにしてみました。
エンジンマネージャーやVVPPマネージャーの参照を渡してもらって、複数の処理が必要な関数を切り出した感じです。
なので一部、ただgetやfetchするだけの関数は移動させてません。

操作部分だけ移行させましたが、そもそもマネージャークラスの作成から担うこともできそうですが、一旦どうなるかわからなかったのでやめてます。
main.tsからEngineManagerやVvppManagerを直接参照できなくなり、疎結合になる一方で設計がまだどうなるかわからないから最悪リバートもありえそうだなぁと思い。

ほぼ行を移動させているので、↓のコマンドだと差分が見やすいかも。
```bash
git diff -w --color-moved=dimmed-zebra --color-moved-ws=ignore-all-space upstream/main
```

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2260#issuecomment-2349275014
- https://github.com/VOICEVOX/voicevox/issues/1194

## その他

処理の流れは変わってないはず。
ただ関数の移動だけでは済まないところがいくつかあったので、そこはコードが書き換わってます。

* IPC 通信で レンダラーに命令を送っている部分(`reloadCallback`)
	* DIすることも可能だけど、一箇所だけだったしちょっとややこしくなりそうだしで今回はコールバックにしてみました
* 関数化したもの（`updateEngineSetting`と`restartEngines`と`gracefulShutdown`）

あと一旦ドキュメントは書き換えなくても良さそう･･･なはず。
