### PR TITLE
fix: preset周りのコードを実験的機能から通常機能に変更する

### DIFF
--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -239,6 +239,25 @@ const migrations: [string, (store: Record<string, unknown>) => unknown][] = [
       return config;
     },
   ],
+  [
+    ">=0.21",
+    (config) => {
+      // プリセット機能を実験的機能から通常機能に
+      const experimentalSetting =
+        config.experimentalSetting as ExperimentalSettingType;
+      if ("enablePreset" in experimentalSetting) {
+        config.enablePreset = experimentalSetting.enablePreset;
+        delete experimentalSetting.enablePreset;
+      }
+      if ("shouldApplyDefaultPresetOnVoiceChanged" in experimentalSetting) {
+        config.shouldApplyDefaultPresetOnVoiceChanged =
+          experimentalSetting.shouldApplyDefaultPresetOnVoiceChanged;
+        delete experimentalSetting.shouldApplyDefaultPresetOnVoiceChanged;
+      }
+
+      return config;
+    },
+  ],
 ];
 
 export type Metadata = {

--- a/src/components/Dialog/SettingDialog/SettingDialog.vue
+++ b/src/components/Dialog/SettingDialog/SettingDialog.vue
@@ -96,24 +96,19 @@
               <ToggleCell
                 title="プリセット機能"
                 description="ONの場合、プリセット機能を有効にします。パラメータを登録したり適用したりできます。"
-                :modelValue="experimentalSetting.enablePreset"
+                :modelValue="enablePreset"
                 @update:modelValue="changeEnablePreset"
               />
               <QSlideTransition>
                 <!-- q-slide-transitionはheightだけをアニメーションするのでdivで囲う -->
-                <div v-show="experimentalSetting.enablePreset">
+                <div v-show="enablePreset">
                   <ToggleCell
                     title="スタイル変更時にデフォルトプリセットを適用"
                     description="ONの場合、キャラやスタイルの変更時にデフォルトプリセットが自動的に適用されます。"
                     class="in-slide-transition-workaround"
-                    :modelValue="
-                      experimentalSetting.shouldApplyDefaultPresetOnVoiceChanged
-                    "
+                    :modelValue="shouldApplyDefaultPresetOnVoiceChanged"
                     @update:modelValue="
-                      changeExperimentalSetting(
-                        'shouldApplyDefaultPresetOnVoiceChanged',
-                        $event,
-                      )
+                      changeShouldApplyDefaultPresetOnVoiceChanged($event)
                     "
                   />
                 </div>
@@ -709,6 +704,13 @@ const [enableMemoNotation, changeEnableMemoNotation] =
 const [enableRubyNotation, changeEnableRubyNotation] =
   useRootMiscSetting("enableRubyNotation");
 
+const [enablePreset, _changeEnablePreset] = useRootMiscSetting("enablePreset");
+
+const [
+  shouldApplyDefaultPresetOnVoiceChanged,
+  changeShouldApplyDefaultPresetOnVoiceChanged,
+] = useRootMiscSetting("shouldApplyDefaultPresetOnVoiceChanged");
+
 const canSetAudioOutputDevice = computed(() => {
   return !!HTMLAudioElement.prototype.setSinkId;
 });
@@ -799,17 +801,11 @@ const changeinheritAudioInfo = async (inheritAudioInfo: boolean) => {
 const changeEnablePreset = (value: boolean) => {
   if (value) {
     // プリセット機能をONにしたときは「デフォルトプリセットを自動で適用」もONにする
-    void changeExperimentalSetting("enablePreset", true);
-    void changeExperimentalSetting(
-      "shouldApplyDefaultPresetOnVoiceChanged",
-      true,
-    );
+    _changeEnablePreset(true);
+    changeShouldApplyDefaultPresetOnVoiceChanged(true);
   } else {
-    void changeExperimentalSetting("enablePreset", false);
-    void changeExperimentalSetting(
-      "shouldApplyDefaultPresetOnVoiceChanged",
-      false,
-    );
+    _changeEnablePreset(false);
+    changeShouldApplyDefaultPresetOnVoiceChanged(false);
   }
 };
 

--- a/src/components/Talk/AudioInfo.vue
+++ b/src/components/Talk/AudioInfo.vue
@@ -640,9 +640,7 @@ const morphingRateSlider = previewSliderHelper({
 });
 
 // プリセット
-const enablePreset = computed(
-  () => store.state.experimentalSetting.enablePreset,
-);
+const enablePreset = computed(() => store.state.enablePreset);
 
 const presetItems = computed(() => store.state.presetItems);
 const presetKeys = computed(() => store.state.presetKeys);

--- a/src/store/preset.ts
+++ b/src/store/preset.ts
@@ -14,7 +14,10 @@ import { Preset, PresetKey, Voice, VoiceId } from "@/type/preload";
 export function determineNextPresetKey(
   state: Pick<
     State,
-    "defaultPresetKeys" | "experimentalSetting" | "inheritAudioInfo"
+    | "defaultPresetKeys"
+    | "enablePreset"
+    | "shouldApplyDefaultPresetOnVoiceChanged"
+    | "inheritAudioInfo"
   >,
   voice: Voice,
   presetKeyCandidate: PresetKey | undefined,
@@ -31,7 +34,7 @@ export function determineNextPresetKey(
       // 初回作成時
       return {
         nextPresetKey: defaultPresetKeyForCurrentVoice,
-        shouldApplyPreset: state.experimentalSetting.enablePreset,
+        shouldApplyPreset: state.enablePreset,
       };
     }
     case "copy": {
@@ -47,12 +50,12 @@ export function determineNextPresetKey(
       // それ以外はデフォルトプリセットを割り当て、適用するかはプリセットのON/OFFに依存
       return {
         nextPresetKey: defaultPresetKeyForCurrentVoice,
-        shouldApplyPreset: state.experimentalSetting.enablePreset,
+        shouldApplyPreset: state.enablePreset,
       };
     }
     case "changeVoice": {
       // ボイス切り替え時
-      if (state.experimentalSetting.shouldApplyDefaultPresetOnVoiceChanged) {
+      if (state.shouldApplyDefaultPresetOnVoiceChanged) {
         // デフォルトプリセットを適用する
         return {
           nextPresetKey: defaultPresetKeyForCurrentVoice,

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -143,6 +143,8 @@ export const settingStore = createPartialStore<SettingStoreTypes>({
         "showAddAudioItemButton",
         "splitTextWhenPaste",
         "splitterPosition",
+        "enablePreset",
+        "shouldApplyDefaultPresetOnVoiceChanged",
         "enableMultiEngine",
         "enableRubyNotation",
         "enableMemoNotation",

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -43,8 +43,6 @@ export const settingStoreState: SettingStoreState = {
   acceptTerms: "Unconfirmed",
   acceptRetrieveTelemetry: "Unconfirmed",
   experimentalSetting: {
-    enablePreset: false,
-    shouldApplyDefaultPresetOnVoiceChanged: false,
     enableInterrogativeUpspeak: false,
     enableMorphing: false,
     enableMultiSelect: false,
@@ -63,6 +61,8 @@ export const settingStoreState: SettingStoreState = {
     notifyOnGenerate: false,
   },
   engineSettings: {},
+  enablePreset: false,
+  shouldApplyDefaultPresetOnVoiceChanged: false,
   enableMultiEngine: false,
   enableMemoNotation: false,
   enableRubyNotation: false,

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -559,8 +559,6 @@ export type ThemeSetting = {
 };
 
 export const experimentalSettingSchema = z.object({
-  enablePreset: z.boolean().default(false),
-  shouldApplyDefaultPresetOnVoiceChanged: z.boolean().default(false),
   enableInterrogativeUpspeak: z.boolean().default(false),
   enableMorphing: z.boolean().default(false),
   enableMultiSelect: z.boolean().default(false),
@@ -592,6 +590,8 @@ export const rootMiscSettingSchema = z.object({
     .enum(["PERIOD_AND_NEW_LINE", "NEW_LINE", "OFF"])
     .default("PERIOD_AND_NEW_LINE"),
   splitterPosition: splitterPositionSchema.default({}),
+  enablePreset: z.boolean().default(false), // プリセット機能
+  shouldApplyDefaultPresetOnVoiceChanged: z.boolean().default(false), // スタイル変更時にデフォルトプリセットを適用するか
   enableMultiEngine: z.boolean().default(false),
   enableMemoNotation: z.boolean().default(false), // メモ記法を有効にするか
   enableRubyNotation: z.boolean().default(false), // ルビ記法を有効にするか


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/pull/1719

で、プリセット機能を通常機能にしたはずなのですが、設定画面のUIだけ変えてconfig.jsonの中身を変えていなかったので、変更しました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/1719

## その他

（config.vue周りの書き換えを忘れていたのであとで変更します）
