### PR TITLE
Fix: フレーズのレンダリングでエラーになることがあるのを修正

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1695,7 +1695,9 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
                     foundPhrase.trackId,
                     phraseKey,
                   );
-            if (renderStartStageId != undefined) {
+            if (renderStartStageId == undefined) {
+              phrase.state = "PLAYABLE";
+            } else {
               renderStartStageIds.set(phraseKey, renderStartStageId);
               phrase.state = "WAITING_TO_BE_RENDERED";
             }


### PR DESCRIPTION
## 内容

レンダリングの必要はないのに`state`が`WAITING_TO_BE_RENDERED`のままになっているフレーズが存在してエラーになっていたので、修正します。

## その他
たぶん d3904c495ad0af7f57cb8e57c4578728ad008e0f からバグってます。