### PR TITLE
refactor: エンジン情報のキャッシュを作らないように変更

### DIFF
--- a/docs/res/起動シーケンス図.md
+++ b/docs/res/起動シーケンス図.md
@@ -25,7 +25,7 @@ flowchart
       870482["store.get registeredEngineDirs"] --> 250263
       222321 --> 967432["engine.runEngineAll"]
       656570["engine.fetchEngineInfos"] --> 870482
-      110954["engine.initializeEngineInfosAndAltPortInfo"] --> 656570
+      110954["engine.initializeAltPortInfo"] --> 656570
       967432 --> 302398["runtimeInfo.setEngineInfos"]
       302398 --> 321984
       subgraph 656570["engine.fetchEngineInfos"]

--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -132,8 +132,8 @@ export class EngineAndVvppController {
 
   // エンジンの準備と起動
   async launchEngines() {
-    // エンジンの追加と削除を反映させるためEngineInfoとAltPortInfosを再生成する。
-    this.engineInfoManager.initializeEngineInfosAndAltPortInfo();
+    // AltPortInfosを再生成する。
+    this.engineInfoManager.initializeAltPortInfo();
 
     // TODO: デフォルトエンジンの処理をConfigManagerに移してブラウザ版と共通化する
     const engineInfos = this.engineInfoManager.fetchEngineInfos();

--- a/src/backend/electron/manager/engineInfoManager.ts
+++ b/src/backend/electron/manager/engineInfoManager.ts
@@ -18,9 +18,9 @@ import { AltPortInfos } from "@/store/type";
 import { BaseConfigManager } from "@/backend/common/ConfigManager";
 
 /**
- * デフォルトエンジンの情報を作成する
+ * デフォルトエンジンの情報を取得する
  */
-function createDefaultEngineInfos(defaultEngineDir: string): EngineInfo[] {
+function fetchDefaultEngineInfos(defaultEngineDir: string): EngineInfo[] {
   // TODO: envから直接ではなく、envに書いたengine_manifest.jsonから情報を得るようにする
   const defaultEngineInfosEnv =
     import.meta.env.VITE_DEFAULT_ENGINE_INFOS ?? "[]";
@@ -48,9 +48,6 @@ export class EngineInfoManager {
   defaultEngineDir: string;
   vvppEngineDir: string;
 
-  defaultEngineInfos: EngineInfo[] = [];
-  additionalEngineInfos: EngineInfo[] = [];
-
   /** 代替ポート情報 */
   public altPortInfos: AltPortInfos = {};
 
@@ -65,10 +62,10 @@ export class EngineInfoManager {
   }
 
   /**
-   * 追加エンジンの一覧を作成する。
+   * 追加エンジンの一覧を取得する。
    * FIXME: store.get("registeredEngineDirs")への副作用をEngineManager外に移動する
    */
-  private createAdditionalEngineInfos(): EngineInfo[] {
+  private fetchAdditionalEngineInfos(): EngineInfo[] {
     const engines: EngineInfo[] = [];
     const addEngine = (engineDir: string, type: "vvpp" | "path") => {
       const manifestPath = path.join(engineDir, "engine_manifest.json");
@@ -139,7 +136,20 @@ export class EngineInfoManager {
    * 全てのエンジンの一覧を取得する。デフォルトエンジン＋追加エンジン。
    */
   fetchEngineInfos(): EngineInfo[] {
-    return [...this.defaultEngineInfos, ...this.additionalEngineInfos];
+    const engineInfos = [
+      ...fetchDefaultEngineInfos(this.defaultEngineDir),
+      ...this.fetchAdditionalEngineInfos(),
+    ];
+    // URLを代替ポートに置き換える
+    engineInfos.forEach((engineInfo) => {
+      const altPortInfo = this.altPortInfos[engineInfo.uuid];
+      if (altPortInfo) {
+        const url = new URL(engineInfo.host);
+        url.port = altPortInfo.to.toString();
+        engineInfo.host = url.origin;
+      }
+    });
+    return engineInfos;
   }
 
   /**
@@ -170,11 +180,9 @@ export class EngineInfoManager {
   }
 
   /**
-   * EngineInfosとAltPortInfoを初期化する。
+   * AltPortInfoを初期化する。
    */
-  initializeEngineInfosAndAltPortInfo() {
-    this.defaultEngineInfos = createDefaultEngineInfos(this.defaultEngineDir);
-    this.additionalEngineInfos = this.createAdditionalEngineInfos();
+  initializeAltPortInfo() {
     this.altPortInfos = {};
   }
 
@@ -189,9 +197,6 @@ export class EngineInfoManager {
       from: Number(url.port),
       to: port,
     };
-
-    url.port = port.toString();
-    engineInfo.host = url.toString();
   }
 
   /**

--- a/src/backend/electron/manager/engineInfoManager.ts
+++ b/src/backend/electron/manager/engineInfoManager.ts
@@ -140,7 +140,7 @@ export class EngineInfoManager {
       ...fetchDefaultEngineInfos(this.defaultEngineDir),
       ...this.fetchAdditionalEngineInfos(),
     ];
-    // URLを代替ポートに置き換える
+    // 代替ポートに置き換える
     engineInfos.forEach((engineInfo) => {
       const altPortInfo = this.altPortInfos[engineInfo.uuid];
       if (altPortInfo) {

--- a/src/backend/electron/manager/engineProcessManager.ts
+++ b/src/backend/electron/manager/engineProcessManager.ts
@@ -88,39 +88,34 @@ export class EngineProcessManager {
     // { hostname (localhost), port (50021) } <- url (http://localhost:50021)
     const engineHostInfo = url2HostInfo(new URL(engineInfo.host));
 
+    // ポートが塞がっていれば代替ポートを探す
+    let port = engineHostInfo.port;
     log.info(
-      `ENGINE ${engineId}: Checking whether port ${engineHostInfo.port} is assignable...`,
+      `ENGINE ${engineId}: Checking whether port ${port} is assignable...`,
     );
 
-    if (
-      !(await isAssignablePort(engineHostInfo.port, engineHostInfo.hostname))
-    ) {
+    if (!(await isAssignablePort(port, engineHostInfo.hostname))) {
       // ポートを既に割り当てているプロセスidの取得
       const pid = await getPidFromPort(engineHostInfo);
       if (pid != undefined) {
         const processName = await getProcessNameFromPid(engineHostInfo, pid);
         log.warn(
-          `ENGINE ${engineId}: Port ${engineHostInfo.port} has already been assigned by ${processName} (pid=${pid})`,
+          `ENGINE ${engineId}: Port ${port} has already been assigned by ${processName} (pid=${pid})`,
         );
       } else {
         // ポートは使用不可能だがプロセスidは見つからなかった
-        log.warn(
-          `ENGINE ${engineId}: Port ${engineHostInfo.port} was unavailable`,
-        );
+        log.warn(`ENGINE ${engineId}: Port ${port} was unavailable`);
       }
 
       // 代替ポートの検索
-      const altPort = await findAltPort(
-        engineHostInfo.port,
-        engineHostInfo.hostname,
-      );
+      const altPort = await findAltPort(port, engineHostInfo.hostname);
 
       // 代替ポートが見つからないとき
       if (altPort == undefined) {
         log.error(`ENGINE ${engineId}: No Alternative Port Found`);
         dialog.showErrorBox(
           `${engineInfo.name} の起動に失敗しました`,
-          `${engineHostInfo.port}番ポートの代わりに利用可能なポートが見つかりませんでした。PCを再起動してください。`,
+          `${port}番ポートの代わりに利用可能なポートが見つかりませんでした。PCを再起動してください。`,
         );
         app.exit(1);
         throw new Error("No Alternative Port Found");
@@ -129,8 +124,10 @@ export class EngineProcessManager {
       // 代替ポート情報を更新
       this.engineAltPortUpdater(engineId, altPort);
       log.warn(
-        `ENGINE ${engineId}: Applied Alternative Port: ${engineHostInfo.port} -> ${altPort}`,
+        `ENGINE ${engineId}: Applied Alternative Port: ${port} -> ${altPort}`,
       );
+
+      port = altPort;
     }
 
     log.info(`ENGINE ${engineId}: Starting process`);
@@ -157,7 +154,7 @@ export class EngineProcessManager {
       "--host",
       new URL(engineInfo.host).hostname,
       "--port",
-      new URL(engineInfo.host).port,
+      port.toString(),
     ]);
 
     log.info(`ENGINE ${engineId} path: ${enginePath}`);

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -402,7 +402,7 @@ export type MinimumEngineManifestType = z.infer<
 
 export type EngineInfo = {
   uuid: EngineId;
-  host: string; // NOTE: 実際はorigin（プロトコルとhostnameとport）が代入される
+  host: string; // NOTE: 実際はorigin（プロトコルとhostnameとport）が入る
   name: string;
   path?: string; // エンジンディレクトリのパス
   executionEnabled: boolean;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -402,7 +402,7 @@ export type MinimumEngineManifestType = z.infer<
 
 export type EngineInfo = {
   uuid: EngineId;
-  host: string;
+  host: string; // NOTE: 実際はorigin（プロトコルとhostnameとport）が代入される
   name: string;
   path?: string; // エンジンディレクトリのパス
   executionEnabled: boolean;


### PR DESCRIPTION
## 内容

EngineInfoManagerで、エンジン情報のキャッシュを作らないようにしてみました。
これは毎回エンジン情報をディレクトリやファイルから取ってくるようになってしまいますが、キャッシュ由来のバグがなくなるのでこっちの方がいいかなぁと。

↓の関連issueのタスクでエンジン情報を何度か取得・登録を繰り返しそうなので、一旦変えてみました。
不要そうならまた後で戻してもいいかも。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1194
- https://github.com/VOICEVOX/voicevox/pull/2270

## その他

調査してそもそもこうした方がいいと思った経緯はこんな感じです。

* キャッシュを作ってる意味の調査
	* additionalEngineInfosのキャッシュが作られた理由
		* ポートが変わった時にEngineInfoの.hostも書き換えるから、インスタンス変数にしておく必要がある
			* https://github.com/VOICEVOX/voicevox/pull/1352
	* defaultEngineInfosのキャッシュが作られている理由
		* blame追ってみた感じ、[昔はbackground.tsにconst変数を直書きしていて](https://github.com/sabonerune/voicevox/commit/0662bc791bb81b2e75d54dd448f3b3769698be82#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL118)、それをマネージャークラスにそのまま移したからインスタンス変数になった
		* その後ポート変更時に.hostを書き換えるので、インスタンス変数にしておく必要があった

多分キャッシュを作るより、毎回ロードする方が分かりやすいはず。
fetchEngineInfosを毎回ロードするように変更して、代替ポート情報に合わせてhostを書き換えるようにした。

･･･という感じです！
