### PR TITLE
ソング：誤操作を減らすため「最初に戻る」ボタンと「プレイ」ボタンの間にスペースを設ける

### DIFF
--- a/src/components/Sing/ToolBar/ToolBar.vue
+++ b/src/components/Sing/ToolBar/ToolBar.vue
@@ -699,6 +699,7 @@ onUnmounted(() => {
 
 .sing-transport-button {
   color: var(--scheme-color-on-surface-variant);
+  margin-right: 0.25rem;
 }
 
 .sing-playback-button {


### PR DESCRIPTION
## 内容

掲題の状態で使いづらいという報告をXで見つけたもの
小さな修正のためプルリク

## 関連 Issue

ref #2277 
close #2277 

## スクリーンショット・動画など

## その他
