### PR TITLE
ソング: シーケンサ左クリックデフォルトの動作を調整する

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -421,6 +421,12 @@ const editingLyricNote = computed(() => {
 const showGuideLine = ref(true);
 const guideLineX = ref(0);
 
+// ドラッグ中かどうか
+const isDragging = ref(false);
+// ドラッグ開始位置
+const dragStartX = ref(0);
+const dragStartY = ref(0);
+
 // プレビュー中でないときの処理
 // TODO: ステートパターンにして、この処理をIdleStateに移す
 watch([ctrlKey, shiftKey, nowPreviewing, editTarget], () => {
@@ -925,7 +931,7 @@ const endPreview = () => {
     }
     const previewPitchEditType = previewPitchEdit.value.type;
     if (previewPitchEditType === "draw") {
-      // カーソルを動かさずにマウスのボタンを離したときに1フレームのみの変更になり、
+      // カーソルを動かさずにマウスのボタンを離したときに1フレーム��みの変更になり、
       // 1フレームの変更はピッチ編集ラインとして表示されないので、無視する
       if (previewPitchEdit.value.data.length >= 2) {
         // 平滑化を行う
@@ -962,7 +968,19 @@ const onNoteBarMouseDown = (event: MouseEvent, note: Note) => {
   }
   const mouseButton = getButton(event);
   if (mouseButton === "LEFT_BUTTON") {
-    startPreview(event, "MOVE_NOTE", note);
+    if (event.shiftKey) {
+      // Shift+左クリックの処理
+      if (selectedNoteIds.value.has(note.id)) {
+        // 既に選択されている場合は選択から削除
+        void store.dispatch("DESELECT_NOTES", { noteIds: [note.id] });
+      } else {
+        // 選択されていない場合は選択に追加
+        void store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
+      }
+    } else {
+      // 移動
+      startPreview(event, "MOVE_NOTE", note);
+    }
   } else if (!selectedNoteIds.value.has(note.id)) {
     selectOnlyThis(note);
   }
@@ -1007,16 +1025,26 @@ const onMouseDown = (event: MouseEvent) => {
     return;
   }
   const mouseButton = getButton(event);
-  // TODO: メニューが表示されている場合はメニュー非表示のみ行いたい
   if (editTarget.value === "NOTE") {
     if (mouseButton === "LEFT_BUTTON") {
       if (event.shiftKey) {
+        // 空白部分でのShift+左クリック：矩形選択を開始
         isRectSelecting.value = true;
         rectSelectStartX.value = cursorX.value;
         rectSelectStartY.value = cursorY.value;
         setCursorState(CursorState.CROSSHAIR);
       } else {
-        startPreview(event, "ADD_NOTE");
+        // 通常の左クリック処理
+        isDragging.value = true;
+        dragStartX.value = cursorX.value;
+        dragStartY.value = cursorY.value;
+        if (selectedNoteIds.value.size === 0) {
+          // ノート未選択時は新規ノート追加
+          startPreview(event, "ADD_NOTE");
+        } else {
+          // ノート選択中は選択解除
+          void store.dispatch("DESELECT_ALL_NOTES");
+        }
       }
     } else {
       void store.dispatch("DESELECT_ALL_NOTES");
@@ -1044,6 +1072,16 @@ const onMouseMove = (event: MouseEvent) => {
 
   if (nowPreviewing.value) {
     executePreviewProcess.value = true;
+  } else if (isDragging.value && editTarget.value === "NOTE") {
+    // ドラッグ距離が3px以上の場合はノート追加
+    const DRAG_THRESHOLD = 3;
+    const dragDistance = Math.sqrt(
+      Math.pow(cursorX.value - dragStartX.value, 2) +
+        Math.pow(cursorY.value - dragStartY.value, 2),
+    );
+    if (dragDistance > DRAG_THRESHOLD) {
+      startPreview(event, "ADD_NOTE");
+    }
   } else {
     const scrollLeft = sequencerBodyElement.scrollLeft;
     const cursorBaseX = (scrollLeft + cursorX.value) / zoomX.value;
@@ -1066,6 +1104,7 @@ const onMouseUp = (event: MouseEvent) => {
   } else if (nowPreviewing.value) {
     endPreview();
   }
+  isDragging.value = false;
 };
 
 /**

--- a/src/composables/useCursorState.ts
+++ b/src/composables/useCursorState.ts
@@ -35,14 +35,9 @@ export const useCursorState = () => {
     cursorState.value = state;
   };
 
-  const resetCursorState = () => {
-    cursorState.value = CursorState.UNSET;
-  };
-
   return {
     cursorState,
     cursorClass,
     setCursorState,
-    resetCursorState,
   };
 };

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -787,6 +787,17 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
     },
   },
 
+  DESELECT_NOTES: {
+    mutation(state, { noteIds }: { noteIds: NoteId[] }) {
+      for (const noteId of noteIds) {
+        state._selectedNoteIds.delete(noteId);
+      }
+    },
+    async action({ mutations }, { noteIds }: { noteIds: NoteId[] }) {
+      mutations.DESELECT_NOTES({ noteIds });
+    },
+  },
+
   DESELECT_ALL_NOTES: {
     mutation(state) {
       state.editingLyricNoteId = undefined;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -939,6 +939,11 @@ export type SingingStoreTypes = {
     action({ trackId }: { trackId: TrackId }): void;
   };
 
+  DESELECT_NOTES: {
+    mutation: { noteIds: NoteId[] };
+    action(payload: { noteIds: NoteId[] }): void;
+  };
+
   DESELECT_ALL_NOTES: {
     mutation: undefined;
     action(): void;


### PR DESCRIPTION
## 内容

要議論かもです(いったんドラフト)

シーケンサにおいて:

- ノート選択中に左クリックでは選択キャンセルにする
- ノート選択中に左クリック+ドラッグではノート追加(ドロー)を行える
- 複数選択時に選択中のノートShift+左クリックで選択除外

## 関連 Issue

ref #2039 
close #2039 

## スクリーンショット・動画など

なし

## その他
