### PR TITLE
ソング: ループ範囲を設定できるようにする

### DIFF
--- a/src/components/Sing/SequencerGrid.vue
+++ b/src/components/Sing/SequencerGrid.vue
@@ -83,6 +83,27 @@
       :y2="gridHeight"
       class="sequencer-grid-measure-line"
     />
+    <!-- ループエリア外を暗くする -->
+    <g v-if="isLoopEnabled">
+      <!-- 左側 -->
+      <rect
+        x="0"
+        y="0"
+        :width="loopStartX"
+        :height="gridHeight"
+        class="sequencer-grid-loop-mask"
+        pointer-events="none"
+      />
+      <!-- 右側 -->
+      <rect
+        :x="loopEndX"
+        y="0"
+        :width="gridWidth - loopEndX"
+        :height="gridHeight"
+        class="sequencer-grid-loop-mask"
+        pointer-events="none"
+      />
+    </g>
   </svg>
 </template>
 
@@ -91,8 +112,10 @@ import { computed } from "vue";
 import { useStore } from "@/store";
 import { keyInfos, getKeyBaseHeight, tickToBaseX } from "@/sing/viewHelper";
 import { getMeasureDuration, getNoteDuration } from "@/sing/domain";
+import { useLoopControl } from "@/composables/useLoopControl";
 
 const store = useStore();
+const { isLoopEnabled, loopStartTick, loopEndTick } = useLoopControl();
 const tpqn = computed(() => store.state.tpqn);
 const timeSignatures = computed(() => store.state.timeSignatures);
 const zoomX = computed(() => store.state.sequencerZoomX);
@@ -165,6 +188,13 @@ const snapLinePositions = computed(() => {
     return (currentTick / measureTicks) * measureWidth.value;
   });
 });
+// ループのX座標を計算
+const loopStartX = computed(() => {
+  return tickToBaseX(loopStartTick.value, tpqn.value) * zoomX.value;
+});
+const loopEndX = computed(() => {
+  return tickToBaseX(loopEndTick.value, tpqn.value) * zoomX.value;
+});
 </script>
 
 <style scoped lang="scss">
@@ -216,6 +246,11 @@ const snapLinePositions = computed(() => {
   backface-visibility: hidden;
   stroke: var(--scheme-color-sing-grid-beat-line);
   stroke-width: 1px;
+}
+
+.sequencer-grid-loop-mask {
+  fill: var(--scheme-color-sing-surface-container);
+  opacity: 0.3;
 }
 
 .edit-pitch {

--- a/src/components/Sing/SequencerLoopControl.vue
+++ b/src/components/Sing/SequencerLoopControl.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="sequencer-loop-control">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      :width="props.width"
+      :height="32"
+      shape-rendering="crispEdges"
+    >
+      <!-- ループ範囲 -->
+      <rect
+        v-if="isLoopEnabled"
+        :x="loopStartX - props.offset"
+        y="0"
+        :width="loopEndX - loopStartX"
+        :height="8"
+        class="loop-range"
+      />
+      <!-- ループ開始 -->
+      <line
+        v-if="isLoopEnabled"
+        :x1="loopStartX - props.offset"
+        :x2="loopStartX - props.offset"
+        y1="0"
+        :y2="16"
+        class="loop-marker loop-start-marker"
+      />
+      <!-- ループ終了 -->
+      <line
+        v-if="isLoopEnabled"
+        :x1="loopEndX - props.offset"
+        :x2="loopEndX - props.offset"
+        y1="0"
+        :y2="16"
+        class="loop-marker loop-end-marker"
+      />
+    </svg>
+    <!-- ループ開始ハンドル -->
+    <div
+      v-if="isLoopEnabled"
+      class="loop-handle loop-start-handle"
+      :style="{ left: `${loopStartX - props.offset}px` }"
+      @mousedown="startDragging('start', $event)"
+    ></div>
+    <!-- ループ終了ハンドル -->
+    <div
+      v-if="isLoopEnabled"
+      class="loop-handle loop-end-handle"
+      :style="{ left: `${loopEndX - props.offset}px` }"
+      @mousedown="startDragging('end', $event)"
+    ></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onUnmounted } from "vue";
+import { useStore } from "@/store";
+import { useLoopControl } from "@/composables/useLoopControl";
+import { tickToBaseX, baseXToTick } from "@/sing/viewHelper";
+
+const props = defineProps<{
+  width: number;
+  offset: number;
+}>();
+
+const store = useStore();
+const { isLoopEnabled, loopStartTick, loopEndTick, setLoopRange } =
+  useLoopControl();
+
+const tpqn = computed(() => store.state.tpqn);
+const sequencerZoomX = computed(() => store.state.sequencerZoomX);
+
+const loopStartX = computed(
+  () => tickToBaseX(loopStartTick.value, tpqn.value) * sequencerZoomX.value,
+);
+const loopEndX = computed(
+  () => tickToBaseX(loopEndTick.value, tpqn.value) * sequencerZoomX.value,
+);
+
+// ドラッグ状態の管理
+const isDragging = ref(false);
+const dragTarget = ref<"start" | "end" | null>(null);
+const dragStartX = ref(0);
+
+const startDragging = (target: "start" | "end", event: MouseEvent) => {
+  isDragging.value = true;
+  dragTarget.value = target;
+  dragStartX.value = event.clientX;
+  // FIXME: 仮でdocumentにaddEventListener
+  // documentに指定しないとドラッグ中に他の要素に被ってドラッグができなくなる
+  document.addEventListener("mousemove", onDrag);
+  document.addEventListener("mouseup", stopDragging);
+};
+
+const onDrag = (event: MouseEvent) => {
+  if (!isDragging.value || !dragTarget.value) return;
+
+  const startX = event.clientX - dragStartX.value;
+  const newX =
+    (dragTarget.value === "start" ? loopStartX.value : loopEndX.value) + startX;
+  const newTick = Math.max(
+    0,
+    baseXToTick(newX / sequencerZoomX.value, tpqn.value),
+  );
+
+  if (dragTarget.value === "start") {
+    if (newTick < loopEndTick.value) {
+      setLoopRange(newTick, loopEndTick.value);
+    }
+  } else {
+    if (newTick > loopStartTick.value) {
+      setLoopRange(loopStartTick.value, newTick);
+    }
+  }
+
+  dragStartX.value = event.clientX;
+};
+
+const stopDragging = () => {
+  isDragging.value = false;
+  dragTarget.value = null;
+  // FIXME: 仮
+  document.removeEventListener("mousemove", onDrag);
+  document.removeEventListener("mouseup", stopDragging);
+};
+
+// FIXME: 仮でアンマウント時にremoveEventListener
+onUnmounted(() => {
+  document.removeEventListener("mousemove", onDrag);
+  document.removeEventListener("mouseup", stopDragging);
+});
+</script>
+
+<style scoped lang="scss">
+// FIXME:スタイルは別途調整
+.sequencer-loop-control {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.loop-range {
+  fill: var(--scheme-color-secondary); // FIXME: 仮
+  opacity: 0.25;
+}
+
+.loop-marker {
+  stroke: var(--scheme-color-secondary); // FIXME: 仮
+  stroke-width: 4px;
+}
+
+.loop-handle {
+  position: absolute;
+  top: 0;
+  width: 8px;
+  height: 100%;
+  cursor: ew-resize;
+  background-color: var(--scheme-color-secondary-surface); // FIXME: 仮
+  pointer-events: auto;
+
+  &.loop-start-handle,
+  &.loop-end-handle {
+    transform: translateX(-50%);
+  }
+}
+</style>

--- a/src/composables/useLoopControl.ts
+++ b/src/composables/useLoopControl.ts
@@ -1,0 +1,65 @@
+// useLoopControl.ts
+import { computed } from "vue";
+import { useStore } from "@/store";
+import { tickToSecond } from "@/sing/domain";
+
+export function useLoopControl() {
+  const store = useStore();
+
+  const isLoopEnabled = computed({
+    get: () => store.state.isLoopEnabled,
+    set: (value) => store.commit("SET_LOOP_ENABLED", { isLoopEnabled: value }),
+  });
+
+  const loopStartTick = computed({
+    get: () => store.state.loopStartTick,
+    set: (value) => store.commit("SET_LOOP_START", { loopStartTick: value }),
+  });
+
+  const loopEndTick = computed({
+    get: () => store.state.loopEndTick,
+    set: (value) => store.commit("SET_LOOP_END", { loopEndTick: value }),
+  });
+
+  const setLoopEnabled = (value: boolean) => {
+    void store.dispatch("SET_LOOP_ENABLED", { isLoopEnabled: value });
+  };
+
+  const setLoopRange = (startTick: number, endTick: number) => {
+    void store.dispatch("SET_LOOP_RANGE", {
+      loopStartTick: startTick,
+      loopEndTick: endTick,
+    });
+  };
+
+  const loopStartTime = computed(() =>
+    tickToSecond(loopStartTick.value, store.state.tempos, store.state.tpqn),
+  );
+
+  const loopEndTime = computed(() =>
+    tickToSecond(loopEndTick.value, store.state.tempos, store.state.tpqn),
+  );
+
+  const handleLoop = (currentTime: number) => {
+    if (!isLoopEnabled.value || loopEndTick.value <= 0) return currentTime;
+
+    if (currentTime >= loopEndTime.value) {
+      return (
+        loopStartTime.value +
+        ((currentTime - loopStartTime.value) %
+          (loopEndTime.value - loopStartTime.value))
+      );
+    }
+
+    return currentTime;
+  };
+
+  return {
+    isLoopEnabled,
+    loopStartTick,
+    loopEndTick,
+    setLoopEnabled,
+    setLoopRange,
+    handleLoop,
+  };
+}

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -840,6 +840,9 @@ export type SingingStoreState = {
   nowAudioExporting: boolean;
   cancellationOfAudioExportRequested: boolean;
   isSongSidebarOpen: boolean;
+  isLoopEnabled: boolean;
+  loopStartTick: number;
+  loopEndTick: number;
 };
 
 export type SingingStoreTypes = {
@@ -1262,6 +1265,30 @@ export type SingingStoreTypes = {
   };
 
   SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS: {
+    action(): void;
+  };
+
+  SET_LOOP_ENABLED: {
+    mutation: { isLoopEnabled: boolean };
+    action(payload: { isLoopEnabled: boolean }): void;
+  };
+
+  SET_LOOP_RANGE: {
+    mutation: { loopStartTick: number; loopEndTick: number };
+    action(payload: { loopStartTick: number; loopEndTick: number }): void;
+  };
+
+  SET_LOOP_START: {
+    mutation: { loopStartTick: number };
+    action(payload: { loopStartTick: number }): void;
+  };
+
+  SET_LOOP_END: {
+    mutation: { loopEndTick: number };
+    action(payload: { loopEndTick: number }): void;
+  };
+
+  TOGGLE_LOOP: {
     action(): void;
   };
 };


### PR DESCRIPTION
## 内容

以下の内容を行います

- ループ範囲を設定できるようにする
- ミニマップ(トラックリスト)からもループすることを見越す

## 関連 Issue

ref #2224
close #2224

## スクリーンショット・動画など

表示は仮です
<img width="1312" alt="スクリーンショット 2024-10-02 2 03 52" src="https://github.com/user-attachments/assets/e6f5b8d4-32e4-455b-8f87-387ef323ce83">


## その他

ドラフトとし、仕様を確認・考慮中です