### PR TITLE
ファイル保存全般をアトミックにする

### DIFF
--- a/src/backend/electron/electronConfig.ts
+++ b/src/backend/electron/electronConfig.ts
@@ -1,9 +1,9 @@
 import { join } from "path";
 import fs from "fs";
 import { app } from "electron";
+import { writeFileSafely } from "./fileHelper";
 import { BaseConfigManager, Metadata } from "@/backend/common/ConfigManager";
 import { ConfigType } from "@/type/preload";
-import { writeFileSafely } from "@/helpers/fileHelper";
 
 export class ElectronConfigManager extends BaseConfigManager {
   protected getAppVersion() {

--- a/src/backend/electron/electronConfig.ts
+++ b/src/backend/electron/electronConfig.ts
@@ -1,9 +1,9 @@
 import { join } from "path";
 import fs from "fs";
 import { app } from "electron";
-import { moveFile } from "move-file";
 import { BaseConfigManager, Metadata } from "@/backend/common/ConfigManager";
 import { ConfigType } from "@/type/preload";
+import { writeFileSafely } from "@/helpers/fileHelper";
 
 export class ElectronConfigManager extends BaseConfigManager {
   protected getAppVersion() {
@@ -23,16 +23,10 @@ export class ElectronConfigManager extends BaseConfigManager {
   }
 
   protected async save(config: ConfigType & Metadata) {
-    // ファイル書き込みに失敗したときに設定が消えないように、tempファイル書き込み後上書き移動する
-    const temp_path = `${this.configPath}.tmp`;
-    await fs.promises.writeFile(
-      temp_path,
+    await writeFileSafely(
+      this.configPath,
       JSON.stringify(config, undefined, 2),
     );
-
-    await moveFile(temp_path, this.configPath, {
-      overwrite: true,
-    });
   }
 
   private get configPath(): string {

--- a/src/backend/electron/electronConfig.ts
+++ b/src/backend/electron/electronConfig.ts
@@ -23,10 +23,7 @@ export class ElectronConfigManager extends BaseConfigManager {
   }
 
   protected async save(config: ConfigType & Metadata) {
-    await writeFileSafely(
-      this.configPath,
-      JSON.stringify(config, undefined, 2),
-    );
+    writeFileSafely(this.configPath, JSON.stringify(config, undefined, 2));
   }
 
   private get configPath(): string {

--- a/src/backend/electron/fileHelper.ts
+++ b/src/backend/electron/fileHelper.ts
@@ -1,15 +1,15 @@
 import fs from "fs";
-import { moveFile } from "move-file";
+import { moveFileSync } from "move-file";
 
-export async function writeFileSafely(
+export function writeFileSafely(
   path: string,
   data: string | NodeJS.ArrayBufferView,
 ) {
   // ファイル書き込みに失敗したときに設定が消えないように、tempファイル書き込み後上書き移動する
   const temp_path = `${path}.tmp`;
-  await fs.promises.writeFile(temp_path, data);
+  fs.writeFileSync(temp_path, data);
 
-  await moveFile(temp_path, path, {
+  moveFileSync(temp_path, path, {
     overwrite: true,
   });
 }

--- a/src/backend/electron/fileHelper.ts
+++ b/src/backend/electron/fileHelper.ts
@@ -1,15 +1,18 @@
 import fs from "fs";
 import { moveFileSync } from "move-file";
 
+/**
+ * 書き込みに失敗したときにファイルが消えないように、
+ * tmpファイル書き込み後、保存先ファイルに上書きする
+ */
 export function writeFileSafely(
   path: string,
   data: string | NodeJS.ArrayBufferView,
 ) {
-  // ファイル書き込みに失敗したときに設定が消えないように、tempファイル書き込み後上書き移動する
-  const temp_path = `${path}.tmp`;
-  fs.writeFileSync(temp_path, data);
+  const tmpPath = `${path}.tmp`;
+  fs.writeFileSync(tmpPath, data);
 
-  moveFileSync(temp_path, path, {
+  moveFileSync(tmpPath, path, {
     overwrite: true,
   });
 }

--- a/src/backend/electron/fileHelper.ts
+++ b/src/backend/electron/fileHelper.ts
@@ -1,0 +1,15 @@
+import fs from "fs";
+import { moveFile } from "move-file";
+
+export async function writeFileSafely(
+  path: string,
+  data: string | NodeJS.ArrayBufferView,
+) {
+  // ファイル書き込みに失敗したときに設定が消えないように、tempファイル書き込み後上書き移動する
+  const temp_path = `${path}.tmp`;
+  await fs.promises.writeFile(temp_path, data);
+
+  await moveFile(temp_path, path, {
+    overwrite: true,
+  });
+}

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -40,6 +40,7 @@ import {
   TextAsset,
 } from "@/type/preload";
 import { themes } from "@/domain/theme";
+import { writeFileSafely } from "@/helpers/fileHelper";
 
 type SingleInstanceLockData = {
   filePath: string | undefined;
@@ -742,9 +743,9 @@ registerIpcMainHandle<IpcMainHandle>({
     win.show();
   },
 
-  WRITE_FILE: (_, { filePath, buffer }) => {
+  WRITE_FILE: async (_, { filePath, buffer }) => {
     try {
-      fs.writeFileSync(
+      await writeFileSafely(
         filePath,
         new DataView(buffer instanceof Uint8Array ? buffer.buffer : buffer),
       );

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -743,9 +743,9 @@ registerIpcMainHandle<IpcMainHandle>({
     win.show();
   },
 
-  WRITE_FILE: async (_, { filePath, buffer }) => {
+  WRITE_FILE: (_, { filePath, buffer }) => {
     try {
-      await writeFileSafely(
+      writeFileSafely(
         filePath,
         new DataView(buffer instanceof Uint8Array ? buffer.buffer : buffer),
       );

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -28,6 +28,7 @@ import { RuntimeInfoManager } from "./manager/RuntimeInfoManager";
 import { registerIpcMainHandle, ipcMainSendProxy, IpcMainHandle } from "./ipc";
 import { getConfigManager } from "./electronConfig";
 import { EngineAndVvppController } from "./engineAndVvppController";
+import { writeFileSafely } from "./fileHelper";
 import { failure, success } from "@/type/result";
 import { AssetTextFileNames } from "@/type/staticResources";
 import {
@@ -40,7 +41,6 @@ import {
   TextAsset,
 } from "@/type/preload";
 import { themes } from "@/domain/theme";
-import { writeFileSafely } from "@/helpers/fileHelper";
 
 type SingleInstanceLockData = {
   filePath: string | undefined;

--- a/src/backend/electron/manager/RuntimeInfoManager.ts
+++ b/src/backend/electron/manager/RuntimeInfoManager.ts
@@ -99,7 +99,7 @@ export class RuntimeInfoManager {
 
       // ファイル書き出し
       try {
-        await writeFileSafely(
+        writeFileSafely(
           this.runtimeInfoPath,
           JSON.stringify(runtimeInfoFormatFor3rdParty), // FIXME: zod化する
         );

--- a/src/backend/electron/manager/RuntimeInfoManager.ts
+++ b/src/backend/electron/manager/RuntimeInfoManager.ts
@@ -7,7 +7,7 @@ import AsyncLock from "async-lock";
 import log from "electron-log/main";
 import type { AltPortInfos } from "@/store/type";
 import { EngineId, EngineInfo } from "@/type/preload";
-import { writeFileSafely } from "@/helpers/fileHelper";
+import { writeFileSafely } from "@/backend/electron/fileHelper";
 
 /**
  * ランタイム情報書き出しに必要なEngineInfo

--- a/src/backend/electron/manager/RuntimeInfoManager.ts
+++ b/src/backend/electron/manager/RuntimeInfoManager.ts
@@ -3,11 +3,11 @@
  * ランタイム情報には起動しているエンジンのURLなどが含まれる。
  */
 
-import fs from "fs";
 import AsyncLock from "async-lock";
 import log from "electron-log/main";
 import type { AltPortInfos } from "@/store/type";
 import { EngineId, EngineInfo } from "@/type/preload";
+import { writeFileSafely } from "@/helpers/fileHelper";
 
 /**
  * ランタイム情報書き出しに必要なEngineInfo
@@ -99,7 +99,7 @@ export class RuntimeInfoManager {
 
       // ファイル書き出し
       try {
-        await fs.promises.writeFile(
+        await writeFileSafely(
           this.runtimeInfoPath,
           JSON.stringify(runtimeInfoFormatFor3rdParty), // FIXME: zod化する
         );

--- a/src/helpers/fileHelper.ts
+++ b/src/helpers/fileHelper.ts
@@ -1,19 +1,4 @@
-import fs from "fs";
-import { moveFile } from "move-file";
 import { ResultError } from "@/type/result";
-
-export async function writeFileSafely(
-  path: string,
-  data: string | NodeJS.ArrayBufferView,
-) {
-  // ファイル書き込みに失敗したときに設定が消えないように、tempファイル書き込み後上書き移動する
-  const temp_path = `${path}.tmp`;
-  await fs.promises.writeFile(temp_path, data);
-
-  await moveFile(temp_path, path, {
-    overwrite: true,
-  });
-}
 
 /** ファイル書き込み時のエラーメッセージを生成する */
 // instanceof ResultErrorで生まれるResultError<any>を受け取れるようにするため、anyを許容する

--- a/src/helpers/fileHelper.ts
+++ b/src/helpers/fileHelper.ts
@@ -1,4 +1,19 @@
+import fs from "fs";
+import { moveFile } from "move-file";
 import { ResultError } from "@/type/result";
+
+export async function writeFileSafely(
+  path: string,
+  data: string | NodeJS.ArrayBufferView,
+) {
+  // ファイル書き込みに失敗したときに設定が消えないように、tempファイル書き込み後上書き移動する
+  const temp_path = `${path}.tmp`;
+  await fs.promises.writeFile(temp_path, data);
+
+  await moveFile(temp_path, path, {
+    overwrite: true,
+  });
+}
 
 /** ファイル書き込み時のエラーメッセージを生成する */
 // instanceof ResultErrorで生まれるResultError<any>を受け取れるようにするため、anyを許容する


### PR DESCRIPTION
## ファイル保存全般をアトミックにする

@RikitoNoto さんが #2098 で作成してくださったファイル保存を
~~`src/helpers/fileHelper.ts`にヘルパー関数として切り出しました。~~
上記のファイルはレンダラープロセスからも参照されるため、
`src/backend/electron/fileHelper.ts`にヘルパー関数として切り出しました。

それに伴い、
- `src/backend/electron/electronConfig.ts` の `ElectronConfigManager.save`
- `src/backend/electron/main.ts`の`WRITE_FILE`部分
- `src/backend/electron/manager/RuntimeInfoManager.ts` の`exportFile` 関数

のファイル保存処理をヘルパー関数で置き換えました。

それぞれ、
- `設定/ツールバーのカスタマイズ`から設定を変更し、保存ボタンを押した時
- プロジェクトを変更し、保存した時
- 起動時のruntime-info.json生成時

にwriteFileSafelyのmoveFile呼び出しの前でelectronを停止したときにtmpファイルが存在しており、electronを再起動してファイルが正しく開ける/正しく起動できることを確認しました。

## 関連 Issue

ref #2103 #2098 
close #2103 

## その他
`src/backend/electron/main.ts`の`WRITE_FILE`部分を非同期関数に変えてしまったのですが、こちらで問題ないでしょうか？