### PR TITLE
feat: `electron:serve`起動時にエディタを起動しないオプションを追加

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -10,7 +10,11 @@
             "port": 9222,
             "request": "attach",
             "type": "chrome",
-            "webRoot": "${workspaceFolder}",
+            "webRoot": "${workspaceFolder}/src",
+            "resolveSourceMapLocations": [
+              "${workspaceFolder}/**",
+              "!**/node_modules/**"
+            ],
             "timeout": 20000, // 20 * 1000 ms程度あればビルド時間は間に合うはず
         },
         {
@@ -27,6 +31,21 @@
             "type": "node"
         },
         {
+            "name": "Launch Electron without electron:serve",
+            "request": "launch",
+            "type": "node",
+            "runtimeExecutable": "npx",
+            "args": [
+                "electron",
+                ".",
+                "--no-sandbox"
+            ],
+            "preLaunchTask": "Electron Serve Only",
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        },
+        {
             "name": "Attach by Process ID",
             // .bin viteを指定するとElectronのMain Processのデバッグが可能
             "processId": "${command:PickProcess}",
@@ -35,12 +54,23 @@
                 "<node_internals>/**"
             ],
             "type": "node"
-        },
+        }
     ],
     "compounds": [
         {
             "name": "Launch Electron Main/Renderer",
-            "configurations": ["Attach to Renderer Process", "Launch Electron Main Process via NPM"],
+            "configurations": [
+                "Attach to Renderer Process",
+                "Launch Electron Main Process via NPM"
+            ],
+            "stopAll": true
+        },
+        {
+            "name": "Launch Electron Main/Renderer without electron:serve",
+            "configurations": [
+                "Attach to Renderer Process",
+                "Launch Electron without electron:serve"
+            ],
             "stopAll": true
         }
     ]

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -31,7 +31,8 @@
             "type": "node"
         },
         {
-            "name": "Launch Electron without electron:serve",
+            "name": "Launch Electron Main Process without hot reload",
+            // Electronのみを起動
             "request": "launch",
             "type": "node",
             "runtimeExecutable": "npx",
@@ -40,7 +41,8 @@
                 ".",
                 "--no-sandbox"
             ],
-            "preLaunchTask": "Electron Serve Only",
+            // 事前にElectronを起動せずにバックグラウンドで"electron:serve"を実行する
+            "preLaunchTask": "Electron Serve without Launch Electron",
             "skipFiles": [
                 "<node_internals>/**"
             ]
@@ -66,10 +68,10 @@
             "stopAll": true
         },
         {
-            "name": "Launch Electron Main/Renderer without electron:serve",
+            "name": "Launch Electron Main/Renderer without hot reload",
             "configurations": [
                 "Attach to Renderer Process",
-                "Launch Electron without electron:serve"
+                "Launch Electron Main Process without hot reload"
             ],
             "stopAll": true
         }

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -6,14 +6,13 @@
     "configurations": [
         {
             "name": "Attach to Renderer Process",
-            // NOTE: background.tsで指定しているremote-debugging-port
-            "port": 9222,
+            "port": 9222, // NOTE: background.tsで指定しているremote-debugging-port
             "request": "attach",
             "type": "chrome",
             "webRoot": "${workspaceFolder}/src",
             "resolveSourceMapLocations": [
-              "${workspaceFolder}/**",
-              "!**/node_modules/**"
+                "${workspaceFolder}/**",
+                "!**/node_modules/**"
             ],
             "timeout": 20000, // 20 * 1000 ms程度あればビルド時間は間に合うはず
         },
@@ -31,8 +30,9 @@
             "type": "node"
         },
         {
+            // 直接Electronのみを起動し、バックグラウンドで"electron:serve"を実行する
+            // NOTE: ホットリロードできない代わりに、デバッグ起動が軽い
             "name": "Launch Electron Main Process without hot reload",
-            // Electronのみを起動
             "request": "launch",
             "type": "node",
             "runtimeExecutable": "npx",
@@ -41,7 +41,6 @@
                 ".",
                 "--no-sandbox"
             ],
-            // 事前にElectronを起動せずにバックグラウンドで"electron:serve"を実行する
             "preLaunchTask": "Electron Serve without Launch Electron",
             "skipFiles": [
                 "<node_internals>/**"
@@ -68,6 +67,7 @@
             "stopAll": true
         },
         {
+            // ホットリロードできない代わりにデバッグ起動が軽いモード
             "name": "Launch Electron Main/Renderer without hot reload",
             "configurations": [
                 "Attach to Renderer Process",

--- a/.vscode/tasks.template.json
+++ b/.vscode/tasks.template.json
@@ -1,11 +1,10 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
             "label": "Electron Serve without Launch Electron",
             // Electronを起動せずにバックグラウンドで"electron:serve"を実行する
+            // NOTE: デバッグ起動を軽くできる
             "type": "npm",
             "script": "electron:serve",
             "options": {

--- a/.vscode/tasks.template.json
+++ b/.vscode/tasks.template.json
@@ -1,0 +1,28 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Electron Serve Only",
+            "type": "npm",
+            "script": "electron:serve",
+            "options": {
+                "env": {
+                    "SKIP_LAUNCH_EDITOR": "1"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": ""
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "building for development\\.\\.\\.",
+                    "endsPattern": "main process build is complete\\."
+                }
+            }
+        }
+    ]
+}

--- a/.vscode/tasks.template.json
+++ b/.vscode/tasks.template.json
@@ -4,12 +4,13 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Electron Serve Only",
+            "label": "Electron Serve without Launch Electron",
+            // Electronを起動せずにバックグラウンドで"electron:serve"を実行する
             "type": "npm",
             "script": "electron:serve",
             "options": {
                 "env": {
-                    "SKIP_LAUNCH_EDITOR": "1"
+                    "SKIP_LAUNCH_ELECTRON": "1"
                 }
             },
             "isBackground": true,

--- a/README.md
+++ b/README.md
@@ -297,7 +297,9 @@ npx openapi-generator-cli version-manager list
 
 npm scripts の `serve` や `electron:serve` などの開発ビルド下では、ビルドに使用している vite で sourcemap を出力するため、ソースコードと出力されたコードの対応付けが行われます。
 
-`.vscode/launch.template.json` をコピーして `.vscode/launch.json` を作成することで、開発ビルドを VS Code から実行し、デバッグを可能にするタスクが有効になります。
+`.vscode/launch.template.json` をコピーして `.vscode/launch.json` を、
+`.vscode/tasks.template.json` をコピーして `.vscode/tasks.json` を作成することで、
+開発ビルドを VS Code から実行し、デバッグを可能にするタスクが有効になります。
 
 ## ライセンス
 

--- a/src/backend/electron/ipc.ts
+++ b/src/backend/electron/ipc.ts
@@ -68,8 +68,8 @@ export const ipcMainSendProxy = new Proxy(
 const validateIpcSender = (event: IpcMainInvokeEvent) => {
   let isValid: boolean;
   const senderUrl = new URL(event.senderFrame.url);
-  if (process.env.VITE_DEV_SERVER_URL != undefined) {
-    const devServerUrl = new URL(process.env.VITE_DEV_SERVER_URL);
+  if (import.meta.env.VITE_DEV_SERVER_URL != undefined) {
+    const devServerUrl = new URL(import.meta.env.VITE_DEV_SERVER_URL);
     isValid = senderUrl.origin === devServerUrl.origin;
   } else {
     isValid = senderUrl.protocol === "app:";

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -145,7 +145,7 @@ protocol.registerSchemesAsPrivileged([
   { scheme: "app", privileges: { secure: true, standard: true, stream: true } },
 ]);
 
-const firstUrl = process.env.VITE_DEV_SERVER_URL ?? "app://./index.html";
+const firstUrl = import.meta.env.VITE_DEV_SERVER_URL ?? "app://./index.html";
 
 // engine
 const vvppEngineDir = path.join(app.getPath("userData"), "vvpp-engines");
@@ -280,7 +280,7 @@ async function createWindow() {
   }
 
   // ソフトウェア起動時はプロトコルを app にする
-  if (process.env.VITE_DEV_SERVER_URL == undefined) {
+  if (import.meta.env.VITE_DEV_SERVER_URL == undefined) {
     protocol.handle("app", (request) => {
       // 読み取り先のファイルがインストールディレクトリ内であることを確認する
       // ref: https://www.electronjs.org/ja/docs/latest/api/protocol#protocolhandlescheme-handler

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_NAME: string;
   readonly VITE_APP_VERSION: string;
   readonly VITE_DEFAULT_ENGINE_INFOS: string;
+  readonly VITE_DEV_SERVER_URL: string | undefined;
   readonly VITE_OFFICIAL_WEBSITE_URL: string;
   readonly VITE_LATEST_UPDATE_INFOS_URL: string;
   readonly VITE_GTM_CONTAINER_ID: string;

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -44,10 +44,6 @@ test("起動したら「利用規約に関するお知らせ」が表示され�
   const app = await electron.launch({
     args: ["."],
     timeout: process.env.CI ? 0 : 60000,
-    env: {
-      ...process.env,
-      VITE_DEV_SERVER_URL: "http://localhost:7357",
-    },
   });
 
   const sut = await app.firstWindow({

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -46,7 +46,7 @@ export default defineConfig((options) => {
     ? "inline"
     : false;
   const launchEditor =
-    process.env.SKIP_LAUNCH_EDITOR !== "1" && options.mode !== "test";
+    process.env.SKIP_LAUNCH_ELECTRON !== "1" && options.mode !== "test";
   return {
     root: path.resolve(__dirname, "src"),
     envDir: __dirname,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -45,6 +45,8 @@ export default defineConfig((options) => {
   const sourcemap: BuildOptions["sourcemap"] = shouldEmitSourcemap
     ? "inline"
     : false;
+  const launchEditor =
+    process.env.SKIP_LAUNCH_EDITOR !== "1" && options.mode !== "test";
   return {
     root: path.resolve(__dirname, "src"),
     envDir: __dirname,
@@ -87,7 +89,8 @@ export default defineConfig((options) => {
             entry: "./src/backend/electron/main.ts",
             // ref: https://github.com/electron-vite/vite-plugin-electron/pull/122
             onstart: ({ startup }) => {
-              if (options.mode !== "test") {
+              console.log("main process build is complete.");
+              if (launchEditor) {
                 void startup([".", "--no-sandbox"]);
               }
             },
@@ -103,7 +106,9 @@ export default defineConfig((options) => {
             // ref: https://electron-vite.github.io/guide/preload-not-split.html
             entry: "./src/backend/electron/preload.ts",
             onstart({ reload }) {
-              reload();
+              if (launchEditor) {
+                reload();
+              }
             },
             vite: {
               plugins: [tsconfigPaths({ root: __dirname })],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -94,7 +94,7 @@ export default defineConfig((options) => {
             // ref: https://github.com/electron-vite/vite-plugin-electron/pull/122
             onstart: ({ startup }) => {
               console.log("main process build is complete.");
-              if (skipLahnchElectron) {
+              if (!skipLahnchElectron) {
                 void startup([".", "--no-sandbox"]);
               }
             },
@@ -110,7 +110,7 @@ export default defineConfig((options) => {
             // ref: https://electron-vite.github.io/guide/preload-not-split.html
             entry: "./src/backend/electron/preload.ts",
             onstart({ reload }) {
-              if (skipLahnchElectron) {
+              if (!skipLahnchElectron) {
                 reload();
               }
             },


### PR DESCRIPTION
## 内容

いつからかはっきり覚えていないのですがVSCodeを使用したメインプロセスのデバッグの起動が自分の環境では非常に遅くなりました。(自分のPCのスペックが低いというのもありますが…)
恐らくデバッガが開発サーバーを監視していることが原因だと思います。

このPRで開発サーバーの起動とElectronの起動を分離することでメインプロセスデバッグ時の起動を高速化します。

## その他

`SKIP_LAUNCH_EDITOR`環境変数に`1`を設定したうえで`electron:serve`を実行するとエディタの起動とメインプロセスのリロードが行われなくなります。
この状態で `npx electron . --no-sandbox`を実行するとエディタが起動します。
そのための`launch.template.json`と`tasks.template.json`追加しました。

`VITE_DEV_SERVER_URL`はビルド時に埋め込まれます。

レンダラープロセスの`sourcemap`が正しく検出できていなかったので変更しました。
