### PR TITLE
vuexのstoreの呼び出しをリテラル引数からDot記法へ: src/store/

### DIFF
--- a/src/components/Dialog/Dialog.ts
+++ b/src/components/Dialog/Dialog.ts
@@ -11,7 +11,7 @@ import {
   ErrorTypeForSaveAllResultDialog,
 } from "@/store/type";
 import { DotNotationDispatch } from "@/store/vuex";
-import { withProgressDotNotation as withProgress } from "@/store/ui";
+import { withProgress } from "@/store/ui";
 
 type MediaType = "audio" | "text";
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2,7 +2,7 @@ import path from "path";
 import Encoding from "encoding-japanese";
 import {
   createDotNotationUILockAction as createUILockAction,
-  withProgressDotNotation as withProgress,
+  withProgress,
 } from "./ui";
 import {
   AudioItem,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1,9 +1,6 @@
 import path from "path";
 import Encoding from "encoding-japanese";
-import {
-  createDotNotationUILockAction as createUILockAction,
-  withProgress,
-} from "./ui";
+import { createUILockAction, withProgress } from "./ui";
 import {
   AudioItem,
   SaveResultObject,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -28,7 +28,7 @@ import {
   filterCharacterInfosByStyleType,
   DEFAULT_PROJECT_NAME,
 } from "./utility";
-import { createDotNotationPartialStore as createPartialStore } from "./vuex";
+import { createPartialStore } from "./vuex";
 import { determineNextPresetKey } from "./preset";
 import {
   fetchAudioFromAudioItem,

--- a/src/store/audioPlayer.ts
+++ b/src/store/audioPlayer.ts
@@ -57,7 +57,7 @@ export const audioPlayerStore = createPartialStore<AudioPlayerStoreTypes>({
 
   PLAY_AUDIO_PLAYER: {
     async action(
-      { state, commit },
+      { state, mutations },
       { offset, audioKey }: { offset?: number; audioKey?: AudioKey },
     ) {
       const audioElement = getAudioElement();
@@ -88,7 +88,7 @@ export const audioPlayerStore = createPartialStore<AudioPlayerStoreTypes>({
       // 再生終了時にresolveされるPromiseを返す
       const played = async () => {
         if (audioKey) {
-          commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: true });
+          mutations.SET_AUDIO_NOW_PLAYING({ audioKey, nowPlaying: true });
         }
       };
       audioElement.addEventListener("play", played);
@@ -103,7 +103,7 @@ export const audioPlayerStore = createPartialStore<AudioPlayerStoreTypes>({
         audioElement.removeEventListener("play", played);
         audioElement.removeEventListener("pause", paused);
         if (audioKey) {
-          commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: false });
+          mutations.SET_AUDIO_NOW_PLAYING({ audioKey, nowPlaying: false });
         }
       });
 

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -4,7 +4,7 @@ import { enablePatches, enableMapSet, Immer } from "immer";
 import { Command, CommandStoreState, CommandStoreTypes, State } from "./type";
 import { applyPatches } from "@/store/immerPatchUtility";
 import {
-  createDotNotationPartialStore as createPartialStore,
+  createPartialStore,
   Mutation,
   MutationsBase,
   MutationTree,

--- a/src/store/dictionary.ts
+++ b/src/store/dictionary.ts
@@ -1,4 +1,4 @@
-import { createDotNotationPartialStore as createPartialStore } from "./vuex";
+import { createPartialStore } from "./vuex";
 import { UserDictWord, UserDictWordToJSON } from "@/openapi";
 import { DictionaryStoreState, DictionaryStoreTypes } from "@/store/type";
 import { EngineId } from "@/type/preload";

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -1,5 +1,5 @@
 import { EngineState, EngineStoreState, EngineStoreTypes } from "./type";
-import { createDotNotationUILockAction as createUILockAction } from "./ui";
+import { createUILockAction } from "./ui";
 import { createPartialStore } from "./vuex";
 import { createLogger } from "@/domain/frontend/log";
 import type { EngineManifest } from "@/openapi";

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -1,6 +1,6 @@
 import { EngineState, EngineStoreState, EngineStoreTypes } from "./type";
 import { createDotNotationUILockAction as createUILockAction } from "./ui";
-import { createDotNotationPartialStore as createPartialStore } from "./vuex";
+import { createPartialStore } from "./vuex";
 import { createLogger } from "@/domain/frontend/log";
 import type { EngineManifest } from "@/openapi";
 import type { EngineId, EngineInfo } from "@/type/preload";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -34,7 +34,7 @@ import { settingStoreState, settingStore } from "./setting";
 import { presetStoreState, presetStore } from "./preset";
 import { dictionaryStoreState, dictionaryStore } from "./dictionary";
 import { proxyStore, proxyStoreState } from "./proxy";
-import { createPartialStore } from "./vuex";
+import { createDotNotationPartialStore as createPartialStore } from "./vuex";
 import { engineStoreState, engineStore } from "./engine";
 import { filterCharacterInfosByStyleType } from "./utility";
 import {
@@ -200,7 +200,7 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
   },
 
   LOAD_DEFAULT_STYLE_IDS: {
-    async action({ commit, getters }) {
+    async action({ mutations, getters }) {
       let defaultStyleIds = await window.backend.getSetting("defaultStyleIds");
 
       const allCharacterInfos = getters.GET_ALL_CHARACTER_INFOS;
@@ -244,7 +244,7 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
         }),
       ];
 
-      commit("SET_DEFAULT_STYLE_IDS", { defaultStyleIds });
+      mutations.SET_DEFAULT_STYLE_IDS({ defaultStyleIds });
     },
   },
 
@@ -281,17 +281,17 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
         }
       }
     },
-    async action({ commit }, defaultStyleIds) {
-      commit("SET_DEFAULT_STYLE_IDS", { defaultStyleIds });
+    async action({ mutations }, defaultStyleIds) {
+      mutations.SET_DEFAULT_STYLE_IDS({ defaultStyleIds });
       await window.backend.setSetting("defaultStyleIds", defaultStyleIds);
     },
   },
 
   LOAD_USER_CHARACTER_ORDER: {
-    async action({ commit }) {
+    async action({ mutations }) {
       const userCharacterOrder =
         await window.backend.getSetting("userCharacterOrder");
-      commit("SET_USER_CHARACTER_ORDER", { userCharacterOrder });
+      mutations.SET_USER_CHARACTER_ORDER({ userCharacterOrder });
     },
   },
 
@@ -299,8 +299,8 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
     mutation(state, { userCharacterOrder }) {
       state.userCharacterOrder = userCharacterOrder;
     },
-    async action({ commit }, userCharacterOrder) {
-      commit("SET_USER_CHARACTER_ORDER", { userCharacterOrder });
+    async action({ mutations }, userCharacterOrder) {
+      mutations.SET_USER_CHARACTER_ORDER({ userCharacterOrder });
       await window.backend.setSetting("userCharacterOrder", userCharacterOrder);
     },
   },
@@ -319,16 +319,16 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
   },
 
   INIT_VUEX: {
-    async action({ dispatch }) {
+    async action({ actions }) {
       const promises = [];
 
       // 設定ファイルからstoreへ読み込む
-      promises.push(dispatch("HYDRATE_UI_STORE"));
-      promises.push(dispatch("HYDRATE_PRESET_STORE"));
-      promises.push(dispatch("HYDRATE_SETTING_STORE"));
+      promises.push(actions.HYDRATE_UI_STORE());
+      promises.push(actions.HYDRATE_PRESET_STORE());
+      promises.push(actions.HYDRATE_SETTING_STORE());
 
       await Promise.all(promises).then(() => {
-        void dispatch("ON_VUEX_READY");
+        void actions.ON_VUEX_READY();
       });
     },
   },
@@ -337,8 +337,8 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
     mutation(state, { isMultiEngineOffMode }) {
       state.isMultiEngineOffMode = isMultiEngineOffMode;
     },
-    action({ commit }, isMultiEngineOffMode) {
-      commit("SET_IS_MULTI_ENGINE_OFF_MODE", { isMultiEngineOffMode });
+    action({ mutations }, isMultiEngineOffMode) {
+      mutations.SET_IS_MULTI_ENGINE_OFF_MODE({ isMultiEngineOffMode });
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -34,7 +34,7 @@ import { settingStoreState, settingStore } from "./setting";
 import { presetStoreState, presetStore } from "./preset";
 import { dictionaryStoreState, dictionaryStore } from "./dictionary";
 import { proxyStore, proxyStoreState } from "./proxy";
-import { createDotNotationPartialStore as createPartialStore } from "./vuex";
+import { createPartialStore } from "./vuex";
 import { engineStoreState, engineStore } from "./engine";
 import { filterCharacterInfosByStyleType } from "./utility";
 import {

--- a/src/store/preset.ts
+++ b/src/store/preset.ts
@@ -1,4 +1,4 @@
-import { createDotNotationPartialStore as createPartialStore } from "./vuex";
+import { createPartialStore } from "./vuex";
 import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 import { uuid4 } from "@/helpers/random";
 import { PresetStoreState, PresetStoreTypes, State } from "@/store/type";

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,6 +1,6 @@
 import { getBaseName } from "./utility";
 import { createPartialStore, DotNotationDispatch } from "./vuex";
-import { createDotNotationUILockAction as createUILockAction } from "@/store/ui";
+import { createUILockAction } from "@/store/ui";
 import {
   AllActions,
   AudioItem,

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -399,9 +399,9 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
   },
 
   CLEAR_UNDO_HISTORY: {
-    action({ commit }) {
-      commit("RESET_SAVED_LAST_COMMAND_IDS");
-      commit("CLEAR_COMMANDS");
+    action({ mutations }) {
+      mutations.RESET_SAVED_LAST_COMMAND_IDS();
+      mutations.CLEAR_COMMANDS();
     },
   },
 });

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,8 +1,5 @@
 import { getBaseName } from "./utility";
-import {
-  createDotNotationPartialStore as createPartialStore,
-  DotNotationDispatch,
-} from "./vuex";
+import { createPartialStore, DotNotationDispatch } from "./vuex";
 import { createDotNotationUILockAction as createUILockAction } from "@/store/ui";
 import {
   AllActions,

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -1,6 +1,6 @@
 import { SettingStoreState, SettingStoreTypes } from "./type";
 import { createDotNotationUILockAction as createUILockAction } from "./ui";
-import { createDotNotationPartialStore as createPartialStore } from "./vuex";
+import { createPartialStore } from "./vuex";
 import { themes } from "@/domain/theme";
 import {
   showAlertDialog,

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -1,5 +1,5 @@
 import { SettingStoreState, SettingStoreTypes } from "./type";
-import { createDotNotationUILockAction as createUILockAction } from "./ui";
+import { createUILockAction } from "./ui";
 import { createPartialStore } from "./vuex";
 import { themes } from "@/domain/theme";
 import {

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { toRaw } from "vue";
 import { createPartialStore } from "./vuex";
-import { createDotNotationUILockAction as createUILockAction } from "./ui";
+import { createUILockAction } from "./ui";
 import {
   Tempo,
   TimeSignature,

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { toRaw } from "vue";
-import { createDotNotationPartialStore as createPartialStore } from "./vuex";
+import { createPartialStore } from "./vuex";
 import { createDotNotationUILockAction as createUILockAction } from "./ui";
 import {
   Tempo,

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -2,7 +2,6 @@ import {
   Action,
   ActionContext,
   ActionsBase,
-  Dispatch,
   DotNotationAction,
   DotNotationActionContext,
   DotNotationDispatch,
@@ -79,14 +78,6 @@ export function createDotNotationUILockAction<
 }
 
 export function withProgress<T>(
-  action: Promise<T>,
-  dispatch: Dispatch<AllActions>,
-): Promise<T> {
-  void dispatch("START_PROGRESS");
-  return action.finally(() => dispatch("RESET_PROGRESS"));
-}
-
-export function withProgressDotNotation<T>(
   action: Promise<T>,
   actions: DotNotationDispatch<AllActions>,
 ): Promise<T> {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -35,27 +35,6 @@ import {
 
 export function createUILockAction<S, A extends ActionsBase, K extends keyof A>(
   action: (
-    context: ActionContext<S, S, AllGetters, AllActions, AllMutations>,
-    payload: Parameters<A[K]>[0],
-  ) => ReturnType<A[K]> extends Promise<unknown>
-    ? ReturnType<A[K]>
-    : Promise<ReturnType<A[K]>>,
-): Action<S, S, A, K, AllGetters, AllActions, AllMutations> {
-  return (context, payload: Parameters<A[K]>[0]) => {
-    context.commit("LOCK_UI");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-    return action(context, payload).finally(() => {
-      context.commit("UNLOCK_UI");
-    });
-  };
-}
-
-export function createDotNotationUILockAction<
-  S,
-  A extends ActionsBase,
-  K extends keyof A,
->(
-  action: (
     context: DotNotationActionContext<
       S,
       S,
@@ -141,7 +120,7 @@ export const uiStore = createPartialStore<UiStoreTypes>({
   },
 
   ASYNC_UI_LOCK: {
-    action: createDotNotationUILockAction(
+    action: createUILockAction(
       async (_, { callback }: { callback: () => Promise<void> }) => {
         await callback();
       },
@@ -236,27 +215,21 @@ export const uiStore = createPartialStore<UiStoreTypes>({
   },
 
   SHOW_ALERT_DIALOG: {
-    action: createDotNotationUILockAction(
-      async (_, payload: AlertDialogOptions) => {
-        return await showAlertDialog(payload);
-      },
-    ),
+    action: createUILockAction(async (_, payload: AlertDialogOptions) => {
+      return await showAlertDialog(payload);
+    }),
   },
 
   SHOW_CONFIRM_DIALOG: {
-    action: createDotNotationUILockAction(
-      async (_, payload: ConfirmDialogOptions) => {
-        return await showConfirmDialog(payload);
-      },
-    ),
+    action: createUILockAction(async (_, payload: ConfirmDialogOptions) => {
+      return await showConfirmDialog(payload);
+    }),
   },
 
   SHOW_WARNING_DIALOG: {
-    action: createDotNotationUILockAction(
-      async (_, payload: WarningDialogOptions) => {
-        return await showWarningDialog(payload);
-      },
-    ),
+    action: createUILockAction(async (_, payload: WarningDialogOptions) => {
+      return await showWarningDialog(payload);
+    }),
   },
 
   SHOW_NOTIFY_AND_NOT_SHOW_AGAIN_BUTTON: {
@@ -463,7 +436,7 @@ export const uiStore = createPartialStore<UiStoreTypes>({
   },
 
   RELOAD_APP: {
-    action: createDotNotationUILockAction(
+    action: createUILockAction(
       async (
         { actions },
         { isMultiEngineOffMode }: { isMultiEngineOffMode?: boolean },

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -1,6 +1,4 @@
 import {
-  Action,
-  ActionContext,
   ActionsBase,
   DotNotationAction,
   DotNotationActionContext,

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -13,7 +13,7 @@ import {
   UiStoreState,
   UiStoreTypes,
 } from "./type";
-import { createDotNotationPartialStore as createPartialStore } from "./vuex";
+import { createPartialStore } from "./vuex";
 import { ActivePointScrollMode } from "@/type/preload";
 import {
   AlertDialogOptions,

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -441,45 +441,6 @@ export const createPartialStore = <
   A extends ActionsBase = StoreType<T, "action">,
   M extends MutationsBase = StoreType<T, "mutation">,
 >(
-  options: PartialStoreOptions<State, T, G, A, M>,
-): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
-  const obj = Object.keys(options).reduce(
-    (acc, cur) => {
-      const option = options[cur];
-
-      /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-      if (option.getter) {
-        acc.getters[cur] = option.getter;
-      }
-      if (option.mutation) {
-        acc.mutations[cur] = option.mutation;
-      }
-      if (option.action) {
-        acc.actions[cur] = option.action;
-      }
-      /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-
-      return acc;
-    },
-
-    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-    {
-      getters: Object.create(null),
-      mutations: Object.create(null),
-      actions: Object.create(null),
-    },
-    /*  eslint-enable @typescript-eslint/no-unsafe-assignment */
-  );
-
-  return obj;
-};
-
-export const createDotNotationPartialStore = <
-  T extends StoreTypesBase,
-  G extends GettersBase = StoreType<T, "getter">,
-  A extends ActionsBase = StoreType<T, "action">,
-  M extends MutationsBase = StoreType<T, "mutation">,
->(
   options: DotNotationPartialStoreOptions<State, T, G, A, M>,
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
   const obj = Object.keys(options).reduce(

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -401,30 +401,6 @@ type PartialStoreOptions<
         : never
       : GAM extends "action"
         ? K extends keyof A
-          ? Action<S, S, A, K, AllGetters, AllActions, AllMutations>
-          : never
-        : GAM extends "mutation"
-          ? K extends keyof M
-            ? Mutation<S, M, K>
-            : never
-          : never;
-  };
-};
-
-type DotNotationPartialStoreOptions<
-  S,
-  T extends StoreTypesBase,
-  G extends GettersBase,
-  A extends ActionsBase,
-  M extends MutationsBase,
-> = {
-  [K in keyof T]: {
-    [GAM in keyof T[K]]: GAM extends "getter"
-      ? K extends keyof G
-        ? Getter<S, S, G, K, AllGetters>
-        : never
-      : GAM extends "action"
-        ? K extends keyof A
           ? DotNotationAction<S, S, A, K, AllGetters, AllActions, AllMutations>
           : never
         : GAM extends "mutation"
@@ -441,7 +417,7 @@ export const createPartialStore = <
   A extends ActionsBase = StoreType<T, "action">,
   M extends MutationsBase = StoreType<T, "mutation">,
 >(
-  options: DotNotationPartialStoreOptions<State, T, G, A, M>,
+  options: PartialStoreOptions<State, T, G, A, M>,
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
   const obj = Object.keys(options).reduce(
     (acc, cur) => {


### PR DESCRIPTION
## 内容
+ https://github.com/VOICEVOX/voicevox/pull/2099
+ https://github.com/VOICEVOX/voicevox/pull/2170
+ https://github.com/VOICEVOX/voicevox/pull/2180
+ https://github.com/VOICEVOX/voicevox/pull/2213
+ https://github.com/VOICEVOX/voicevox/pull/2266
+ https://github.com/VOICEVOX/voicevox/pull/2326
の続きです。

store/フォルダ内のdispatch("ACTION1", payloads) のような引数におけるリテラル指定から actions.ACTION(payload) のようにdot記法によるアクセスに変更します。


+ src/store/index.ts
+ src/store/audioPlayer.ts
+ src/store/project.ts
を対応しています。

また、`withProgressDotNotation` や `createDotNotationPartialStore` といったDotNotationが付いた名前を元に戻しています。

## 関連 Issue

+ https://github.com/VOICEVOX/voicevox/issues/2088

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
