### PR TITLE
vuexのstoreの呼び出しをリテラル引数からDot記法へ: components/Dialog

### DIFF
--- a/src/components/Dialog/AcceptDialog/AcceptRetrieveTelemetryDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptRetrieveTelemetryDialog.vue
@@ -39,7 +39,7 @@ const modelValueComputed = computed({
 });
 
 const handler = (acceptRetrieveTelemetry: boolean) => {
-  void store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
+  void store.actions.SET_ACCEPT_RETRIEVE_TELEMETRY({
     acceptRetrieveTelemetry: acceptRetrieveTelemetry ? "Accepted" : "Refused",
   });
 
@@ -48,6 +48,6 @@ const handler = (acceptRetrieveTelemetry: boolean) => {
 
 const privacyPolicy = ref("");
 onMounted(async () => {
-  privacyPolicy.value = await store.dispatch("GET_PRIVACY_POLICY_TEXT");
+  privacyPolicy.value = await store.actions.GET_PRIVACY_POLICY_TEXT();
 });
 </script>

--- a/src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
@@ -35,11 +35,11 @@ const modelValueComputed = computed({
 });
 
 const handler = (acceptTerms: boolean) => {
-  void store.dispatch("SET_ACCEPT_TERMS", {
+  void store.actions.SET_ACCEPT_TERMS({
     acceptTerms: acceptTerms ? "Accepted" : "Rejected",
   });
   if (acceptTerms) {
-    void store.dispatch("CHECK_EDITED_AND_NOT_SAVE", {
+    void store.actions.CHECK_EDITED_AND_NOT_SAVE({
       closeOrReload: "close",
     });
   }
@@ -49,6 +49,6 @@ const handler = (acceptTerms: boolean) => {
 
 const terms = ref("");
 onMounted(async () => {
-  terms.value = await store.dispatch("GET_POLICY_TEXT");
+  terms.value = await store.actions.GET_POLICY_TEXT();
 });
 </script>

--- a/src/components/Dialog/AllDialog.vue
+++ b/src/components/Dialog/AllDialog.vue
@@ -52,20 +52,20 @@ const store = useStore();
 // ライセンス表示
 const isHelpDialogOpenComputed = computed({
   get: () => store.state.isHelpDialogOpen,
-  set: (val) => store.dispatch("SET_DIALOG_OPEN", { isHelpDialogOpen: val }),
+  set: (val) => store.actions.SET_DIALOG_OPEN({ isHelpDialogOpen: val }),
 });
 
 // 設定
 const isSettingDialogOpenComputed = computed({
   get: () => store.state.isSettingDialogOpen,
-  set: (val) => store.dispatch("SET_DIALOG_OPEN", { isSettingDialogOpen: val }),
+  set: (val) => store.actions.SET_DIALOG_OPEN({ isSettingDialogOpen: val }),
 });
 
 // ショートカットキー設定
 const isHotkeySettingDialogOpenComputed = computed({
   get: () => store.state.isHotkeySettingDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isHotkeySettingDialogOpen: val,
     }),
 });
@@ -74,7 +74,7 @@ const isHotkeySettingDialogOpenComputed = computed({
 const isToolbarSettingDialogOpenComputed = computed({
   get: () => store.state.isToolbarSettingDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isToolbarSettingDialogOpen: val,
     }),
 });
@@ -83,7 +83,7 @@ const isToolbarSettingDialogOpenComputed = computed({
 const isAcceptTermsDialogOpenComputed = computed({
   get: () => store.state.isAcceptTermsDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isAcceptTermsDialogOpen: val,
     }),
 });
@@ -97,7 +97,7 @@ const isCharacterOrderDialogOpenComputed = computed({
     !store.state.isAcceptTermsDialogOpen &&
     store.state.isCharacterOrderDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isCharacterOrderDialogOpen: val,
     }),
 });
@@ -115,7 +115,7 @@ const isDefaultStyleSelectDialogOpenComputed = computed({
     !store.state.isCharacterOrderDialogOpen &&
     store.state.isDefaultStyleSelectDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isDefaultStyleSelectDialogOpen: val,
     }),
 });
@@ -124,7 +124,7 @@ const isDefaultStyleSelectDialogOpenComputed = computed({
 const isEngineManageDialogOpenComputed = computed({
   get: () => store.state.isEngineManageDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isEngineManageDialogOpen: val,
     }),
 });
@@ -133,7 +133,7 @@ const isEngineManageDialogOpenComputed = computed({
 const isDictionaryManageDialogOpenComputed = computed({
   get: () => store.state.isDictionaryManageDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isDictionaryManageDialogOpen: val,
     }),
 });
@@ -145,7 +145,7 @@ const isAcceptRetrieveTelemetryDialogOpenComputed = computed({
     !store.state.isDefaultStyleSelectDialogOpen &&
     store.state.isAcceptRetrieveTelemetryDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isAcceptRetrieveTelemetryDialogOpen: val,
     }),
 });
@@ -165,7 +165,7 @@ const canOpenNotificationDialog = computed(() => {
 const isExportSongAudioDialogOpen = computed({
   get: () => store.state.isExportSongAudioDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isExportSongAudioDialogOpen: val,
     }),
 });
@@ -174,7 +174,7 @@ const isExportSongAudioDialogOpen = computed({
 const isImportSongProjectDialogOpenComputed = computed({
   get: () => store.state.isImportSongProjectDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isImportSongProjectDialogOpen: val,
     }),
 });

--- a/src/components/Dialog/CharacterOrderDialog.vue
+++ b/src/components/Dialog/CharacterOrderDialog.vue
@@ -164,7 +164,7 @@ watch(
   async (newValue, oldValue) => {
     if (!oldValue && newValue) {
       // 新しいキャラクター
-      newCharacters.value = await store.dispatch("GET_NEW_CHARACTERS");
+      newCharacters.value = await store.actions.GET_NEW_CHARACTERS();
 
       // サンプルの順番、新しいキャラクターは上に
       sampleCharacterOrder.value = [
@@ -256,8 +256,7 @@ const togglePlayOrStop = (
 const characterOrderDragging = ref(false);
 
 const closeDialog = () => {
-  void store.dispatch(
-    "SET_USER_CHARACTER_ORDER",
+  void store.actions.SET_USER_CHARACTER_ORDER(
     characterOrder.value.map((info) => info.metas.speakerUuid),
   );
   stop();

--- a/src/components/Dialog/DefaultStyleListDialog.vue
+++ b/src/components/Dialog/DefaultStyleListDialog.vue
@@ -191,8 +191,7 @@ watch([() => props.modelValue], async ([newValue]) => {
 const isHoverableItem = ref(true);
 
 const closeDialog = () => {
-  void store.dispatch(
-    "SET_DEFAULT_STYLE_IDS",
+  void store.actions.SET_DEFAULT_STYLE_IDS(
     Object.entries(selectedStyleIndexes.value).map(
       ([speakerUuidStr, styleIndex]) => {
         const speakerUuid = SpeakerId(speakerUuidStr);

--- a/src/components/Dialog/DefaultStyleSelectDialog.vue
+++ b/src/components/Dialog/DefaultStyleSelectDialog.vue
@@ -215,7 +215,7 @@ const closeDialog = () => {
   const defaultStyleIds = JSON.parse(
     JSON.stringify(store.state.defaultStyleIds),
   ) as DefaultStyleId[];
-  void store.dispatch("SET_DEFAULT_STYLE_IDS", [
+  void store.actions.SET_DEFAULT_STYLE_IDS([
     ...defaultStyleIds.filter(
       (defaultStyleId) =>
         defaultStyleId.speakerUuid !== props.characterInfo.metas.speakerUuid,

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -339,10 +339,10 @@ const loadingDictProcess = async () => {
   loadingDictState.value = "loading";
   try {
     userDict.value = await createUILockAction(
-      store.dispatch("LOAD_ALL_USER_DICT"),
+      store.actions.LOAD_ALL_USER_DICT(),
     );
   } catch {
-    const result = await store.dispatch("SHOW_ALERT_DIALOG", {
+    const result = await store.actions.SHOW_ALERT_DIALOG({
       title: "辞書の取得に失敗しました",
       message: "エンジンの再起動をお試しください。",
     });
@@ -352,9 +352,9 @@ const loadingDictProcess = async () => {
   }
   loadingDictState.value = "synchronizing";
   try {
-    await createUILockAction(store.dispatch("SYNC_ALL_USER_DICT"));
+    await createUILockAction(store.actions.SYNC_ALL_USER_DICT());
   } catch {
-    await store.dispatch("SHOW_ALERT_DIALOG", {
+    await store.actions.SHOW_ALERT_DIALOG({
       title: "辞書の同期に失敗しました",
       message: "エンジンの再起動をお試しください。",
     });
@@ -441,7 +441,7 @@ const setYomi = async (text: string, changeWord?: boolean) => {
     text = convertLongVowel(text);
     accentPhrase.value = (
       await createUILockAction(
-        store.dispatch("FETCH_ACCENT_PHRASES", {
+        store.actions.FETCH_ACCENT_PHRASES({
           text: text + "ガ'",
           engineId,
           styleId,
@@ -465,7 +465,7 @@ const changeAccent = async (_: number, accent: number) => {
     accentPhrase.value.accent = accent;
     accentPhrase.value = (
       await createUILockAction(
-        store.dispatch("FETCH_MORA_DATA", {
+        store.actions.FETCH_MORA_DATA({
           accentPhrases: [accentPhrase.value],
           engineId,
           styleId,
@@ -479,7 +479,7 @@ const play = async () => {
   if (!accentPhrase.value) return;
 
   nowGenerating.value = true;
-  const audioItem = await store.dispatch("GENERATE_AUDIO_ITEM", {
+  const audioItem = await store.actions.GENERATE_AUDIO_ITEM({
     text: yomi.value,
     voice: voiceComputed.value,
   });
@@ -491,13 +491,13 @@ const play = async () => {
 
   let fetchAudioResult: FetchAudioResult;
   try {
-    fetchAudioResult = await store.dispatch("FETCH_AUDIO_FROM_AUDIO_ITEM", {
+    fetchAudioResult = await store.actions.FETCH_AUDIO_FROM_AUDIO_ITEM({
       audioItem,
     });
   } catch (e) {
     window.backend.logError(e);
     nowGenerating.value = false;
-    void store.dispatch("SHOW_ALERT_DIALOG", {
+    void store.actions.SHOW_ALERT_DIALOG({
       title: "生成に失敗しました",
       message: "エンジンの再起動をお試しください。",
     });
@@ -507,11 +507,11 @@ const play = async () => {
   const { blob } = fetchAudioResult;
   nowGenerating.value = false;
   nowPlaying.value = true;
-  await store.dispatch("PLAY_AUDIO_BLOB", { audioBlob: blob });
+  await store.actions.PLAY_AUDIO_BLOB({ audioBlob: blob });
   nowPlaying.value = false;
 };
 const stop = () => {
-  void store.dispatch("STOP_AUDIO");
+  void store.actions.STOP_AUDIO();
 };
 
 // accent phraseにあるaccentと実際に登録するアクセントには差が生まれる
@@ -562,7 +562,7 @@ const saveWord = async () => {
   const accent = computeRegisteredAccent();
   if (selectedId.value) {
     try {
-      await store.dispatch("REWRITE_WORD", {
+      await store.actions.REWRITE_WORD({
         wordUuid: selectedId.value,
         surface: surface.value,
         pronunciation: yomi.value,
@@ -570,7 +570,7 @@ const saveWord = async () => {
         priority: wordPriority.value,
       });
     } catch {
-      void store.dispatch("SHOW_ALERT_DIALOG", {
+      void store.actions.SHOW_ALERT_DIALOG({
         title: "単語の更新に失敗しました",
         message: "エンジンの再起動をお試しください。",
       });
@@ -579,7 +579,7 @@ const saveWord = async () => {
   } else {
     try {
       await createUILockAction(
-        store.dispatch("ADD_WORD", {
+        store.actions.ADD_WORD({
           surface: surface.value,
           pronunciation: yomi.value,
           accentType: accent,
@@ -587,7 +587,7 @@ const saveWord = async () => {
         }),
       );
     } catch {
-      void store.dispatch("SHOW_ALERT_DIALOG", {
+      void store.actions.SHOW_ALERT_DIALOG({
         title: "単語の登録に失敗しました",
         message: "エンジンの再起動をお試しください。",
       });
@@ -598,7 +598,7 @@ const saveWord = async () => {
   toInitialState();
 };
 const deleteWord = async () => {
-  const result = await store.dispatch("SHOW_WARNING_DIALOG", {
+  const result = await store.actions.SHOW_WARNING_DIALOG({
     title: "登録された単語を削除しますか？",
     message: "削除された単語は元に戻せません。",
     actionName: "削除",
@@ -606,12 +606,12 @@ const deleteWord = async () => {
   if (result === "OK") {
     try {
       await createUILockAction(
-        store.dispatch("DELETE_WORD", {
+        store.actions.DELETE_WORD({
           wordUuid: selectedId.value,
         }),
       );
     } catch {
-      void store.dispatch("SHOW_ALERT_DIALOG", {
+      void store.actions.SHOW_ALERT_DIALOG({
         title: "単語の削除に失敗しました",
         message: "エンジンの再起動をお試しください。",
       });
@@ -622,7 +622,7 @@ const deleteWord = async () => {
   }
 };
 const resetWord = async (id: string) => {
-  const result = await store.dispatch("SHOW_WARNING_DIALOG", {
+  const result = await store.actions.SHOW_WARNING_DIALOG({
     title: "単語の変更をリセットしますか？",
     message: "単語の変更は破棄されてリセットされます。",
     actionName: "リセット",
@@ -637,7 +637,7 @@ const resetWord = async (id: string) => {
 };
 const discardOrNotDialog = async (okCallback: () => void) => {
   if (isWordChanged.value) {
-    const result = await store.dispatch("SHOW_WARNING_DIALOG", {
+    const result = await store.actions.SHOW_WARNING_DIALOG({
       title: "単語の追加・変更を破棄しますか？",
       message: "破棄すると、単語の追加・変更はリセットされます。",
       actionName: "破棄",

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -338,8 +338,8 @@ watch(
       const id = EngineId(idStr);
       if (engineStates.value[id] !== "READY") continue;
       if (engineVersions.value[id]) continue;
-      const version = await store
-        .dispatch("INSTANTIATE_ENGINE_CONNECTOR", { engineId: id })
+      const version = await store.actions
+        .INSTANTIATE_ENGINE_CONNECTOR({ engineId: id })
         .then((instance) => instance.invoke("versionVersionGet")({}))
         .then((version) => {
           // OpenAPIのバグで"latest"のようにダブルクォーテーションで囲まれていることがあるので外す
@@ -408,7 +408,7 @@ const getEngineDirValidationMessage = (result: EngineDirValidationResult) => {
 };
 
 const addEngine = async () => {
-  const result = await store.dispatch("SHOW_WARNING_DIALOG", {
+  const result = await store.actions.SHOW_WARNING_DIALOG({
     title: "エンジン追加の確認",
     message:
       "この操作はコンピュータに損害を与える可能性があります。エンジンの配布元が信頼できない場合は追加しないでください。",
@@ -418,7 +418,7 @@ const addEngine = async () => {
     if (engineLoaderType.value === "dir") {
       await lockUi(
         "addingEngine",
-        store.dispatch("ADD_ENGINE_DIR", {
+        store.actions.ADD_ENGINE_DIR({
           engineDir: newEngineDir.value,
         }),
       );
@@ -429,7 +429,7 @@ const addEngine = async () => {
     } else {
       const success = await lockUi(
         "addingEngine",
-        store.dispatch("INSTALL_VVPP_ENGINE", vvppFilePath.value),
+        store.actions.INSTALL_VVPP_ENGINE(vvppFilePath.value),
       );
       if (success) {
         void requireReload(
@@ -450,7 +450,7 @@ const deleteEngine = async () => {
     throw new Error("default engine cannot be deleted");
   }
 
-  const result = await store.dispatch("SHOW_CONFIRM_DIALOG", {
+  const result = await store.actions.SHOW_CONFIRM_DIALOG({
     title: "エンジン削除の確認",
     message: "選択中のエンジンを削除します。よろしいですか？",
     actionName: "削除",
@@ -463,7 +463,7 @@ const deleteEngine = async () => {
           throw new Error("assert engineInfos[selectedId.value].path");
         await lockUi(
           "deletingEngine",
-          store.dispatch("REMOVE_ENGINE_DIR", {
+          store.actions.REMOVE_ENGINE_DIR({
             engineDir,
           }),
         );
@@ -475,7 +475,7 @@ const deleteEngine = async () => {
       case "vvpp": {
         const success = await lockUi(
           "deletingEngine",
-          store.dispatch("UNINSTALL_VVPP_ENGINE", engineId),
+          store.actions.UNINSTALL_VVPP_ENGINE(engineId),
         );
         if (success) {
           void requireReload(
@@ -497,19 +497,19 @@ const selectEngine = (id: EngineId) => {
 const openSelectedEngineDirectory = () => {
   if (selectedId.value == undefined)
     throw new Error("assert selectedId.value != undefined");
-  void store.dispatch("OPEN_ENGINE_DIRECTORY", { engineId: selectedId.value });
+  void store.actions.OPEN_ENGINE_DIRECTORY({ engineId: selectedId.value });
 };
 
 const restartSelectedEngine = () => {
   if (selectedId.value == undefined)
     throw new Error("assert selectedId.value != undefined");
-  void store.dispatch("RESTART_ENGINES", {
+  void store.actions.RESTART_ENGINES({
     engineIds: [selectedId.value],
   });
 };
 
 const requireReload = async (message: string) => {
-  const result = await store.dispatch("SHOW_WARNING_DIALOG", {
+  const result = await store.actions.SHOW_WARNING_DIALOG({
     title: "再読み込みが必要です",
     message: message,
     actionName: "再読み込み",
@@ -517,7 +517,7 @@ const requireReload = async (message: string) => {
   });
   toInitialState();
   if (result === "OK") {
-    void store.dispatch("CHECK_EDITED_AND_NOT_SAVE", {
+    void store.actions.CHECK_EDITED_AND_NOT_SAVE({
       closeOrReload: "reload",
     });
   }
@@ -535,8 +535,7 @@ const selectEngineDir = async () => {
       newEngineDirValidationState.value = null;
       return;
     }
-    newEngineDirValidationState.value = await store.dispatch(
-      "VALIDATE_ENGINE_DIR",
+    newEngineDirValidationState.value = await store.actions.VALIDATE_ENGINE_DIR(
       {
         engineDir: path,
       },

--- a/src/components/Dialog/ExportSongAudioDialog/Container.vue
+++ b/src/components/Dialog/ExportSongAudioDialog/Container.vue
@@ -21,9 +21,9 @@ const handleExportAudio = async (
 ) => {
   let result: SaveResultObject;
   if (target === "master") {
-    result = await store.dispatch("EXPORT_AUDIO_FILE", { setting });
+    result = await store.actions.EXPORT_AUDIO_FILE({ setting });
   } else {
-    result = await store.dispatch("EXPORT_STEM_AUDIO_FILE", { setting });
+    result = await store.actions.EXPORT_STEM_AUDIO_FILE({ setting });
   }
 
   notifyResult(

--- a/src/components/Dialog/HelpDialog/HelpDialog.vue
+++ b/src/components/Dialog/HelpDialog/HelpDialog.vue
@@ -116,9 +116,7 @@ const store = useStore();
 const { warn } = createLogger("HelpDialog");
 
 const updateInfos = ref<UpdateInfoObject[]>();
-void store
-  .dispatch("GET_UPDATE_INFOS")
-  .then((obj) => (updateInfos.value = obj));
+void store.actions.GET_UPDATE_INFOS().then((obj) => (updateInfos.value = obj));
 
 if (!import.meta.env.VITE_LATEST_UPDATE_INFOS_URL) {
   throw new Error(
@@ -132,26 +130,24 @@ const newUpdateResult = useFetchNewUpdateInfos(
 
 // エディタのOSSライセンス取得
 const licenses = ref<Record<string, string>[]>();
-void store.dispatch("GET_OSS_LICENSES").then((obj) => (licenses.value = obj));
+void store.actions.GET_OSS_LICENSES().then((obj) => (licenses.value = obj));
 
 const policy = ref<string>();
-void store.dispatch("GET_POLICY_TEXT").then((obj) => (policy.value = obj));
+void store.actions.GET_POLICY_TEXT().then((obj) => (policy.value = obj));
 
 const howToUse = ref<string>();
-void store
-  .dispatch("GET_HOW_TO_USE_TEXT")
-  .then((obj) => (howToUse.value = obj));
+void store.actions.GET_HOW_TO_USE_TEXT().then((obj) => (howToUse.value = obj));
 
 const ossCommunityInfos = ref<string>();
-void store
-  .dispatch("GET_OSS_COMMUNITY_INFOS")
+void store.actions
+  .GET_OSS_COMMUNITY_INFOS()
   .then((obj) => (ossCommunityInfos.value = obj));
 
 const qAndA = ref<string>();
-void store.dispatch("GET_Q_AND_A_TEXT").then((obj) => (qAndA.value = obj));
+void store.actions.GET_Q_AND_A_TEXT().then((obj) => (qAndA.value = obj));
 
 const contact = ref<string>();
-void store.dispatch("GET_CONTACT_TEXT").then((obj) => (contact.value = obj));
+void store.actions.GET_CONTACT_TEXT().then((obj) => (contact.value = obj));
 
 const pagedata = computed(() => {
   const data: PageData[] = [

--- a/src/components/Dialog/HotkeySettingDialog.vue
+++ b/src/components/Dialog/HotkeySettingDialog.vue
@@ -208,7 +208,7 @@ const changeHotkeySettings = (
     action: action as HotkeyActionNameType,
     combination,
   });
-  return store.dispatch("SET_HOTKEY_SETTINGS", {
+  return store.actions.SET_HOTKEY_SETTINGS({
     data: {
       action: action as HotkeyActionNameType,
       combination,
@@ -263,7 +263,7 @@ const setHotkeyDialogOpened = () => {
 };
 
 const resetHotkey = async (action: string) => {
-  const result = await store.dispatch("SHOW_CONFIRM_DIALOG", {
+  const result = await store.actions.SHOW_CONFIRM_DIALOG({
     title: "ショートカットキーを初期値に戻します",
     message: `${action}のショートカットキーを初期値に戻します。\n本当に戻しますか？`,
     actionName: "初期値に戻す",

--- a/src/components/Dialog/ImportSongProjectDialog.vue
+++ b/src/components/Dialog/ImportSongProjectDialog.vue
@@ -263,7 +263,7 @@ const handleFileChange = async (event: Event) => {
   try {
     if (file.name.endsWith(".vvproj")) {
       const vvproj = await file.text();
-      const parsedProject = await store.dispatch("PARSE_PROJECT_FILE", {
+      const parsedProject = await store.actions.PARSE_PROJECT_FILE({
         projectJson: vvproj,
       });
       project.value = {
@@ -307,12 +307,12 @@ const handleImportTrack = () => {
   }
   // トラックをインポート
   if (project.value.type === "vvproj") {
-    void store.dispatch("COMMAND_IMPORT_VOICEVOX_PROJECT", {
+    void store.actions.COMMAND_IMPORT_VOICEVOX_PROJECT({
       project: project.value.project,
       trackIndexes: selectedTrackIndexes.value,
     });
   } else {
-    void store.dispatch("COMMAND_IMPORT_UTAFORMATIX_PROJECT", {
+    void store.actions.COMMAND_IMPORT_UTAFORMATIX_PROJECT({
       project: project.value.project,
       trackIndexes: selectedTrackIndexes.value,
     });

--- a/src/components/Dialog/PresetManageDialog.vue
+++ b/src/components/Dialog/PresetManageDialog.vue
@@ -95,21 +95,21 @@ const reorderPreset = (featurePresetList: (Preset & { key: PresetKey })[]) => {
   // デフォルトプリセットは表示するlistから除外しているので、末尾に追加しておかないと失われる
   const defaultPresetKeys = presetKeys.value.filter(isDefaultPresetKey);
 
-  void store
-    .dispatch("SAVE_PRESET_ORDER", {
+  void store.actions
+    .SAVE_PRESET_ORDER({
       presetKeys: [...newPresetKeys, ...defaultPresetKeys],
     })
     .finally(() => (isPreview.value = false));
 };
 
 const deletePreset = async (key: PresetKey) => {
-  const result = await store.dispatch("SHOW_CONFIRM_DIALOG", {
+  const result = await store.actions.SHOW_CONFIRM_DIALOG({
     title: "プリセット削除の確認",
     message: `プリセット "${presetItems.value[key].name}" を削除してもよろしいですか？`,
     actionName: "削除",
   });
   if (result === "OK") {
-    await store.dispatch("DELETE_PRESET", {
+    await store.actions.DELETE_PRESET({
       presetKey: key,
     });
   }

--- a/src/components/Dialog/SettingDialog/SettingDialog.vue
+++ b/src/components/Dialog/SettingDialog/SettingDialog.vue
@@ -180,7 +180,7 @@
                     :disabled="isDefaultConfirmedTips"
                     @click="
                       () => {
-                        store.dispatch('RESET_CONFIRMED_TIPS');
+                        store.actions.RESET_CONFIRMED_TIPS();
                         hasResetConfirmedTips = true;
                       }
                     "
@@ -527,7 +527,7 @@ const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
 const activePointScrollMode = computed({
   get: () => store.state.activePointScrollMode,
   set: (activePointScrollMode: ActivePointScrollMode) => {
-    void store.dispatch("SET_ACTIVE_POINT_SCROLL_MODE", {
+    void store.actions.SET_ACTIVE_POINT_SCROLL_MODE({
       activePointScrollMode,
     });
   },
@@ -550,7 +550,7 @@ const undoableTrackOperationsLabels = {
 const undoableTrackOperations = computed({
   get: () => store.state.undoableTrackOperations,
   set: (undoableTrackOperations) => {
-    void store.dispatch("SET_ROOT_MISC_SETTING", {
+    void store.actions.SET_ROOT_MISC_SETTING({
       key: "undoableTrackOperations",
       value: undoableTrackOperations,
     });
@@ -561,7 +561,7 @@ const undoableTrackOperations = computed({
 const currentThemeNameComputed = computed({
   get: () => store.state.currentTheme,
   set: (currentTheme: string) => {
-    void store.dispatch("SET_CURRENT_THEME_SETTING", { currentTheme });
+    void store.actions.SET_CURRENT_THEME_SETTING({ currentTheme });
   },
 });
 
@@ -654,7 +654,7 @@ if (navigator.mediaDevices) {
 const acceptRetrieveTelemetryComputed = computed({
   get: () => store.state.acceptRetrieveTelemetry == "Accepted",
   set: (acceptRetrieveTelemetry: boolean) => {
-    void store.dispatch("SET_ACCEPT_RETRIEVE_TELEMETRY", {
+    void store.actions.SET_ACCEPT_RETRIEVE_TELEMETRY({
       acceptRetrieveTelemetry: acceptRetrieveTelemetry ? "Accepted" : "Refused",
     });
 
@@ -662,7 +662,7 @@ const acceptRetrieveTelemetryComputed = computed({
       return;
     }
 
-    void store.dispatch("SHOW_ALERT_DIALOG", {
+    void store.actions.SHOW_ALERT_DIALOG({
       title: "ソフトウェア利用状況のデータ収集の無効化",
       message:
         "ソフトウェア利用状況のデータ収集を完全に無効にするには、VOICEVOXを再起動する必要があります",
@@ -672,21 +672,21 @@ const acceptRetrieveTelemetryComputed = computed({
 });
 
 const changeUseGpu = async (useGpu: boolean) => {
-  void store.dispatch("SHOW_LOADING_SCREEN", {
+  void store.actions.SHOW_LOADING_SCREEN({
     message: "起動モードを変更中です",
   });
 
-  await store.dispatch("CHANGE_USE_GPU", {
+  await store.actions.CHANGE_USE_GPU({
     useGpu,
     engineId: selectedEngineId.value,
   });
 
-  void store.dispatch("HIDE_ALL_LOADING_SCREEN");
+  void store.actions.HIDE_ALL_LOADING_SCREEN();
 };
 
 const changeinheritAudioInfo = async (inheritAudioInfo: boolean) => {
   if (store.state.inheritAudioInfo === inheritAudioInfo) return;
-  void store.dispatch("SET_INHERIT_AUDIOINFO", { inheritAudioInfo });
+  void store.actions.SET_INHERIT_AUDIOINFO({ inheritAudioInfo });
 };
 
 const changeEnablePreset = (value: boolean) => {
@@ -704,7 +704,7 @@ const changeExperimentalSetting = async (
   key: keyof ExperimentalSettingType,
   data: boolean,
 ) => {
-  void store.dispatch("SET_EXPERIMENTAL_SETTING", {
+  void store.actions.SET_EXPERIMENTAL_SETTING({
     experimentalSetting: { ...experimentalSetting.value, [key]: data },
   });
 };
@@ -754,7 +754,7 @@ const handleSavingSettingChange = (
   key: keyof SavingSetting,
   data: string | boolean | number,
 ) => {
-  void store.dispatch("SET_SAVING_SETTING", {
+  void store.actions.SET_SAVING_SETTING({
     data: { ...savingSetting.value, [key]: data },
   });
 };
@@ -766,7 +766,7 @@ const outputSamplingRate = computed({
   },
   set: async (outputSamplingRate: SamplingRateOption) => {
     if (outputSamplingRate !== "engineDefault") {
-      const result = await store.dispatch("SHOW_CONFIRM_DIALOG", {
+      const result = await store.actions.SHOW_CONFIRM_DIALOG({
         title: "出力サンプリングレートを変更します",
         message:
           "出力サンプリングレートを変更しても、音質は変化しません。また、音声の生成処理に若干時間がかかる場合があります。\n変更しますか？",
@@ -778,7 +778,7 @@ const outputSamplingRate = computed({
       }
     }
 
-    void store.dispatch("SET_ENGINE_SETTING", {
+    void store.actions.SET_ENGINE_SETTING({
       engineId: selectedEngineId.value,
       engineSetting: {
         ...store.state.engineSettings[selectedEngineId.value],

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -208,7 +208,7 @@ watch(
 );
 
 const applyDefaultSetting = async () => {
-  const result = await store.dispatch("SHOW_CONFIRM_DIALOG", {
+  const result = await store.actions.SHOW_CONFIRM_DIALOG({
     title: "ツールバーをデフォルトに戻します",
     message: "ツールバーをデフォルトに戻します。\nよろしいですか？",
     actionName: "はい",
@@ -220,14 +220,14 @@ const applyDefaultSetting = async () => {
   }
 };
 const saveCustomToolbar = () => {
-  void store.dispatch("SET_TOOLBAR_SETTING", {
+  void store.actions.SET_TOOLBAR_SETTING({
     data: [...toolbarButtons.value],
   });
 };
 
 const finishOrNotDialog = async () => {
   if (isChanged.value) {
-    const result = await store.dispatch("SHOW_WARNING_DIALOG", {
+    const result = await store.actions.SHOW_WARNING_DIALOG({
       title: "カスタマイズを終了しますか？",
       message:
         "保存せずに終了すると、カスタマイズは破棄されてリセットされます。",

--- a/src/components/Dialog/UpdateNotificationDialog/Container.vue
+++ b/src/components/Dialog/UpdateNotificationDialog/Container.vue
@@ -30,7 +30,7 @@ const store = useStore();
 const isDialogOpenComputed = computed({
   get: () => store.state.isUpdateNotificationDialogOpen,
   set: (val) =>
-    store.dispatch("SET_DIALOG_OPEN", {
+    store.actions.SET_DIALOG_OPEN({
       isUpdateNotificationDialogOpen: val,
     }),
 });
@@ -48,7 +48,7 @@ const currentVersionGetter = async () => {
     .getAppInfos()
     .then((obj) => obj.version);
 
-  await store.dispatch("WAIT_VUEX_READY", { timeout: 15000 });
+  await store.actions.WAIT_VUEX_READY({ timeout: 15000 });
   const skipUpdateVersion = store.state.skipUpdateVersion ?? "0.0.0";
   if (semver.valid(skipUpdateVersion) == undefined) {
     throw new Error(`skipUpdateVersionが不正です: ${skipUpdateVersion}`);
@@ -67,7 +67,7 @@ const newUpdateResult = useFetchNewUpdateInfos(
 
 // 新しいバージョンのアップデートがスキップされたときの処理
 const handleSkipThisVersionClick = (version: string) => {
-  void store.dispatch("SET_ROOT_MISC_SETTING", {
+  void store.actions.SET_ROOT_MISC_SETTING({
     key: "skipUpdateVersion",
     value: version,
   });


### PR DESCRIPTION
## 内容
+ https://github.com/VOICEVOX/voicevox/pull/2099
+ https://github.com/VOICEVOX/voicevox/pull/2170
+ https://github.com/VOICEVOX/voicevox/pull/2180
+ https://github.com/VOICEVOX/voicevox/pull/2213
+ https://github.com/VOICEVOX/voicevox/pull/2266
+ https://github.com/VOICEVOX/voicevox/pull/2326
+ https://github.com/VOICEVOX/voicevox/pull/2327
の続きです。

components/Dialog/フォルダ内のdispatch("ACTION1", payloads) のような引数におけるリテラル指定から actions.ACTION(payload) のようにdot記法によるアクセスに変更します。


+ src/components/Dialog/AcceptDialog/AcceptRetrieveTelemetryDialog.vue
+ src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
+ src/components/Dialog/AllDialog.vue
+ src/components/Dialog/CharacterOrderDialog.vue
+ src/components/Dialog/DefaultStyleListDialog.vue
+ src/components/Dialog/DefaultStyleSelectDialog.vue
+ src/components/Dialog/DictionaryManageDialog.vue
+ src/components/Dialog/EngineManageDialog.vue
+ src/components/Dialog/ExportSongAudioDialog/Container.vue
+ src/components/Dialog/HelpDialog/HelpDialog.vue
+ src/components/Dialog/HotkeySettingDialog.vue
+ src/components/Dialog/ImportSongProjectDialog.vue
+ src/components/Dialog/PresetManageDialog.vue
+ src/components/Dialog/SettingDialog/SettingDialog.vue
+ src/components/Dialog/ToolBarCustomDialog.vue
+ src/components/Dialog/UpdateNotificationDialog/Container.vue
を対応しています。

## 関連 Issue

+ https://github.com/VOICEVOX/voicevox/issues/2088

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

dispatch\([\s\n]*"([A-Z_]*)",?
actions.$1(
と正規表現で置換してその後眼力チェックしています。
