### PR TITLE
vuexのstoreの呼び出しをリテラル引数からDot記法へ: components/Menu

### DIFF
--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -110,62 +110,60 @@ watch(titleText, (newTitle) => {
 });
 
 const closeAllDialog = () => {
-  void store.dispatch("SET_DIALOG_OPEN", {
+  void store.actions.SET_DIALOG_OPEN({
     isSettingDialogOpen: false,
   });
-  void store.dispatch("SET_DIALOG_OPEN", {
+  void store.actions.SET_DIALOG_OPEN({
     isHelpDialogOpen: false,
   });
-  void store.dispatch("SET_DIALOG_OPEN", {
+  void store.actions.SET_DIALOG_OPEN({
     isHotkeySettingDialogOpen: false,
   });
-  void store.dispatch("SET_DIALOG_OPEN", {
+  void store.actions.SET_DIALOG_OPEN({
     isToolbarSettingDialogOpen: false,
   });
-  void store.dispatch("SET_DIALOG_OPEN", {
+  void store.actions.SET_DIALOG_OPEN({
     isCharacterOrderDialogOpen: false,
   });
-  void store.dispatch("SET_DIALOG_OPEN", {
+  void store.actions.SET_DIALOG_OPEN({
     isDefaultStyleSelectDialogOpen: false,
   });
 };
 
 const openHelpDialog = () => {
-  void store.dispatch("SET_DIALOG_OPEN", {
+  void store.actions.SET_DIALOG_OPEN({
     isHelpDialogOpen: true,
   });
 };
 
 const createNewProject = async () => {
   if (!uiLocked.value) {
-    await store.dispatch("CREATE_NEW_PROJECT", {});
+    await store.actions.CREATE_NEW_PROJECT({});
   }
 };
 
 const saveProject = async () => {
   if (!uiLocked.value) {
-    await store.dispatch("SAVE_PROJECT_FILE", { overwrite: true });
+    await store.actions.SAVE_PROJECT_FILE({ overwrite: true });
   }
 };
 
 const saveProjectAs = async () => {
   if (!uiLocked.value) {
-    await store.dispatch("SAVE_PROJECT_FILE", {});
+    await store.actions.SAVE_PROJECT_FILE({});
   }
 };
 
 const importProject = () => {
   if (!uiLocked.value) {
-    void store.dispatch("LOAD_PROJECT_FILE", {});
+    void store.actions.LOAD_PROJECT_FILE({});
   }
 };
 
 // 「最近使ったプロジェクト」のメニュー
 const recentProjectsSubMenuData = ref<MenuItemData[]>([]);
 const updateRecentProjects = async () => {
-  const recentlyUsedProjects = await store.dispatch(
-    "GET_RECENTLY_USED_PROJECTS",
-  );
+  const recentlyUsedProjects = await store.actions.GET_RECENTLY_USED_PROJECTS();
   recentProjectsSubMenuData.value =
     recentlyUsedProjects.length === 0
       ? [
@@ -183,7 +181,7 @@ const updateRecentProjects = async () => {
           type: "button",
           label: projectFilePath,
           onClick: () => {
-            void store.dispatch("LOAD_PROJECT_FILE", {
+            void store.actions.LOAD_PROJECT_FILE({
               filePath: projectFilePath,
             });
           },
@@ -206,7 +204,7 @@ const engineSubMenuData = computed<MenuItemData[]>(() => {
         type: "button",
         label: "再起動",
         onClick: () => {
-          void store.dispatch("RESTART_ENGINES", {
+          void store.actions.RESTART_ENGINES({
             engineIds: [engineInfo.uuid],
           });
         },
@@ -228,7 +226,7 @@ const engineSubMenuData = computed<MenuItemData[]>(() => {
                 type: "button",
                 label: "フォルダを開く",
                 onClick: () => {
-                  void store.dispatch("OPEN_ENGINE_DIRECTORY", {
+                  void store.actions.OPEN_ENGINE_DIRECTORY({
                     engineId: engineInfo.uuid,
                   });
                 },
@@ -238,7 +236,7 @@ const engineSubMenuData = computed<MenuItemData[]>(() => {
                 type: "button",
                 label: "再起動",
                 onClick: () => {
-                  void store.dispatch("RESTART_ENGINES", {
+                  void store.actions.RESTART_ENGINES({
                     engineIds: [engineInfo.uuid],
                   });
                 },
@@ -254,7 +252,7 @@ const engineSubMenuData = computed<MenuItemData[]>(() => {
         type: "button",
         label: "全てのエンジンを再起動",
         onClick: () => {
-          void store.dispatch("RESTART_ENGINES", {
+          void store.actions.RESTART_ENGINES({
             engineIds: engineIds.value,
           });
         },
@@ -267,7 +265,7 @@ const engineSubMenuData = computed<MenuItemData[]>(() => {
       type: "button",
       label: "エンジンの管理",
       onClick: () => {
-        void store.dispatch("SET_DIALOG_OPEN", {
+        void store.actions.SET_DIALOG_OPEN({
           isEngineManageDialogOpen: true,
         });
       },
@@ -280,7 +278,7 @@ const engineSubMenuData = computed<MenuItemData[]>(() => {
       type: "button",
       label: "マルチエンジンをオンにして再読み込み",
       onClick() {
-        void store.dispatch("RELOAD_APP", {
+        void store.actions.RELOAD_APP({
           isMultiEngineOffMode: false,
         });
       },
@@ -355,7 +353,7 @@ const menudata = computed<MenuItemData[]>(() => [
         label: "元に戻す",
         onClick: async () => {
           if (!uiLocked.value) {
-            await store.dispatch("UNDO", { editor: props.editor });
+            await store.actions.UNDO({ editor: props.editor });
           }
         },
         disabled: !canUndo.value,
@@ -366,7 +364,7 @@ const menudata = computed<MenuItemData[]>(() => [
         label: "やり直す",
         onClick: async () => {
           if (!uiLocked.value) {
-            await store.dispatch("REDO", { editor: props.editor });
+            await store.actions.REDO({ editor: props.editor });
           }
         },
         disabled: !canRedo.value,
@@ -379,7 +377,7 @@ const menudata = computed<MenuItemData[]>(() => [
               label: "すべて選択",
               onClick: async () => {
                 if (!uiLocked.value && isMultiSelectEnabled.value) {
-                  await store.dispatch("SET_SELECTED_AUDIO_KEYS", {
+                  await store.actions.SET_SELECTED_AUDIO_KEYS({
                     audioKeys: audioKeys.value,
                   });
                 }
@@ -421,7 +419,7 @@ const menudata = computed<MenuItemData[]>(() => [
         type: "button",
         label: "キー割り当て",
         onClick() {
-          void store.dispatch("SET_DIALOG_OPEN", {
+          void store.actions.SET_DIALOG_OPEN({
             isHotkeySettingDialogOpen: true,
           });
         },
@@ -431,7 +429,7 @@ const menudata = computed<MenuItemData[]>(() => [
         type: "button",
         label: "ツールバーのカスタマイズ",
         onClick() {
-          void store.dispatch("SET_DIALOG_OPEN", {
+          void store.actions.SET_DIALOG_OPEN({
             isToolbarSettingDialogOpen: true,
           });
         },
@@ -441,7 +439,7 @@ const menudata = computed<MenuItemData[]>(() => [
         type: "button",
         label: "キャラクター並び替え・試聴",
         onClick() {
-          void store.dispatch("SET_DIALOG_OPEN", {
+          void store.actions.SET_DIALOG_OPEN({
             isCharacterOrderDialogOpen: true,
           });
         },
@@ -451,7 +449,7 @@ const menudata = computed<MenuItemData[]>(() => [
         type: "button",
         label: "デフォルトスタイル",
         onClick() {
-          void store.dispatch("SET_DIALOG_OPEN", {
+          void store.actions.SET_DIALOG_OPEN({
             isDefaultStyleSelectDialogOpen: true,
           });
         },
@@ -461,7 +459,7 @@ const menudata = computed<MenuItemData[]>(() => [
         type: "button",
         label: "読み方＆アクセント辞書",
         onClick() {
-          void store.dispatch("SET_DIALOG_OPEN", {
+          void store.actions.SET_DIALOG_OPEN({
             isDictionaryManageDialogOpen: true,
           });
         },
@@ -472,7 +470,7 @@ const menudata = computed<MenuItemData[]>(() => [
         type: "button",
         label: "オプション",
         onClick() {
-          void store.dispatch("SET_DIALOG_OPEN", {
+          void store.actions.SET_DIALOG_OPEN({
             isSettingDialogOpen: true,
           });
         },

--- a/src/components/Menu/MenuBar/MinMaxCloseButtons.vue
+++ b/src/components/Menu/MenuBar/MinMaxCloseButtons.vue
@@ -97,7 +97,7 @@ const $q = useQuasar();
 const store = useStore();
 
 const closeWindow = async () => {
-  void store.dispatch("CHECK_EDITED_AND_NOT_SAVE", { closeOrReload: "close" });
+  void store.actions.CHECK_EDITED_AND_NOT_SAVE({ closeOrReload: "close" });
 };
 const minimizeWindow = () => window.backend.minimizeWindow();
 const maximizeWindow = () => window.backend.maximizeWindow();

--- a/src/components/Menu/MenuBar/TitleBarEditorSwitcher.vue
+++ b/src/components/Menu/MenuBar/TitleBarEditorSwitcher.vue
@@ -30,7 +30,7 @@ const openedEditor = computed(() => store.state.openedEditor);
 const uiLocked = computed(() => store.getters.UI_LOCKED);
 
 const switchEditor = async (editor: EditorType) => {
-  await store.dispatch("SET_OPENED_EDITOR", { editor });
+  await store.actions.SET_OPENED_EDITOR({ editor });
 };
 </script>
 


### PR DESCRIPTION
## 内容
+ https://github.com/VOICEVOX/voicevox/pull/2099
+ https://github.com/VOICEVOX/voicevox/pull/2170
+ https://github.com/VOICEVOX/voicevox/pull/2180
+ https://github.com/VOICEVOX/voicevox/pull/2213
+ https://github.com/VOICEVOX/voicevox/pull/2266
+ https://github.com/VOICEVOX/voicevox/pull/2326
+ https://github.com/VOICEVOX/voicevox/pull/2327
+ https://github.com/VOICEVOX/voicevox/pull/2328
の続きです。

components/Menu/フォルダ内のdispatch("ACTION1", payloads) のような引数におけるリテラル指定から actions.ACTION(payload) のようにdot記法によるアクセスに変更します。


+ src/components/Menu/MenuBar/MenuBar.vue
+ src/components/Menu/MenuBar/MinMaxCloseButtons.vue
+ src/components/Menu/MenuBar/TitleBarEditorSwitcher.vue
を対応しています。

## 関連 Issue

+ https://github.com/VOICEVOX/voicevox/issues/2088

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

dispatch\([\s\n]*"([A-Z_]*)",?
actions.$1(
と正規表現で置換してその後眼力チェックしています。
