### PR TITLE
vuexのstoreの呼び出しをリテラル引数からDot記法へ: components/Sing

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -377,7 +377,7 @@ const onLyricInput = (text: string, note: Note) => {
 
 const onLyricConfirmed = (nextNoteId: NoteId | undefined) => {
   commitPreviewLyrics();
-  void store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: nextNoteId });
+  void store.actions.SET_EDITING_LYRIC_NOTE_ID({ noteId: nextNoteId });
 };
 
 // プレビュー
@@ -763,9 +763,9 @@ const getYInBorderBox = (clientY: number, element: HTMLElement) => {
 };
 
 const selectOnlyThis = (note: Note) => {
-  void store.dispatch("DESELECT_ALL_NOTES");
-  void store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
-  void store.dispatch("PLAY_PREVIEW_SOUND", {
+  void store.actions.DESELECT_ALL_NOTES();
+  void store.actions.SELECT_NOTES({ noteIds: [note.id] });
+  void store.actions.PLAY_PREVIEW_SOUND({
     noteNumber: note.noteNumber,
     duration: PREVIEW_SOUND_DURATION,
   });
@@ -811,7 +811,7 @@ const startPreview = (event: MouseEvent, mode: PreviewMode, note?: Note) => {
         noteNumber: cursorNoteNumber,
         lyric: getDoremiFromNoteNumber(cursorNoteNumber),
       };
-      void store.dispatch("DESELECT_ALL_NOTES");
+      void store.actions.DESELECT_ALL_NOTES();
       copiedNotes.push(note);
     } else {
       if (!note) {
@@ -834,9 +834,9 @@ const startPreview = (event: MouseEvent, mode: PreviewMode, note?: Note) => {
             noteIdsToSelect.push(noteId);
           }
         }
-        void store.dispatch("SELECT_NOTES", { noteIds: noteIdsToSelect });
+        void store.actions.SELECT_NOTES({ noteIds: noteIdsToSelect });
       } else if (isOnCommandOrCtrlKeyDown(event)) {
-        void store.dispatch("SELECT_NOTES", { noteIds: [note.id] });
+        void store.actions.SELECT_NOTES({ noteIds: [note.id] });
       } else if (!selectedNoteIds.value.has(note.id)) {
         void selectOnlyThis(note);
       }
@@ -895,21 +895,21 @@ const endPreview = () => {
     // 編集ターゲットがノートのときにプレビューを開始した場合の処理
     if (edited) {
       if (previewMode.value === "ADD_NOTE") {
-        void store.dispatch("COMMAND_ADD_NOTES", {
+        void store.actions.COMMAND_ADD_NOTES({
           notes: previewNotes.value,
           trackId: selectedTrackId.value,
         });
-        void store.dispatch("SELECT_NOTES", {
+        void store.actions.SELECT_NOTES({
           noteIds: previewNotes.value.map((value) => value.id),
         });
       } else {
-        void store.dispatch("COMMAND_UPDATE_NOTES", {
+        void store.actions.COMMAND_UPDATE_NOTES({
           notes: previewNotes.value,
           trackId: selectedTrackId.value,
         });
       }
       if (previewNotes.value.length === 1) {
-        void store.dispatch("PLAY_PREVIEW_SOUND", {
+        void store.actions.PLAY_PREVIEW_SOUND({
           noteNumber: previewNotes.value[0].noteNumber,
           duration: PREVIEW_SOUND_DURATION,
         });
@@ -932,14 +932,14 @@ const endPreview = () => {
         applyGaussianFilter(data, 0.7);
         data = data.map((value) => Math.exp(value));
 
-        void store.dispatch("COMMAND_SET_PITCH_EDIT_DATA", {
+        void store.actions.COMMAND_SET_PITCH_EDIT_DATA({
           pitchArray: data,
           startFrame: previewPitchEdit.value.startFrame,
           trackId: selectedTrackId.value,
         });
       }
     } else if (previewPitchEditType === "erase") {
-      void store.dispatch("COMMAND_ERASE_PITCH_EDIT_DATA", {
+      void store.actions.COMMAND_ERASE_PITCH_EDIT_DATA({
         startFrame: previewPitchEdit.value.startFrame,
         frameLength: previewPitchEdit.value.frameLength,
         trackId: selectedTrackId.value,
@@ -972,7 +972,7 @@ const onNoteBarDoubleClick = (event: MouseEvent, note: Note) => {
   }
   const mouseButton = getButton(event);
   if (mouseButton === "LEFT_BUTTON" && note.id !== state.editingLyricNoteId) {
-    void store.dispatch("SET_EDITING_LYRIC_NOTE_ID", { noteId: note.id });
+    void store.actions.SET_EDITING_LYRIC_NOTE_ID({ noteId: note.id });
   }
 };
 
@@ -1017,7 +1017,7 @@ const onMouseDown = (event: MouseEvent) => {
         startPreview(event, "ADD_NOTE");
       }
     } else {
-      void store.dispatch("DESELECT_ALL_NOTES");
+      void store.actions.DESELECT_ALL_NOTES();
     }
   } else if (editTarget.value === "PITCH") {
     if (mouseButton === "LEFT_BUTTON") {
@@ -1105,9 +1105,9 @@ const rectSelect = (additive: boolean) => {
     }
   }
   if (!additive) {
-    void store.dispatch("DESELECT_ALL_NOTES");
+    void store.actions.DESELECT_ALL_NOTES();
   }
-  void store.dispatch("SELECT_NOTES", { noteIds: noteIdsToSelect });
+  void store.actions.SELECT_NOTES({ noteIds: noteIdsToSelect });
 };
 
 const onMouseEnter = () => {
@@ -1128,13 +1128,13 @@ const handleNotesArrowUp = () => {
   if (editedNotes.some((note) => note.noteNumber > 127)) {
     return;
   }
-  void store.dispatch("COMMAND_UPDATE_NOTES", {
+  void store.actions.COMMAND_UPDATE_NOTES({
     notes: editedNotes,
     trackId: selectedTrackId.value,
   });
 
   if (editedNotes.length === 1) {
-    void store.dispatch("PLAY_PREVIEW_SOUND", {
+    void store.actions.PLAY_PREVIEW_SOUND({
       noteNumber: editedNotes[0].noteNumber,
       duration: PREVIEW_SOUND_DURATION,
     });
@@ -1150,13 +1150,13 @@ const handleNotesArrowDown = () => {
   if (editedNotes.some((note) => note.noteNumber < 0)) {
     return;
   }
-  void store.dispatch("COMMAND_UPDATE_NOTES", {
+  void store.actions.COMMAND_UPDATE_NOTES({
     notes: editedNotes,
     trackId: selectedTrackId.value,
   });
 
   if (editedNotes.length === 1) {
-    void store.dispatch("PLAY_PREVIEW_SOUND", {
+    void store.actions.PLAY_PREVIEW_SOUND({
       noteNumber: editedNotes[0].noteNumber,
       duration: PREVIEW_SOUND_DURATION,
     });
@@ -1173,7 +1173,7 @@ const handleNotesArrowRight = () => {
     // TODO: 例外処理は`UPDATE_NOTES`内に移す？
     return;
   }
-  void store.dispatch("COMMAND_UPDATE_NOTES", {
+  void store.actions.COMMAND_UPDATE_NOTES({
     notes: editedNotes,
     trackId: selectedTrackId.value,
   });
@@ -1191,7 +1191,7 @@ const handleNotesArrowLeft = () => {
   ) {
     return;
   }
-  void store.dispatch("COMMAND_UPDATE_NOTES", {
+  void store.actions.COMMAND_UPDATE_NOTES({
     notes: editedNotes,
     trackId: selectedTrackId.value,
   });
@@ -1202,7 +1202,7 @@ const handleNotesBackspaceOrDelete = () => {
     // TODO: 例外処理は`COMMAND_REMOVE_SELECTED_NOTES`内に移す？
     return;
   }
-  void store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
+  void store.actions.COMMAND_REMOVE_SELECTED_NOTES();
 };
 
 const handleKeydown = (event: KeyboardEvent) => {
@@ -1230,7 +1230,7 @@ const handleKeydown = (event: KeyboardEvent) => {
       handleNotesBackspaceOrDelete();
       break;
     case "Escape":
-      void store.dispatch("DESELECT_ALL_NOTES");
+      void store.actions.DESELECT_ALL_NOTES();
       break;
   }
 };
@@ -1251,7 +1251,7 @@ const setZoomX = (value: number | null) => {
   const scrollTop = sequencerBodyElement.scrollTop;
   const clientWidth = sequencerBodyElement.clientWidth;
 
-  void store.dispatch("SET_ZOOM_X", { zoomX: newZoomX }).then(() => {
+  void store.actions.SET_ZOOM_X({ zoomX: newZoomX }).then(() => {
     const centerBaseX = (scrollLeft + clientWidth / 2) / oldZoomX;
     const newScrollLeft = centerBaseX * newZoomX - clientWidth / 2;
     sequencerBodyElement.scrollTo(newScrollLeft, scrollTop);
@@ -1274,7 +1274,7 @@ const setZoomY = (value: number | null) => {
   const scrollTop = sequencerBodyElement.scrollTop;
   const clientHeight = sequencerBodyElement.clientHeight;
 
-  void store.dispatch("SET_ZOOM_Y", { zoomY: newZoomY }).then(() => {
+  void store.actions.SET_ZOOM_Y({ zoomY: newZoomY }).then(() => {
     const centerBaseY = (scrollTop + clientHeight / 2) / oldZoomY;
     const newScrollTop = centerBaseY * newZoomY - clientHeight / 2;
     sequencerBodyElement.scrollTo(scrollLeft, newScrollTop);
@@ -1301,7 +1301,7 @@ const onWheel = (event: WheelEvent) => {
     const scrollTop = sequencerBodyElement.scrollTop;
     guideLineX.value = 0; // 補助線がはみ出さないように位置を一旦0にする
 
-    void store.dispatch("SET_ZOOM_X", { zoomX: newZoomX }).then(() => {
+    void store.actions.SET_ZOOM_X({ zoomX: newZoomX }).then(() => {
       const cursorBaseX = (scrollLeft + cursorX.value) / oldZoomX;
       const newScrollLeft = cursorBaseX * newZoomX - cursorX.value;
       sequencerBodyElement.scrollTo(newScrollLeft, scrollTop);
@@ -1392,7 +1392,7 @@ onActivated(() => {
 
 // リスナー登録
 onActivated(() => {
-  void store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  void store.actions.ADD_PLAYHEAD_POSITION_CHANGE_LISTENER({
     listener: playheadPositionChangeListener,
   });
 
@@ -1403,7 +1403,7 @@ onActivated(() => {
 
 // リスナー解除
 onDeactivated(() => {
-  void store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  void store.actions.REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER({
     listener: playheadPositionChangeListener,
   });
 
@@ -1426,7 +1426,7 @@ registerHotkeyWithCleanup({
     if (selectedNoteIds.value.size === 0) {
       return;
     }
-    void store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+    void store.actions.COPY_NOTES_TO_CLIPBOARD();
   },
 });
 
@@ -1440,7 +1440,7 @@ registerHotkeyWithCleanup({
     if (selectedNoteIds.value.size === 0) {
       return;
     }
-    void store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+    void store.actions.COMMAND_CUT_NOTES_TO_CLIPBOARD();
   },
 });
 
@@ -1451,7 +1451,7 @@ registerHotkeyWithCleanup({
     if (nowPreviewing.value) {
       return;
     }
-    void store.dispatch("COMMAND_PASTE_NOTES_FROM_CLIPBOARD");
+    void store.actions.COMMAND_PASTE_NOTES_FROM_CLIPBOARD();
   },
 });
 
@@ -1462,7 +1462,7 @@ registerHotkeyWithCleanup({
     if (nowPreviewing.value) {
       return;
     }
-    void store.dispatch("SELECT_ALL_NOTES_IN_TRACK", {
+    void store.actions.SELECT_ALL_NOTES_IN_TRACK({
       trackId: selectedTrackId.value,
     });
   },
@@ -1477,7 +1477,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       label: "コピー",
       onClick: () => {
         contextMenu.value?.hide();
-        void store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+        void store.actions.COPY_NOTES_TO_CLIPBOARD();
       },
       disabled: !isNoteSelected.value,
       disableWhenUiLocked: true,
@@ -1487,7 +1487,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       label: "切り取り",
       onClick: () => {
         contextMenu.value?.hide();
-        void store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+        void store.actions.COMMAND_CUT_NOTES_TO_CLIPBOARD();
       },
       disabled: !isNoteSelected.value,
       disableWhenUiLocked: true,
@@ -1497,7 +1497,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       label: "貼り付け",
       onClick: () => {
         contextMenu.value?.hide();
-        void store.dispatch("COMMAND_PASTE_NOTES_FROM_CLIPBOARD");
+        void store.actions.COMMAND_PASTE_NOTES_FROM_CLIPBOARD();
       },
       disableWhenUiLocked: true,
     },
@@ -1507,7 +1507,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       label: "すべて選択",
       onClick: () => {
         contextMenu.value?.hide();
-        void store.dispatch("SELECT_ALL_NOTES_IN_TRACK", {
+        void store.actions.SELECT_ALL_NOTES_IN_TRACK({
           trackId: selectedTrackId.value,
         });
       },
@@ -1518,7 +1518,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       label: "選択解除",
       onClick: () => {
         contextMenu.value?.hide();
-        void store.dispatch("DESELECT_ALL_NOTES");
+        void store.actions.DESELECT_ALL_NOTES();
       },
       disabled: !isNoteSelected.value,
       disableWhenUiLocked: true,
@@ -1529,7 +1529,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       label: "クオンタイズ",
       onClick: () => {
         contextMenu.value?.hide();
-        void store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
+        void store.actions.COMMAND_QUANTIZE_SELECTED_NOTES();
       },
       disabled: !isNoteSelected.value,
       disableWhenUiLocked: true,
@@ -1540,7 +1540,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       label: "削除",
       onClick: () => {
         contextMenu.value?.hide();
-        void store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
+        void store.actions.COMMAND_REMOVE_SELECTED_NOTES();
       },
       disabled: !isNoteSelected.value,
       disableWhenUiLocked: true,

--- a/src/components/Sing/SequencerKeys.vue
+++ b/src/components/Sing/SequencerKeys.vue
@@ -156,14 +156,14 @@ let resizeObserver: ResizeObserver | undefined;
 
 const onMouseDown = (noteNumber: number) => {
   noteNumberOfKeyBeingPressed.value = noteNumber;
-  void store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
+  void store.actions.PLAY_PREVIEW_SOUND({ noteNumber });
 };
 
 const onMouseUp = () => {
   if (noteNumberOfKeyBeingPressed.value != undefined) {
     const noteNumber = noteNumberOfKeyBeingPressed.value;
     noteNumberOfKeyBeingPressed.value = undefined;
-    void store.dispatch("STOP_PREVIEW_SOUND", { noteNumber });
+    void store.actions.STOP_PREVIEW_SOUND({ noteNumber });
   }
 };
 
@@ -172,11 +172,11 @@ const onMouseEnter = (noteNumber: number) => {
     noteNumberOfKeyBeingPressed.value != undefined &&
     noteNumberOfKeyBeingPressed.value !== noteNumber
   ) {
-    void store.dispatch("STOP_PREVIEW_SOUND", {
+    void store.actions.STOP_PREVIEW_SOUND({
       noteNumber: noteNumberOfKeyBeingPressed.value,
     });
     noteNumberOfKeyBeingPressed.value = noteNumber;
-    void store.dispatch("PLAY_PREVIEW_SOUND", { noteNumber });
+    void store.actions.PLAY_PREVIEW_SOUND({ noteNumber });
   }
 };
 

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -197,7 +197,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       disabled: props.nowPreviewing,
       onClick: async () => {
         contextMenu.value?.hide();
-        await store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+        await store.actions.COPY_NOTES_TO_CLIPBOARD();
       },
       disableWhenUiLocked: true,
     },
@@ -207,7 +207,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       disabled: props.nowPreviewing,
       onClick: async () => {
         contextMenu.value?.hide();
-        await store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+        await store.actions.COMMAND_CUT_NOTES_TO_CLIPBOARD();
       },
       disableWhenUiLocked: true,
     },
@@ -218,7 +218,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       disabled: props.nowPreviewing || !props.isSelected,
       onClick: async () => {
         contextMenu.value?.hide();
-        await store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
+        await store.actions.COMMAND_QUANTIZE_SELECTED_NOTES();
       },
       disableWhenUiLocked: true,
     },
@@ -229,7 +229,7 @@ const contextMenuData = computed<ContextMenuItemData[]>(() => {
       disabled: props.nowPreviewing || !props.isSelected,
       onClick: async () => {
         contextMenu.value?.hide();
-        await store.dispatch("COMMAND_REMOVE_SELECTED_NOTES");
+        await store.actions.COMMAND_REMOVE_SELECTED_NOTES();
       },
       disableWhenUiLocked: true,
     },

--- a/src/components/Sing/SequencerRuler/Container.vue
+++ b/src/components/Sing/SequencerRuler/Container.vue
@@ -39,7 +39,7 @@ const sequencerZoomX = computed(() => store.state.sequencerZoomX);
 const playheadTicks = ref(0);
 
 const updatePlayheadTicks = (ticks: number) => {
-  void store.dispatch("SET_PLAYHEAD_POSITION", { position: ticks });
+  void store.actions.SET_PLAYHEAD_POSITION({ position: ticks });
 };
 
 const playheadPositionChangeListener = (position: number) => {
@@ -47,17 +47,17 @@ const playheadPositionChangeListener = (position: number) => {
 };
 
 onMounted(() => {
-  void store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  void store.actions.ADD_PLAYHEAD_POSITION_CHANGE_LISTENER({
     listener: playheadPositionChangeListener,
   });
 });
 onUnmounted(() => {
-  void store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  void store.actions.REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER({
     listener: playheadPositionChangeListener,
   });
 });
 
 const deselectAllNotes = () => {
-  void store.dispatch("DESELECT_ALL_NOTES");
+  void store.actions.DESELECT_ALL_NOTES();
 };
 </script>

--- a/src/components/Sing/SideBar/SideBar.vue
+++ b/src/components/Sing/SideBar/SideBar.vue
@@ -89,10 +89,10 @@ const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
 const addTrack = async () => {
   const willNextSelectedTrackIndex =
     trackOrder.value.indexOf(selectedTrackId.value) + 1;
-  await store.dispatch("COMMAND_INSERT_EMPTY_TRACK", {
+  await store.actions.COMMAND_INSERT_EMPTY_TRACK({
     prevTrackId: selectedTrackId.value,
   });
-  await store.dispatch("SELECT_TRACK", {
+  await store.actions.SELECT_TRACK({
     trackId: trackOrder.value[willNextSelectedTrackIndex],
   });
 };
@@ -104,24 +104,24 @@ const deleteTrack = async () => {
   if (willNextSelectedTrackIndex < 0) {
     willNextSelectedTrackIndex = 0;
   }
-  await store.dispatch("COMMAND_DELETE_TRACK", {
+  await store.actions.COMMAND_DELETE_TRACK({
     trackId: selectedTrackId.value,
   });
-  await store.dispatch("SELECT_TRACK", {
+  await store.actions.SELECT_TRACK({
     trackId: trackOrder.value[willNextSelectedTrackIndex],
   });
 };
 
 const unsoloAllTracks = () => {
   if (store.state.undoableTrackOperations.soloAndMute) {
-    void store.dispatch("COMMAND_UNSOLO_ALL_TRACKS");
+    void store.actions.COMMAND_UNSOLO_ALL_TRACKS();
   } else {
-    void store.dispatch("UNSOLO_ALL_TRACKS");
+    void store.actions.UNSOLO_ALL_TRACKS();
   }
 };
 
 const reorderTracks = (trackOrder: TrackId[]) => {
-  void store.dispatch("COMMAND_REORDER_TRACKS", {
+  void store.actions.COMMAND_REORDER_TRACKS({
     trackOrder,
   });
 };

--- a/src/components/Sing/SideBar/TrackItem.vue
+++ b/src/components/Sing/SideBar/TrackItem.vue
@@ -194,23 +194,23 @@ const shouldPlayTrack = computed(() =>
 
 const setTrackPan = (pan: number) => {
   if (store.state.undoableTrackOperations.panAndGain) {
-    void store.dispatch("COMMAND_SET_TRACK_PAN", {
+    void store.actions.COMMAND_SET_TRACK_PAN({
       trackId: props.trackId,
       pan,
     });
   } else {
-    void store.dispatch("SET_TRACK_PAN", { trackId: props.trackId, pan });
+    void store.actions.SET_TRACK_PAN({ trackId: props.trackId, pan });
   }
 };
 
 const setTrackGain = (gain: number) => {
   if (store.state.undoableTrackOperations.panAndGain) {
-    void store.dispatch("COMMAND_SET_TRACK_GAIN", {
+    void store.actions.COMMAND_SET_TRACK_GAIN({
       trackId: props.trackId,
       gain,
     });
   } else {
-    void store.dispatch("SET_TRACK_GAIN", { trackId: props.trackId, gain });
+    void store.actions.SET_TRACK_GAIN({ trackId: props.trackId, gain });
   }
 };
 
@@ -228,7 +228,7 @@ const updateTrackName = () => {
     return;
   }
 
-  void store.dispatch("COMMAND_SET_TRACK_NAME", {
+  void store.actions.COMMAND_SET_TRACK_NAME({
     trackId: props.trackId,
     name: temporaryTrackName.value,
   });
@@ -236,23 +236,23 @@ const updateTrackName = () => {
 
 const setTrackMute = (mute: boolean) => {
   if (store.state.undoableTrackOperations.soloAndMute) {
-    void store.dispatch("COMMAND_SET_TRACK_MUTE", {
+    void store.actions.COMMAND_SET_TRACK_MUTE({
       trackId: props.trackId,
       mute,
     });
   } else {
-    void store.dispatch("SET_TRACK_MUTE", { trackId: props.trackId, mute });
+    void store.actions.SET_TRACK_MUTE({ trackId: props.trackId, mute });
   }
 };
 
 const setTrackSolo = (solo: boolean) => {
   if (store.state.undoableTrackOperations.soloAndMute) {
-    void store.dispatch("COMMAND_SET_TRACK_SOLO", {
+    void store.actions.COMMAND_SET_TRACK_SOLO({
       trackId: props.trackId,
       solo,
     });
   } else {
-    void store.dispatch("SET_TRACK_SOLO", { trackId: props.trackId, solo });
+    void store.actions.SET_TRACK_SOLO({ trackId: props.trackId, solo });
   }
 };
 
@@ -275,16 +275,16 @@ const trackCharacter = computed<
   return undefined;
 });
 const selectTrack = () => {
-  void store.dispatch("SET_SELECTED_TRACK", { trackId: props.trackId });
+  void store.actions.SET_SELECTED_TRACK({ trackId: props.trackId });
 };
 
 const addTrack = async () => {
   const willNextSelectedTrackIndex =
     trackOrder.value.indexOf(props.trackId) + 1;
-  await store.dispatch("COMMAND_INSERT_EMPTY_TRACK", {
+  await store.actions.COMMAND_INSERT_EMPTY_TRACK({
     prevTrackId: props.trackId,
   });
-  await store.dispatch("SELECT_TRACK", {
+  await store.actions.SELECT_TRACK({
     trackId: trackOrder.value[willNextSelectedTrackIndex],
   });
 };
@@ -299,9 +299,9 @@ const deleteTrack = async () => {
       willNextSelectedTrackIndex = 0;
     }
   }
-  await store.dispatch("COMMAND_DELETE_TRACK", { trackId: props.trackId });
+  await store.actions.COMMAND_DELETE_TRACK({ trackId: props.trackId });
   if (willNextSelectedTrackIndex != undefined) {
-    await store.dispatch("SELECT_TRACK", {
+    await store.actions.SELECT_TRACK({
       trackId: trackOrder.value[willNextSelectedTrackIndex],
     });
   }

--- a/src/components/Sing/SingEditor.vue
+++ b/src/components/Sing/SingEditor.vue
@@ -75,7 +75,7 @@ watch(
   () => store.state.tracks.size,
   (tracksSize, oldTracksSize) => {
     if (oldTracksSize <= 1 && tracksSize > 1) {
-      void store.dispatch("SET_SONG_SIDEBAR_OPEN", { isSongSidebarOpen: true });
+      void store.actions.SET_SONG_SIDEBAR_OPEN({ isSongSidebarOpen: true });
     }
   },
 );
@@ -88,7 +88,7 @@ const nowAudioExporting = computed(() => {
 });
 
 const cancelExport = () => {
-  void store.dispatch("CANCEL_AUDIO_EXPORT");
+  void store.actions.CANCEL_AUDIO_EXPORT();
 };
 
 const isCompletedInitialStartup = ref(false);
@@ -100,17 +100,17 @@ onetimeWatch(
       return "continue";
 
     if (!isProjectFileLoaded) {
-      await store.dispatch("SET_TPQN", { tpqn: DEFAULT_TPQN });
-      await store.dispatch("SET_TEMPOS", { tempos: [createDefaultTempo(0)] });
-      await store.dispatch("SET_TIME_SIGNATURES", {
+      await store.actions.SET_TPQN({ tpqn: DEFAULT_TPQN });
+      await store.actions.SET_TEMPOS({ tempos: [createDefaultTempo(0)] });
+      await store.actions.SET_TIME_SIGNATURES({
         timeSignatures: [createDefaultTimeSignature(1)],
       });
       const trackId = store.state.trackOrder[0];
-      await store.dispatch("SET_NOTES", { notes: [], trackId });
+      await store.actions.SET_NOTES({ notes: [], trackId });
       // CI上のe2eテストのNemoエンジンには歌手がいないためエラーになるのでワークアラウンド
       // FIXME: 歌手をいると見せかけるmock APIを作り、ここのtry catchを削除する
       try {
-        await store.dispatch("SET_SINGER", {
+        await store.actions.SET_SINGER({
           trackId,
           withRelated: true,
         });
@@ -119,9 +119,9 @@ onetimeWatch(
       }
     }
 
-    await store.dispatch("SET_VOLUME", { volume: 0.6 });
-    await store.dispatch("SET_PLAYHEAD_POSITION", { position: 0 });
-    await store.dispatch("SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS");
+    await store.actions.SET_VOLUME({ volume: 0.6 });
+    await store.actions.SET_PLAYHEAD_POSITION({ position: 0 });
+    await store.actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     isCompletedInitialStartup.value = true;
 
     return "unwatch";

--- a/src/components/Sing/ToolBar/ToolBar.vue
+++ b/src/components/Sing/ToolBar/ToolBar.vue
@@ -221,21 +221,21 @@ registerHotkeyWithCleanup({
 });
 
 const undo = () => {
-  void store.dispatch("UNDO", { editor });
+  void store.actions.UNDO({ editor });
 };
 const redo = () => {
-  void store.dispatch("REDO", { editor });
+  void store.actions.REDO({ editor });
 };
 
 const editTarget = computed(() => store.state.sequencerEditTarget);
 
 const changeEditTarget = (editTarget: SequencerEditTarget) => {
-  void store.dispatch("SET_EDIT_TARGET", { editTarget });
+  void store.actions.SET_EDIT_TARGET({ editTarget });
 };
 
 const isSidebarOpen = computed(() => store.state.isSongSidebarOpen);
 const toggleSidebar = () => {
-  void store.dispatch("SET_SONG_SIDEBAR_OPEN", {
+  void store.actions.SET_SONG_SIDEBAR_OPEN({
     isSongSidebarOpen: !isSidebarOpen.value,
   });
 };
@@ -315,7 +315,7 @@ const setBeats = (beats: { label: string; value: number }) => {
   if (!isValidBeats(beats.value)) {
     return;
   }
-  void store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
+  void store.actions.COMMAND_SET_TIME_SIGNATURE({
     timeSignature: {
       measureNumber: 1,
       beats: beats.value,
@@ -328,7 +328,7 @@ const setBeatType = (beatType: { label: string; value: number }) => {
   if (!isValidBeatType(beatType.value)) {
     return;
   }
-  void store.dispatch("COMMAND_SET_TIME_SIGNATURE", {
+  void store.actions.COMMAND_SET_TIME_SIGNATURE({
     timeSignature: {
       measureNumber: 1,
       beats: timeSignatures.value[0].beats,
@@ -359,7 +359,7 @@ const setVolumeRangeAdjustmentInputBuffer = (
 
 const setTempo = () => {
   const bpm = bpmInputBuffer.value;
-  void store.dispatch("COMMAND_SET_TEMPO", {
+  void store.actions.COMMAND_SET_TEMPO({
     tempo: {
       position: 0,
       bpm,
@@ -369,7 +369,7 @@ const setTempo = () => {
 
 const setKeyRangeAdjustment = () => {
   const keyRangeAdjustment = keyRangeAdjustmentInputBuffer.value;
-  void store.dispatch("COMMAND_SET_KEY_RANGE_ADJUSTMENT", {
+  void store.actions.COMMAND_SET_KEY_RANGE_ADJUSTMENT({
     keyRangeAdjustment,
     trackId: selectedTrackId.value,
   });
@@ -377,7 +377,7 @@ const setKeyRangeAdjustment = () => {
 
 const setVolumeRangeAdjustment = () => {
   const volumeRangeAdjustment = volumeRangeAdjustmentInputBuffer.value;
-  void store.dispatch("COMMAND_SET_VOLUME_RANGE_ADJUSTMENT", {
+  void store.actions.COMMAND_SET_VOLUME_RANGE_ADJUSTMENT({
     volumeRangeAdjustment,
     trackId: selectedTrackId.value,
   });
@@ -410,15 +410,15 @@ const playHeadPositionMilliSecStr = computed(() => {
 const nowPlaying = computed(() => store.state.nowPlaying);
 
 const play = () => {
-  void store.dispatch("SING_PLAY_AUDIO");
+  void store.actions.SING_PLAY_AUDIO();
 };
 
 const stop = () => {
-  void store.dispatch("SING_STOP_AUDIO");
+  void store.actions.SING_STOP_AUDIO();
 };
 
 const goToZero = () => {
-  void store.dispatch("SET_PLAYHEAD_POSITION", { position: 0 });
+  void store.actions.SET_PLAYHEAD_POSITION({ position: 0 });
 };
 
 const volume = computed({
@@ -426,7 +426,7 @@ const volume = computed({
     return store.state.volume * 100;
   },
   set(value: number) {
-    void store.dispatch("SET_VOLUME", { volume: value / 100 });
+    void store.actions.SET_VOLUME({ volume: value / 100 });
   },
 });
 
@@ -458,7 +458,7 @@ const snapTypeSelectModel = computed({
     );
   },
   set(value) {
-    void store.dispatch("SET_SNAP_TYPE", {
+    void store.actions.SET_SNAP_TYPE({
       snapType: value.snapType,
     });
   },
@@ -469,13 +469,13 @@ const playheadPositionChangeListener = (position: number) => {
 };
 
 onMounted(() => {
-  void store.dispatch("ADD_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  void store.actions.ADD_PLAYHEAD_POSITION_CHANGE_LISTENER({
     listener: playheadPositionChangeListener,
   });
 });
 
 onUnmounted(() => {
-  void store.dispatch("REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER", {
+  void store.actions.REMOVE_PLAYHEAD_POSITION_CHANGE_LISTENER({
     listener: playheadPositionChangeListener,
   });
 });

--- a/src/components/Sing/menuBarData.ts
+++ b/src/components/Sing/menuBarData.ts
@@ -12,14 +12,14 @@ export const useMenuBarData = () => {
 
   const importExternalSongProject = async () => {
     if (uiLocked.value) return;
-    await store.dispatch("SET_DIALOG_OPEN", {
+    await store.actions.SET_DIALOG_OPEN({
       isImportSongProjectDialogOpen: true,
     });
   };
 
   const exportAudioFile = async () => {
     if (uiLocked.value) return;
-    await store.dispatch("SET_DIALOG_OPEN", {
+    await store.actions.SET_DIALOG_OPEN({
       isExportSongAudioDialogOpen: true,
     });
   };
@@ -53,7 +53,7 @@ export const useMenuBarData = () => {
       label: "コピー",
       onClick: () => {
         if (uiLocked.value) return;
-        void store.dispatch("COPY_NOTES_TO_CLIPBOARD");
+        void store.actions.COPY_NOTES_TO_CLIPBOARD();
       },
       disableWhenUiLocked: true,
       disabled: !isNotesSelected.value,
@@ -63,7 +63,7 @@ export const useMenuBarData = () => {
       label: "切り取り",
       onClick: () => {
         if (uiLocked.value) return;
-        void store.dispatch("COMMAND_CUT_NOTES_TO_CLIPBOARD");
+        void store.actions.COMMAND_CUT_NOTES_TO_CLIPBOARD();
       },
       disableWhenUiLocked: true,
       disabled: !isNotesSelected.value,
@@ -73,7 +73,7 @@ export const useMenuBarData = () => {
       label: "貼り付け",
       onClick: () => {
         if (uiLocked.value) return;
-        void store.dispatch("COMMAND_PASTE_NOTES_FROM_CLIPBOARD");
+        void store.actions.COMMAND_PASTE_NOTES_FROM_CLIPBOARD();
       },
       disableWhenUiLocked: true,
     },
@@ -83,7 +83,7 @@ export const useMenuBarData = () => {
       label: "すべて選択",
       onClick: () => {
         if (uiLocked.value) return;
-        void store.dispatch("SELECT_ALL_NOTES_IN_TRACK", {
+        void store.actions.SELECT_ALL_NOTES_IN_TRACK({
           trackId: store.getters.SELECTED_TRACK_ID,
         });
       },
@@ -94,7 +94,7 @@ export const useMenuBarData = () => {
       label: "選択解除",
       onClick: () => {
         if (uiLocked.value) return;
-        void store.dispatch("DESELECT_ALL_NOTES");
+        void store.actions.DESELECT_ALL_NOTES();
       },
       disableWhenUiLocked: true,
     },
@@ -104,7 +104,7 @@ export const useMenuBarData = () => {
       label: "クオンタイズ",
       onClick: () => {
         if (uiLocked.value) return;
-        void store.dispatch("COMMAND_QUANTIZE_SELECTED_NOTES");
+        void store.actions.COMMAND_QUANTIZE_SELECTED_NOTES();
       },
       disableWhenUiLocked: true,
     },


### PR DESCRIPTION
## 内容
+ https://github.com/VOICEVOX/voicevox/pull/2099
+ https://github.com/VOICEVOX/voicevox/pull/2170
+ https://github.com/VOICEVOX/voicevox/pull/2180
+ https://github.com/VOICEVOX/voicevox/pull/2213
+ https://github.com/VOICEVOX/voicevox/pull/2266
+ https://github.com/VOICEVOX/voicevox/pull/2326
+ https://github.com/VOICEVOX/voicevox/pull/2327
+ https://github.com/VOICEVOX/voicevox/pull/2328
+ https://github.com/VOICEVOX/voicevox/pull/2329
の続きです。

components/Sing/フォルダ内のdispatch("ACTION1", payloads) のような引数におけるリテラル指定から actions.ACTION(payload) のようにdot記法によるアクセスに変更します。

+ src/components/Sing/ScoreSequencer.vue
+ src/components/Sing/SequencerKeys.vue
+ src/components/Sing/SequencerNote.vue
+ src/components/Sing/SequencerRuler/Container.vue
+ src/components/Sing/SideBar/SideBar.vue
+ src/components/Sing/SideBar/TrackItem.vue
+ src/components/Sing/SingEditor.vue
+ src/components/Sing/ToolBar/ToolBar.vue
+ src/components/Sing/menuBarData.ts
を対応しています。

## 関連 Issue

+ https://github.com/VOICEVOX/voicevox/issues/2088

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

dispatch\([\s\n]*"([A-Z_]*)",?
actions.$1(
と正規表現で置換してその後眼力チェックしています。
