### PR TITLE
vuexのstoreの呼び出しをリテラル引数からDot記法へ: composables, plugins

### DIFF
--- a/src/composables/useLyricInput.ts
+++ b/src/composables/useLyricInput.ts
@@ -50,7 +50,7 @@ export const useLyricInput = () => {
       newNotes.push({ ...note, lyric });
     }
     previewLyrics.value = new Map();
-    void store.dispatch("COMMAND_UPDATE_NOTES", {
+    void store.actions.COMMAND_UPDATE_NOTES({
       notes: newNotes,
       trackId: store.getters.SELECTED_TRACK_ID,
     });

--- a/src/composables/useRootMiscSetting.ts
+++ b/src/composables/useRootMiscSetting.ts
@@ -11,7 +11,7 @@ export const useRootMiscSetting = <T extends keyof RootMiscSettingType>(
   const setter = (value: RootMiscSettingType[T]) => {
     // Vuexの型処理でUnionが解かれてしまうのを迂回している
     // FIXME: このワークアラウンドをなくす
-    void store.dispatch("SET_ROOT_MISC_SETTING", {
+    void store.actions.SET_ROOT_MISC_SETTING({
       key: key as never,
       value,
     });

--- a/src/plugins/ipcMessageReceiverPlugin.ts
+++ b/src/plugins/ipcMessageReceiverPlugin.ts
@@ -10,31 +10,31 @@ export const ipcMessageReceiver: Plugin = {
   ) => {
     window.backend.onReceivedIPCMsg({
       LOAD_PROJECT_FILE: (_, { filePath, confirm } = {}) =>
-        void options.store.dispatch("LOAD_PROJECT_FILE", { filePath, confirm }),
+        void options.store.actions.LOAD_PROJECT_FILE({ filePath, confirm }),
 
-      DETECT_MAXIMIZED: () => options.store.dispatch("DETECT_MAXIMIZED"),
+      DETECT_MAXIMIZED: () => options.store.actions.DETECT_MAXIMIZED(),
 
-      DETECT_UNMAXIMIZED: () => options.store.dispatch("DETECT_UNMAXIMIZED"),
+      DETECT_UNMAXIMIZED: () => options.store.actions.DETECT_UNMAXIMIZED(),
 
       DETECTED_ENGINE_ERROR: (_, { engineId }) =>
-        options.store.dispatch("DETECTED_ENGINE_ERROR", { engineId }),
+        options.store.actions.DETECTED_ENGINE_ERROR({ engineId }),
 
       DETECT_PINNED: () => {
-        void options.store.dispatch("DETECT_PINNED");
+        void options.store.actions.DETECT_PINNED();
       },
 
       DETECT_UNPINNED: () => {
-        void options.store.dispatch("DETECT_UNPINNED");
+        void options.store.actions.DETECT_UNPINNED();
       },
 
       DETECT_ENTER_FULLSCREEN: () =>
-        options.store.dispatch("DETECT_ENTER_FULLSCREEN"),
+        options.store.actions.DETECT_ENTER_FULLSCREEN(),
 
       DETECT_LEAVE_FULLSCREEN: () =>
-        options.store.dispatch("DETECT_LEAVE_FULLSCREEN"),
+        options.store.actions.DETECT_LEAVE_FULLSCREEN(),
 
       CHECK_EDITED_AND_NOT_SAVE: (_, obj) => {
-        void options.store.dispatch("CHECK_EDITED_AND_NOT_SAVE", obj);
+        void options.store.actions.CHECK_EDITED_AND_NOT_SAVE(obj);
       },
 
       DETECT_RESIZED: debounce(


### PR DESCRIPTION
## 内容
+ https://github.com/VOICEVOX/voicevox/pull/2099
+ https://github.com/VOICEVOX/voicevox/pull/2170
+ https://github.com/VOICEVOX/voicevox/pull/2180
+ https://github.com/VOICEVOX/voicevox/pull/2213
+ https://github.com/VOICEVOX/voicevox/pull/2266
+ https://github.com/VOICEVOX/voicevox/pull/2326
+ https://github.com/VOICEVOX/voicevox/pull/2327
+ https://github.com/VOICEVOX/voicevox/pull/2328
+ https://github.com/VOICEVOX/voicevox/pull/2329
+ https://github.com/VOICEVOX/voicevox/pull/2330
の続きです。

今までのPR以外のファイルでのdispatch("ACTION1", payloads) のような引数におけるリテラル指定から actions.ACTION(payload) のようにdot記法によるアクセスに変更します。

+ src/composables/useLyricInput.ts
+ src/composables/useRootMiscSetting.ts
+ src/plugins/ipcMessageReceiverPlugin.ts

を対応しています。

## 関連 Issue

+ https://github.com/VOICEVOX/voicevox/issues/2088

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

dispatch\([\s\n]*"([A-Z_]*)",?
actions.$1(
と正規表現で置換してその後眼力チェックしています。
