### PR TITLE
fix: ファイルエラーのメッセージを少しわかりやすくする

### DIFF
--- a/src/helpers/fileHelper.ts
+++ b/src/helpers/fileHelper.ts
@@ -20,7 +20,7 @@ export function generateWriteErrorMessage(writeFileResult: ResultError<any>) {
     }
 
     if (code?.startsWith("ENOENT")) {
-      return "ファイルが見つかりません。";
+      return "指定されたファイルまたはフォルダが見つかりません。";
     }
   }
 


### PR DESCRIPTION
## 内容

ファイルエラーのメッセージを少しわかりやすくします。
おそらくディレクトリが無いときもエラーになるので、ファイルがないorフォルダがないとしました。

## その他
