### PR TITLE
refactor: managerクラスの取得方法を変更

### DIFF
--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -224,8 +224,7 @@ export class EngineAndVvppController {
       log.info(
         "All ENGINE process kill operations done. Running post engine kill process",
       );
-      const vvppManager = getVvppManager();
-      return vvppManager.handleMarkedEngineDirs();
+      return this.vvppManager.handleMarkedEngineDirs();
     });
   }
 

--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -239,9 +239,9 @@ export class EngineAndVvppController {
 
 let manager: EngineAndVvppController | undefined;
 
-export const getEngineAndVvppController = () => {
+export function getEngineAndVvppController() {
   if (manager == undefined) {
     manager = new EngineAndVvppController();
   }
   return manager;
-};
+}

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -20,14 +20,20 @@ import log from "electron-log/main";
 import dayjs from "dayjs";
 import windowStateKeeper from "electron-window-state";
 import { hasSupportedGpu } from "./device";
-import EngineInfoManager from "./manager/engineInfoManager";
-import EngineProcessManager from "./manager/engineProcessManager";
-import VvppManager, { isVvppFile } from "./manager/vvppManager";
+import {
+  getEngineInfoManager,
+  initializeEngineInfoManager,
+} from "./manager/engineInfoManager";
+import {
+  getEngineProcessManager,
+  initializeEngineProcessManager,
+} from "./manager/engineProcessManager";
+import { initializeVvppManager, isVvppFile } from "./manager/vvppManager";
 import configMigration014 from "./configMigration014";
-import { RuntimeInfoManager } from "./manager/RuntimeInfoManager";
+import { initializeRuntimeInfoManager } from "./manager/RuntimeInfoManager";
 import { registerIpcMainHandle, ipcMainSendProxy, IpcMainHandle } from "./ipc";
 import { getConfigManager } from "./electronConfig";
-import { EngineAndVvppController } from "./engineAndVvppController";
+import { getEngineAndVvppController } from "./engineAndVvppController";
 import { writeFileSafely } from "./fileHelper";
 import { failure, success } from "@/type/result";
 import { AssetTextFileNames } from "@/type/staticResources";
@@ -170,35 +176,25 @@ const onEngineProcessError = (engineInfo: EngineInfo, error: Error) => {
   dialog.showErrorBox("音声合成エンジンエラー", error.message);
 };
 
-const runtimeInfoManager = new RuntimeInfoManager(
+initializeRuntimeInfoManager(
   path.join(app.getPath("userData"), "runtime-info.json"),
   app.getVersion(),
 );
 
-const configManager = getConfigManager();
-
-const engineInfoManager = new EngineInfoManager({
-  configManager,
+initializeEngineInfoManager({
   defaultEngineDir: appDirPath,
   vvppEngineDir,
 });
-const engineProcessManager = new EngineProcessManager({
-  configManager,
-  onEngineProcessError,
-  engineInfosFetcher:
-    engineInfoManager.fetchEngineInfos.bind(engineInfoManager),
-  engineAltPortUpdater: engineInfoManager.updateAltPort.bind(engineInfoManager),
-  engineSettingsGetter: () => configManager.get("engineSettings"),
-});
-const vvppManager = new VvppManager({ vvppEngineDir });
 
-const engineAndVvppController = new EngineAndVvppController(
-  runtimeInfoManager,
-  configManager,
-  engineInfoManager,
-  engineProcessManager,
-  vvppManager,
-);
+initializeEngineProcessManager({ onEngineProcessError });
+
+initializeVvppManager({ vvppEngineDir });
+
+const configManager = getConfigManager();
+
+const engineInfoManager = getEngineInfoManager();
+
+const engineAndVvppController = getEngineAndVvppController();
 
 // エンジンのフォルダを開く
 function openEngineDirectory(engineId: EngineId) {
@@ -649,7 +645,8 @@ registerIpcMainHandle<IpcMainHandle>({
   },
 
   RESTART_ENGINE: async (_, { engineId }) => {
-    return engineProcessManager.restartEngine(engineId);
+    const manager = getEngineProcessManager();
+    return manager.restartEngine(engineId);
   },
 
   OPEN_ENGINE_DIRECTORY: async (_, { engineId }) => {

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -121,7 +121,7 @@ process.on("uncaughtException", (error) => {
   } else {
     const { message, name } = error;
     let detailedMessage = "";
-    detailedMessage += `メインプロセスで原因不明のエラーが発生しました。\n`;
+    detailedMessage += `メインプロセスで原因不明��エラーが発生しました。\n`;
     detailedMessage += `エラー名: ${name}\n`;
     detailedMessage += `メッセージ: ${message}\n`;
     if (error.stack) {
@@ -176,24 +176,20 @@ const onEngineProcessError = (engineInfo: EngineInfo, error: Error) => {
   dialog.showErrorBox("音声合成エンジンエラー", error.message);
 };
 
-initializeRuntimeInfoManager(
-  path.join(app.getPath("userData"), "runtime-info.json"),
-  app.getVersion(),
-);
-
+initializeRuntimeInfoManager({
+  runtimeInfoPath: path.join(app.getPath("userData"), "runtime-info.json"),
+  appVersion: app.getVersion(),
+});
 initializeEngineInfoManager({
   defaultEngineDir: appDirPath,
   vvppEngineDir,
 });
-
 initializeEngineProcessManager({ onEngineProcessError });
-
 initializeVvppManager({ vvppEngineDir });
 
 const configManager = getConfigManager();
-
 const engineInfoManager = getEngineInfoManager();
-
+const engineProcessManager = getEngineProcessManager();
 const engineAndVvppController = getEngineAndVvppController();
 
 // エンジンのフォルダを開く
@@ -645,8 +641,7 @@ registerIpcMainHandle<IpcMainHandle>({
   },
 
   RESTART_ENGINE: async (_, { engineId }) => {
-    const manager = getEngineProcessManager();
-    return manager.restartEngine(engineId);
+    return engineProcessManager.restartEngine(engineId);
   },
 
   OPEN_ENGINE_DIRECTORY: async (_, { engineId }) => {

--- a/src/backend/electron/manager/RuntimeInfoManager.ts
+++ b/src/backend/electron/manager/RuntimeInfoManager.ts
@@ -117,11 +117,11 @@ export class RuntimeInfoManager {
 
 let manager: RuntimeInfoManager | undefined;
 
-export function initializeRuntimeInfoManager(
-  runtimeInfoPath: string,
-  appVersion: string,
-) {
-  manager = new RuntimeInfoManager(runtimeInfoPath, appVersion);
+export function initializeRuntimeInfoManager(payload: {
+  runtimeInfoPath: string;
+  appVersion: string;
+}) {
+  manager = new RuntimeInfoManager(payload.runtimeInfoPath, payload.appVersion);
 }
 
 export function getRuntimeInfoManager() {

--- a/src/backend/electron/manager/RuntimeInfoManager.ts
+++ b/src/backend/electron/manager/RuntimeInfoManager.ts
@@ -114,3 +114,19 @@ export class RuntimeInfoManager {
     });
   }
 }
+
+let manager: RuntimeInfoManager | undefined;
+
+export const initializeRuntimeInfoManager = (
+  runtimeInfoPath: string,
+  appVersion: string,
+) => {
+  manager = new RuntimeInfoManager(runtimeInfoPath, appVersion);
+};
+
+export const getRuntimeInfoManager = () => {
+  if (manager == undefined) {
+    throw new Error("RuntimeInfoManager is not initialized");
+  }
+  return manager;
+};

--- a/src/backend/electron/manager/RuntimeInfoManager.ts
+++ b/src/backend/electron/manager/RuntimeInfoManager.ts
@@ -117,16 +117,16 @@ export class RuntimeInfoManager {
 
 let manager: RuntimeInfoManager | undefined;
 
-export const initializeRuntimeInfoManager = (
+export function initializeRuntimeInfoManager(
   runtimeInfoPath: string,
   appVersion: string,
-) => {
+) {
   manager = new RuntimeInfoManager(runtimeInfoPath, appVersion);
-};
+}
 
-export const getRuntimeInfoManager = () => {
+export function getRuntimeInfoManager() {
   if (manager == undefined) {
     throw new Error("RuntimeInfoManager is not initialized");
   }
   return manager;
-};
+}

--- a/src/backend/electron/manager/engineInfoManager.ts
+++ b/src/backend/electron/manager/engineInfoManager.ts
@@ -6,6 +6,7 @@ import { dialog } from "electron"; // FIXME: ここでelectronをimportするの
 
 import log from "electron-log/main";
 
+import { getConfigManager } from "../electronConfig";
 import {
   EngineInfo,
   EngineDirValidationResult,
@@ -14,7 +15,6 @@ import {
   minimumEngineManifestSchema,
 } from "@/type/preload";
 import { AltPortInfos } from "@/store/type";
-import { BaseConfigManager } from "@/backend/common/ConfigManager";
 import { loadEnvEngineInfos } from "@/domain/defaultEngine/envEngineInfo";
 
 /**
@@ -45,19 +45,13 @@ function fetchDefaultEngineInfos(defaultEngineDir: string): EngineInfo[] {
 
 /** エンジンの情報を管理するクラス */
 export class EngineInfoManager {
-  configManager: BaseConfigManager;
   defaultEngineDir: string;
   vvppEngineDir: string;
 
   /** 代替ポート情報 */
   public altPortInfos: AltPortInfos = {};
 
-  constructor(payload: {
-    configManager: BaseConfigManager;
-    defaultEngineDir: string;
-    vvppEngineDir: string;
-  }) {
-    this.configManager = payload.configManager;
+  constructor(payload: { defaultEngineDir: string; vvppEngineDir: string }) {
     this.defaultEngineDir = payload.defaultEngineDir;
     this.vvppEngineDir = payload.vvppEngineDir;
   }
@@ -114,8 +108,9 @@ export class EngineInfoManager {
         log.log(`Failed to load engine: ${result}, ${engineDir}`);
       }
     }
+    const configManager = getConfigManager();
     // FIXME: この関数の引数でregisteredEngineDirsを受け取り、動かないエンジンをreturnして、EngineManager外でconfig.setする
-    for (const engineDir of this.configManager.get("registeredEngineDirs")) {
+    for (const engineDir of configManager.get("registeredEngineDirs")) {
       const result = addEngine(engineDir, "path");
       if (result !== "ok") {
         log.log(`Failed to load engine: ${result}, ${engineDir}`);
@@ -125,9 +120,9 @@ export class EngineInfoManager {
           "エンジンの読み込みに失敗しました。",
           `${engineDir}を読み込めませんでした。このエンジンは削除されます。`,
         );
-        this.configManager.set(
+        configManager.set(
           "registeredEngineDirs",
-          this.configManager
+          configManager
             .get("registeredEngineDirs")
             .filter((p) => p !== engineDir),
         );
@@ -221,4 +216,18 @@ export class EngineInfoManager {
   }
 }
 
-export default EngineInfoManager;
+let manager: EngineInfoManager | undefined;
+
+export const initializeEngineInfoManager = (payload: {
+  defaultEngineDir: string;
+  vvppEngineDir: string;
+}) => {
+  manager = new EngineInfoManager(payload);
+};
+
+export const getEngineInfoManager = () => {
+  if (manager == undefined) {
+    throw new Error("EngineInfoManager is not initialized");
+  }
+  return manager;
+};

--- a/src/backend/electron/manager/engineInfoManager.ts
+++ b/src/backend/electron/manager/engineInfoManager.ts
@@ -218,16 +218,16 @@ export class EngineInfoManager {
 
 let manager: EngineInfoManager | undefined;
 
-export const initializeEngineInfoManager = (payload: {
+export function initializeEngineInfoManager(payload: {
   defaultEngineDir: string;
   vvppEngineDir: string;
-}) => {
+}) {
   manager = new EngineInfoManager(payload);
-};
+}
 
-export const getEngineInfoManager = () => {
+export function getEngineInfoManager() {
   if (manager == undefined) {
     throw new Error("EngineInfoManager is not initialized");
   }
   return manager;
-};
+}

--- a/src/backend/electron/manager/engineProcessManager.ts
+++ b/src/backend/electron/manager/engineProcessManager.ts
@@ -1,4 +1,4 @@
-import { spawn, ChildProcess } from "child_process";
+import { ChildProcess, spawn } from "child_process";
 import path from "path";
 import treeKill from "tree-kill";
 
@@ -13,8 +13,9 @@ import {
   isAssignablePort,
 } from "../portHelper";
 
-import { EngineInfo, EngineId, EngineSettings } from "@/type/preload";
-import { BaseConfigManager } from "@/backend/common/ConfigManager";
+import { getConfigManager } from "../electronConfig";
+import { getEngineInfoManager } from "./engineInfoManager";
+import { EngineId, EngineInfo } from "@/type/preload";
 
 type EngineProcessContainer = {
   willQuitEngine: boolean;
@@ -24,35 +25,23 @@ type EngineProcessContainer = {
 /** エンジンプロセスを管理するクラス */
 export class EngineProcessManager {
   onEngineProcessError: (engineInfo: EngineInfo, error: Error) => void;
-  engineInfosFetcher: () => Readonly<EngineInfo>[];
-  engineAltPortUpdater: (engineId: EngineId, port: number) => void;
-  engineSettingsGetter: () => Partial<EngineSettings>;
 
   defaultEngineInfos: EngineInfo[] = [];
   additionalEngineInfos: EngineInfo[] = [];
   engineProcessContainers: Record<EngineId, EngineProcessContainer> = {};
 
   constructor(payload: {
-    configManager: BaseConfigManager;
     onEngineProcessError: (engineInfo: EngineInfo, error: Error) => void;
-    /** エンジン情報を取得する関数 */
-    engineInfosFetcher: () => Readonly<EngineInfo>[];
-    /** エンジンの代替ポート情報を更新する関数 */
-    engineAltPortUpdater: (engineId: EngineId, port: number) => void;
-    /** エンジン設定を取得する関数 */
-    engineSettingsGetter: () => Partial<EngineSettings>;
   }) {
     this.onEngineProcessError = payload.onEngineProcessError;
-    this.engineInfosFetcher = payload.engineInfosFetcher;
-    this.engineAltPortUpdater = payload.engineAltPortUpdater;
-    this.engineSettingsGetter = payload.engineSettingsGetter;
   }
 
   /**
    * 全てのエンジンを起動する。
    */
   async runEngineAll() {
-    const engineInfos = this.engineInfosFetcher();
+    const engineInfoManager = getEngineInfoManager();
+    const engineInfos = engineInfoManager.fetchEngineInfos();
     log.info(`Starting ${engineInfos.length} engine/s...`);
 
     for (const engineInfo of engineInfos) {
@@ -65,7 +54,8 @@ export class EngineProcessManager {
    * エンジンを起動する。
    */
   async runEngine(engineId: EngineId) {
-    const engineInfos = this.engineInfosFetcher();
+    const engineInfoManager = getEngineInfoManager();
+    const engineInfos = engineInfoManager.fetchEngineInfos();
     const engineInfo = engineInfos.find(
       (engineInfo) => engineInfo.uuid === engineId,
     );
@@ -126,7 +116,7 @@ export class EngineProcessManager {
       }
 
       // 代替ポート情報を更新
-      this.engineAltPortUpdater(engineId, altPort);
+      engineInfoManager.updateAltPort(engineId, altPort);
       log.warn(
         `ENGINE ${engineId}: Applied Alternative Port: ${port} -> ${altPort}`,
       );
@@ -145,7 +135,8 @@ export class EngineProcessManager {
     const engineProcessContainer = this.engineProcessContainers[engineId];
     engineProcessContainer.willQuitEngine = false;
 
-    const engineSetting = this.engineSettingsGetter()[engineId];
+    const configManager = getConfigManager();
+    const engineSetting = configManager.get("engineSettings")[engineId];
     if (engineSetting == undefined)
       throw new Error(`No such engineSetting: engineId == ${engineId}`);
 
@@ -366,4 +357,17 @@ export class EngineProcessManager {
   }
 }
 
-export default EngineProcessManager;
+let manager: EngineProcessManager | undefined;
+
+export const initializeEngineProcessManager = (payload: {
+  onEngineProcessError: (engineInfo: EngineInfo, error: Error) => void;
+}) => {
+  manager = new EngineProcessManager(payload);
+};
+
+export const getEngineProcessManager = () => {
+  if (manager == undefined) {
+    throw new Error("EngineProcessManager is not initialized");
+  }
+  return manager;
+};

--- a/src/backend/electron/manager/engineProcessManager.ts
+++ b/src/backend/electron/manager/engineProcessManager.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, spawn } from "child_process";
+import { spawn, ChildProcess } from "child_process";
 import path from "path";
 import treeKill from "tree-kill";
 
@@ -36,12 +36,18 @@ export class EngineProcessManager {
     this.onEngineProcessError = payload.onEngineProcessError;
   }
 
+  private get configManager() {
+    return getConfigManager();
+  }
+  private get engineInfoManager() {
+    return getEngineInfoManager();
+  }
+
   /**
    * 全てのエンジンを起動する。
    */
   async runEngineAll() {
-    const engineInfoManager = getEngineInfoManager();
-    const engineInfos = engineInfoManager.fetchEngineInfos();
+    const engineInfos = this.engineInfoManager.fetchEngineInfos();
     log.info(`Starting ${engineInfos.length} engine/s...`);
 
     for (const engineInfo of engineInfos) {
@@ -54,8 +60,7 @@ export class EngineProcessManager {
    * エンジンを起動する。
    */
   async runEngine(engineId: EngineId) {
-    const engineInfoManager = getEngineInfoManager();
-    const engineInfos = engineInfoManager.fetchEngineInfos();
+    const engineInfos = this.engineInfoManager.fetchEngineInfos();
     const engineInfo = engineInfos.find(
       (engineInfo) => engineInfo.uuid === engineId,
     );
@@ -135,8 +140,7 @@ export class EngineProcessManager {
     const engineProcessContainer = this.engineProcessContainers[engineId];
     engineProcessContainer.willQuitEngine = false;
 
-    const configManager = getConfigManager();
-    const engineSetting = configManager.get("engineSettings")[engineId];
+    const engineSetting = this.configManager.get("engineSettings")[engineId];
     if (engineSetting == undefined)
       throw new Error(`No such engineSetting: engineId == ${engineId}`);
 

--- a/src/backend/electron/manager/engineProcessManager.ts
+++ b/src/backend/electron/manager/engineProcessManager.ts
@@ -121,7 +121,7 @@ export class EngineProcessManager {
       }
 
       // 代替ポート情報を更新
-      engineInfoManager.updateAltPort(engineId, altPort);
+      this.engineInfoManager.updateAltPort(engineId, altPort);
       log.warn(
         `ENGINE ${engineId}: Applied Alternative Port: ${port} -> ${altPort}`,
       );

--- a/src/backend/electron/manager/engineProcessManager.ts
+++ b/src/backend/electron/manager/engineProcessManager.ts
@@ -359,15 +359,15 @@ export class EngineProcessManager {
 
 let manager: EngineProcessManager | undefined;
 
-export const initializeEngineProcessManager = (payload: {
+export function initializeEngineProcessManager(payload: {
   onEngineProcessError: (engineInfo: EngineInfo, error: Error) => void;
-}) => {
+}) {
   manager = new EngineProcessManager(payload);
-};
+}
 
-export const getEngineProcessManager = () => {
+export function getEngineProcessManager() {
   if (manager == undefined) {
     throw new Error("EngineProcessManager is not initialized");
   }
   return manager;
-};
+}

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -383,3 +383,16 @@ export class VvppManager {
 }
 
 export default VvppManager;
+
+let manager: VvppManager | undefined;
+
+export const initializeVvppManager = (payload: { vvppEngineDir: string }) => {
+  manager = new VvppManager(payload);
+};
+
+export const getVvppManager = () => {
+  if (manager == undefined) {
+    throw new Error("EngineInfoManager is not initialized");
+  }
+  return manager;
+};

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -386,13 +386,13 @@ export default VvppManager;
 
 let manager: VvppManager | undefined;
 
-export const initializeVvppManager = (payload: { vvppEngineDir: string }) => {
+export function initializeVvppManager(payload: { vvppEngineDir: string }) {
   manager = new VvppManager(payload);
-};
+}
 
-export const getVvppManager = () => {
+export function getVvppManager() {
   if (manager == undefined) {
     throw new Error("EngineInfoManager is not initialized");
   }
   return manager;
-};
+}


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox/pull/2298#pullrequestreview-2379408774 で提案されたリファクタリングです

## その他

`EngineAndVvppController`がget～で煩雑になった感じがします。
ただ、複数のマネージャーをまとめて管理するためのものだから仕方がない？