### PR TITLE
Refactor: moraPatternをdomain/japaneseに移動

### DIFF
--- a/src/domain/japanese/index.ts
+++ b/src/domain/japanese/index.ts
@@ -40,3 +40,18 @@ export const convertLongVowel = (text: string): string => {
     .replace(/(?<=[ん]ー*)ー/g, "ん")
     .replace(/(?<=[っ]ー*)ー/g, "っ");
 };
+
+// 参考：https://github.com/VOICEVOX/voicevox_core/blob/0848630d81ae3e917c6ff2038f0b15bbd4270702/crates/voicevox_core/src/user_dict/word.rs#L83-L90
+export const moraPattern = new RegExp(
+  "(?:" +
+    "[イ][ェ]|[ヴ][ャュョ]|[トド][ゥ]|[テデ][ィャュョ]|[デ][ェ]|[クグ][ヮ]|" + // rule_others
+    "[キシチニヒミリギジビピ][ェャュョ]|" + // rule_line_i
+    "[ツフヴ][ァ]|[ウスツフヴズ][ィ]|[ウツフヴ][ェォ]|" + // rule_line_u
+    "[ァ-ヴー]|" + // rule_one_mora
+    "[い][ぇ]|[ゃゅょ]|[とど][ぅ]|[てで][ぃゃゅょ]|[で][ぇ]|[くぐ][ゎ]|" + // rule_others
+    "[きしちにひみりぎじびぴ][ぇゃゅょ]|" + // rule_line_i
+    "[つふゔ][ぁ]|[うすつふゔず][ぃ]|[うつふゔ][ぇぉ]|" + // rule_line_u
+    "[ぁ-ゔー]" + // rule_one_mora
+    ")",
+  "g",
+);

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -1,5 +1,5 @@
 import { calculateHash } from "./utility";
-import { convertLongVowel } from "@/domain/japanese";
+import { convertLongVowel, moraPattern } from "@/domain/japanese";
 import {
   Note,
   Phrase,
@@ -533,21 +533,6 @@ export function applyPitchEdit(
     }
   }
 }
-
-// 参考：https://github.com/VOICEVOX/voicevox_core/blob/0848630d81ae3e917c6ff2038f0b15bbd4270702/crates/voicevox_core/src/user_dict/word.rs#L83-L90
-export const moraPattern = new RegExp(
-  "(?:" +
-    "[イ][ェ]|[ヴ][ャュョ]|[トド][ゥ]|[テデ][ィャュョ]|[デ][ェ]|[クグ][ヮ]|" + // rule_others
-    "[キシチニヒミリギジビピ][ェャュョ]|" + // rule_line_i
-    "[ツフヴ][ァ]|[ウスツフヴズ][ィ]|[ウツフヴ][ェォ]|" + // rule_line_u
-    "[ァ-ヴー]|" + // rule_one_mora
-    "[い][ぇ]|[ゃゅょ]|[とど][ぅ]|[てで][ぃゃゅょ]|[で][ぇ]|[くぐ][ゎ]|" + // rule_others
-    "[きしちにひみりぎじびぴ][ぇゃゅょ]|" + // rule_line_i
-    "[つふゔ][ぁ]|[うすつふゔず][ぃ]|[うつふゔ][ぇぉ]|" + // rule_line_u
-    "[ぁ-ゔー]" + // rule_one_mora
-    ")",
-  "g",
-);
 
 /**
  * 文字列をモーラと非モーラに分割する。長音は展開される。連続する非モーラはまとめる。


### PR DESCRIPTION
## 内容

moraPattern関数をjapanese.tsに移動させます。

- https://github.com/VOICEVOX/voicevox/pull/2152/

のために必要で、リファクタリングとして切り出しました。

## 関連 Issue

#2152

## その他
