### PR TITLE
Refactoring: ホットキー周りの初期値などをdomainに切り出す

### DIFF
--- a/src/backend/browser/sandbox.ts
+++ b/src/backend/browser/sandbox.ts
@@ -13,10 +13,10 @@ import {
   EngineId,
   EngineSettingType,
   EngineSettings,
-  HotkeySettingType,
   Sandbox,
 } from "@/type/preload";
 import { AssetTextFileNames } from "@/type/staticResources";
+import { HotkeySettingType } from "@/domain/hotkeyAction";
 
 const toStaticPath = (fileName: string) =>
   `${import.meta.env.BASE_URL}/${fileName}`.replaceAll(/\/\/+/g, "/");

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -5,15 +5,17 @@ import {
   ConfigType,
   configSchema,
   DefaultStyleId,
-  defaultHotkeySettings,
-  HotkeySettingType,
   ExperimentalSettingType,
-  HotkeyCombination,
   VoiceId,
   PresetKey,
 } from "@/type/preload";
 import { ensureNotNullish } from "@/helpers/errorHelper";
 import { loadEnvEngineInfos } from "@/domain/defaultEngine/envEngineInfo";
+import {
+  HotkeyCombination,
+  defaultHotkeySettings,
+  HotkeySettingType,
+} from "@/domain/hotkeyAction";
 
 const lockKey = "save";
 

--- a/src/components/Dialog/HotkeyRecordingDialog.vue
+++ b/src/components/Dialog/HotkeyRecordingDialog.vue
@@ -83,7 +83,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { HotkeyCombination } from "@/type/preload";
+import { HotkeyCombination } from "@/domain/hotkeyAction";
 
 const props = defineProps<{
   isHotkeyDialogOpened: boolean;

--- a/src/components/Dialog/HotkeySettingDialog.vue
+++ b/src/components/Dialog/HotkeySettingDialog.vue
@@ -126,12 +126,12 @@ import BaseButton from "@/components/Base/BaseButton.vue";
 import BaseIconButton from "@/components/Base/BaseIconButton.vue";
 import BaseScrollArea from "@/components/Base/BaseScrollArea.vue";
 import { useStore } from "@/store";
-import {
-  defaultHotkeySettings,
-  HotkeyActionNameType,
-  HotkeyCombination,
-} from "@/type/preload";
 import { useHotkeyManager, eventToCombination } from "@/plugins/hotkeyPlugin";
+import {
+  HotkeyCombination,
+  HotkeyActionNameType,
+  defaultHotkeySettings,
+} from "@/domain/hotkeyAction";
 
 const props = defineProps<{
   modelValue: boolean;

--- a/src/components/Menu/MenuItem.vue
+++ b/src/components/Menu/MenuItem.vue
@@ -74,7 +74,7 @@
 import { ref, computed, watch } from "vue";
 import { MenuItemData } from "./type";
 import { useStore } from "@/store";
-import { hotkeyActionNameSchema } from "@/type/preload";
+import { hotkeyActionNameSchema } from "@/domain/hotkeyAction";
 const props = withDefaults(
   defineProps<{
     selected?: boolean;

--- a/src/components/Talk/TalkEditor.vue
+++ b/src/components/Talk/TalkEditor.vue
@@ -135,12 +135,14 @@ import {
   PresetKey,
   SplitterPositionType,
   Voice,
-  HotkeyActionNameType,
-  actionPostfixSelectNthCharacter,
 } from "@/type/preload";
 import { useHotkeyManager } from "@/plugins/hotkeyPlugin";
 import onetimeWatch from "@/helpers/onetimeWatch";
 import path from "@/helpers/path";
+import {
+  actionPostfixSelectNthCharacter,
+  HotkeyActionNameType,
+} from "@/domain/hotkeyAction";
 
 const props = defineProps<{
   isEnginesReady: boolean;

--- a/src/domain/hotkeyAction.ts
+++ b/src/domain/hotkeyAction.ts
@@ -1,0 +1,199 @@
+import { z } from "zod";
+import { isMac } from "@/helpers/platform";
+
+const hotkeyCombinationSchema = z.string().brand("HotkeyCombination");
+export type HotkeyCombination = z.infer<typeof hotkeyCombinationSchema>;
+export const HotkeyCombination = (
+  hotkeyCombination: string,
+): HotkeyCombination => hotkeyCombinationSchema.parse(hotkeyCombination);
+
+// 共通のアクション名
+export const actionPostfixSelectNthCharacter = "番目のキャラクターを選択";
+
+export const hotkeyActionNameSchema = z.enum([
+  "音声書き出し",
+  "選択音声を書き出し",
+  "音声を繋げて書き出し",
+  "再生/停止",
+  "連続再生/停止",
+  "ｱｸｾﾝﾄ欄を表示",
+  "ｲﾝﾄﾈｰｼｮﾝ欄を表示",
+  "長さ欄を表示",
+  "テキスト欄を追加",
+  "テキスト欄を複製",
+  "テキスト欄を削除",
+  "テキスト欄からフォーカスを外す",
+  "テキスト欄にフォーカスを戻す",
+  "元に戻す",
+  "やり直す",
+  "新規プロジェクト",
+  "プロジェクトを名前を付けて保存",
+  "プロジェクトを上書き保存",
+  "プロジェクトを読み込む",
+  "テキストを読み込む",
+  "全体のイントネーションをリセット",
+  "選択中のアクセント句のイントネーションをリセット",
+  "コピー",
+  "切り取り",
+  "貼り付け",
+  "すべて選択",
+  "選択解除",
+  "全セルを選択",
+  `1${actionPostfixSelectNthCharacter}`,
+  `2${actionPostfixSelectNthCharacter}`,
+  `3${actionPostfixSelectNthCharacter}`,
+  `4${actionPostfixSelectNthCharacter}`,
+  `5${actionPostfixSelectNthCharacter}`,
+  `6${actionPostfixSelectNthCharacter}`,
+  `7${actionPostfixSelectNthCharacter}`,
+  `8${actionPostfixSelectNthCharacter}`,
+  `9${actionPostfixSelectNthCharacter}`,
+  `10${actionPostfixSelectNthCharacter}`,
+  "全画面表示を切り替え",
+  "拡大",
+  "縮小",
+  "拡大率のリセット",
+]);
+export type HotkeyActionNameType = z.infer<typeof hotkeyActionNameSchema>;
+
+export const hotkeySettingSchema = z.object({
+  action: hotkeyActionNameSchema,
+  combination: hotkeyCombinationSchema,
+});
+export type HotkeySettingType = z.infer<typeof hotkeySettingSchema>;
+
+// ホットキーを追加したときは設定のマイグレーションが必要
+export const defaultHotkeySettings: HotkeySettingType[] = [
+  {
+    action: "音声書き出し",
+    combination: HotkeyCombination(!isMac ? "Ctrl E" : "Meta E"),
+  },
+  {
+    action: "選択音声を書き出し",
+    combination: HotkeyCombination("E"),
+  },
+  {
+    action: "音声を繋げて書き出し",
+    combination: HotkeyCombination(""),
+  },
+  {
+    action: "再生/停止",
+    combination: HotkeyCombination("Space"),
+  },
+  {
+    action: "連続再生/停止",
+    combination: HotkeyCombination("Shift Space"),
+  },
+  {
+    action: "ｱｸｾﾝﾄ欄を表示",
+    combination: HotkeyCombination("1"),
+  },
+  {
+    action: "ｲﾝﾄﾈｰｼｮﾝ欄を表示",
+    combination: HotkeyCombination("2"),
+  },
+  {
+    action: "長さ欄を表示",
+    combination: HotkeyCombination("3"),
+  },
+  {
+    action: "テキスト欄を追加",
+    combination: HotkeyCombination("Shift Enter"),
+  },
+  {
+    action: "テキスト欄を複製",
+    combination: HotkeyCombination(!isMac ? "Ctrl D" : "Meta D"),
+  },
+  {
+    action: "テキスト欄を削除",
+    combination: HotkeyCombination("Shift Delete"),
+  },
+  {
+    action: "テキスト欄からフォーカスを外す",
+    combination: HotkeyCombination("Escape"),
+  },
+  {
+    action: "テキスト欄にフォーカスを戻す",
+    combination: HotkeyCombination("Enter"),
+  },
+  {
+    action: "元に戻す",
+    combination: HotkeyCombination(!isMac ? "Ctrl Z" : "Meta Z"),
+  },
+  {
+    action: "やり直す",
+    combination: HotkeyCombination(!isMac ? "Ctrl Y" : "Shift Meta Z"),
+  },
+  {
+    action: "拡大",
+    combination: HotkeyCombination(""),
+  },
+  {
+    action: "縮小",
+    combination: HotkeyCombination(""),
+  },
+  {
+    action: "拡大率のリセット",
+    combination: HotkeyCombination(""),
+  },
+  {
+    action: "新規プロジェクト",
+    combination: HotkeyCombination(!isMac ? "Ctrl N" : "Meta N"),
+  },
+  {
+    action: "全画面表示を切り替え",
+    combination: HotkeyCombination(!isMac ? "F11" : "Ctrl Meta F"),
+  },
+  {
+    action: "プロジェクトを名前を付けて保存",
+    combination: HotkeyCombination(!isMac ? "Ctrl Shift S" : "Shift Meta S"),
+  },
+  {
+    action: "プロジェクトを上書き保存",
+    combination: HotkeyCombination(!isMac ? "Ctrl S" : "Meta S"),
+  },
+  {
+    action: "プロジェクトを読み込む",
+    combination: HotkeyCombination(!isMac ? "Ctrl O" : "Meta O"),
+  },
+  {
+    action: "テキストを読み込む",
+    combination: HotkeyCombination(""),
+  },
+  {
+    action: "全体のイントネーションをリセット",
+    combination: HotkeyCombination(!isMac ? "Ctrl G" : "Meta G"),
+  },
+  {
+    action: "選択中のアクセント句のイントネーションをリセット",
+    combination: HotkeyCombination("R"),
+  },
+  {
+    action: "コピー",
+    combination: HotkeyCombination(!isMac ? "Ctrl C" : "Meta C"),
+  },
+  {
+    action: "切り取り",
+    combination: HotkeyCombination(!isMac ? "Ctrl X" : "Meta X"),
+  },
+  {
+    action: "貼り付け",
+    combination: HotkeyCombination(!isMac ? "Ctrl V" : "Meta V"),
+  },
+  {
+    action: "すべて選択",
+    combination: HotkeyCombination(!isMac ? "Ctrl A" : "Meta A"),
+  },
+  {
+    action: "選択解除",
+    combination: HotkeyCombination("Escape"),
+  },
+  ...Array.from({ length: 10 }, (_, index) => {
+    const roleKey = index == 9 ? 0 : index + 1;
+    return {
+      action:
+        `${index + 1}${actionPostfixSelectNthCharacter}` as HotkeyActionNameType,
+      combination: HotkeyCombination(`${!isMac ? "Ctrl" : "Meta"} ${roleKey}`),
+    };
+  }),
+];

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -13,7 +13,7 @@ import {
   HotkeyActionNameType,
   HotkeyCombination,
   HotkeySettingType,
-} from "@/type/preload";
+} from "@/domain/hotkeyAction";
 import { createLogger } from "@/domain/frontend/log";
 
 const hotkeyManagerKey = "hotkeyManager";

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -7,7 +7,6 @@ import {
   showQuestionDialog,
 } from "@/components/Dialog/Dialog";
 import {
-  HotkeySettingType,
   SavingSetting,
   ExperimentalSettingType,
   ToolbarSettingType,
@@ -16,6 +15,7 @@ import {
   RootMiscSettingType,
 } from "@/type/preload";
 import { IsEqual } from "@/type/utility";
+import { HotkeySettingType } from "@/domain/hotkeyAction";
 
 export const settingStoreState: SettingStoreState = {
   openedEditor: undefined,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -26,7 +26,6 @@ import {
   DefaultStyleId,
   AcceptRetrieveTelemetryStatus,
   AcceptTermsStatus,
-  HotkeySettingType,
   MoraDataType,
   SavingSetting,
   ThemeConf,
@@ -72,6 +71,7 @@ import {
   timeSignatureSchema,
   trackSchema,
 } from "@/domain/project/schema";
+import { HotkeySettingType } from "@/domain/hotkeyAction";
 
 /**
  * エディタ用のAudioQuery

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -5,7 +5,6 @@ import {
   EngineId,
   EngineInfo,
   EngineSettingType,
-  HotkeySettingType,
   MessageBoxReturnValue,
   NativeThemeType,
   TextAsset,
@@ -13,6 +12,7 @@ import {
 } from "@/type/preload";
 import { AltPortInfos } from "@/store/type";
 import { Result } from "@/type/result";
+import { HotkeySettingType } from "@/domain/hotkeyAction";
 
 /**
  * invoke, handle

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -2,17 +2,15 @@ import { z } from "zod";
 import { IpcSOData } from "./ipc";
 import { AltPortInfos } from "@/store/type";
 import { Result } from "@/type/result";
-import { isMac } from "@/helpers/platform";
+import {
+  HotkeySettingType,
+  hotkeySettingSchema,
+  defaultHotkeySettings,
+} from "@/domain/hotkeyAction";
 
 const urlStringSchema = z.string().url().brand("URL");
 export type UrlString = z.infer<typeof urlStringSchema>;
 export const UrlString = (url: string): UrlString => urlStringSchema.parse(url);
-
-const hotkeyCombinationSchema = z.string().brand("HotkeyCombination");
-export type HotkeyCombination = z.infer<typeof hotkeyCombinationSchema>;
-export const HotkeyCombination = (
-  hotkeyCombination: string,
-): HotkeyCombination => hotkeyCombinationSchema.parse(hotkeyCombination);
 
 export const engineIdSchema = z.string().brand<"EngineId">();
 export type EngineId = z.infer<typeof engineIdSchema>;
@@ -50,145 +48,6 @@ export const CommandId = (id: string): CommandId => commandIdSchema.parse(id);
 export const trackIdSchema = z.string().brand<"TrackId">();
 export type TrackId = z.infer<typeof trackIdSchema>;
 export const TrackId = (id: string): TrackId => trackIdSchema.parse(id);
-
-// 共通のアクション名
-export const actionPostfixSelectNthCharacter = "番目のキャラクターを選択";
-
-// ホットキーを追加したときは設定のマイグレーションが必要
-export const defaultHotkeySettings: HotkeySettingType[] = [
-  {
-    action: "音声書き出し",
-    combination: HotkeyCombination(!isMac ? "Ctrl E" : "Meta E"),
-  },
-  {
-    action: "選択音声を書き出し",
-    combination: HotkeyCombination("E"),
-  },
-  {
-    action: "音声を繋げて書き出し",
-    combination: HotkeyCombination(""),
-  },
-  {
-    action: "再生/停止",
-    combination: HotkeyCombination("Space"),
-  },
-  {
-    action: "連続再生/停止",
-    combination: HotkeyCombination("Shift Space"),
-  },
-  {
-    action: "ｱｸｾﾝﾄ欄を表示",
-    combination: HotkeyCombination("1"),
-  },
-  {
-    action: "ｲﾝﾄﾈｰｼｮﾝ欄を表示",
-    combination: HotkeyCombination("2"),
-  },
-  {
-    action: "長さ欄を表示",
-    combination: HotkeyCombination("3"),
-  },
-  {
-    action: "テキスト欄を追加",
-    combination: HotkeyCombination("Shift Enter"),
-  },
-  {
-    action: "テキスト欄を複製",
-    combination: HotkeyCombination(!isMac ? "Ctrl D" : "Meta D"),
-  },
-  {
-    action: "テキスト欄を削除",
-    combination: HotkeyCombination("Shift Delete"),
-  },
-  {
-    action: "テキスト欄からフォーカスを外す",
-    combination: HotkeyCombination("Escape"),
-  },
-  {
-    action: "テキスト欄にフォーカスを戻す",
-    combination: HotkeyCombination("Enter"),
-  },
-  {
-    action: "元に戻す",
-    combination: HotkeyCombination(!isMac ? "Ctrl Z" : "Meta Z"),
-  },
-  {
-    action: "やり直す",
-    combination: HotkeyCombination(!isMac ? "Ctrl Y" : "Shift Meta Z"),
-  },
-  {
-    action: "拡大",
-    combination: HotkeyCombination(""),
-  },
-  {
-    action: "縮小",
-    combination: HotkeyCombination(""),
-  },
-  {
-    action: "拡大率のリセット",
-    combination: HotkeyCombination(""),
-  },
-  {
-    action: "新規プロジェクト",
-    combination: HotkeyCombination(!isMac ? "Ctrl N" : "Meta N"),
-  },
-  {
-    action: "全画面表示を切り替え",
-    combination: HotkeyCombination(!isMac ? "F11" : "Ctrl Meta F"),
-  },
-  {
-    action: "プロジェクトを名前を付けて保存",
-    combination: HotkeyCombination(!isMac ? "Ctrl Shift S" : "Shift Meta S"),
-  },
-  {
-    action: "プロジェクトを上書き保存",
-    combination: HotkeyCombination(!isMac ? "Ctrl S" : "Meta S"),
-  },
-  {
-    action: "プロジェクトを読み込む",
-    combination: HotkeyCombination(!isMac ? "Ctrl O" : "Meta O"),
-  },
-  {
-    action: "テキストを読み込む",
-    combination: HotkeyCombination(""),
-  },
-  {
-    action: "全体のイントネーションをリセット",
-    combination: HotkeyCombination(!isMac ? "Ctrl G" : "Meta G"),
-  },
-  {
-    action: "選択中のアクセント句のイントネーションをリセット",
-    combination: HotkeyCombination("R"),
-  },
-  {
-    action: "コピー",
-    combination: HotkeyCombination(!isMac ? "Ctrl C" : "Meta C"),
-  },
-  {
-    action: "切り取り",
-    combination: HotkeyCombination(!isMac ? "Ctrl X" : "Meta X"),
-  },
-  {
-    action: "貼り付け",
-    combination: HotkeyCombination(!isMac ? "Ctrl V" : "Meta V"),
-  },
-  {
-    action: "すべて選択",
-    combination: HotkeyCombination(!isMac ? "Ctrl A" : "Meta A"),
-  },
-  {
-    action: "選択解除",
-    combination: HotkeyCombination("Escape"),
-  },
-  ...Array.from({ length: 10 }, (_, index) => {
-    const roleKey = index == 9 ? 0 : index + 1;
-    return {
-      action:
-        `${index + 1}${actionPostfixSelectNthCharacter}` as HotkeyActionNameType,
-      combination: HotkeyCombination(`${!isMac ? "Ctrl" : "Meta"} ${roleKey}`),
-    };
-  }),
-];
 
 export const defaultToolbarButtonSetting: ToolbarSettingType = [
   "PLAY_CONTINUOUSLY",
@@ -435,59 +294,6 @@ export type MorphableTargetInfoTable = Record<
       }
     >
 >;
-
-export const hotkeyActionNameSchema = z.enum([
-  "音声書き出し",
-  "選択音声を書き出し",
-  "音声を繋げて書き出し",
-  "再生/停止",
-  "連続再生/停止",
-  "ｱｸｾﾝﾄ欄を表示",
-  "ｲﾝﾄﾈｰｼｮﾝ欄を表示",
-  "長さ欄を表示",
-  "テキスト欄を追加",
-  "テキスト欄を複製",
-  "テキスト欄を削除",
-  "テキスト欄からフォーカスを外す",
-  "テキスト欄にフォーカスを戻す",
-  "元に戻す",
-  "やり直す",
-  "新規プロジェクト",
-  "プロジェクトを名前を付けて保存",
-  "プロジェクトを上書き保存",
-  "プロジェクトを読み込む",
-  "テキストを読み込む",
-  "全体のイントネーションをリセット",
-  "選択中のアクセント句のイントネーションをリセット",
-  "コピー",
-  "切り取り",
-  "貼り付け",
-  "すべて選択",
-  "選択解除",
-  "全セルを選択",
-  `1${actionPostfixSelectNthCharacter}`,
-  `2${actionPostfixSelectNthCharacter}`,
-  `3${actionPostfixSelectNthCharacter}`,
-  `4${actionPostfixSelectNthCharacter}`,
-  `5${actionPostfixSelectNthCharacter}`,
-  `6${actionPostfixSelectNthCharacter}`,
-  `7${actionPostfixSelectNthCharacter}`,
-  `8${actionPostfixSelectNthCharacter}`,
-  `9${actionPostfixSelectNthCharacter}`,
-  `10${actionPostfixSelectNthCharacter}`,
-  "全画面表示を切り替え",
-  "拡大",
-  "縮小",
-  "拡大率のリセット",
-]);
-
-export type HotkeyActionNameType = z.infer<typeof hotkeyActionNameSchema>;
-
-export const hotkeySettingSchema = z.object({
-  action: hotkeyActionNameSchema,
-  combination: hotkeyCombinationSchema,
-});
-export type HotkeySettingType = z.infer<typeof hotkeySettingSchema>;
 
 export type HotkeyReturnType =
   | void

--- a/tests/unit/lib/hotkeyManager.spec.ts
+++ b/tests/unit/lib/hotkeyManager.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { HotkeyManager, HotkeysJs, HotkeyAction } from "@/plugins/hotkeyPlugin";
-import { HotkeyCombination, HotkeySettingType } from "@/type/preload";
+import { HotkeyCombination, HotkeySettingType } from "@/domain/hotkeyAction";
 
 type DummyHotkeysJs = HotkeysJs & {
   registeredHotkeys: {


### PR DESCRIPTION
## 内容

タイトルの通り、ショートカットキー周りのコードをpreload.tsからdomainに移します。
preload.tsダイエットの一貫。

isMacがpreload.ts側に定義されていて相互参照になってしまいそうです。
これは

- https://github.com/VOICEVOX/voicevox/pull/2365

に含まれる、isMacなどをhelperに移すリファクタリングで解決するはず。

## その他

- https://github.com/VOICEVOX/voicevox/pull/2357

でisMacをDI可能にしようとしたとき、結構複雑だったのでとりあえず切り出しだけやってしまおうと思いました。
