### PR TITLE
Fix: 拍子ラベルがずれていたのを修正する

### DIFF
--- a/src/components/Sing/ToolBar/ToolBar.vue
+++ b/src/components/Sing/ToolBar/ToolBar.vue
@@ -589,7 +589,7 @@ const snapTypeSelectModel = computed({
 
   :deep(.q-field__label) {
     font-size: 9px;
-    top: 2px;
+    top: 5.5px;
     margin-left: 6px;
     transform: translateY(0) !important;
     color: var(--scheme-color-on-surface-variant);


### PR DESCRIPTION
## 内容

ソングのツールバーの拍子ラベルがずれていたのを修正します
<img width="138" alt="スクリーンショット 2024-11-20 2 39 57" src="https://github.com/user-attachments/assets/ae12bb2e-d449-4020-8278-60d6821e3f77">

## 関連 Issue

ref #2370 
close #2370

## スクリーンショット・動画など

<img width="257" alt="スクリーンショット 2024-11-20 2 51 09" src="https://github.com/user-attachments/assets/799dea79-43e9-48cf-8a13-619a71827c5e">


## その他
