### PR TITLE
Add:ルーラークリックでスナップ位置に再生ヘッドをあわせる

### DIFF
--- a/src/components/Sing/SequencerRuler/Container.vue
+++ b/src/components/Sing/SequencerRuler/Container.vue
@@ -6,6 +6,7 @@
     :sequencerZoomX
     :numMeasures
     :playheadTicks
+    :sequencerSnapType
     @update:playheadTicks="updatePlayheadTicks"
     @deselectAllNotes="deselectAllNotes"
   />
@@ -35,6 +36,7 @@ const store = useStore();
 const tpqn = computed(() => store.state.tpqn);
 const timeSignatures = computed(() => store.state.timeSignatures);
 const sequencerZoomX = computed(() => store.state.sequencerZoomX);
+const sequencerSnapType = computed(() => store.state.sequencerSnapType);
 
 const playheadTicks = computed(() => store.getters.PLAYHEAD_POSITION);
 

--- a/src/components/Sing/SequencerRuler/Presentation.vue
+++ b/src/components/Sing/SequencerRuler/Presentation.vue
@@ -206,7 +206,7 @@ onUnmounted(() => {
   background: var(--scheme-color-inverse-surface);
   pointer-events: none;
   will-change: transform;
-  z-index: 10000;
+  z-index: vars.$z-index-sing-playhead;
 }
 
 .sequencer-ruler-measure-number {

--- a/src/components/Sing/SequencerRuler/Presentation.vue
+++ b/src/components/Sing/SequencerRuler/Presentation.vue
@@ -62,7 +62,12 @@
 
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted } from "vue";
-import { getMeasureDuration, getTimeSignaturePositions } from "@/sing/domain";
+import {
+  getMeasureDuration,
+  getTimeSignaturePositions,
+  getNoteDuration,
+  snapTicksToGrid,
+} from "@/sing/domain";
 import { baseXToTick, tickToBaseX } from "@/sing/viewHelper";
 import { TimeSignature } from "@/store/type";
 
@@ -73,6 +78,7 @@ const props = defineProps<{
   tpqn: number;
   timeSignatures: TimeSignature[];
   sequencerZoomX: number;
+  sequencerSnapType: number;
 }>();
 const playheadTicks = defineModel<number>("playheadTicks", { required: true });
 const emit = defineEmits<{
@@ -134,6 +140,10 @@ const playheadX = computed(() => {
   return Math.floor(baseX * props.sequencerZoomX);
 });
 
+const snapTicks = computed(() => {
+  return getNoteDuration(props.sequencerSnapType, props.tpqn);
+});
+
 const onClick = (event: MouseEvent) => {
   emit("deselectAllNotes");
 
@@ -142,7 +152,10 @@ const onClick = (event: MouseEvent) => {
     throw new Error("sequencerRulerElement is null.");
   }
   const baseX = (props.offset + event.offsetX) / props.sequencerZoomX;
-  const ticks = baseXToTick(baseX, props.tpqn);
+  const ticks = snapTicksToGrid(
+    baseXToTick(baseX, props.tpqn),
+    snapTicks.value,
+  );
   playheadTicks.value = ticks;
 };
 
@@ -193,7 +206,7 @@ onUnmounted(() => {
   background: var(--scheme-color-inverse-surface);
   pointer-events: none;
   will-change: transform;
-  z-index: vars.$z-index-sing-playhead;
+  z-index: 10000;
 }
 
 .sequencer-ruler-measure-number {

--- a/src/components/Sing/SequencerRuler/index.stories.ts
+++ b/src/components/Sing/SequencerRuler/index.stories.ts
@@ -19,6 +19,7 @@ const meta: Meta<typeof Presentation> = {
     tpqn: 480,
     offset: 0,
     numMeasures: 32,
+    sequencerSnapType: 4,
     "onUpdate:playheadTicks": fn<(value: number) => void>(),
     onDeselectAllNotes: fn(),
   },

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -591,3 +591,11 @@ export const shouldPlayTracks = (tracks: Map<TrackId, Track>): Set<TrackId> => {
       .map(([trackId]) => trackId),
   );
 };
+
+/**
+ * 指定されたティックをグリッドに合わせて丸める。
+ * グリッドはsnapTicksの倍数になる。
+ */
+export function snapTicksToGrid(ticks: number, snapTicks: number): number {
+  return Math.round(ticks / snapTicks) * snapTicks;
+}

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -593,8 +593,7 @@ export const shouldPlayTracks = (tracks: Map<TrackId, Track>): Set<TrackId> => {
 };
 
 /**
- * 指定されたティックをグリッドに合わせて丸める。
- * グリッドはsnapTicksの倍数になる。
+ * 指定されたティックを直近のグリッドに合わせる
  */
 export function snapTicksToGrid(ticks: number, snapTicks: number): number {
   return Math.round(ticks / snapTicks) * snapTicks;


### PR DESCRIPTION
## 内容

以下の機能を追加します

- ルーラークリックでの再生ヘッド位置変更時にスナップにあわせる

たとえば小節頭などで微妙にずれる問題がなくなります

## 関連 Issue

ref #2295 
close #2295

## スクリーンショット・動画など

変化がわかりづらいためなし
(クリック位置と一番近いスナップグリッドの位置に再生ヘッドが移動します)

## その他

1/2など大きいスナップの場合は1/4が上限にするなども考えましたが
いまいち挙動がわかりづらくなった＆1/2であれば1/2にスナップして欲しい感あったので
単にスナップグリッドにあわせる形にしています