### PR TITLE
Fix: yargsのインポートを修正

### DIFF
--- a/tools/mergeLicenses.mts
+++ b/tools/mergeLicenses.mts
@@ -1,8 +1,6 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-
 import process from "process";
 import fs from "fs";
-import yargs from "yargs/yargs";
+import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 const argv = await yargs(hideBin(process.argv))


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/pull/2361

でgenerateLicense側のyargs/yargsは変わっていた一方、こっちは変わってなくてエラーになってたので修正します。

## 関連 Issue

ref #2361

## その他

なんでlintが通ったのか若干不明
