### PR TITLE
Fix:同じ歌詞が連続した場合に、Tabキーによる歌詞ハイライトが動作しない問題を修正（#2345）

### DIFF
--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -94,7 +94,7 @@ const onLyricInput = (event: Event) => {
 };
 
 watch(
-  () => props.editingLyricNote.lyric,
+  () => props.editingLyricNote.id,
   () => {
     void nextTick(() => {
       lyricInput.value?.focus();


### PR DESCRIPTION
## 内容
同じ歌詞が連続した場合に、Tabキーによる歌詞ハイライトが動作しない問題を修正。
## 不具合原因
https://github.com/VOICEVOX/voicevox/issues/2345#issuecomment-2462328501

上記参照。手持ちの環境（0.21.1）でも、同じ歌詞が連続した場合に歌詞ハイライトが効かなくなる現象が再現できた。
よって上記を不具合原因として修正を行った。
## 修正内容
watchの監視対象をノートの歌詞文字列ではなく、ノートIdに変更した。
これにより、同じ歌詞が連続した場合でも、Tabキーによる歌詞ハイライトが動作するように修正した。
## 関連 Issue
ref #2345

## スクリーンショット・動画など
修正内容を投入したVOICEVOXの動作動画。
不具合が解消されている。

https://github.com/user-attachments/assets/84824a13-1960-494b-8a6d-693b5ee57dbd
## その他
https://github.com/VOICEVOX/voicevox/pull/2218
既に@sigprogrammingさんが指摘されているように、元々watchの監視対象はeditingLyricNote（参照）でしたが、上記PRにおいて、歌詞の内容を監視対象とするように変更されています。
上記PRを若干漁ってみたのですが、該当箇所に関する議論は見当たりませんでした（私の見落としでしたら申し訳ないです）。
もしもこの変更が、何らかの明確な意図を持って行われたものであれば、教えていただけると幸いです。私が確認した限り、今回の修正によるデグレは起きないという考えです。
