### PR TITLE
fix:  初回起動時の利用規約への同意ボタンの挙動が逆になっているのを直す

### DIFF
--- a/src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
@@ -38,7 +38,7 @@ const handler = (acceptTerms: boolean) => {
   void store.actions.SET_ACCEPT_TERMS({
     acceptTerms: acceptTerms ? "Accepted" : "Rejected",
   });
-  if (acceptTerms) {
+  if (!acceptTerms) {
     void store.actions.CHECK_EDITED_AND_NOT_SAVE({
       closeOrReload: "close",
     });


### PR DESCRIPTION
## 内容

初回起動時の利用規約への同意ボタンの挙動が逆になっているのを直します。

- https://github.com/VOICEVOX/voicevox/issues/2391

## 関連 Issue

close #2391 

## その他
