### PR TITLE
Refactor: いらないhotkeyデフォルト設定取得関数を失くす

### DIFF
--- a/src/backend/browser/sandbox.ts
+++ b/src/backend/browser/sandbox.ts
@@ -9,7 +9,6 @@ import {
 import { getConfigManager } from "./browserConfig";
 import { IpcSOData } from "@/type/ipc";
 import {
-  defaultHotkeySettings,
   defaultToolbarButtonSetting,
   EngineId,
   EngineSettingType,
@@ -246,9 +245,6 @@ export const api: Sandbox = {
   },
   changePinWindow() {
     throw new Error(`Not supported on Browser version: changePinWindow`);
-  },
-  getDefaultHotkeySettings() {
-    return Promise.resolve(defaultHotkeySettings);
   },
   getDefaultToolbarSetting() {
     return Promise.resolve(defaultToolbarButtonSetting);

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -40,7 +40,6 @@ import { AssetTextFileNames } from "@/type/staticResources";
 import {
   EngineInfo,
   SystemError,
-  defaultHotkeySettings,
   defaultToolbarButtonSetting,
   EngineId,
   TextAsset,
@@ -693,10 +692,6 @@ registerIpcMainHandle<IpcMainHandle>({
     } else {
       win.setAlwaysOnTop(true);
     }
-  },
-
-  GET_DEFAULT_HOTKEY_SETTINGS: () => {
-    return defaultHotkeySettings;
   },
 
   GET_DEFAULT_TOOLBAR_SETTING: () => {

--- a/src/backend/electron/preload.ts
+++ b/src/backend/electron/preload.ts
@@ -176,10 +176,6 @@ const api: Sandbox = {
     return ipcRendererInvokeProxy.HOTKEY_SETTINGS({ newData });
   },
 
-  getDefaultHotkeySettings: async () => {
-    return await ipcRendererInvokeProxy.GET_DEFAULT_HOTKEY_SETTINGS();
-  },
-
   getDefaultToolbarSetting: async () => {
     return await ipcRendererInvokeProxy.GET_DEFAULT_TOOLBAR_SETTING();
   },

--- a/src/components/Dialog/HotkeySettingDialog.vue
+++ b/src/components/Dialog/HotkeySettingDialog.vue
@@ -127,9 +127,9 @@ import BaseIconButton from "@/components/Base/BaseIconButton.vue";
 import BaseScrollArea from "@/components/Base/BaseScrollArea.vue";
 import { useStore } from "@/store";
 import {
+  defaultHotkeySettings,
   HotkeyActionNameType,
   HotkeyCombination,
-  HotkeySettingType,
 } from "@/type/preload";
 import { useHotkeyManager, eventToCombination } from "@/plugins/hotkeyPlugin";
 
@@ -225,13 +225,8 @@ const setHotkeyDialogOpened = () => {
   document.removeEventListener("keydown", recordCombination);
 };
 
-const defaultSettings = ref<HotkeySettingType[]>([]);
-void window.backend
-  .getDefaultHotkeySettings()
-  .then((settings) => (defaultSettings.value = settings));
-
 const isDefaultCombination = (action: string) => {
-  const defaultSetting = defaultSettings.value.find(
+  const defaultSetting = defaultHotkeySettings.find(
     (value) => value.action === action,
   );
   const hotkeySetting = hotkeySettings.value.find(
@@ -250,7 +245,7 @@ const resetHotkey = async (action: string) => {
 
   if (result !== "OK") return;
 
-  const setting = defaultSettings.value.find((value) => value.action == action);
+  const setting = defaultHotkeySettings.find((value) => value.action == action);
   if (setting == undefined) {
     return;
   }

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -178,11 +178,6 @@ export type IpcIHData = {
     return: HotkeySettingType[];
   };
 
-  GET_DEFAULT_HOTKEY_SETTINGS: {
-    args: [];
-    return: HotkeySettingType[];
-  };
-
   GET_DEFAULT_TOOLBAR_SETTING: {
     args: [];
     return: ToolbarSettingType;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -268,7 +268,6 @@ export interface Sandbox {
   hotkeySettings(newData?: HotkeySettingType): Promise<HotkeySettingType[]>;
   checkFileExists(file: string): Promise<boolean>;
   changePinWindow(): void;
-  getDefaultHotkeySettings(): Promise<HotkeySettingType[]>;
   getDefaultToolbarSetting(): Promise<ToolbarSettingType>;
   setNativeTheme(source: NativeThemeType): void;
   vuexReady(): void;


### PR DESCRIPTION
## 内容

ファクタリングプルリクエストです。
ショートカットキーのデフォルトの設定を返す関数があるのですが、普通にただの定数なのでそのままエクスポートして使えばいいことに気づきました。

- https://github.com/VOICEVOX/voicevox/pull/2348

のプルリクエストを見ていて気づきました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2348

## その他

リンクしているプルリクエストがマージされた後にdraftを外そうと思います。

- [x] TODO: ちゃんとショートカットキーを変更した後、「デフォルトに戻す」ボタンがenableになってるか確認する
