### PR TITLE
fix: ソングの編集ツールのアイコンが読み込まれていないときに表示が崩れるのを修正する

### DIFF
--- a/src/components/Sing/SequencerToolPalette.vue
+++ b/src/components/Sing/SequencerToolPalette.vue
@@ -110,6 +110,7 @@ defineEmits<{
 
   .material-symbols-outlined {
     font-size: 20px;
+    max-width: 20px;
   }
 
   .q-btn {

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -13,9 +13,9 @@
 }
 
 @font-face {
-  font-display: swap;
+  font-display: block;
   font-family: "Material Symbols Outlined";
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/material-symbols-outlined-regular.woff2') format('woff2');
+  src: url("../fonts/material-symbols-outlined-regular.woff2") format("woff2");
 }


### PR DESCRIPTION
## 内容

ソングの編集ツールのアイコンが読み込まれていないときに表示が崩れるのを修正します。

フォントが読み込まれてない間、元の文字列が表示されていました。
これを表示されないように（block）し、空欄になってもなお横幅は取られてしまうっぽいのでmax-widthをフォントサイズと同じサイズにしました。

後々コンポーネント化してもいいかも。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/discussions/57
