### PR TITLE
fix: ツールチップのアニメーションの時間を微調整

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1,6 +1,6 @@
 <template>
   <ErrorBoundary>
-    <TooltipProvider disableHoverableContent>
+    <TooltipProvider disableHoverableContent :delayDuration="500">
       <MenuBar
         v-if="openedEditor != undefined"
         :fileSubMenuData="subMenuData.fileSubMenuData.value"


### PR DESCRIPTION
## 内容

ツールチップのアニメーションの時間を微調整します。
ツールチップの現れ始めがデフォルト700ミリ秒なのを、500ミリ秒まで縮めました。

ちなみに遷移時間の100msのままです。
VS Codeのツールチップの表示と遷移と同じくらいになってるはず･･･？

（右上のこの辺にカーソルを当てるとツールチップが出てきました）
![image](https://github.com/user-attachments/assets/376b233b-4e39-4fce-9f0f-a60136fc0180)


## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/discussions/57