### PR TITLE
ソング：Speakerの初期化時にUIをロックしないようにする

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -570,7 +570,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         audioKeys,
       });
       await actions
-        .INITIALIZE_ENGINE_SPEAKER({
+        .INITIALIZE_ENGINE_CHARACTER({
           engineId,
           styleId,
           uiLock: true,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -573,6 +573,7 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         .INITIALIZE_ENGINE_SPEAKER({
           engineId,
           styleId,
+          uiLock: true,
         })
         .finally(() => {
           mutations.SET_AUDIO_KEYS_WITH_INITIALIZING_SPEAKER({

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -330,12 +330,12 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
-  INITIALIZE_ENGINE_SPEAKER: {
+  INITIALIZE_ENGINE_CHARACTER: {
     /**
-     * 指定した話者（スタイルID）に対してエンジン側の初期化を行い、即座に音声合成ができるようにする。
+     * 指定したキャラクター（スタイルID）に対してエンジン側の初期化を行い、即座に音声合成ができるようにする。
      */
     async action({ actions }, { engineId, styleId, uiLock }) {
-      const requestEngineToInitializeSpeaker = () =>
+      const requestEngineToInitializeCharacter = () =>
         actions
           .INSTANTIATE_ENGINE_CONNECTOR({
             engineId,
@@ -348,10 +348,10 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
 
       if (uiLock) {
         await actions.ASYNC_UI_LOCK({
-          callback: requestEngineToInitializeSpeaker,
+          callback: requestEngineToInitializeCharacter,
         });
       } else {
-        await requestEngineToInitializeSpeaker();
+        await requestEngineToInitializeCharacter();
       }
     },
   },

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -334,19 +334,25 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     /**
      * 指定した話者（スタイルID）に対してエンジン側の初期化を行い、即座に音声合成ができるようにする。
      */
-    async action({ actions }, { engineId, styleId }) {
-      await actions.ASYNC_UI_LOCK({
-        callback: () =>
-          actions
-            .INSTANTIATE_ENGINE_CONNECTOR({
-              engineId,
-            })
-            .then((instance) =>
-              instance.invoke("initializeSpeakerInitializeSpeakerPost")({
-                speaker: styleId,
-              }),
-            ),
-      });
+    async action({ actions }, { engineId, styleId, uiLock }) {
+      const requestEngineToInitializeSpeaker = () =>
+        actions
+          .INSTANTIATE_ENGINE_CONNECTOR({
+            engineId,
+          })
+          .then((instance) =>
+            instance.invoke("initializeSpeakerInitializeSpeakerPost")({
+              speaker: styleId,
+            }),
+          );
+
+      if (uiLock) {
+        await actions.ASYNC_UI_LOCK({
+          callback: requestEngineToInitializeSpeaker,
+        });
+      } else {
+        await requestEngineToInitializeSpeaker();
+      }
     },
   },
   VALIDATE_ENGINE_DIR: {

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -823,7 +823,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       // 指定されたstyleIdに対して、エンジン側の初期化を行う
       const isInitialized = await actions.IS_INITIALIZED_ENGINE_SPEAKER(singer);
       if (!isInitialized) {
-        await actions.INITIALIZE_ENGINE_SPEAKER(singer);
+        await actions.INITIALIZE_ENGINE_SPEAKER({
+          engineId: singer.engineId,
+          styleId: singer.styleId,
+          uiLock: false,
+        });
       }
     },
   },

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -823,7 +823,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       // 指定されたstyleIdに対して、エンジン側の初期化を行う
       const isInitialized = await actions.IS_INITIALIZED_ENGINE_SPEAKER(singer);
       if (!isInitialized) {
-        await actions.INITIALIZE_ENGINE_SPEAKER({
+        await actions.INITIALIZE_ENGINE_CHARACTER({
           engineId: singer.engineId,
           styleId: singer.styleId,
           uiLock: false,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1639,7 +1639,11 @@ export type EngineStoreTypes = {
   };
 
   INITIALIZE_ENGINE_SPEAKER: {
-    action(payload: { engineId: EngineId; styleId: StyleId }): void;
+    action(payload: {
+      engineId: EngineId;
+      styleId: StyleId;
+      uiLock: boolean;
+    }): void;
   };
 
   VALIDATE_ENGINE_DIR: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1638,7 +1638,7 @@ export type EngineStoreTypes = {
     action(payload: { engineId: EngineId; styleId: StyleId }): Promise<boolean>;
   };
 
-  INITIALIZE_ENGINE_SPEAKER: {
+  INITIALIZE_ENGINE_CHARACTER: {
     action(payload: {
       engineId: EngineId;
       styleId: StyleId;


### PR DESCRIPTION
## 内容

ソングで、Speakerの初期化時にUIをロックしないようにします。
トークではロックするようにします。（今までと同じ挙動）

## 関連 Issue

close #2359

## その他
