### PR TITLE
[release-0.22] fix: 「キャンセル」と「破棄する」がややこしそうだったので修正

### DIFF
--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -253,6 +253,14 @@
             <div class="row q-px-md save-delete-reset-buttons">
               <QSpace />
               <QBtn
+                outline
+                textColor="display"
+                class="text-no-wrap text-bold q-mr-sm"
+                :disable="uiLocked"
+                @click="discardOrNotDialog(cancel)"
+                >キャンセル</QBtn
+              >
+              <QBtn
                 v-show="!!selectedId"
                 outline
                 textColor="display"
@@ -260,14 +268,6 @@
                 :disable="uiLocked || !isWordChanged"
                 @click="resetWord(selectedId)"
                 >リセット</QBtn
-              >
-              <QBtn
-                outline
-                textColor="display"
-                class="text-no-wrap text-bold q-mr-sm"
-                :disable="uiLocked"
-                @click="discardOrNotDialog(cancel)"
-                >キャンセル</QBtn
               >
               <QBtn
                 outline

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -603,6 +603,7 @@ const deleteWord = async () => {
     message: "削除された単語は元に戻せません。",
     actionName: "削除する",
     isWarningColorButton: true,
+    cancel: "削除しない",
   });
   if (result === "OK") {
     try {
@@ -627,6 +628,8 @@ const resetWord = async (id: string) => {
     title: "単語の変更をリセットしますか？",
     message: "単語の変更は破棄されてリセットされます。",
     actionName: "リセットする",
+    isWarningColorButton: true,
+    cancel: "リセットしない",
   });
   if (result === "OK") {
     selectedId.value = id;
@@ -640,8 +643,9 @@ const discardOrNotDialog = async (okCallback: () => void) => {
   if (isWordChanged.value) {
     const result = await store.actions.SHOW_WARNING_DIALOG({
       title: "単語の追加・変更を破棄しますか？",
-      message: "破棄すると、単語の追加・変更はリセットされます。",
+      message: "変更を破棄すると、単語の追加・変更はリセットされます。",
       actionName: "破棄する",
+      cancel: "破棄しない",
       isWarningColorButton: true,
     });
     if (result === "OK") {

--- a/tests/e2e/browser/辞書ダイアログ.spec.ts
+++ b/tests/e2e/browser/辞書ダイアログ.spec.ts
@@ -121,7 +121,7 @@ test("「設定」→「読み方＆アクセント辞書」で「読み方＆�
   await page.waitForTimeout(100);
   await getNewestQuasarDialog(page)
     .getByRole("button")
-    .filter({ hasText: "削除" })
+    .filter({ hasText: "削除する" })
     .click();
   await page.waitForTimeout(100);
 


### PR DESCRIPTION
## 内容

「破棄しますか？」に対して「キャンセル」「破棄する」となっていてややこしかったので修正します。
（もともとそうだったのを微調整の時に変えてしまっていました 🙇 ）

あとキャンセルボタン左の法則がVOICEVOXにあって辞書ダイアログがそれに従ってなかったので、そこもついでに変更しておきます。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/discussions/57

## その他

↓で @jdkfx さんにご指摘いただけたのがきっかけで気づけました 🙏 

- https://github.com/VOICEVOX/voicevox/pull/2290


