### PR TITLE
相対import部分を修正

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
     "plugin:@voicevox/all",
     "plugin:storybook/recommended",
   ],
-  plugins: ["import"],
+  plugins: ["import", "no-relative-import-paths"],
   parser: vueEslintParser,
   parserOptions: vueEslintParserOptions,
   ignorePatterns: ["dist/**/*", "dist_*/**/*", "node_modules/**/*"],
@@ -92,6 +92,15 @@ module.exports = {
       },
     ],
     "import/order": "error",
+    // "import/no-relative-packages": ["off"],
+    "no-relative-import-paths/no-relative-import-paths": [
+      "error",
+      {
+        allowSameFolder: true,
+        rootDir: "src",
+        prefix: "@",
+      },
+    ],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,7 +92,6 @@ module.exports = {
       },
     ],
     "import/order": "error",
-    // "import/no-relative-packages": ["off"],
     "no-relative-import-paths/no-relative-import-paths": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-import": "2.29.1",
+        "eslint-plugin-no-relative-import-paths": "1.5.5",
         "eslint-plugin-prettier": "5.1.3",
         "eslint-plugin-storybook": "0.8.0",
         "eslint-plugin-vue": "9.26.0",
@@ -7561,6 +7562,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.5.tgz",
+      "integrity": "sha512-UjudFFdBbv93v0CsVdEKcMLbBzRIjeK2PubTctX57tgnHxZcMj1Jm8lDBWoETnPxk0S5g5QLSltEM+511yL4+w==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.1.3",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-import": "2.29.1",
+    "eslint-plugin-no-relative-import-paths": "1.5.5",
     "eslint-plugin-prettier": "5.1.3",
     "eslint-plugin-storybook": "0.8.0",
     "eslint-plugin-vue": "9.26.0",

--- a/src/backend/electron/manager/engineInfoManager.ts
+++ b/src/backend/electron/manager/engineInfoManager.ts
@@ -6,7 +6,7 @@ import { dialog } from "electron"; // FIXME: ここでelectronをimportするの
 
 import log from "electron-log/main";
 
-import { getConfigManager } from "../electronConfig";
+import { getConfigManager } from "@/backend/electron/electronConfig";
 import {
   EngineInfo,
   EngineDirValidationResult,

--- a/src/backend/electron/manager/engineProcessManager.ts
+++ b/src/backend/electron/manager/engineProcessManager.ts
@@ -5,16 +5,16 @@ import treeKill from "tree-kill";
 import { app, dialog } from "electron"; // FIXME: ここでelectronをimportするのは良くない
 
 import log from "electron-log/main";
+import { getEngineInfoManager } from "./engineInfoManager";
 import {
   findAltPort,
   getPidFromPort,
   getProcessNameFromPid,
   type HostInfo,
   isAssignablePort,
-} from "../portHelper";
+} from "@/backend/electron/portHelper";
 
-import { getConfigManager } from "../electronConfig";
-import { getEngineInfoManager } from "./engineInfoManager";
+import { getConfigManager } from "@/backend/electron/electronConfig";
 import { EngineId, EngineInfo } from "@/type/preload";
 
 type EngineProcessContainer = {

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -267,8 +267,8 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import BaseToggleGroup from "../Base/BaseToggleGroup.vue";
-import BaseToggleGroupItem from "../Base/BaseToggleGroupItem.vue";
+import BaseToggleGroup from "@/components/Base/BaseToggleGroup.vue";
+import BaseToggleGroupItem from "@/components/Base/BaseToggleGroupItem.vue";
 import BaseButton from "@/components/Base/BaseButton.vue";
 import BaseListItem from "@/components/Base/BaseListItem.vue";
 import BaseNavigationView from "@/components/Base/BaseNavigationView.vue";

--- a/src/components/Dialog/ExportSongAudioDialog/Container.vue
+++ b/src/components/Dialog/ExportSongAudioDialog/Container.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script setup lang="ts">
-import { notifyResult } from "../Dialog";
 import Presentation, { ExportTarget } from "./Presentation.vue";
+import { notifyResult } from "@/components/Dialog/Dialog";
 import { useStore } from "@/store";
 import { SaveResultObject, SongExportSetting } from "@/store/type";
 

--- a/src/components/Menu/ContextMenu/Presentation.vue
+++ b/src/components/Menu/ContextMenu/Presentation.vue
@@ -28,8 +28,8 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from "vue";
 import { QMenu } from "quasar";
-import MenuItem from "../MenuItem.vue";
-import { MenuItemButton, MenuItemSeparator } from "../type";
+import MenuItem from "@/components/Menu/MenuItem.vue";
+import { MenuItemButton, MenuItemSeparator } from "@/components/Menu/type";
 
 defineProps<{
   header?: string;

--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -29,10 +29,10 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import { useQuasar } from "quasar";
-import { MenuItemData, MenuItemRoot } from "../type";
-import MenuButton from "../MenuButton.vue";
 import TitleBarButtons from "./TitleBarButtons.vue";
 import TitleBarEditorSwitcher from "./TitleBarEditorSwitcher.vue";
+import { MenuItemData, MenuItemRoot } from "@/components/Menu/type";
+import MenuButton from "@/components/Menu/MenuButton.vue";
 import { useStore } from "@/store";
 import { HotkeyAction, useHotkeyManager } from "@/plugins/hotkeyPlugin";
 import { useEngineIcons } from "@/composables/useEngineIcons";

--- a/src/components/Sing/ToolBar/ToolBar.vue
+++ b/src/components/Sing/ToolBar/ToolBar.vue
@@ -160,8 +160,8 @@
 
 <script setup lang="ts">
 import { computed, watch, ref } from "vue";
-import PlayheadPositionDisplay from "../PlayheadPositionDisplay.vue";
 import EditTargetSwicher from "./EditTargetSwicher.vue";
+import PlayheadPositionDisplay from "@/components/Sing/PlayheadPositionDisplay.vue";
 import { useStore } from "@/store";
 
 import {


### PR DESCRIPTION
## 内容

- 同じ親のディレクトリでない場合のimport文を修正
  - `../`のように相対パスでimportしている部分を`@/`をつけて絶対パスにする

## 関連 Issue

ref https://github.com/VOICEVOX/voicevox/issues/295

- このPRでは同じ親のディレクトリなのに`@/`でimportしている部分は検知していない

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

- 修正のためにサードパーティのESLintプラグインを入れている
- VOICEVOX内でのサードパーティプラグインの扱いがわからないため、どんなルールで修正を行なったかという共有のためにもPRに含めている