### PR TITLE
fix(test): Linux の e2e テストで、electron を --no-sandbox で動くように

### DIFF
--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -42,7 +42,7 @@ test.beforeEach(async () => {
 
 test("起動したら「利用規約に関するお知らせ」が表示される", async () => {
   const app = await electron.launch({
-    args: ["--no-sandbox", "."],
+    args: ["--no-sandbox", "."], // NOTE: --no-sandbox はUbuntu 24.04で動かすのに必要
     timeout: process.env.CI ? 0 : 60000,
   });
 

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -42,7 +42,7 @@ test.beforeEach(async () => {
 
 test("起動したら「利用規約に関するお知らせ」が表示される", async () => {
   const app = await electron.launch({
-    args: ["."],
+    args: ["--no-sandbox", "."],
     timeout: process.env.CI ? 0 : 60000,
   });
 


### PR DESCRIPTION
## 内容
- https://github.com/VOICEVOX/voicevox/actions/runs/12339042097/job/34654643682 で ubuntu-latest が Ubuntu 24.04 になり、テストが通らなくなったため、electron 起動時の引数に `--no-sandbox` を追加するように

## 関連 Issue
ref: #2071 #2141
