### PR TITLE
doc: [release-0.22] macOSのサポートバージョンを上げ忘れていたので上げる

### DIFF
--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -9,7 +9,7 @@
 Windows／Mac／Linux 搭載の PC に対応しています。
 
 ※Windows：Windows 10・Windows 11  
-※Mac：macOS 12(Monterey)以降  
+※Mac：macOS 13(Ventura)以降  
 ※Linux：Ubuntu 20.04・Ubuntu 22.04
 
 #### GPU 版


### PR DESCRIPTION
## 内容

0.22からmacOS 12がサポートされなくなりました。
まあ････バージョン0.22.2からこの記載が入る感じで！！

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/discussions/57

## その他
