### PR TITLE
ソング：レンダリング処理をリファクタリング

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1697,6 +1697,32 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const lastRestDurationSeconds = 0.5; // TODO: 設定できるようにする
       const fadeOutDurationSeconds = 0.15; // TODO: 設定できるようにする
 
+      /**
+       * レンダリング中に変更される可能性のあるデータのコピーを作成する。
+       */
+      const createSnapshot = () => {
+        return {
+          tpqn: state.tpqn,
+          tempos: cloneWithUnwrapProxy(state.tempos),
+          tracks: cloneWithUnwrapProxy(state.tracks),
+          trackOverlappingNoteIds: new Map(
+            [...state.tracks.keys()].map((trackId) => [
+              trackId,
+              getters.OVERLAPPING_NOTE_IDS(trackId),
+            ]),
+          ),
+          engineFrameRates: new Map(
+            Object.entries(state.engineManifests).map(
+              ([engineId, engineManifest]) => [
+                engineId as EngineId,
+                engineManifest.frameRate,
+              ],
+            ),
+          ),
+          editorFrameRate: state.editorFrameRate,
+        } as const;
+      };
+
       const calcPhraseFirstRestDuration = (
         prevPhraseLastNote: Note | undefined,
         phraseFirstNote: Note,
@@ -2392,28 +2418,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
 
       const render = async () => {
         const firstRestMinDurationSeconds = 0.12;
-
-        // レンダリング中に変更される可能性のあるデータのコピー
-        const snapshot = {
-          tpqn: state.tpqn,
-          tempos: cloneWithUnwrapProxy(state.tempos),
-          tracks: cloneWithUnwrapProxy(state.tracks),
-          trackOverlappingNoteIds: new Map(
-            [...state.tracks.keys()].map((trackId) => [
-              trackId,
-              getters.OVERLAPPING_NOTE_IDS(trackId),
-            ]),
-          ),
-          engineFrameRates: new Map(
-            Object.entries(state.engineManifests).map(
-              ([engineId, engineManifest]) => [
-                engineId as EngineId,
-                engineManifest.frameRate,
-              ],
-            ),
-          ),
-          editorFrameRate: state.editorFrameRate,
-        } as const;
+        const snapshot = createSnapshot();
 
         const renderStartStageIds = new Map<PhraseKey, PhraseRenderStageId>();
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2446,8 +2446,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             firstRestMinDurationSeconds,
             trackId,
           );
-          for (const [phraseHash, phrase] of phrases) {
-            generatedPhrases.set(phraseHash, phrase);
+          for (const [phraseKey, phrase] of phrases) {
+            generatedPhrases.set(phraseKey, phrase);
           }
         }
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2422,8 +2422,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
 
         const renderStartStageIds = new Map<PhraseKey, PhraseRenderStageId>();
 
-        // フレーズを更新する
-
         // 重なっているノートを削除する
         const filteredTrackNotes = new Map<TrackId, Note[]>();
         for (const [trackId, track] of snapshot.tracks) {
@@ -2522,12 +2520,13 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           }
         }
 
+        // state.phrasesを更新する
         mutations.SET_PHRASES({ phrases: mergedPhrases });
 
         logger.info("Phrases updated.");
 
-        // 各フレーズのレンダリングを行う
-
+        // シンガーが設定されていないフレーズとレンダリング未完了のフレーズが
+        // プレビュー音で再生されるようにする
         for (const [phraseKey, phrase] of state.phrases.entries()) {
           if (
             phrase.state === "SINGER_IS_NOT_SET" ||
@@ -2556,6 +2555,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             mutations.SET_SEQUENCE_ID_TO_PHRASE({ phraseKey, sequenceId });
           }
         }
+
+        // 各フレーズのレンダリングを行い、レンダリングされた音声が再生されるようにする
         const phrasesToBeRendered = new Map(
           [...state.phrases.entries()].filter(([, phrase]) => {
             return phrase.state === "WAITING_TO_BE_RENDERED";

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1790,7 +1790,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         phraseFirstRestMinDurationSeconds: number,
         trackId: TrackId,
       ) => {
-        const generatePhrases = new Map<PhraseKey, Phrase>();
+        const generatedPhrases = new Map<PhraseKey, Phrase>();
 
         let phraseNotes: Note[] = [];
         let prevPhraseLastNote: Note | undefined = undefined;
@@ -1827,7 +1827,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               startTime: phraseStartTime,
               trackId,
             });
-            generatePhrases.set(phraseKey, {
+            generatedPhrases.set(phraseKey, {
               firstRestDuration: phraseFirstRestDuration,
               notes: phraseNotes,
               startTime: phraseStartTime,
@@ -1841,7 +1841,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             }
           }
         }
-        return generatePhrases;
+        return generatedPhrases;
       };
 
       const generateQuerySource = (


### PR DESCRIPTION
## 内容

#2261 でレンダリングの流れを変更しますが、変更する前に一度リファクタリングを行っておいた方が良さそうなので、リファクタリングを行います。

以下を行います。（分けてコミットしています）
- `PhraseRenderContext`と`PhraseRenderer`を一旦無くす
  - レンダリングの流れを変更しやすいように
- 以下の処理を分ける
  - 新しく作られたフレーズと`state`にある既存のフレーズをマージ
  - レンダリング開始ステージの決定
  - `phrase.state`の更新
- 以下の処理を分ける
  - 重なっているノートを削除する処理
  - フレーズの生成
- `searchPhrases`から`generatePhrases`に変更
- スナップショットを作成する処理を関数化
- コメントを整理

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2261

## その他
