### PR TITLE
refactor: LOAD_PROJECT_FILEのconfirmがずっと使われてないので消す

### DIFF
--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -1032,7 +1032,6 @@ app.on("second-instance", async (_event, _argv, _workDir, rawData) => {
     log.info("Second instance launched with vvproj file");
     ipcMainSendProxy.LOAD_PROJECT_FILE(win, {
       filePath: data.filePath,
-      confirm: true,
     });
   }
   if (win) {

--- a/src/plugins/ipcMessageReceiverPlugin.ts
+++ b/src/plugins/ipcMessageReceiverPlugin.ts
@@ -9,8 +9,8 @@ export const ipcMessageReceiver: Plugin = {
     options: { store: Store<State, AllGetters, AllActions, AllMutations> },
   ) => {
     window.backend.onReceivedIPCMsg({
-      LOAD_PROJECT_FILE: (_, { filePath, confirm } = {}) =>
-        void options.store.actions.LOAD_PROJECT_FILE({ filePath, confirm }),
+      LOAD_PROJECT_FILE: (_, { filePath } = {}) =>
+        void options.store.actions.LOAD_PROJECT_FILE({ filePath }),
 
       DETECT_MAXIMIZED: () => options.store.actions.DETECT_MAXIMIZED(),
 

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -171,7 +171,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
     action: createUILockAction(
       async (
         { actions, mutations, getters },
-        { filePath, confirm }: { filePath?: string; confirm?: boolean },
+        { filePath }: { filePath?: string },
       ) => {
         if (!filePath) {
           // Select and load a project File.
@@ -199,7 +199,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             projectJson: text,
           });
 
-          if (confirm !== false && getters.IS_EDITED) {
+          if (getters.IS_EDITED) {
             const result = await actions.SAVE_OR_DISCARD_PROJECT_FILE({
               additionalMessage:
                 "プロジェクトをロードすると現在のプロジェクトは破棄されます。",

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1809,7 +1809,7 @@ export type ProjectStoreTypes = {
   };
 
   LOAD_PROJECT_FILE: {
-    action(payload: { filePath?: string; confirm?: boolean }): boolean;
+    action(payload: { filePath?: string }): boolean;
   };
 
   SAVE_PROJECT_FILE: {

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -244,7 +244,7 @@ export type IpcIHData = {
  */
 export type IpcSOData = {
   LOAD_PROJECT_FILE: {
-    args: [obj: { filePath?: string; confirm?: boolean }];
+    args: [obj: { filePath?: string }];
     return: void;
   };
 


### PR DESCRIPTION
## 内容

`LOAD_PROJECT_FILE`のconfirmがずっと使われてないので消しました。

無指定の時とtrueのときの動作が同じで、falseのときのみ確認ダイアログを必ず出さないようなロジックになってます。
でもfalseを与えているところが1つもないので、消してしまって大丈夫そうでした。
必要になったら足すのが良さそう（YAGNI原則）

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2431

の解決を行っている時に気づきました

## スクリーンショット・動画など

## その他
