### PR TITLE
fix: ドラッグアンドドロップでプロジェクトファイルやテキストファイルが読み込めなかったのを直す

### DIFF
--- a/src/backend/browser/sandbox.ts
+++ b/src/backend/browser/sandbox.ts
@@ -286,4 +286,7 @@ export const api: Sandbox = {
   reloadApp(/* obj: { isMultiEngineOffMode: boolean } */) {
     throw new Error(`Not supported on Browser version: reloadApp`);
   },
+  getPathForFile(/* file: File */) {
+    throw new Error(`Not supported on Browser version: getPathForFile`);
+  },
 };

--- a/src/backend/electron/preload.ts
+++ b/src/backend/electron/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type { IpcRendererInvoke } from "./ipc";
 import {
   ConfigType,
@@ -229,6 +229,11 @@ const api: Sandbox = {
    */
   reloadApp: async ({ isMultiEngineOffMode }) => {
     await ipcRendererInvokeProxy.RELOAD_APP({ isMultiEngineOffMode });
+  },
+
+  /** webUtils.getPathForFileを呼ぶ */
+  getPathForFile: (file) => {
+    return webUtils.getPathForFile(file);
   },
 };
 

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -165,6 +165,7 @@ onMounted(async () => {
   // プロジェクトファイルが指定されていればロード
   if (typeof projectFilePath === "string" && projectFilePath !== "") {
     isProjectFileLoaded.value = await store.actions.LOAD_PROJECT_FILE({
+      type: "path",
       filePath: projectFilePath,
     });
   } else {

--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -157,7 +157,7 @@ const saveProjectAs = async () => {
 
 const importProject = () => {
   if (!uiLocked.value) {
-    void store.actions.LOAD_PROJECT_FILE({});
+    void store.actions.LOAD_PROJECT_FILE({ type: "dialog" });
   }
 };
 
@@ -198,6 +198,7 @@ const updateRecentProjects = async () => {
           label: projectFilePath,
           onClick: () => {
             void store.actions.LOAD_PROJECT_FILE({
+              type: "path",
               filePath: projectFilePath,
             });
           },

--- a/src/components/Talk/TalkEditor.vue
+++ b/src/components/Talk/TalkEditor.vue
@@ -143,7 +143,6 @@ import {
   actionPostfixSelectNthCharacter,
   HotkeyActionNameType,
 } from "@/domain/hotkeyAction";
-import { webUtils } from "@/helpers/electronRenderer";
 import { isElectron } from "@/helpers/platform";
 
 const props = defineProps<{

--- a/src/components/Talk/ToolBar.vue
+++ b/src/components/Talk/ToolBar.vue
@@ -145,7 +145,7 @@ const saveProject = async () => {
   await store.actions.SAVE_PROJECT_FILE({ overwrite: true });
 };
 const importTextFile = () => {
-  void store.actions.COMMAND_IMPORT_FROM_FILE({});
+  void store.actions.COMMAND_IMPORT_FROM_FILE({ type: "dialog" });
 };
 
 const usableButtons: Record<

--- a/src/components/Talk/menuBarData.ts
+++ b/src/components/Talk/menuBarData.ts
@@ -46,7 +46,7 @@ export const useMenuBarData = () => {
       type: "button",
       label: "テキスト読み込み",
       onClick: () => {
-        void store.actions.COMMAND_IMPORT_FROM_FILE({});
+        void store.actions.COMMAND_IMPORT_FROM_FILE({ type: "dialog" });
       },
       disableWhenUiLocked: true,
     },

--- a/src/plugins/ipcMessageReceiverPlugin.ts
+++ b/src/plugins/ipcMessageReceiverPlugin.ts
@@ -9,8 +9,11 @@ export const ipcMessageReceiver: Plugin = {
     options: { store: Store<State, AllGetters, AllActions, AllMutations> },
   ) => {
     window.backend.onReceivedIPCMsg({
-      LOAD_PROJECT_FILE: (_, { filePath } = {}) =>
-        void options.store.actions.LOAD_PROJECT_FILE({ filePath }),
+      LOAD_PROJECT_FILE: (_, { filePath }) =>
+        void options.store.actions.LOAD_PROJECT_FILE({
+          type: "path",
+          filePath,
+        }),
 
       DETECT_MAXIMIZED: () => options.store.actions.DETECT_MAXIMIZED(),
 

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2880,24 +2880,36 @@ export const audioCommandStore = transformCommandStore(
           prevAudioKey: undefined,
         });
       },
+      /**
+       * セリフテキストファイルを読み込む。
+       * ファイル選択ダイアログを表示するか、ファイルパス指定するか、Fileインスタンスを渡すか選べる。
+       */
       action: createUILockAction(
-        async (
-          { state, mutations, actions, getters },
-          { filePath }: { filePath?: string },
-        ) => {
-          if (!filePath) {
+        async ({ state, mutations, actions, getters }, payload) => {
+          let filePath: undefined | string;
+          if (payload.type == "dialog") {
             filePath = await window.backend.showImportFileDialog({
               title: "セリフ読み込み",
             });
             if (!filePath) return;
+          } else if (payload.type == "path") {
+            filePath = payload.filePath;
           }
-          let body = new TextDecoder("utf-8").decode(
-            await window.backend.readFile({ filePath }).then(getValueOrThrow),
-          );
+
+          let buf: ArrayBuffer;
+          if (filePath != undefined) {
+            buf = await window.backend
+              .readFile({ filePath })
+              .then(getValueOrThrow);
+          } else {
+            if (payload.type != "file")
+              throw new UnreachableError("payload.type != 'file'");
+            buf = await payload.file.arrayBuffer();
+          }
+
+          let body = new TextDecoder("utf-8").decode(buf);
           if (body.includes("\ufffd")) {
-            body = new TextDecoder("shift-jis").decode(
-              await window.backend.readFile({ filePath }).then(getValueOrThrow),
-            );
+            body = new TextDecoder("shift-jis").decode(buf);
           }
           const audioItems: AudioItem[] = [];
           let baseAudioItem: AudioItem | undefined = undefined;

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -21,7 +21,7 @@ import {
   DEFAULT_TPQN,
 } from "@/sing/domain";
 import { EditorType } from "@/type/preload";
-import { IsEqual } from "@/type/utility";
+import { IsEqual, UnreachableError } from "@/type/utility";
 import {
   showAlertDialog,
   showMessageDialog,
@@ -166,15 +166,13 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
   LOAD_PROJECT_FILE: {
     /**
      * プロジェクトファイルを読み込む。読み込めたかの成否が返る。
+     * ファイル選択ダイアログを表示するか、ファイルパス指定するか、Fileインスタンスを渡すか選べる。
      * エラー発生時はダイアログが表示される。
      */
     action: createUILockAction(
-      async (
-        { actions, mutations, getters },
-        { filePath }: { filePath?: string },
-      ) => {
-        if (!filePath) {
-          // Select and load a project File.
+      async ({ actions, mutations, getters }, payload) => {
+        let filePath: undefined | string;
+        if (payload.type == "dialog") {
           const ret = await window.backend.showProjectLoadDialog({
             title: "プロジェクトファイルの選択",
           });
@@ -182,17 +180,25 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             return false;
           }
           filePath = ret[0];
+        } else if (payload.type == "path") {
+          filePath = payload.filePath;
         }
 
-        let buf: ArrayBuffer;
         try {
-          buf = await window.backend
-            .readFile({ filePath })
-            .then(getValueOrThrow);
+          let buf: ArrayBuffer;
+          if (filePath != undefined) {
+            buf = await window.backend
+              .readFile({ filePath })
+              .then(getValueOrThrow);
 
-          await actions.APPEND_RECENTLY_USED_PROJECT({
-            filePath,
-          });
+            await actions.APPEND_RECENTLY_USED_PROJECT({
+              filePath,
+            });
+          } else {
+            if (payload.type != "file")
+              throw new UnreachableError("payload.type != 'file'");
+            buf = await payload.file.arrayBuffer();
+          }
 
           const text = new TextDecoder("utf-8").decode(buf).trim();
           const parsedProjectData = await actions.PARSE_PROJECT_FILE({

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -686,7 +686,12 @@ export type AudioCommandStoreTypes = {
     mutation: {
       audioKeyItemPairs: { audioItem: AudioItem; audioKey: AudioKey }[];
     };
-    action(payload: { filePath?: string }): void;
+    action(
+      payload:
+        | { type: "dialog" }
+        | { type: "path"; filePath: string }
+        | { type: "file"; file: File },
+    ): void;
   };
 
   COMMAND_PUT_TEXTS: {
@@ -1826,7 +1831,12 @@ export type ProjectStoreTypes = {
   };
 
   LOAD_PROJECT_FILE: {
-    action(payload: { filePath?: string }): boolean;
+    action(
+      payload:
+        | { type: "dialog" }
+        | { type: "path"; filePath: string }
+        | { type: "file"; file: File },
+    ): boolean;
   };
 
   SAVE_PROJECT_FILE: {

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -244,7 +244,7 @@ export type IpcIHData = {
  */
 export type IpcSOData = {
   LOAD_PROJECT_FILE: {
-    args: [obj: { filePath?: string }];
+    args: [obj: { filePath: string }];
     return: void;
   };
 

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -143,6 +143,7 @@ export interface Sandbox {
   uninstallVvppEngine(engineId: EngineId): Promise<boolean>;
   validateEngineDir(engineDir: string): Promise<EngineDirValidationResult>;
   reloadApp(obj: { isMultiEngineOffMode?: boolean }): Promise<void>;
+  getPathForFile(file: File): string;
 }
 
 export type AppInfos = {


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/2431

の解決プルリクエストです。
一応[このプルリクエスト](https://github.com/VOICEVOX/voicevox/pull/2432)が先に必要です。

経緯は[issue側のコメント](https://github.com/VOICEVOX/voicevox/issues/2431#issuecomment-2558514836)に書いています。

解決方法として、ブラウザ側に持ってこられたFileはelectronの関数を使ってパスを取得できるぽかったので、その経路を用意しました。
ブラウザの時はこの関数が使えないので、代わりにそのままFileオブジェクトを渡せるようにしました。

## 関連 Issue

close #2431

## その他

- [x] https://github.com/VOICEVOX/voicevox/pull/2432

ついでにブラウザでのドラッグ&ドロップも動くようになったはず。便利。
