### PR TITLE
fix: YMM4のカスタムボイス機能が使えない問題の対策

### DIFF
--- a/src/backend/electron/fileHelper.ts
+++ b/src/backend/electron/fileHelper.ts
@@ -9,6 +9,21 @@ export function writeFileSafely(
   path: string,
   data: string | NodeJS.ArrayBufferView,
 ) {
+  try {
+    // 上書きでないのなら直接書き込む
+    fs.writeFileSync(path, data, { flag: "wx" });
+    return;
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException;
+    if (e.code !== "EEXIST") {
+      throw e;
+    }
+    const stat = fs.statSync(path, { throwIfNoEntry: false });
+    if (stat != undefined && !stat.isFile()) {
+      // 書き込み先に既にフォルダ等があり上書きできない場合
+      throw e;
+    }
+  }
   const tmpPath = `${path}.tmp`;
   fs.writeFileSync(tmpPath, data);
 


### PR DESCRIPTION
## 内容

YMM4のカスタムボイス機能が正常に動作しないというXのポストを見かけたため修正しました。
[ymm4/faq/ゆっくりボイス/外部の音声合成エンジンで作成した音声ファイルを使用したい](https://manjubox.net/ymm4/faq/%E3%82%86%E3%81%A3%E3%81%8F%E3%82%8A%E3%83%9C%E3%82%A4%E3%82%B9/%E5%A4%96%E9%83%A8%E3%81%AE%E9%9F%B3%E5%A3%B0%E5%90%88%E6%88%90%E3%82%A8%E3%83%B3%E3%82%B8%E3%83%B3%E3%81%A7%E4%BD%9C%E6%88%90%E3%81%97%E3%81%9F%E9%9F%B3%E5%A3%B0%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%9F%E3%81%84/)

原因の詳細は不明ですが音声ファイルを一時ファイルに書き込みファイル名を変更していることが問題のようです。
- ref: #2368 

このPRでは書き込み先にファイルが存在しない場合は直接書き込むように変更します。

## その他

`writeFileSafely`で気になったこと
- `${path}.tmp`が既に存在した場合それを上書きしてしまう。ユーザーが作成していないと仮定しても本当に平気だろうか?
- `moveFileSync`失敗時に作成した一時ファイルの後始末をしていない。