### PR TITLE
test: ツールバーのカスタマイズダイアログの可視性チェックを改善

### DIFF
--- a/tests/e2e/browser/ツールバーカスタマイズダイアログ.spec.ts
+++ b/tests/e2e/browser/ツールバーカスタマイズダイアログ.spec.ts
@@ -22,8 +22,9 @@ test("ツールバーのカスタマイズでボタンを追加でき、デフ�
   await page.getByText("設定").click();
   await page.waitForTimeout(100);
   await getQuasarMenu(page, "ツールバーのカスタマイズ").click();
-  await page.waitForTimeout(100);
-  await expect(page.getByText("ツールバーのカスタマイズ")).toBeVisible();
+  await expect(
+    getNewestQuasarDialog(page).getByText("ツールバーのカスタマイズ"),
+  ).toBeVisible();
 
   // 全部書き出しボタンを追加する
   expect(


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/actions/runs/12518033773/job/34919807377

にて落ちていたmacOSのテストを改善します。
メニューが閉じきる前にダイアログが表示されると、「ツールバーのカスタマイズ」というテキストが2箇所に現れてテストが落ちるっぽいです。
タイミングによっては落ちないので厄介。

## その他
