### PR TITLE
test: エンジンモックに辞書機能とAquesTalk風記法機能追加＋エンジンモックの辞書のテスト追加

### DIFF
--- a/src/mock/engineMock/aquestalkLikeMock.ts
+++ b/src/mock/engineMock/aquestalkLikeMock.ts
@@ -1,0 +1,199 @@
+/**
+ * AquesTalk 風記法テキストをパースするモジュール。
+ * VOICEVOX ENGINEの voicevox_engine/tts_pipeline/kana_converter.py の移植。
+ */
+
+import { moraToPhonemes } from "./phonemeMock";
+import { AccentPhrase, Mora } from "@/openapi";
+
+enum ParseKanaErrorCode {
+  UNKNOWN_TEXT = "判別できない読み仮名があります: {text}",
+  ACCENT_TOP = "句頭にアクセントは置けません: {text}",
+  ACCENT_TWICE = "1つのアクセント句に二つ以上のアクセントは置けません: {text}",
+  ACCENT_NOTFOUND = "アクセントを指定していないアクセント句があります: {text}",
+  EMPTY_PHRASE = "{position}番目のアクセント句が空白です",
+  INTERROGATION_MARK_NOT_AT_END = "アクセント句末以外に「？」は置けません: {text}",
+  INFINITE_LOOP = "処理時に無限ループになってしまいました...バグ報告をお願いします。",
+}
+
+const _LOOP_LIMIT = 300;
+
+// AquesTalk 風記法特殊文字
+const _UNVOICE_SYMBOL = "_"; // 無声化
+const _ACCENT_SYMBOL = "'"; // アクセント位置
+const _NOPAUSE_DELIMITER = "/"; // ポーズ無しアクセント句境界
+const _PAUSE_DELIMITER = "、"; // ポーズ有りアクセント句境界
+const _WIDE_INTERROGATION_MARK = "？"; // 疑問形
+
+// AquesTalk 風記法とモーラの対応。無声母音も含む。（音素長・音高 0 初期化）
+const _kana2mora: Record<string, Mora> = {};
+Object.entries(moraToPhonemes).forEach(([kana, [consonant, vowel]]) => {
+  _kana2mora[kana] = {
+    text: kana,
+    consonant: consonant,
+    consonantLength: consonant ? 0 : undefined,
+    vowel: vowel,
+    vowelLength: 0,
+    pitch: 0,
+  };
+
+  if (["a", "i", "u", "e", "o"].includes(vowel)) {
+    // 「`_` で無声化」の実装。例: "_ホ" -> "hO"
+    // NOTE: 現行の型システムは Conditional Literal + upper に非対応.
+    // FIXME: バリデーションする
+    const upperVowel = vowel.toUpperCase();
+
+    _kana2mora[_UNVOICE_SYMBOL + kana] = {
+      text: kana,
+      consonant: consonant,
+      consonantLength: consonant ? 0 : undefined,
+      vowel: upperVowel,
+      vowelLength: 0,
+      pitch: 0,
+    };
+  }
+});
+
+/**
+ * 単一アクセント句に相当するAquesTalk 風記法テキストからアクセント句オブジェクトを生成
+ * longest matchによりモーラ化。入力長Nに対し計算量O(N^2)。
+ */
+function _textToAccentPhrase(phrase: string): AccentPhrase {
+  // NOTE: ポーズと疑問形はこの関数内で処理しない
+
+  let accentIndex: number | undefined = undefined;
+  const moras: Mora[] = [];
+
+  let baseIndex = 0; // パース開始位置。ここから右の文字列をstackに詰めていく。
+  let stack = ""; // 保留中の文字列
+  let matchedText: string | undefined = undefined; // 最後にマッチした仮名
+
+  let outerLoop = 0;
+  while (baseIndex < phrase.length) {
+    outerLoop += 1;
+
+    // 「`'` でアクセント位置」の実装
+    if (phrase[baseIndex] === _ACCENT_SYMBOL) {
+      // 「アクセント位置はちょうど１つ」の実装
+      if (moras.length === 0) {
+        throw new Error(
+          ParseKanaErrorCode.ACCENT_TOP.replace("{text}", phrase),
+        );
+      }
+      if (accentIndex != undefined) {
+        throw new Error(
+          ParseKanaErrorCode.ACCENT_TWICE.replace("{text}", phrase),
+        );
+      }
+
+      accentIndex = moras.length;
+      baseIndex += 1;
+      continue;
+    }
+
+    // モーラ探索
+    // より長い要素からなるモーラが見つかれば上書き（longest match）
+    // 例: phrase "キャ" -> "キ" 検出 -> "キャ" 検出/上書き -> Mora("キャ")
+    for (let watchIndex = baseIndex; watchIndex < phrase.length; watchIndex++) {
+      // アクセント位置特殊文字が来たら探索打ち切り
+      if (phrase[watchIndex] === _ACCENT_SYMBOL) {
+        break;
+      }
+      stack += phrase[watchIndex];
+
+      if (_kana2mora[stack]) {
+        matchedText = stack;
+      }
+    }
+
+    if (matchedText == undefined) {
+      throw new Error(ParseKanaErrorCode.UNKNOWN_TEXT.replace("{text}", stack));
+    } else {
+      // push mora
+      const baseMora = _kana2mora[matchedText];
+      moras.push({ ...baseMora });
+
+      baseIndex += matchedText.length;
+      stack = "";
+      matchedText = undefined;
+    }
+
+    if (outerLoop > _LOOP_LIMIT) {
+      throw new Error(ParseKanaErrorCode.INFINITE_LOOP);
+    }
+  }
+
+  if (accentIndex == undefined) {
+    throw new Error(
+      ParseKanaErrorCode.ACCENT_NOTFOUND.replace("{text}", phrase),
+    );
+  }
+
+  return { moras, accent: accentIndex, pauseMora: undefined };
+}
+
+/**
+ * AquesTalk 風記法テキストからアクセント句系列を生成
+ */
+export function parseKana(text: string): AccentPhrase[] {
+  const parsedResults: AccentPhrase[] = [];
+  if (text.length === 0) {
+    throw new Error(ParseKanaErrorCode.EMPTY_PHRASE.replace("{position}", "1"));
+  }
+
+  let phraseBase = 0;
+  for (let i = 0; i <= text.length; i++) {
+    // アクセント句境界（`/`か`、`）の出現までインデックス進展
+    if (
+      i === text.length ||
+      text[i] === _PAUSE_DELIMITER ||
+      text[i] === _NOPAUSE_DELIMITER
+    ) {
+      let phrase = text.substring(phraseBase, i);
+      if (phrase.length === 0) {
+        throw new Error(
+          ParseKanaErrorCode.EMPTY_PHRASE.replace(
+            "{position}",
+            String(parsedResults.length + 1),
+          ),
+        );
+      }
+      phraseBase = i + 1;
+
+      // 「`？` で疑問文」の実装
+      const isInterrogative = phrase.includes(_WIDE_INTERROGATION_MARK);
+      if (isInterrogative) {
+        if (phrase.indexOf(_WIDE_INTERROGATION_MARK) !== phrase.length - 1) {
+          throw new Error(
+            ParseKanaErrorCode.INTERROGATION_MARK_NOT_AT_END.replace(
+              "{text}",
+              phrase,
+            ),
+          );
+        }
+        // 疑問形はモーラでなくアクセント句属性で表現
+        phrase = phrase.replace(_WIDE_INTERROGATION_MARK, "");
+      }
+
+      const accentPhrase = _textToAccentPhrase(phrase);
+
+      // 「`、` で無音付き区切り」の実装
+      if (i < text.length && text[i] === _PAUSE_DELIMITER) {
+        accentPhrase.pauseMora = {
+          text: "、",
+          consonant: undefined,
+          consonantLength: undefined,
+          vowel: "pau",
+          vowelLength: 0,
+          pitch: 0,
+        };
+      }
+
+      accentPhrase.isInterrogative = isInterrogative;
+
+      parsedResults.push(accentPhrase);
+    }
+  }
+
+  return parsedResults;
+}

--- a/src/mock/engineMock/dictMock.ts
+++ b/src/mock/engineMock/dictMock.ts
@@ -1,0 +1,97 @@
+/**
+ * 辞書のモック
+ */
+
+import { uuid4 } from "@/helpers/random";
+import {
+  AddUserDictWordUserDictWordPostRequest,
+  DefaultApiInterface,
+  DeleteUserDictWordUserDictWordWordUuidDeleteRequest,
+  RewriteUserDictWordUserDictWordWordUuidPutRequest,
+  UserDictWord,
+} from "@/openapi";
+import { Brand } from "@/type/utility";
+
+type UserDictWordId = Brand<string, "UserDictWordId">;
+
+/** 単語追加リクエストで送られる断片的な単語情報からUserDictWordを作成する */
+function createWord(
+  wordProperty: AddUserDictWordUserDictWordPostRequest,
+): UserDictWord {
+  return {
+    surface: wordProperty.surface,
+    pronunciation: wordProperty.pronunciation,
+    accentType: wordProperty.accentType,
+    partOfSpeech: "名詞",
+    partOfSpeechDetail1: "一般",
+    partOfSpeechDetail2: "*",
+    partOfSpeechDetail3: "*",
+    inflectionalType: "*",
+    inflectionalForm: "*",
+    stem: "*",
+    yomi: wordProperty.pronunciation,
+    priority: wordProperty.priority ?? 5,
+    accentAssociativeRule: "*",
+  };
+}
+
+/**
+ * 辞書のモックを作成するクラス。
+ */
+export class DictMock {
+  private userDictWords: Map<UserDictWordId, UserDictWord>;
+
+  constructor() {
+    this.userDictWords = new Map();
+  }
+
+  /**
+   * テキストに対して辞書を適用する。
+   * 単純なテキスト置換を行う。
+   */
+  applyDict(text: string): string {
+    for (const word of this.userDictWords.values()) {
+      text = text.replace(new RegExp(word.surface, "g"), word.pronunciation);
+    }
+    return text;
+  }
+
+  /** 辞書系のOpenAPIの関数を返す */
+  createDictMock(): Pick<
+    DefaultApiInterface,
+    | "getUserDictWordsUserDictGet"
+    | "addUserDictWordUserDictWordPost"
+    | "rewriteUserDictWordUserDictWordWordUuidPut"
+    | "deleteUserDictWordUserDictWordWordUuidDelete"
+  > {
+    return {
+      getUserDictWordsUserDictGet: async (): Promise<{
+        [key: UserDictWordId]: UserDictWord;
+      }> => {
+        return Object.fromEntries(this.userDictWords.entries());
+      },
+
+      addUserDictWordUserDictWordPost: async (
+        payload: AddUserDictWordUserDictWordPostRequest,
+      ) => {
+        const id = uuid4() as UserDictWordId;
+        const word = createWord(payload);
+        this.userDictWords.set(id, word);
+        return id;
+      },
+
+      rewriteUserDictWordUserDictWordWordUuidPut: async (
+        payload: RewriteUserDictWordUserDictWordWordUuidPutRequest,
+      ) => {
+        const word = createWord(payload);
+        this.userDictWords.set(payload.wordUuid as UserDictWordId, word);
+      },
+
+      deleteUserDictWordUserDictWordWordUuidDelete: async (
+        payload: DeleteUserDictWordUserDictWordWordUuidDeleteRequest,
+      ) => {
+        this.userDictWords.delete(payload.wordUuid as UserDictWordId);
+      },
+    };
+  }
+}

--- a/src/mock/engineMock/talkModelMock.ts
+++ b/src/mock/engineMock/talkModelMock.ts
@@ -4,6 +4,7 @@
 
 import { builder, IpadicFeatures, Tokenizer } from "kuromoji";
 import { moraToPhonemes } from "./phonemeMock";
+import { parseKana } from "./aquestalkLikeMock";
 import { moraPattern } from "@/domain/japanese";
 import { AccentPhrase, Mora } from "@/openapi";
 
@@ -225,6 +226,22 @@ export async function textToActtentPhrasesMock(text: string, styleId: number) {
       lastMora.pitch = 0;
     }
   }
+
+  // 長さとピッチを代入
+  replaceLengthMock(accentPhrases, styleId);
+  replacePitchMock(accentPhrases, styleId);
+
+  return accentPhrases;
+}
+
+/**
+ * AquesTalk風記法をアクセント句に変換する。
+ */
+export async function aquestalkLikeToAccentPhrasesMock(
+  text: string,
+  styleId: number,
+) {
+  const accentPhrases: AccentPhrase[] = parseKana(text);
 
   // 長さとピッチを代入
   replaceLengthMock(accentPhrases, styleId);

--- a/src/plugins/hotkeyPlugin.ts
+++ b/src/plugins/hotkeyPlugin.ts
@@ -15,6 +15,7 @@ import {
   HotkeySettingType,
 } from "@/domain/hotkeyAction";
 import { createLogger } from "@/domain/frontend/log";
+import { Brand } from "@/type/utility";
 
 const hotkeyManagerKey = "hotkeyManager";
 export const useHotkeyManager = () => {
@@ -35,7 +36,7 @@ export const useHotkeyManager = () => {
 
 type Editor = "talk" | "song";
 
-type BindingKey = string & { __brand: "BindingKey" }; // BindingKey専用のブランド型
+type BindingKey = Brand<string, "BindingKey">;
 
 /**
  * ショートカットキーの処理を登録するための型。

--- a/src/type/utility.ts
+++ b/src/type/utility.ts
@@ -1,3 +1,6 @@
+/** ブランド型を作る */
+export type Brand<K, T> = K & { __brand: T };
+
 // XとYが同じ型かどうかを判定する
 export type IsEqual<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2

--- a/tests/unit/mock/engineMock/__snapshots__/index.spec.ts.snap
+++ b/tests/unit/mock/engineMock/__snapshots__/index.spec.ts.snap
@@ -174,3 +174,45 @@ exports[`createOpenAPIEngineMock > singFrameAudioQuerySingFrameAudioQueryPost 1`
 exports[`createOpenAPIEngineMock > synthesisSynthesisPost 1`] = `"23f4b910863418a7188648f7c5226a0f02b9d067b964be1690b69b1e9ffde7bc"`;
 
 exports[`createOpenAPIEngineMock > versionVersionGet 1`] = `"mock"`;
+
+exports[`createOpenAPIEngineMock > 辞書系 1`] = `
+{
+  "00000000-0000-4000-0000-000000000001": {
+    "accentAssociativeRule": "*",
+    "accentType": 1,
+    "inflectionalForm": "*",
+    "inflectionalType": "*",
+    "partOfSpeech": "名詞",
+    "partOfSpeechDetail1": "一般",
+    "partOfSpeechDetail2": "*",
+    "partOfSpeechDetail3": "*",
+    "priority": 5,
+    "pronunciation": "テストテスト",
+    "stem": "*",
+    "surface": "テスト",
+    "yomi": "テストテスト",
+  },
+}
+`;
+
+exports[`createOpenAPIEngineMock > 辞書系 2`] = `
+{
+  "00000000-0000-4000-0000-000000000001": {
+    "accentAssociativeRule": "*",
+    "accentType": 1,
+    "inflectionalForm": "*",
+    "inflectionalType": "*",
+    "partOfSpeech": "名詞",
+    "partOfSpeechDetail1": "一般",
+    "partOfSpeechDetail2": "*",
+    "partOfSpeechDetail3": "*",
+    "priority": 5,
+    "pronunciation": "テストテストテスト",
+    "stem": "*",
+    "surface": "テスト",
+    "yomi": "テストテストテスト",
+  },
+}
+`;
+
+exports[`createOpenAPIEngineMock > 辞書系 3`] = `{}`;

--- a/tests/unit/mock/engineMock/index.spec.ts
+++ b/tests/unit/mock/engineMock/index.spec.ts
@@ -1,5 +1,10 @@
 import { hash } from "../../utils";
+import { resetMockMode } from "@/helpers/random";
 import { createOpenAPIEngineMock } from "@/mock/engineMock";
+
+beforeEach(() => {
+  resetMockMode();
+});
 
 describe("createOpenAPIEngineMock", () => {
   const mock = createOpenAPIEngineMock();
@@ -64,5 +69,33 @@ describe("createOpenAPIEngineMock", () => {
       speaker: 0,
     });
     expect(await hash(await response.arrayBuffer())).toMatchSnapshot();
+  });
+
+  it("辞書系", async () => {
+    let response;
+
+    // 単語の追加
+    const wordUuid = await mock.addUserDictWordUserDictWordPost({
+      surface: "テスト",
+      pronunciation: "テストテスト",
+      accentType: 1,
+    });
+    response = await mock.getUserDictWordsUserDictGet();
+    expect(response).toMatchSnapshot();
+
+    // 単語の変更
+    await mock.rewriteUserDictWordUserDictWordWordUuidPut({
+      wordUuid,
+      surface: "テスト",
+      pronunciation: "テストテストテスト",
+      accentType: 1,
+    });
+    response = await mock.getUserDictWordsUserDictGet();
+    expect(response).toMatchSnapshot();
+
+    // 単語の削除
+    await mock.deleteUserDictWordUserDictWordWordUuidDelete({ wordUuid });
+    response = await mock.getUserDictWordsUserDictGet();
+    expect(response).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## 内容

エンジンモックに辞書系とAquesTalk風記法の機能を追加し、エンジンモックの辞書のテストも追加しました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2442

## その他

これも正直レビューが難しいと思うので、テストコードだけレビューもらってエイヤでマージになりそう。
