### PR TITLE
test: VVPPデフォルトエンジンを使うテストを書く

### DIFF
--- a/.env.test-electron-default-vvpp
+++ b/.env.test-electron-default-vvpp
@@ -1,0 +1,17 @@
+# VVPPデフォルトエンジンでのテスト用の.envファイル。
+
+VITE_APP_NAME=voicevox
+VITE_DEFAULT_ENGINE_INFOS=`[
+    {
+        "type": "downloadVvpp",
+        "name": "VOICEVOX Engine",
+        "uuid": "074fc39e-678b-4c13-8916-ffca8d505d1d",
+        "executionEnabled": true,
+        "executionArgs": [],
+        "host": "http://127.0.0.1:50021",
+        "latestUrl": "https://voicevox.hiroshiba.jp/latestDefaultEngineInfos.json"
+    }
+]`
+VITE_OFFICIAL_WEBSITE_URL=https://voicevox.hiroshiba.jp/
+VITE_LATEST_UPDATE_INFOS_URL=https://voicevox.hiroshiba.jp/updateInfos.json
+VITE_GTM_CONTAINER_ID=GTM-DUMMY

--- a/.env.test-electron-default-vvpp
+++ b/.env.test-electron-default-vvpp
@@ -4,12 +4,12 @@ VITE_APP_NAME=voicevox
 VITE_DEFAULT_ENGINE_INFOS=`[
     {
         "type": "downloadVvpp",
-        "name": "VOICEVOX Engine",
-        "uuid": "074fc39e-678b-4c13-8916-ffca8d505d1d",
+        "name": "VOICEVOX Nemo Engine",
+        "uuid": "208cf94d-43d2-4cf5-abc0-9783cac36d29",
         "executionEnabled": true,
         "executionArgs": [],
-        "host": "http://127.0.0.1:50021",
-        "latestUrl": "https://voicevox.hiroshiba.jp/latestDefaultEngineInfos.json"
+        "host": "http://127.0.0.1:50121",
+        "latestUrl": "https://voicevox.hiroshiba.jp/nemoLatestDefaultEngineInfos.json"
     }
 ]`
 VITE_OFFICIAL_WEBSITE_URL=https://voicevox.hiroshiba.jp/

--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -50,11 +50,11 @@ export class EngineAndVvppController {
       await this.vvppManager.install(vvppPath);
       return true;
     } catch (e) {
+      log.error(`Failed to install ${vvppPath},`, e);
       dialog.showErrorBox(
         "インストールエラー",
         `${vvppPath} をインストールできませんでした。`,
       );
-      log.error(`Failed to install ${vvppPath},`, e);
       return false;
     }
   }

--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -34,8 +34,12 @@ type EnvEngineInfoType = z.infer<typeof envEngineInfoSchema>;
 
 /** .envからデフォルトエンジン情報を読み込む */
 export function loadEnvEngineInfos(): EnvEngineInfoType[] {
+  // プロセスの環境変数VITE_DEFAULT_ENGINE_INFOSがあればそちらを優先する
+  // NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されれば不要になる。
   const defaultEngineInfosEnv =
-    import.meta.env.VITE_DEFAULT_ENGINE_INFOS ?? "[]";
+    process.env.VITE_DEFAULT_ENGINE_INFOS ??
+    import.meta.env.VITE_DEFAULT_ENGINE_INFOS ??
+    "[]";
 
   // FIXME: 「.envを書き換えてください」というログを出したい
   // NOTE: domainディレクトリなのでログを出す方法がなく、Errorオプションのcauseを用いてもelectron-logがcauseのログを出してくれない

--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 
 import { engineIdSchema } from "@/type/preload";
+import { isElectron } from "@/helpers/platform";
 
 /** .envに書くデフォルトエンジン情報のスキーマ */
 const envEngineInfoSchema = z
@@ -34,12 +35,12 @@ type EnvEngineInfoType = z.infer<typeof envEngineInfoSchema>;
 
 /** .envからデフォルトエンジン情報を読み込む */
 export function loadEnvEngineInfos(): EnvEngineInfoType[] {
-  // プロセスの環境変数VITE_DEFAULT_ENGINE_INFOSがあればそちらを優先する
-  // NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されれば不要になる。
+  // electronのときはプロセスの環境変数を参照する。
+  // NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されればimport.meta.envを使う。
   const defaultEngineInfosEnv =
-    process.env.VITE_DEFAULT_ENGINE_INFOS ??
-    import.meta.env.VITE_DEFAULT_ENGINE_INFOS ??
-    "[]";
+    (isElectron
+      ? process.env.VITE_DEFAULT_ENGINE_INFOS
+      : import.meta.env.VITE_DEFAULT_ENGINE_INFOS) ?? "[]";
 
   // FIXME: 「.envを書き換えてください」というログを出したい
   // NOTE: domainディレクトリなのでログを出す方法がなく、Errorオプションのcauseを用いてもelectron-logがcauseのログを出してくれない

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -3,10 +3,10 @@ import os from "os";
 import path from "path";
 import { _electron as electron, test } from "@playwright/test";
 import dotenv from "dotenv";
+import { options } from "yargs";
+import { BrowserWindow, MessageBoxSyncOptions } from "electron";
 
 test.beforeAll(async () => {
-  dotenv.config(); // FIXME: エンジンの設定直読み
-
   console.log("Waiting for main.js to be built...");
   while (true) {
     try {
@@ -19,40 +19,74 @@ test.beforeAll(async () => {
   console.log("main.js is built.");
 });
 
-// キャッシュなどでテスト結果が変化しないように、appDataをテスト起動時に毎回消去する。
-// cf: https://www.electronjs.org/ja/docs/latest/api/app#appgetpathname
-const appDataMap: Partial<Record<NodeJS.Platform, string>> = {
-  win32: process.env.APPDATA,
-  darwin: os.homedir() + "/Library/Application Support",
-  linux: process.env.XDG_CONFIG_HOME || os.homedir() + "/.config",
-} as const;
-
-const appData = appDataMap[process.platform];
-if (!appData) {
-  throw new Error("Unsupported platform");
-}
-const userDir = path.resolve(appData, `${process.env.VITE_APP_NAME}-test`);
-
 test.beforeEach(async () => {
+  // キャッシュなどでテスト結果が変化しないように、appDataをテスト起動時に毎回消去する。
+  // cf: https://www.electronjs.org/ja/docs/latest/api/app#appgetpathname
+  const appDataMap: Partial<Record<NodeJS.Platform, string>> = {
+    win32: process.env.APPDATA,
+    darwin: os.homedir() + "/Library/Application Support",
+    linux: process.env.XDG_CONFIG_HOME || os.homedir() + "/.config",
+  } as const;
+
+  const appData = appDataMap[process.platform];
+  if (!appData) {
+    throw new Error("Unsupported platform");
+  }
+  const userDir = path.resolve(appData, `${process.env.VITE_APP_NAME}-test`);
+
   await fs.rm(userDir, {
     recursive: true,
     force: true,
   });
 });
 
-test("起動したら「利用規約に関するお知らせ」が表示される", async () => {
-  const app = await electron.launch({
-    args: ["--no-sandbox", "."], // NOTE: --no-sandbox はUbuntu 24.04で動かすのに必要
-    timeout: process.env.CI ? 0 : 60000,
-  });
+[".env", ".env.test-electron-default-vvpp"].forEach((envPath) => {
+  test.describe(`env:${envPath}`, () => {
+    test.beforeEach(() => {
+      dotenv.config({
+        path: path.resolve(__dirname, "..", "..", "..", envPath),
+        override: true,
+      });
+    });
 
-  const sut = await app.firstWindow({
-    timeout: process.env.CI ? 60000 : 30000,
-  });
+    test("起動したら「利用規約に関するお知らせ」が表示される", async () => {
+      const app = await electron.launch({
+        args: ["--no-sandbox", "."], // NOTE: --no-sandbox はUbuntu 24.04で動かすのに必要
+        timeout: process.env.CI ? 0 : 60000,
+      });
 
-  // エンジンが起動し「利用規約に関するお知らせ」が表示されるのを待つ
-  await sut.waitForSelector("text=利用規約に関するお知らせ", {
-    timeout: 60000,
+      // ダイアログのモック
+      await app.evaluate((electron) => {
+        // @ts-expect-error ２種のオーバーロードを無視する
+        electron.dialog.showMessageBoxSync = (
+          win: BrowserWindow,
+          options: MessageBoxSyncOptions,
+        ) => {
+          // デフォルトエンジンのインストールの確認ダイアログ
+          if (
+            options.title == "デフォルトエンジンのインストール" &&
+            options.buttons?.[0] == "インストール"
+          ) {
+            return 0;
+          }
+
+          throw new Error(`Unexpected dialog: ${JSON.stringify(options)}`);
+        };
+      });
+
+      // ログを表示
+      app.on("console", (msg) => {
+        console.log(msg.text());
+      });
+
+      const sut = await app.firstWindow({
+        timeout: process.env.CI ? 60000 : 30000,
+      });
+      // エンジンが起動し「利用規約に関するお知らせ」が表示されるのを待つ
+      await sut.waitForSelector("text=利用規約に関するお知らせ", {
+        timeout: 60000,
+      });
+      await app.close();
+    });
   });
-  await app.close();
 });

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -3,7 +3,6 @@ import os from "os";
 import path from "path";
 import { _electron as electron, test } from "@playwright/test";
 import dotenv from "dotenv";
-import { options } from "yargs";
 import { BrowserWindow, MessageBoxSyncOptions } from "electron";
 
 test.beforeAll(async () => {

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -42,10 +42,7 @@ test.beforeEach(async () => {
 [".env", ".env.test-electron-default-vvpp"].forEach((envPath) => {
   test.describe(`env:${envPath}`, () => {
     test.beforeEach(() => {
-      dotenv.config({
-        path: path.resolve(__dirname, "..", "..", "..", envPath),
-        override: true,
-      });
+      dotenv.config({ path: envPath, override: true });
     });
 
     test("起動したら「利用規約に関するお知らせ」が表示される", async () => {

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -39,8 +39,17 @@ test.beforeEach(async () => {
   });
 });
 
-[".env", ".env.test-electron-default-vvpp"].forEach((envPath) => {
-  test.describe(`env:${envPath}`, () => {
+[
+  {
+    envName: ".env環境",
+    envPath: ".env",
+  },
+  {
+    envName: "VVPPデフォルトエンジン",
+    envPath: ".env.test-electron-default-vvpp",
+  },
+].forEach(({ envName, envPath }) => {
+  test.describe(`${envName}`, () => {
     test.beforeEach(() => {
       dotenv.config({ path: envPath, override: true });
     });


### PR DESCRIPTION
## 内容

VVPPデフォルトエンジンを使うテストを書きます。

途中でelectronのダイアログが来ますが、ダイアログ表示関数を直接上書きすることで無理やり突破します。
将来的にはelectronのダイアログではなくブラウザ表示になる予定なのでこのワークアラウンド不要になる予定です。

変更行数は少ないですが、結構複雑度が上がってしまっています。解決策募集中。。

* VVPPデフォルトエンジン用の.envが増えた
	* VVPPデフォルトエンジンに統一されたらまた減るはず
* デフォルトエンジン情報はimport.meta.env経路以外にprocess.envルートもできた
	* テストしたい環境が２つになったため
	* これもVVPPデフォルトエンジンに統一されたらもとに戻るはず
* electronダイアログを無理やり通るためのモックが増えた
	* これはそもそもGUIが整備されたらダイアログ自体がなくなるはず

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1194

## その他

おそらく動くのですが、VOICEVOXエンジンをダウンロードする部分が重くてタイムアウトになると思います。
Nemo用のlatestDefaultEngineInfosを作ろうと思います。
