### PR TITLE
refactor: ショートカットキー周りのisMacを{isMac: boolean}にする

### DIFF
--- a/src/backend/browser/browserConfig.ts
+++ b/src/backend/browser/browserConfig.ts
@@ -21,7 +21,7 @@ const defaultEngineId = EngineId(defaultEngine.uuid);
 export async function getConfigManager() {
   await configManagerLock.acquire("configManager", async () => {
     if (!configManager) {
-      configManager = new BrowserConfigManager(isMac);
+      configManager = new BrowserConfigManager({ isMac });
       await configManager.initialize();
     }
   });

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -302,6 +302,7 @@ export abstract class BaseConfigManager {
   protected config: ConfigType | undefined;
 
   private lock = new AsyncLock();
+  protected isMac: boolean;
 
   protected abstract exists(): Promise<boolean>;
   protected abstract load(): Promise<Record<string, unknown> & Metadata>;
@@ -309,7 +310,9 @@ export abstract class BaseConfigManager {
 
   protected abstract getAppVersion(): string;
 
-  constructor(protected isMac: boolean) {}
+  constructor({ isMac }: { isMac: boolean }) {
+    this.isMac = isMac;
+  }
 
   public reset() {
     this.config = this.getDefaultConfig();
@@ -326,7 +329,7 @@ export abstract class BaseConfigManager {
         }
       }
       this.config = this.migrateHotkeySettings(
-        getConfigSchema(this.isMac).parse(data),
+        getConfigSchema({ isMac: this.isMac }).parse(data),
       );
       this._save();
     } else {
@@ -357,7 +360,7 @@ export abstract class BaseConfigManager {
   private _save() {
     void this.lock.acquire(lockKey, async () => {
       await this.save({
-        ...getConfigSchema(this.isMac).parse({
+        ...getConfigSchema({ isMac: this.isMac }).parse({
           ...this.config,
         }),
         __internal__: {
@@ -392,22 +395,22 @@ export abstract class BaseConfigManager {
   private migrateHotkeySettings(data: ConfigType): ConfigType {
     const COMBINATION_IS_NONE = HotkeyCombination("####");
     const loadedHotkeys = structuredClone(data.hotkeySettings);
-    const hotkeysWithoutNewCombination = getDefaultHotkeySettings(isMac).map(
-      (defaultHotkey) => {
-        const loadedHotkey = loadedHotkeys.find(
-          (loadedHotkey) => loadedHotkey.action === defaultHotkey.action,
-        );
-        const hotkeyWithoutCombination: HotkeySettingType = {
-          action: defaultHotkey.action,
-          combination: COMBINATION_IS_NONE,
-        };
-        return loadedHotkey ?? hotkeyWithoutCombination;
-      },
-    );
+    const hotkeysWithoutNewCombination = getDefaultHotkeySettings({
+      isMac,
+    }).map((defaultHotkey) => {
+      const loadedHotkey = loadedHotkeys.find(
+        (loadedHotkey) => loadedHotkey.action === defaultHotkey.action,
+      );
+      const hotkeyWithoutCombination: HotkeySettingType = {
+        action: defaultHotkey.action,
+        combination: COMBINATION_IS_NONE,
+      };
+      return loadedHotkey ?? hotkeyWithoutCombination;
+    });
     const migratedHotkeys = hotkeysWithoutNewCombination.map((hotkey) => {
       if (hotkey.combination === COMBINATION_IS_NONE) {
         const newHotkey = ensureNotNullish(
-          getDefaultHotkeySettings(isMac).find(
+          getDefaultHotkeySettings({ isMac }).find(
             (defaultHotkey) => defaultHotkey.action === hotkey.action,
           ),
         );
@@ -434,6 +437,6 @@ export abstract class BaseConfigManager {
   }
 
   protected getDefaultConfig(): ConfigType {
-    return getConfigSchema(this.isMac).parse({});
+    return getConfigSchema({ isMac: this.isMac }).parse({});
   }
 }

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -16,7 +16,6 @@ import {
   getDefaultHotkeySettings,
   HotkeySettingType,
 } from "@/domain/hotkeyAction";
-import { isMac } from "@/helpers/platform";
 
 const lockKey = "save";
 
@@ -396,7 +395,7 @@ export abstract class BaseConfigManager {
     const COMBINATION_IS_NONE = HotkeyCombination("####");
     const loadedHotkeys = structuredClone(data.hotkeySettings);
     const hotkeysWithoutNewCombination = getDefaultHotkeySettings({
-      isMac,
+      isMac: this.isMac,
     }).map((defaultHotkey) => {
       const loadedHotkey = loadedHotkeys.find(
         (loadedHotkey) => loadedHotkey.action === defaultHotkey.action,
@@ -410,7 +409,7 @@ export abstract class BaseConfigManager {
     const migratedHotkeys = hotkeysWithoutNewCombination.map((hotkey) => {
       if (hotkey.combination === COMBINATION_IS_NONE) {
         const newHotkey = ensureNotNullish(
-          getDefaultHotkeySettings({ isMac }).find(
+          getDefaultHotkeySettings({ isMac: this.isMac }).find(
             (defaultHotkey) => defaultHotkey.action === hotkey.action,
           ),
         );

--- a/src/backend/common/ConfigManager.ts
+++ b/src/backend/common/ConfigManager.ts
@@ -300,9 +300,9 @@ export type Metadata = {
  */
 export abstract class BaseConfigManager {
   protected config: ConfigType | undefined;
+  protected isMac: boolean;
 
   private lock = new AsyncLock();
-  protected isMac: boolean;
 
   protected abstract exists(): Promise<boolean>;
   protected abstract load(): Promise<Record<string, unknown> & Metadata>;

--- a/src/backend/electron/electronConfig.ts
+++ b/src/backend/electron/electronConfig.ts
@@ -36,7 +36,7 @@ let configManager: ElectronConfigManager | undefined;
 
 export function getConfigManager(): ElectronConfigManager {
   if (!configManager) {
-    configManager = new ElectronConfigManager(isMac);
+    configManager = new ElectronConfigManager({ isMac });
   }
   return configManager;
 }

--- a/src/components/Dialog/HotkeySettingDialog.vue
+++ b/src/components/Dialog/HotkeySettingDialog.vue
@@ -227,7 +227,7 @@ const setHotkeyDialogOpened = () => {
 };
 
 const isDefaultCombination = (action: string) => {
-  const defaultSetting = getDefaultHotkeySettings(isMac).find(
+  const defaultSetting = getDefaultHotkeySettings({ isMac }).find(
     (value) => value.action === action,
   );
   const hotkeySetting = hotkeySettings.value.find(
@@ -245,7 +245,7 @@ const resetHotkey = async (action: string) => {
 
   if (result !== "OK") return;
 
-  const setting = getDefaultHotkeySettings(isMac).find(
+  const setting = getDefaultHotkeySettings({ isMac }).find(
     (value) => value.action == action,
   );
   if (setting == undefined) {

--- a/src/domain/hotkeyAction.ts
+++ b/src/domain/hotkeyAction.ts
@@ -60,7 +60,11 @@ export const hotkeySettingSchema = z.object({
 });
 export type HotkeySettingType = z.infer<typeof hotkeySettingSchema>;
 
-export function getDefaultHotkeySettings(isMac: boolean): HotkeySettingType[] {
+export function getDefaultHotkeySettings({
+  isMac,
+}: {
+  isMac: boolean;
+}): HotkeySettingType[] {
   return [
     {
       action: "音声書き出し",

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -404,7 +404,7 @@ export const rootMiscSettingSchema = z.object({
 });
 export type RootMiscSettingType = z.infer<typeof rootMiscSettingSchema>;
 
-export function getConfigSchema(isMac: boolean) {
+export function getConfigSchema({ isMac }: { isMac: boolean }) {
   return z
     .object({
       inheritAudioInfo: z.boolean().default(true),
@@ -427,7 +427,7 @@ export function getConfigSchema(isMac: boolean) {
         .default({}),
       hotkeySettings: hotkeySettingSchema
         .array()
-        .default(getDefaultHotkeySettings(isMac)),
+        .default(getDefaultHotkeySettings({ isMac })),
       toolbarSetting: toolbarSettingSchema
         .array()
         .default(defaultToolbarButtonSetting),

--- a/tests/unit/backend/common/configManager.spec.ts
+++ b/tests/unit/backend/common/configManager.spec.ts
@@ -4,7 +4,7 @@ import { BaseConfigManager } from "@/backend/common/ConfigManager";
 import { getConfigSchema } from "@/type/preload";
 
 const configBase = {
-  ...getConfigSchema(false).parse({}),
+  ...getConfigSchema({ isMac: false }).parse({}),
   __internal__: {
     migrations: {
       version: "999.999.999",
@@ -13,6 +13,10 @@ const configBase = {
 };
 
 class TestConfigManager extends BaseConfigManager {
+  constructor() {
+    super({ isMac: false });
+  }
+
   getAppVersion() {
     return "999.999.999";
   }
@@ -49,7 +53,7 @@ it("新規作成できる", async () => {
     async () => undefined,
   );
 
-  const configManager = new TestConfigManager(false);
+  const configManager = new TestConfigManager();
   await configManager.initialize();
   expect(configManager).toBeTruthy();
 });
@@ -62,7 +66,7 @@ it("バージョンが保存される", async () => {
     .spyOn(TestConfigManager.prototype, "save")
     .mockImplementation(async () => undefined);
 
-  const configManager = new TestConfigManager(false);
+  const configManager = new TestConfigManager();
   await configManager.initialize();
   await configManager.ensureSaved();
   expect(saveSpy).toHaveBeenCalled();
@@ -82,7 +86,7 @@ for (const [version, data] of pastConfigs) {
       async () => data,
     );
 
-    const configManager = new TestConfigManager(false);
+    const configManager = new TestConfigManager();
     await configManager.initialize();
     expect(configManager).toBeTruthy();
 
@@ -122,7 +126,7 @@ it("0.19.1からのマイグレーション時にハミング・ソングスタ�
   ).map((key) => getStyleIdFromVoiceId(key));
 
   // マイグレーション
-  const configManager = new TestConfigManager(false);
+  const configManager = new TestConfigManager();
   await configManager.initialize();
   const presets = configManager.get("presets");
   const defaultPresetKeys = configManager.get("defaultPresetKeys");
@@ -164,7 +168,7 @@ it("getできる", async () => {
     }),
   );
 
-  const configManager = new TestConfigManager(false);
+  const configManager = new TestConfigManager();
   await configManager.initialize();
   expect(configManager.get("inheritAudioInfo")).toBe(false);
 });
@@ -183,7 +187,7 @@ it("setできる", async () => {
     }),
   );
 
-  const configManager = new TestConfigManager(false);
+  const configManager = new TestConfigManager();
   await configManager.initialize();
   configManager.set("inheritAudioInfo", true);
   expect(configManager.get("inheritAudioInfo")).toBe(true);

--- a/tests/unit/domain/hotkeyAction.spec.ts
+++ b/tests/unit/domain/hotkeyAction.spec.ts
@@ -4,7 +4,7 @@ import {
 } from "@/domain/hotkeyAction";
 
 test("すべてのホットキーに初期値が設定されている", async () => {
-  const defaultHotkeySettings = getDefaultHotkeySettings(false);
+  const defaultHotkeySettings = getDefaultHotkeySettings({ isMac: false });
   const allActionNames = new Set(hotkeyActionNameSchema.options);
   const defaultHotkeyActionsNames = new Set(
     defaultHotkeySettings.map((setting) => setting.action),


### PR DESCRIPTION
## 内容

ショートカットキー周りのisMacを`{isMac: boolean}`にします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2446

## その他

ちなみにDiscordで話題に上がりました。この辺り。
https://discordapp.com/channels/879570910208733277/893889888208977960/1322696371672842331
