### PR TITLE
fix: プロセスIDからプロセスを特定するのを wmic から tasklist に変更

### DIFF
--- a/src/backend/electron/manager/engineProcessManager.ts
+++ b/src/backend/electron/manager/engineProcessManager.ts
@@ -99,7 +99,7 @@ export class EngineProcessManager {
       if (pid != undefined) {
         const processName = await getProcessNameFromPid(engineHostInfo, pid);
         log.warn(
-          `ENGINE ${engineId}: Port ${port} has already been assigned by ${processName} (pid=${pid})`,
+          `ENGINE ${engineId}: Port ${port} has already been assigned by ${processName ?? "(not found)"} (pid=${pid})`,
         );
       } else {
         // ポートは使用不可能だがプロセスidは見つからなかった

--- a/src/backend/electron/portHelper.ts
+++ b/src/backend/electron/portHelper.ts
@@ -175,7 +175,7 @@ export async function getProcessNameFromPid(
   )?.trim();
 
   if (processName == undefined) {
-    portWarn(hostInfo.port, `Not found process id: ${pid}`);
+    portWarn(hostInfo.port, `Not found process name from pid=${pid}!`);
     return undefined;
   } else {
     portLog(hostInfo.port, `Found process name: ${processName}`);

--- a/src/backend/electron/portHelper.ts
+++ b/src/backend/electron/portHelper.ts
@@ -153,7 +153,7 @@ export async function getProcessNameFromPid(
   const exec = isWindows
     ? {
         cmd: "tasklist",
-        args: ["/FI", `"PID eq ${pid}"`, "/NH"],
+        args: ["/FI", `PID eq ${pid}`, "/NH"],
       }
     : {
         cmd: "ps",

--- a/src/backend/electron/portHelper.ts
+++ b/src/backend/electron/portHelper.ts
@@ -153,7 +153,7 @@ export async function getProcessNameFromPid(
   const exec = isWindows
     ? {
         cmd: "tasklist",
-        args: ["/FI", "\"PID eq ${pid}\"", "/NH"],
+        args: ["/FI", `"PID eq ${pid}"`, "/NH"],
       }
     : {
         cmd: "ps",
@@ -170,7 +170,9 @@ export async function getProcessNameFromPid(
    * ```
    * -> `node.exe`
    */
-  const processName = isWindows ? stdout.split("\r\n")[1].split(/ +/)[0] : stdout;
+  const processName = isWindows
+    ? stdout.split("\r\n")[1].split(/ +/)[0]
+    : stdout;
 
   portLog(hostInfo.port, `Found process name: ${processName}`);
   return processName.trim();

--- a/src/backend/electron/portHelper.ts
+++ b/src/backend/electron/portHelper.ts
@@ -152,8 +152,8 @@ export async function getProcessNameFromPid(
   portLog(hostInfo.port, `Getting process name from pid=${pid}...`);
   const exec = isWindows
     ? {
-        cmd: "wmic",
-        args: ["process", "where", `"ProcessID=${pid}"`, "get", "name"],
+        cmd: "tasklist",
+        args: ["/FI", "\"PID eq ${pid}\"", "/NH"],
       }
     : {
         cmd: "ps",
@@ -170,7 +170,7 @@ export async function getProcessNameFromPid(
    * ```
    * -> `node.exe`
    */
-  const processName = isWindows ? stdout.split("\n")[1] : stdout;
+  const processName = isWindows ? stdout.split("\r\n")[1].split(/ +/)[0] : stdout;
 
   portLog(hostInfo.port, `Found process name: ${processName}`);
   return processName.trim();


### PR DESCRIPTION
## 内容
- プロセスIDからプロセスを特定するのを wmic から tasklist に変更
  - wmic が 24H2 から非推奨になったため、tasklist に修正

## 関連 Issue
close #2449 