### PR TITLE
feat: VVPPデフォルトエンジンの進捗を出せるようにし、オンメモリじゃなくする

### DIFF
--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import fs from "fs";
 import { ReadableStream } from "node:stream/web";
-import stream from "node:stream";
 import log from "electron-log/main";
 import { BrowserWindow, dialog } from "electron";
 
@@ -222,11 +221,10 @@ export class EngineAndVvppController {
           const fileStream = fs.createWriteStream(downloadPath);
 
           // ファイルに書き込む
-          for await (const chunk of stream.Readable.fromWeb(
-            res.body as ReadableStream<Uint8Array>, // NOTE: 最新のTypeScriptならasは不要
-          )) {
+          // NOTE: なぜか型が合わないのでasを使っている
+          for await (const chunk of res.body as ReadableStream<Uint8Array>) {
             fileStream.write(chunk);
-            downloadedBytes += (chunk as Uint8Array).length;
+            downloadedBytes += chunk.length;
             callbacks.onProgress({
               type: "download",
               progress: (downloadedBytes / totalBytes) * 100,

--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -223,7 +223,7 @@ export class EngineAndVvppController {
 
           // ファイルに書き込む
           for await (const chunk of stream.Readable.fromWeb(
-            res.body as ReadableStream<Uint8Array>,
+            res.body as ReadableStream<Uint8Array>, // NOTE: 最新のTypeScriptならasは不要
           )) {
             fileStream.write(chunk);
             downloadedBytes += (chunk as Uint8Array).length;

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -966,13 +966,15 @@ app.on("ready", async () => {
     await engineAndVvppController.downloadAndInstallVvppEngine(
       app.getPath("downloads"),
       packageInfo,
-      ({ type, progress }) => {
-        if (Date.now() - lastLogTime > 100) {
-          log.info(
-            `VVPP default engine progress: ${type}: ${Math.floor(progress)}%`,
-          );
-          lastLogTime = Date.now();
-        }
+      {
+        onProgress: ({ type, progress }) => {
+          if (Date.now() - lastLogTime > 100) {
+            log.info(
+              `VVPP default engine progress: ${type}: ${Math.floor(progress)}%`,
+            );
+            lastLogTime = Date.now();
+          }
+        },
       },
     );
   }

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -962,9 +962,18 @@ app.on("ready", async () => {
     }
 
     // ダウンロードしてインストールする
+    let lastLogTime = 0; // とりあえずログを0.1秒に1回だけ出力する
     await engineAndVvppController.downloadAndInstallVvppEngine(
       app.getPath("downloads"),
       packageInfo,
+      ({ type, progress }) => {
+        if (Date.now() - lastLogTime > 100) {
+          log.info(
+            `VVPP default engine progress: ${type}: ${Math.floor(progress)}%`,
+          );
+          lastLogTime = Date.now();
+        }
+      },
     );
   }
 

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -110,9 +110,9 @@ export class VvppManager {
 
   private async extractVvpp(
     vvppLikeFilePath: string,
-    onProgress?: ProgressCallback,
+    callbacks?: { onProgress?: ProgressCallback },
   ): Promise<{ outputDir: string; manifest: MinimumEngineManifestType }> {
-    onProgress?.({ progress: 0 });
+    callbacks?.onProgress?.({ progress: 0 });
 
     const nonce = new Date().getTime().toString();
     const outputDir = path.join(this.vvppEngineDir, ".tmp", nonce);
@@ -221,7 +221,7 @@ export class VvppManager {
               / *(?<percent>\d+)% ?(?<fileCount>\d+)? ?(?<file>.*)/,
             );
             if (progressMatch?.groups?.percent) {
-              onProgress?.({
+              callbacks?.onProgress?.({
                 progress: parseInt(progressMatch.groups.percent),
               });
             }
@@ -233,7 +233,7 @@ export class VvppManager {
 
           child.on("exit", (code) => {
             if (code === 0) {
-              onProgress?.({ progress: 100 });
+              callbacks?.onProgress?.({ progress: 100 });
               resolve();
             } else {
               reject(new Error(`7z exited with code ${code}`));
@@ -273,14 +273,17 @@ export class VvppManager {
   /**
    * 追加
    */
-  async install(vvppPath: string, onProgress?: ProgressCallback) {
-    await this.lock.acquire(lockKey, () => this._install(vvppPath, onProgress));
+  async install(
+    vvppPath: string,
+    callbacks?: { onProgress?: ProgressCallback },
+  ) {
+    await this.lock.acquire(lockKey, () => this._install(vvppPath, callbacks));
   }
-  private async _install(vvppPath: string, onProgress?: ProgressCallback) {
-    const { outputDir, manifest } = await this.extractVvpp(
-      vvppPath,
-      onProgress,
-    );
+  private async _install(
+    vvppPath: string,
+    callbacks?: { onProgress?: ProgressCallback },
+  ) {
+    const { outputDir, manifest } = await this.extractVvpp(vvppPath, callbacks);
 
     const dirName = this.toValidDirName(manifest);
     const engineDirectory = path.join(this.vvppEngineDir, dirName);

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -7,6 +7,7 @@ import { app, dialog } from "electron";
 import MultiStream from "multistream";
 import { glob } from "glob";
 import AsyncLock from "async-lock";
+import { ProgressCallback } from "../type";
 import {
   EngineId,
   EngineInfo,
@@ -109,7 +110,10 @@ export class VvppManager {
 
   private async extractVvpp(
     vvppLikeFilePath: string,
+    onProgress?: ProgressCallback,
   ): Promise<{ outputDir: string; manifest: MinimumEngineManifestType }> {
+    onProgress?.({ progress: 0 });
+
     const nonce = new Date().getTime().toString();
     const outputDir = path.join(this.vvppEngineDir, ".tmp", nonce);
 
@@ -182,7 +186,13 @@ export class VvppManager {
           log.log("Single file, not concatenating");
         }
 
-        const args = ["x", "-o" + outputDir, archiveFile, "-t" + format];
+        const args = [
+          "x",
+          "-o" + outputDir,
+          archiveFile,
+          "-t" + format,
+          "-bsp1", // 進捗出力
+        ];
 
         let sevenZipPath = import.meta.env.VITE_7Z_BIN_NAME;
         if (!sevenZipPath) {
@@ -194,18 +204,27 @@ export class VvppManager {
             sevenZipPath,
           );
         }
-        log.log(
-          "Spawning 7z:",
-          sevenZipPath,
-          args.map((a) => JSON.stringify(a)).join(" "),
-        );
+        log.log("Spawning 7z:", sevenZipPath, args.join(" "));
         await new Promise<void>((resolve, reject) => {
           const child = spawn(sevenZipPath, args, {
             stdio: ["pipe", "pipe", "pipe"],
           });
 
           child.stdout?.on("data", (data: Buffer) => {
-            log.info(`7z STDOUT: ${data.toString("utf-8")}`);
+            const output = data.toString("utf-8");
+            log.info(`7z STDOUT: ${output}`);
+
+            // 進捗を取得
+            // NOTE: ` 75% 106 - pyopenjtalk\open_jtalk_dic_utf_8-1.11\sys.dic` のような出力が来る
+            // TODO: 出力が変わるかもしれないのでテストが必要
+            const progressMatch = output.match(
+              / *(?<percent>\d+)% ?(?<fileCount>\d+)? ?(?<file>.*)/,
+            );
+            if (progressMatch?.groups?.percent) {
+              onProgress?.({
+                progress: parseInt(progressMatch.groups.percent),
+              });
+            }
           });
 
           child.stderr?.on("data", (data: Buffer) => {
@@ -214,6 +233,7 @@ export class VvppManager {
 
           child.on("exit", (code) => {
             if (code === 0) {
+              onProgress?.({ progress: 100 });
               resolve();
             } else {
               reject(new Error(`7z exited with code ${code}`));
@@ -253,11 +273,15 @@ export class VvppManager {
   /**
    * 追加
    */
-  async install(vvppPath: string) {
-    await this.lock.acquire(lockKey, () => this._install(vvppPath));
+  async install(vvppPath: string, onProgress?: ProgressCallback) {
+    await this.lock.acquire(lockKey, () => this._install(vvppPath, onProgress));
   }
-  private async _install(vvppPath: string) {
-    const { outputDir, manifest } = await this.extractVvpp(vvppPath);
+  private async _install(vvppPath: string, onProgress?: ProgressCallback) {
+    const { outputDir, manifest } = await this.extractVvpp(
+      vvppPath,
+      onProgress,
+    );
+
     const dirName = this.toValidDirName(manifest);
     const engineDirectory = path.join(this.vvppEngineDir, dirName);
     const oldEngineDirName = (

--- a/src/backend/electron/type.ts
+++ b/src/backend/electron/type.ts
@@ -1,0 +1,6 @@
+/** 進捗を返すコールバック */
+export type ProgressCallback<T extends string | void = void> = [T] extends [
+  void,
+]
+  ? (payload: { progress: number }) => void
+  : (payload: { type: T; progress: number }) => void;

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -40,10 +40,10 @@ test.beforeEach(async () => {
 });
 
 [
-  {
-    envName: ".env環境",
-    envPath: ".env",
-  },
+  // {
+  //   envName: ".env環境",
+  //   envPath: ".env",
+  // },
   {
     envName: "VVPPデフォルトエンジン",
     envPath: ".env.test-electron-default-vvpp",

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -40,10 +40,10 @@ test.beforeEach(async () => {
 });
 
 [
-  // {
-  //   envName: ".env環境",
-  //   envPath: ".env",
-  // },
+  {
+    envName: ".env環境",
+    envPath: ".env",
+  },
   {
     envName: "VVPPデフォルトエンジン",
     envPath: ".env.test-electron-default-vvpp",


### PR DESCRIPTION
## 内容

VVPPデフォルトエンジンのインストール状況などの進捗を出せるようにします。
将来的にはGUIで表示予定ですが、今はまだログに出すだけです。

ついでにDLしたものがオンメモリになってたのをstreamでファイル出力にします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/1194#issuecomment-2296599278

の第六段。

## その他

進捗表示が必要な関数にonProgressが生えまくるけど、仕方ない･･･のかな。
