### PR TITLE
FIX: `writeFileSafely`の一時ファイルが既存のファイルを上書きしないようにする

### DIFF
--- a/src/backend/electron/fileHelper.ts
+++ b/src/backend/electron/fileHelper.ts
@@ -12,7 +12,7 @@ export function writeFileSafely(
   data: string | NodeJS.ArrayBufferView,
 ) {
   const tmpPath = `${path}-${uuid4()}.tmp`;
-  fs.writeFileSync(tmpPath, data);
+  fs.writeFileSync(tmpPath, data, { flag: "wx" });
 
   try {
     moveFileSync(tmpPath, path, {

--- a/src/backend/electron/fileHelper.ts
+++ b/src/backend/electron/fileHelper.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import log from "electron-log/main";
 import { moveFileSync } from "move-file";
 
 /**
@@ -9,10 +10,34 @@ export function writeFileSafely(
   path: string,
   data: string | NodeJS.ArrayBufferView,
 ) {
-  const tmpPath = `${path}.tmp`;
-  fs.writeFileSync(tmpPath, data);
+  let tmpPath: string;
+  let maxRetries = 16;
+  while (true) {
+    maxRetries--;
+    try {
+      // ランダムな文字列を8文字生成
+      const randStr = Math.floor(Math.random() * 36 ** 8)
+        .toString(36)
+        .padStart(8, "0");
+      tmpPath = `${path}-${randStr}.tmp`;
+      fs.writeFileSync(tmpPath, data, { flag: "wx" });
+      break;
+    } catch (error) {
+      const e = error as NodeJS.ErrnoException;
+      if (e.code !== "EEXIST" || maxRetries <= 0) {
+        throw e;
+      }
+    }
+  }
 
-  moveFileSync(tmpPath, path, {
-    overwrite: true,
-  });
+  try {
+    moveFileSync(tmpPath, path, {
+      overwrite: true,
+    });
+  } catch (error) {
+    fs.promises.unlink(tmpPath).catch((reason) => {
+      log.warn("Fail to remove %s\n  %o", tmpPath, reason);
+    });
+    throw error;
+  }
 }


### PR DESCRIPTION
## 内容

`writeFileSafely`の一時ファイルが既存のファイルを上書きしないようにします。
また、ファイル移動に失敗した場合一時ファイルを削除するようにします。

## 関連 Issue

- ref: https://github.com/VOICEVOX/voicevox/pull/2437#issuecomment-2562914679

## その他

一時ファイル名のランダム文字列部には`Math.rand()`を使っています。
これでも十分なはず？

とりあえず一時ファイルの作成試行回数は16回にしてあります。
あまり回数を増やし過ぎるとメインスレッドを長時間ブロックしてしまいます。