### PR TITLE
fix: electronでプロセスの環境変数がない場合に落ちないように

### DIFF
--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 
 import { engineIdSchema } from "@/type/preload";
+import { isElectron } from "@/helpers/platform";
 
 /** .envに書くデフォルトエンジン情報のスキーマ */
 const envEngineInfoSchema = z

--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -38,9 +38,7 @@ export function loadEnvEngineInfos(): EnvEngineInfoType[] {
   // electronのときはプロセスの環境変数を優先する。
   // NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されればimport.meta.envを使う。
   const defaultEngineInfosEnv =
-    (isElectron && process?.env?.VITE_DEFAULT_ENGINE_INFOS
-      ? process.env.VITE_DEFAULT_ENGINE_INFOS
-      : import.meta.env.VITE_DEFAULT_ENGINE_INFOS) ?? "[]";
+    ((isElectron && process?.env?.VITE_DEFAULT_ENGINE_INFOS) || import.meta.env.VITE_DEFAULT_ENGINE_INFOS) ?? "[]";
 
   // FIXME: 「.envを書き換えてください」というログを出したい
   // NOTE: domainディレクトリなのでログを出す方法がなく、Errorオプションのcauseを用いてもelectron-logがcauseのログを出してくれない

--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -35,10 +35,10 @@ type EnvEngineInfoType = z.infer<typeof envEngineInfoSchema>;
 
 /** .envからデフォルトエンジン情報を読み込む */
 export function loadEnvEngineInfos(): EnvEngineInfoType[] {
-  // electronのときはプロセスの環境変数を参照する。
+  // electronのときはプロセスの環境変数を優先する。
   // NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されればimport.meta.envを使う。
   const defaultEngineInfosEnv =
-    (isElectron
+    (isElectron && process?.env?.VITE_DEFAULT_ENGINE_INFOS
       ? process.env.VITE_DEFAULT_ENGINE_INFOS
       : import.meta.env.VITE_DEFAULT_ENGINE_INFOS) ?? "[]";
 

--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -35,12 +35,10 @@ type EnvEngineInfoType = z.infer<typeof envEngineInfoSchema>;
 
 /** .envからデフォルトエンジン情報を読み込む */
 export function loadEnvEngineInfos(): EnvEngineInfoType[] {
-  // プロセスの環境変数を優先する。
+  // electronのときはプロセスの環境変数を優先する。
   // NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されればimport.meta.envを使う。
   const defaultEngineInfosEnv =
-    process?.env?.VITE_DEFAULT_ENGINE_INFOS ??
-    import.meta.env.VITE_DEFAULT_ENGINE_INFOS ??
-    "[]";
+    ((isElectron && process?.env?.VITE_DEFAULT_ENGINE_INFOS) || import.meta.env.VITE_DEFAULT_ENGINE_INFOS) ?? "[]";
 
   // FIXME: 「.envを書き換えてください」というログを出したい
   // NOTE: domainディレクトリなのでログを出す方法がなく、Errorオプションのcauseを用いてもelectron-logがcauseのログを出してくれない

--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -35,10 +35,12 @@ type EnvEngineInfoType = z.infer<typeof envEngineInfoSchema>;
 
 /** .envからデフォルトエンジン情報を読み込む */
 export function loadEnvEngineInfos(): EnvEngineInfoType[] {
-  // electronのときはプロセスの環境変数を優先する。
+  // プロセスの環境変数を優先する。
   // NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されればimport.meta.envを使う。
   const defaultEngineInfosEnv =
-    ((isElectron && process?.env?.VITE_DEFAULT_ENGINE_INFOS) || import.meta.env.VITE_DEFAULT_ENGINE_INFOS) ?? "[]";
+    process?.env?.VITE_DEFAULT_ENGINE_INFOS ??
+    import.meta.env.VITE_DEFAULT_ENGINE_INFOS ??
+    "[]";
 
   // FIXME: 「.envを書き換えてください」というログを出したい
   // NOTE: domainディレクトリなのでログを出す方法がなく、Errorオプションのcauseを用いてもelectron-logがcauseのログを出してくれない

--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -33,12 +33,28 @@ const envEngineInfoSchema = z
   );
 type EnvEngineInfoType = z.infer<typeof envEngineInfoSchema>;
 
+/**
+ * デフォルトエンジン情報の環境変数を取得する
+ * electronのときはプロセスの環境変数を優先する。
+ * NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されればimport.meta.envを使う。
+ */
+function getDefaultEngineInfosEnv(): string {
+  let engineInfos;
+  if (isElectron) {
+    engineInfos = process?.env?.VITE_DEFAULT_ENGINE_INFOS;
+  }
+  if (engineInfos == undefined) {
+    engineInfos = import.meta.env.VITE_DEFAULT_ENGINE_INFOS;
+  }
+  if (engineInfos == undefined) {
+    engineInfos = "[]";
+  }
+  return engineInfos;
+}
+
 /** .envからデフォルトエンジン情報を読み込む */
 export function loadEnvEngineInfos(): EnvEngineInfoType[] {
-  // electronのときはプロセスの環境変数を優先する。
-  // NOTE: electronテスト環境を切り替えるため。テスト環境が１本化されればimport.meta.envを使う。
-  const defaultEngineInfosEnv =
-    ((isElectron && process?.env?.VITE_DEFAULT_ENGINE_INFOS) || import.meta.env.VITE_DEFAULT_ENGINE_INFOS) ?? "[]";
+  const defaultEngineInfosEnv = getDefaultEngineInfosEnv();
 
   // FIXME: 「.envを書き換えてください」というログを出したい
   // NOTE: domainディレクトリなのでログを出す方法がなく、Errorオプションのcauseを用いてもelectron-logがcauseのログを出してくれない

--- a/src/domain/defaultEngine/envEngineInfo.ts
+++ b/src/domain/defaultEngine/envEngineInfo.ts
@@ -5,7 +5,6 @@
 import { z } from "zod";
 
 import { engineIdSchema } from "@/type/preload";
-import { isElectron } from "@/helpers/platform";
 
 /** .envに書くデフォルトエンジン情報のスキーマ */
 const envEngineInfoSchema = z


### PR DESCRIPTION
## 内容

electronでプロセスの環境変数がない場合に落ちないようにします。
（production環境などでは`process.env.VITE_DEFAULT_ENGINE_INFOS`が存在しないので）

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2444#discussion_r1899887386

## その他
