### PR TITLE
fix(test): [project-sequencer-statemachine] Linux の e2e テストで、electron を --no-sandbox で動くように

### DIFF
--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -42,7 +42,7 @@ test.beforeEach(async () => {
 
 test("起動したら「利用規約に関するお知らせ」が表示される", async () => {
   const app = await electron.launch({
-    args: ["."],
+    args: ["--no-sandbox", "."], // NOTE: --no-sandbox はUbuntu 24.04で動かすのに必要
     timeout: process.env.CI ? 0 : 60000,
   });
 


### PR DESCRIPTION
## 内容

#2421 をproject-sequencer-statemachineブランチに取り込んでubuntuでのテストが落ちないようにします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2403
- 
## その他
