### PR TITLE
fix: VVPPデフォルトエンジンダウンロード後、確実にファイルが閉じられるまで待つ

### DIFF
--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -230,7 +230,13 @@ export class EngineAndVvppController {
               progress: (downloadedBytes / totalBytes) * 100,
             });
           }
+
+          // ファイルを確実に閉じる
+          const { promise, resolve, reject } = Promise.withResolvers();
+          fileStream.on("close", resolve);
+          fileStream.on("error", reject);
           fileStream.close();
+          await promise;
 
           downloadedPaths.push(downloadPath);
           log.info(`Downloaded ${name} to ${downloadPath}`);


### PR DESCRIPTION
## 内容

VVPPデフォルトエンジンダウンロード後、確実にファイルが閉じられるまで待ちます。

close()を呼んで制御が返ってきても、OSがファイルを閉じているとは限らない･･･っぽい？
ので待機するようにしてみます。

## 関連 Issue

fix #2459 

## スクリーンショット・動画など

## その他
