### PR TITLE
fix: エンジンモック内での読点の扱いがちょっと間違っていたので修正

### DIFF
--- a/src/mock/engineMock/talkModelMock.ts
+++ b/src/mock/engineMock/talkModelMock.ts
@@ -182,16 +182,23 @@ export async function textToActtentPhrasesMock(text: string, styleId: number) {
   for (const token of tokens) {
     // 記号の場合は無音を入れて区切る
     if (token.pos == "記号") {
-      if (textPhrase.length == 0) continue;
-
-      const accentPhrase = textToAccentPhraseMock(textPhrase);
-      accentPhrase.pauseMora = {
+      const pauseMora = {
         text: "、",
         vowel: "pau",
         vowelLength: 1 - 1 / (accentPhrases.length + 1),
         pitch: 0,
       };
-      accentPhrases.push(accentPhrase);
+
+      // テキストが空の場合は前のアクセント句に無音を追加、空でない場合は新しいアクセント句を追加
+      let accentPhrase: AccentPhrase;
+      if (textPhrase.length === 0) {
+        accentPhrase = accentPhrases[accentPhrases.length - 1];
+      } else {
+        accentPhrase = textToAccentPhraseMock(textPhrase);
+        accentPhrases.push(accentPhrase);
+      }
+      accentPhrase.pauseMora = pauseMora;
+
       textPhrase = "";
       continue;
     }


### PR DESCRIPTION
## 内容

エンジンモック内での読点の扱いがちょっと間違っていたので修正しました。
助詞の後にも「、」が入るようになりました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2442

から切り出しました。

## スクリーンショット・動画など

## その他
