### PR TITLE
refactor(test): 辞書ダイアログの読み方取得ロジックを改善

### DIFF
--- a/tests/e2e/browser/辞書ダイアログ.spec.ts
+++ b/tests/e2e/browser/辞書ダイアログ.spec.ts
@@ -4,11 +4,21 @@ import { getNewestQuasarDialog } from "../locators";
 
 test.beforeEach(gotoHome);
 
-/** 最後のテキスト欄にテキストを入力し、その読みを取得する */
+/**
+ * 最後のテキスト欄にテキストを入力し、その読みを取得する。
+ * 確実に読みを反映させるために、一度空にしてから入力する。
+ */
 async function getYomi(page: Page, inputText: string): Promise<string> {
   const audioCellInput = page.getByRole("textbox", { name: "行目" }).last();
   const accentPhrase = page.locator(".accent-phrase");
 
+  // 空にする
+  await audioCellInput.click();
+  await audioCellInput.fill("");
+  await audioCellInput.press("Enter");
+  await expect(accentPhrase).not.toBeVisible();
+
+  // 入力する
   await audioCellInput.click();
   await audioCellInput.fill(inputText);
   await audioCellInput.press("Enter");

--- a/tests/e2e/browser/辞書ダイアログ.spec.ts
+++ b/tests/e2e/browser/辞書ダイアログ.spec.ts
@@ -4,29 +4,17 @@ import { getNewestQuasarDialog } from "../locators";
 
 test.beforeEach(gotoHome);
 
-// 読み方を確認する。
-// エンジン起動直後など、たまに読みが反映されないことがあるので、
-// 一度空にする -> テキストが消えたことを確認（消えてなかったらもう一度Enter）->
-// 再度入力する -> 読み方が表示されたことを確認（表示されてなかったらもう一度Enter）
-// という流れで読み方を確認する。
+/** 最後のテキスト欄にテキストを入力し、その読みを取得する */
 async function getYomi(page: Page, inputText: string): Promise<string> {
-  const audioCellInput = page.locator(".audio-cell input").last();
-  await audioCellInput.fill("");
-  let text = "";
-  do {
-    await page.waitForTimeout(100);
-    await audioCellInput.press("Enter");
-    text = (await page.locator(".text-cell").allInnerTexts()).join("");
-  } while (text.length > 0);
+  const audioCellInput = page.getByRole("textbox", { name: "行目" }).last();
+  const accentPhrase = page.locator(".accent-phrase");
 
+  await audioCellInput.click();
   await audioCellInput.fill(inputText);
-  do {
-    await page.waitForTimeout(100);
-    await audioCellInput.press("Enter");
-    text = (await page.locator(".text-cell").allInnerTexts()).join("");
-  } while (text.length === 0);
+  await audioCellInput.press("Enter");
+  await expect(accentPhrase).toBeVisible();
 
-  return text;
+  return (await accentPhrase.allTextContents()).join("");
 }
 
 async function openDictDialog(page: Page): Promise<void> {

--- a/tests/e2e/browser/辞書ダイアログ.spec.ts
+++ b/tests/e2e/browser/辞書ダイアログ.spec.ts
@@ -22,7 +22,7 @@ async function getYomi(page: Page, inputText: string): Promise<string> {
   await audioCellInput.click();
   await audioCellInput.fill(inputText);
   await audioCellInput.press("Enter");
-  await expect(accentPhrase).toBeVisible();
+  await expect(accentPhrase).not.toHaveCount(0);
 
   return (await accentPhrase.allTextContents()).join("");
 }


### PR DESCRIPTION
## 内容

辞書ダイアログの読み方取得ロジックが若干不安定っぽく、たしかmacOSで不安定だったのでリファクタリングしました。
`waitForTimeout`をやめてtoBeVisibleとかを使っています。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2442

の切り出しです。

## スクリーンショット・動画など

## その他
