### PR TITLE
Change: Merge QueueのCIを1回だけ走らせるようにする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - "**"
+      - "!gh-readonly-queue"
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - "**"
-      - "!gh-readonly-queue"
+      - "!gh-readonly-queue/**"
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     branches:
       - "**"
-      - "!gh-readonly-queue/**"
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## 内容

Merge Queueとpushで2回走っていたのをMerge Queueだけにします。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）