### PR TITLE
hotfix: [release-0.22] AudioCellが0個のときにDEFAULT_PROJECT_FILE_BASE_NAMEでエラーが発生しないように修正

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1226,8 +1226,8 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   DEFAULT_PROJECT_FILE_BASE_NAME: {
     getter: (state) => {
-      // NOTE: 起動時にソングエディタが開かれると、トークの初期化が行われずAudioCellが作成されないので、
-      //       state.audioKeys.length === 0になる
+      // NOTE: 起動時にソングエディタが開かれた場合、トークの初期化が行われずAudioCellが作成されない
+      // TODO: ソングエディタが開かれてい場合はこの関数を呼ばないようにし、warningを出す
       if (state.audioKeys.length === 0) {
         return DEFAULT_PROJECT_NAME;
       }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1226,6 +1226,12 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
 
   DEFAULT_PROJECT_FILE_BASE_NAME: {
     getter: (state) => {
+      // NOTE: 起動時にソングエディタが開かれると、トークの初期化が行われずAudioCellが作成されないので、
+      //       state.audioKeys.length === 0になる
+      if (state.audioKeys.length === 0) {
+        return DEFAULT_PROJECT_NAME;
+      }
+
       const headItemText = state.audioItems[state.audioKeys[0]].text;
 
       const tailItemText =


### PR DESCRIPTION
## 内容

AudioCellが0個のときにDEFAULT_PROJECT_FILE_BASE_NAMEでエラーが発生しないようにします。

## 関連 Issue

close #2483

## その他
