### PR TITLE
refactor: createLoggerを少しリファクタリング

### DIFF
--- a/src/domain/frontend/log.ts
+++ b/src/domain/frontend/log.ts
@@ -1,13 +1,16 @@
+type LogLevel = "info" | "warn" | "error";
+type LogFunction = (...args: unknown[]) => void;
+
 /** ログ出力用の関数を生成する。ブラウザ専用。 */
 // TODO: window.backendをDIできるようにする
-export function createLogger(scope: string) {
+export function createLogger(scope: string): Record<LogLevel, LogFunction> {
   return {
     info: createLogFunction("info"),
     warn: createLogFunction("warn"),
     error: createLogFunction("error"),
   };
 
-  function createLogFunction(logType: "info" | "warn" | "error") {
+  function createLogFunction(logType: LogLevel): LogFunction {
     return (...args: unknown[]) => {
       if (window.backend != undefined) {
         const method = (

--- a/src/domain/frontend/log.ts
+++ b/src/domain/frontend/log.ts
@@ -1,22 +1,28 @@
 /** ログ出力用の関数を生成する。ブラウザ専用。 */
 // TODO: window.backendをDIできるようにする
 export function createLogger(scope: string) {
-  const createInner =
-    (
-      method: "logInfo" | "logWarn" | "logError",
-      fallbackMethod: "info" | "warn" | "error",
-    ) =>
-    (...args: unknown[]) => {
-      if (window.backend == undefined) {
-        // eslint-disable-next-line no-console
-        console[fallbackMethod](...args);
+  return {
+    info: createLogFunction("info"),
+    warn: createLogFunction("warn"),
+    error: createLogFunction("error"),
+  };
+
+  function createLogFunction(logType: "info" | "warn" | "error") {
+    return (...args: unknown[]) => {
+      if (window.backend != undefined) {
+        const method = (
+          {
+            info: "logInfo",
+            warn: "logWarn",
+            error: "logError",
+          } as const
+        )[logType];
+        window.backend[method](`[${scope}]`, ...args);
         return;
       }
-      window.backend[method](`[${scope}]`, ...args);
+
+      // eslint-disable-next-line no-console
+      console[logType](...args);
     };
-  return {
-    info: createInner("logInfo", "info"),
-    warn: createInner("logWarn", "warn"),
-    error: createInner("logError", "error"),
-  };
+  }
 }


### PR DESCRIPTION
## 内容

タイトルの通り、createLoggerを少しリファクタリングしました。

## その他

本当はelectron環境問わずloggerを作れる関数を作りたかったんですが、フロントエンドで`electron-log`をimportしようとするとエラーになる問題が解決できずに諦めました。。。
なにか解決策ないのかな。。
