### PR TITLE
Arch Linuxがp7zipを7zipに置き換えたのでメッセージを変更。それと7zzを許容するように。

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -95,9 +95,12 @@ elif command -v 7zr &> /dev/null; then
 elif command -v 7za &> /dev/null; then
     # CentOS/Fedora
     COMMAND_7Z=7za
+elif command -v 7zz &> /dev/null; then
+    # Gentoo
+    COMMAND_7Z=7zz
 else
     cat << 'EOS' && exit 1
-[!] Command '7z', '7zr' or '7za' not found
+[!] Command '7z', '7zr' or '7za', '7zz' not found
 
 Required to extract compressed files
 
@@ -115,7 +118,7 @@ Or
     sudo yum install p7zip
 
 Arch Linux:
-    sudo pacman -S p7zip
+    sudo pacman -S 7zip
 
 MacOS:
     brew install p7zip

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -96,11 +96,11 @@ elif command -v 7za &> /dev/null; then
     # CentOS/Fedora
     COMMAND_7Z=7za
 elif command -v 7zz &> /dev/null; then
-    # Upstream
+    # Official 7zip
     COMMAND_7Z=7zz
 else
     cat << 'EOS' && exit 1
-[!] Command '7z', '7zr' or '7za', '7zz' not found
+[!] Command '7z', '7zr', '7za' or '7zz' not found
 
 Required to extract compressed files
 

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -96,7 +96,7 @@ elif command -v 7za &> /dev/null; then
     # CentOS/Fedora
     COMMAND_7Z=7za
 elif command -v 7zz &> /dev/null; then
-    # Gentoo
+    # Upstream
     COMMAND_7Z=7zz
 else
     cat << 'EOS' && exit 1


### PR DESCRIPTION
## 内容

以前から更新が止まっているp7zipから公式で提供される7zipに移行する動きがいくつかのLinuxディストリにあって、  
Archは7zipに置き換え済み、Ubuntuは24.04、Debianは13でそれぞれp7zipを仮想パッケージにしていて実態が7zipになっている。  

7zzを対象に含めているのは7zip公式のをダウンロードして使う人や、Gentooでapp-arch/7zip、HomeBrewでsevenzipをインストールした人向け。  

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
