### PR TITLE
fix: ブラウザ版でファイル保存できない問題を解決

### DIFF
--- a/src/backend/browser/fakePath.ts
+++ b/src/backend/browser/fakePath.ts
@@ -3,7 +3,7 @@ import { uuid4 } from "@/helpers/random";
 
 const fakePathSchema = z
   .string()
-  .regex(/^<browser-dummy-[0-9a-f]+>-.+$/)
+  .regex(/^<browser-dummy-[-0-9a-f]+>-.+$/)
   .brand("FakePath");
 export type FakePath = z.infer<typeof fakePathSchema>;
 

--- a/tests/unit/backend/browser/fakePath.spec.ts
+++ b/tests/unit/backend/browser/fakePath.spec.ts
@@ -1,0 +1,9 @@
+import { isFakePath, createFakePath } from "@/backend/browser/fakePath";
+
+it.each(["dummy", "日本語", "拡張子付き日本語.wav"])(
+  "FakePathを作れて検証もできる: %s",
+  (input) => {
+    const fakePath = createFakePath(input);
+    expect(isFakePath(fakePath)).toBe(true);
+  },
+);

--- a/tests/unit/backend/browser/fakePath.spec.ts
+++ b/tests/unit/backend/browser/fakePath.spec.ts
@@ -1,9 +1,10 @@
 import { isFakePath, createFakePath } from "@/backend/browser/fakePath";
 
-it.each(["dummy", "日本語", "拡張子付き日本語.wav"])(
-  "FakePathを作れて検証もできる: %s",
-  (input) => {
-    const fakePath = createFakePath(input);
-    expect(isFakePath(fakePath)).toBe(true);
-  },
-);
+it.each([
+  "spaced file name",
+  "filename-with-extension.wav",
+  "日本語ファイル名",
+])("FakePathを作れて検証もできる: %s", (input) => {
+  const fakePath = createFakePath(input);
+  expect(isFakePath(fakePath)).toBe(true);
+});


### PR DESCRIPTION
## 内容

ブラウザ版でファイル保存しようとすると、FakePathのparseが正しくなくてエラーになって保存できなかったので修正しました。
テストで使おうと思って動かなかったことに気づいたので修正しました。

## その他

特に製品版ソフトウェアのVOICEVOXには問題ないエラーでした。
