### PR TITLE
fix!: writeFileSafely関数をmove-file非依存にし、テストを追加

### DIFF
--- a/src/backend/electron/fileHelper.ts
+++ b/src/backend/electron/fileHelper.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import { moveFileSync } from "move-file";
 import { uuid4 } from "@/helpers/random";
 import { createLogger } from "@/helpers/log";
 
@@ -14,15 +13,13 @@ export function writeFileSafely(
   data: string | NodeJS.ArrayBufferView,
 ) {
   const tmpPath = `${path}-${uuid4()}.tmp`;
-  fs.writeFileSync(tmpPath, data, { flag: "wx" });
 
   try {
-    moveFileSync(tmpPath, path, {
-      overwrite: true,
-    });
+    fs.writeFileSync(tmpPath, data, { flag: "wx" });
+    fs.renameSync(tmpPath, path);
   } catch (error) {
     if (fs.existsSync(tmpPath)) {
-      fs.promises.unlink(tmpPath).catch((reason) => {
+      void fs.promises.unlink(tmpPath).catch((reason) => {
         log.warn("Failed to remove %s\n  %o", tmpPath, reason);
       });
     }

--- a/tests/unit/backend/electron/fileHelper.node.spec.ts
+++ b/tests/unit/backend/electron/fileHelper.node.spec.ts
@@ -1,0 +1,39 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { test, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSafely } from "@/backend/electron/fileHelper";
+import { uuid4 } from "@/helpers/random";
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), uuid4()));
+});
+
+afterAll(() => {
+  fs.rmdirSync(tmpDir, { recursive: true });
+});
+
+describe("writeFileSafely", () => {
+  test("ファイルを書き込める", async () => {
+    const filePath = path.join(tmpDir, uuid4());
+    const content = "Hello World";
+    writeFileSafely(filePath, content);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe(content);
+  });
+
+  test("ファイルを上書きできる", async () => {
+    const filePath = path.join(tmpDir, uuid4());
+    fs.writeFileSync(filePath, "old content");
+    const newContent = "new content";
+    writeFileSafely(filePath, newContent);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe(newContent);
+  });
+
+  test("存在しないディレクトリに書き込もうとするとエラー", async () => {
+    const nonExistentDir = path.join(tmpDir, uuid4(), "subdir");
+    const filePath = path.join(nonExistentDir, "test.txt");
+    await expect(writeFileSafely(filePath, "data")).rejects.toThrow();
+  });
+});

--- a/tests/unit/backend/electron/fileHelper.node.spec.ts
+++ b/tests/unit/backend/electron/fileHelper.node.spec.ts
@@ -32,8 +32,8 @@ describe("writeFileSafely", () => {
   });
 
   test("存在しないディレクトリに書き込もうとするとエラー", async () => {
-    const nonExistentDir = path.join(tmpDir, uuid4(), "subdir");
+    const nonExistentDir = path.join(tmpDir, uuid4(), "not-exist");
     const filePath = path.join(nonExistentDir, "test.txt");
-    await expect(writeFileSafely(filePath, "data")).rejects.toThrow();
+    expect(() => writeFileSafely(filePath, "data")).toThrow();
   });
 });

--- a/tests/unit/backend/electron/fileHelper.node.spec.ts
+++ b/tests/unit/backend/electron/fileHelper.node.spec.ts
@@ -36,4 +36,10 @@ describe("writeFileSafely", () => {
     const filePath = path.join(nonExistentDir, "test.txt");
     expect(() => writeFileSafely(filePath, "data")).toThrow();
   });
+
+  test("指定したパスにディレクトリが存在するとエラー", async () => {
+    const filePath = path.join(tmpDir, uuid4());
+    fs.mkdirSync(filePath);
+    expect(() => writeFileSafely(filePath, "data")).toThrow();
+  });
 });


### PR DESCRIPTION
## 内容

writeFileSafely関数をmove-file非依存にし、テストを追加しました。

- https://github.com/VOICEVOX/voicevox/issues/2501

を解決します。
詳細は[こちら](https://github.com/VOICEVOX/voicevox/issues/2501#issuecomment-2610261884)

## 関連 Issue

fix: #2501 
