### PR TITLE
fix: engineAndVvppController.tsの型エラーを直す

### DIFF
--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -234,7 +234,7 @@ export class EngineAndVvppController {
           }
 
           // ファイルを確実に閉じる
-          const { promise, resolve, reject } = Promise.withResolvers();
+          const { promise, resolve, reject } = Promise.withResolvers<void>();
           fileStream.on("close", resolve);
           fileStream.on("error", reject);
           fileStream.close();


### PR DESCRIPTION

## 内容

こうなってしまっていました。

```log
src/backend/electron/engineAndVvppController.ts:238:34 - error TS2345: Argument of type '(value: unknown) => void' is not assignable to parameter of type '() => void'.
  Target signature provides too few arguments. Expected 1 or more, but got 0.

238           fileStream.on("close", resolve);
```

これでビルド時にエラーが出ないと思います。


## その他
