### PR TITLE
chore: 開発実行・ビルド時にvite-plugin-checkerでlintを実行しないようにする

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -79,9 +79,6 @@ export default defineConfig((options) => {
       mode !== "test" &&
         checker({
           overlay: false,
-          eslint: {
-            lintCommand: "eslint --ext .ts,.vue .",
-          },
           vueTsc: true,
         }),
       isElectron && [


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/2515

の解決PRです。

開発時にelectron:serve等で実行するたびになかなか重たいので、vite-plugin-checkerでeslintを走らせないようにします。
型チェックは有用（発見が遅れると手戻りがすごいことがある・気付けないことも多い）なのと、そんなに重くないので残します。
CPU計測結果は[こちら](https://github.com/VOICEVOX/voicevox/issues/2515)。

## 関連 Issue

fix: #2515 

## その他

Discordでのコメント
https://discordapp.com/channels/879570910208733277/893889888208977960/1334812766946459721
