### PR TITLE
[project-sequencer-statemachine] transitionToでonExitが呼ばれた場合でもステートが正しく動作するようにする

### DIFF
--- a/src/sing/sequencerStateMachine/states/moveNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/moveNoteState.ts
@@ -25,7 +25,6 @@ export class MoveNoteState
   private readonly returnStateId: IdleStateId;
 
   private currentCursorPos: PositionOnSequencer;
-  private edited: boolean;
   private applyPreview: boolean;
 
   private innerContext:
@@ -33,6 +32,7 @@ export class MoveNoteState
         targetNotesAtStart: Map<NoteId, Note>;
         previewRequestId: number;
         executePreviewProcess: boolean;
+        edited: boolean;
         guideLineTicksAtStart: number;
       }
     | undefined;
@@ -54,7 +54,6 @@ export class MoveNoteState
     this.returnStateId = args.returnStateId;
 
     this.currentCursorPos = args.cursorPosAtStart;
-    this.edited = false;
     this.applyPreview = false;
   }
 
@@ -93,7 +92,7 @@ export class MoveNoteState
       context.previewNotes.value = previewNotes.map((value) => {
         return editedNotes.get(value.id) ?? value;
       });
-      this.edited = true;
+      this.innerContext.edited = true;
     }
 
     context.guideLineTicks.value =
@@ -131,6 +130,7 @@ export class MoveNoteState
       targetNotesAtStart: targetNotesMap,
       executePreviewProcess: false,
       previewRequestId,
+      edited: false,
       guideLineTicksAtStart: guideLineTicks,
     };
   }
@@ -155,7 +155,7 @@ export class MoveNoteState
         input.mouseEvent.type === "mouseup" &&
         mouseButton === "LEFT_BUTTON"
       ) {
-        this.applyPreview = this.edited;
+        this.applyPreview = this.innerContext.edited;
         setNextState(this.returnStateId, undefined);
       }
     }

--- a/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
@@ -25,7 +25,6 @@ export class ResizeNoteLeftState
   private readonly returnStateId: IdleStateId;
 
   private currentCursorPos: PositionOnSequencer;
-  private edited: boolean;
   private applyPreview: boolean;
 
   private innerContext:
@@ -33,6 +32,7 @@ export class ResizeNoteLeftState
         targetNotesAtStart: Map<NoteId, Note>;
         previewRequestId: number;
         executePreviewProcess: boolean;
+        edited: boolean;
         guideLineTicksAtStart: number;
       }
     | undefined;
@@ -54,7 +54,6 @@ export class ResizeNoteLeftState
     this.returnStateId = args.returnStateId;
 
     this.currentCursorPos = args.cursorPosAtStart;
-    this.edited = false;
     this.applyPreview = false;
   }
 
@@ -89,7 +88,7 @@ export class ResizeNoteLeftState
       context.previewNotes.value = previewNotes.map((value) => {
         return editedNotes.get(value.id) ?? value;
       });
-      this.edited = true;
+      this.innerContext.edited = true;
     }
 
     context.guideLineTicks.value = newNotePos;
@@ -127,6 +126,7 @@ export class ResizeNoteLeftState
       targetNotesAtStart: targetNotesMap,
       executePreviewProcess: false,
       previewRequestId,
+      edited: false,
       guideLineTicksAtStart: guideLineTicks,
     };
   }
@@ -151,7 +151,7 @@ export class ResizeNoteLeftState
         input.mouseEvent.type === "mouseup" &&
         mouseButton === "LEFT_BUTTON"
       ) {
-        this.applyPreview = this.edited;
+        this.applyPreview = this.innerContext.edited;
         setNextState(this.returnStateId, undefined);
       }
     }

--- a/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
@@ -25,13 +25,14 @@ export class ResizeNoteLeftState
   private readonly returnStateId: IdleStateId;
 
   private currentCursorPos: PositionOnSequencer;
+  private edited: boolean;
+  private applyPreview: boolean;
 
   private innerContext:
     | {
         targetNotesAtStart: Map<NoteId, Note>;
         previewRequestId: number;
         executePreviewProcess: boolean;
-        edited: boolean;
         guideLineTicksAtStart: number;
       }
     | undefined;
@@ -53,6 +54,8 @@ export class ResizeNoteLeftState
     this.returnStateId = args.returnStateId;
 
     this.currentCursorPos = args.cursorPosAtStart;
+    this.edited = false;
+    this.applyPreview = false;
   }
 
   private previewResizeLeft(context: Context) {
@@ -86,7 +89,7 @@ export class ResizeNoteLeftState
       context.previewNotes.value = previewNotes.map((value) => {
         return editedNotes.get(value.id) ?? value;
       });
-      this.innerContext.edited = true;
+      this.edited = true;
     }
 
     context.guideLineTicks.value = newNotePos;
@@ -101,8 +104,10 @@ export class ResizeNoteLeftState
     for (const targetNote of targetNotesArray) {
       targetNotesMap.set(targetNote.id, targetNote);
     }
+    const mouseDownNote = getOrThrow(targetNotesMap, this.mouseDownNoteId);
 
     context.previewNotes.value = [...targetNotesArray];
+    context.guideLineTicks.value = mouseDownNote.position;
     context.nowPreviewing.value = true;
 
     const previewIfNeeded = () => {
@@ -122,7 +127,6 @@ export class ResizeNoteLeftState
       targetNotesAtStart: targetNotesMap,
       executePreviewProcess: false,
       previewRequestId,
-      edited: false,
       guideLineTicksAtStart: guideLineTicks,
     };
   }
@@ -147,6 +151,7 @@ export class ResizeNoteLeftState
         input.mouseEvent.type === "mouseup" &&
         mouseButton === "LEFT_BUTTON"
       ) {
+        this.applyPreview = this.edited;
         setNextState(this.returnStateId, undefined);
       }
     }
@@ -161,18 +166,21 @@ export class ResizeNoteLeftState
 
     cancelAnimationFrame(this.innerContext.previewRequestId);
 
-    void context.store.actions.COMMAND_UPDATE_NOTES({
-      notes: previewNotes,
-      trackId: this.targetTrackId,
-    });
-    void context.store.actions.SELECT_NOTES({ noteIds: previewNoteIds });
-
-    if (previewNotes.length === 1) {
-      void context.store.actions.PLAY_PREVIEW_SOUND({
-        noteNumber: previewNotes[0].noteNumber,
-        duration: PREVIEW_SOUND_DURATION,
+    if (this.applyPreview) {
+      void context.store.actions.COMMAND_UPDATE_NOTES({
+        notes: previewNotes,
+        trackId: this.targetTrackId,
       });
+      void context.store.actions.SELECT_NOTES({ noteIds: previewNoteIds });
+
+      if (previewNotes.length === 1) {
+        void context.store.actions.PLAY_PREVIEW_SOUND({
+          noteNumber: previewNotes[0].noteNumber,
+          duration: PREVIEW_SOUND_DURATION,
+        });
+      }
     }
+
     context.previewNotes.value = [];
     context.nowPreviewing.value = false;
   }

--- a/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
@@ -24,7 +24,6 @@ export class ResizeNoteRightState
   private readonly returnStateId: IdleStateId;
 
   private currentCursorPos: PositionOnSequencer;
-  private edited: boolean;
   private applyPreview: boolean;
 
   private innerContext:
@@ -32,6 +31,7 @@ export class ResizeNoteRightState
         targetNotesAtStart: Map<NoteId, Note>;
         previewRequestId: number;
         executePreviewProcess: boolean;
+        edited: boolean;
         guideLineTicksAtStart: number;
       }
     | undefined;
@@ -53,7 +53,6 @@ export class ResizeNoteRightState
     this.returnStateId = args.returnStateId;
 
     this.currentCursorPos = args.cursorPosAtStart;
-    this.edited = false;
     this.applyPreview = false;
   }
 
@@ -87,7 +86,7 @@ export class ResizeNoteRightState
       context.previewNotes.value = previewNotes.map((value) => {
         return editedNotes.get(value.id) ?? value;
       });
-      this.edited = true;
+      this.innerContext.edited = true;
     }
 
     context.guideLineTicks.value = newNoteEndPos;
@@ -126,6 +125,7 @@ export class ResizeNoteRightState
       targetNotesAtStart: targetNotesMap,
       executePreviewProcess: false,
       previewRequestId,
+      edited: false,
       guideLineTicksAtStart: guideLineTicks,
     };
   }
@@ -150,7 +150,7 @@ export class ResizeNoteRightState
         input.mouseEvent.type === "mouseup" &&
         mouseButton === "LEFT_BUTTON"
       ) {
-        this.applyPreview = this.edited;
+        this.applyPreview = this.innerContext.edited;
         setNextState(this.returnStateId, undefined);
       }
     }

--- a/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
@@ -24,13 +24,14 @@ export class ResizeNoteRightState
   private readonly returnStateId: IdleStateId;
 
   private currentCursorPos: PositionOnSequencer;
+  private edited: boolean;
+  private applyPreview: boolean;
 
   private innerContext:
     | {
         targetNotesAtStart: Map<NoteId, Note>;
         previewRequestId: number;
         executePreviewProcess: boolean;
-        edited: boolean;
         guideLineTicksAtStart: number;
       }
     | undefined;
@@ -52,6 +53,8 @@ export class ResizeNoteRightState
     this.returnStateId = args.returnStateId;
 
     this.currentCursorPos = args.cursorPosAtStart;
+    this.edited = false;
+    this.applyPreview = false;
   }
 
   private previewResizeRight(context: Context) {
@@ -84,7 +87,7 @@ export class ResizeNoteRightState
       context.previewNotes.value = previewNotes.map((value) => {
         return editedNotes.get(value.id) ?? value;
       });
-      this.innerContext.edited = true;
+      this.edited = true;
     }
 
     context.guideLineTicks.value = newNoteEndPos;
@@ -99,8 +102,11 @@ export class ResizeNoteRightState
     for (const targetNote of targetNotesArray) {
       targetNotesMap.set(targetNote.id, targetNote);
     }
+    const mouseDownNote = getOrThrow(targetNotesMap, this.mouseDownNoteId);
+    const noteEndPos = mouseDownNote.position + mouseDownNote.duration;
 
     context.previewNotes.value = [...targetNotesArray];
+    context.guideLineTicks.value = noteEndPos;
     context.nowPreviewing.value = true;
 
     const previewIfNeeded = () => {
@@ -120,7 +126,6 @@ export class ResizeNoteRightState
       targetNotesAtStart: targetNotesMap,
       executePreviewProcess: false,
       previewRequestId,
-      edited: false,
       guideLineTicksAtStart: guideLineTicks,
     };
   }
@@ -145,6 +150,7 @@ export class ResizeNoteRightState
         input.mouseEvent.type === "mouseup" &&
         mouseButton === "LEFT_BUTTON"
       ) {
+        this.applyPreview = this.edited;
         setNextState(this.returnStateId, undefined);
       }
     }
@@ -159,20 +165,23 @@ export class ResizeNoteRightState
 
     cancelAnimationFrame(this.innerContext.previewRequestId);
 
-    void context.store.actions.COMMAND_UPDATE_NOTES({
-      notes: previewNotes,
-      trackId: this.targetTrackId,
-    });
-    void context.store.actions.SELECT_NOTES({
-      noteIds: previewNoteIds,
-    });
-
-    if (previewNotes.length === 1) {
-      void context.store.actions.PLAY_PREVIEW_SOUND({
-        noteNumber: previewNotes[0].noteNumber,
-        duration: PREVIEW_SOUND_DURATION,
+    if (this.applyPreview) {
+      void context.store.actions.COMMAND_UPDATE_NOTES({
+        notes: previewNotes,
+        trackId: this.targetTrackId,
       });
+      void context.store.actions.SELECT_NOTES({
+        noteIds: previewNoteIds,
+      });
+
+      if (previewNotes.length === 1) {
+        void context.store.actions.PLAY_PREVIEW_SOUND({
+          noteNumber: previewNotes[0].noteNumber,
+          duration: PREVIEW_SOUND_DURATION,
+        });
+      }
     }
+
     context.previewNotes.value = [];
     context.nowPreviewing.value = false;
   }


### PR DESCRIPTION
## 内容

#2518 でtransitionToメソッドを追加したので、（processのsetNextStateではなく）transitionToでonExitが呼ばれることも考慮する必要があります。
これを考慮して、transitionToでonExitが呼ばれた場合（processが一度も呼ばれずにonExitが呼ばれた場合も含む）でもステートが正しく動作するようにします。
（mouseupの前にonExitが呼ばれた場合はプレビューの適用を行わないようにします）

また、以下も行います。
- onEnterでもguideLineTicksの更新を行うようにする
- SelectNotesWithRectStateでcontext.nowPreviewingの更新を行うようにする
## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2403

## その他
