### PR TITLE
feat: [project-sequencer-statemachine] 調整

### DIFF
--- a/src/composables/useSequencerStateMachine.ts
+++ b/src/composables/useSequencerStateMachine.ts
@@ -5,6 +5,7 @@ import {
   IdleStateId,
   PartialStore,
   Refs,
+  SequencerStateId,
 } from "@/sing/sequencerStateMachine/common";
 import { getNoteDuration } from "@/sing/domain";
 import { createSequencerStateMachine } from "@/sing/sequencerStateMachine";
@@ -38,6 +39,7 @@ export const useSequencerStateMachine = (
     guideLineTicks: ref(0),
   };
 
+  const currentStateId = ref<SequencerStateId>(initialStateId);
   const stateMachine = createSequencerStateMachine(
     {
       ...computedRefs,
@@ -45,10 +47,14 @@ export const useSequencerStateMachine = (
       store,
     },
     initialStateId,
+    (stateId: SequencerStateId) => {
+      currentStateId.value = stateId;
+    },
   );
 
   return {
     stateMachine,
+    currentStateId: computed(() => currentStateId.value),
     nowPreviewing: computed(() => refs.nowPreviewing.value),
     previewNotes: computed(() => refs.previewNotes.value),
     previewRectForRectSelect: computed(

--- a/src/composables/useSequencerStateMachine.ts
+++ b/src/composables/useSequencerStateMachine.ts
@@ -33,6 +33,7 @@ export const useSequencerStateMachine = (
   const refs: Refs = {
     nowPreviewing: ref(false),
     previewNotes: ref([]),
+    previewNoteIds: ref(new Set()),
     previewRectForRectSelect: ref(undefined),
     previewPitchEdit: ref(undefined),
     cursorState: ref("UNSET"),
@@ -57,6 +58,7 @@ export const useSequencerStateMachine = (
     currentStateId: computed(() => currentStateId.value),
     nowPreviewing: computed(() => refs.nowPreviewing.value),
     previewNotes: computed(() => refs.previewNotes.value),
+    previewNoteIds: computed(() => refs.previewNoteIds.value),
     previewRectForRectSelect: computed(
       () => refs.previewRectForRectSelect.value,
     ),

--- a/src/sing/sequencerStateMachine/common.ts
+++ b/src/sing/sequencerStateMachine/common.ts
@@ -134,6 +134,7 @@ export type SequencerStateDefinitions = StateDefinitions<
         cursorPosAtStart: PositionOnSequencer;
         targetTrackId: TrackId;
         returnStateId: IdleStateId;
+        applyImmediatelyAndExit: boolean;
       };
     },
     {

--- a/src/sing/sequencerStateMachine/common.ts
+++ b/src/sing/sequencerStateMachine/common.ts
@@ -1,5 +1,5 @@
 import { ComputedRef, Ref } from "vue";
-import { StateDefinitions } from "@/sing/stateMachine";
+import { StateDefinitions, StateId } from "@/sing/stateMachine";
 import { Rect } from "@/sing/utility";
 import { CursorState, PREVIEW_SOUND_DURATION } from "@/sing/viewHelper";
 import { Store } from "@/store";
@@ -184,6 +184,8 @@ export type SequencerStateDefinitions = StateDefinitions<
     },
   ]
 >;
+
+export type SequencerStateId = StateId<SequencerStateDefinitions>;
 
 /**
  * カーソル位置に対応する補助線の位置を取得する。

--- a/src/sing/sequencerStateMachine/common.ts
+++ b/src/sing/sequencerStateMachine/common.ts
@@ -18,8 +18,14 @@ export type PositionOnSequencer = {
 export type Input =
   | {
       readonly type: "keyboardEvent";
-      readonly targetArea: "SequencerBody";
+      readonly targetArea: "Document";
       readonly keyboardEvent: KeyboardEvent;
+    }
+  | {
+      readonly type: "mouseEvent";
+      readonly targetArea: "Window";
+      readonly mouseEvent: MouseEvent;
+      readonly cursorPos: PositionOnSequencer;
     }
   | {
       readonly type: "mouseEvent";

--- a/src/sing/sequencerStateMachine/common.ts
+++ b/src/sing/sequencerStateMachine/common.ts
@@ -69,6 +69,7 @@ export type ComputedRefs = {
 export type Refs = {
   readonly nowPreviewing: Ref<boolean>;
   readonly previewNotes: Ref<Note[]>;
+  readonly previewNoteIds: Ref<Set<NoteId>>;
   readonly previewRectForRectSelect: Ref<Rect | undefined>;
   readonly previewPitchEdit: Ref<
     | { type: "draw"; data: number[]; startFrame: number }

--- a/src/sing/sequencerStateMachine/index.ts
+++ b/src/sing/sequencerStateMachine/index.ts
@@ -3,6 +3,7 @@ import {
   IdleStateId,
   Input,
   SequencerStateDefinitions,
+  SequencerStateId,
 } from "@/sing/sequencerStateMachine/common";
 import { StateMachine } from "@/sing/stateMachine";
 
@@ -21,6 +22,7 @@ import { ErasePitchState } from "@/sing/sequencerStateMachine/states/erasePitchS
 export const createSequencerStateMachine = (
   context: Context,
   initialStateId: IdleStateId,
+  onStateChanged: (stateId: SequencerStateId) => void,
 ) => {
   return new StateMachine<SequencerStateDefinitions, Input, Context>(
     {
@@ -38,5 +40,6 @@ export const createSequencerStateMachine = (
     },
     context,
     initialStateId,
+    onStateChanged,
   );
 };

--- a/src/sing/sequencerStateMachine/states/addNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/addNoteState.ts
@@ -24,6 +24,7 @@ export class AddNoteState
   private readonly cursorPosAtStart: PositionOnSequencer;
   private readonly targetTrackId: TrackId;
   private readonly returnStateId: IdleStateId;
+  private readonly applyImmediatelyAndExit: boolean;
 
   private currentCursorPos: PositionOnSequencer;
   private applyPreview: boolean;
@@ -40,10 +41,12 @@ export class AddNoteState
     cursorPosAtStart: PositionOnSequencer;
     targetTrackId: TrackId;
     returnStateId: IdleStateId;
+    applyImmediatelyAndExit: boolean;
   }) {
     this.cursorPosAtStart = args.cursorPosAtStart;
     this.targetTrackId = args.targetTrackId;
     this.returnStateId = args.returnStateId;
+    this.applyImmediatelyAndExit = args.applyImmediatelyAndExit;
 
     this.currentCursorPos = args.cursorPosAtStart;
     this.applyPreview = false;
@@ -75,7 +78,13 @@ export class AddNoteState
     context.guideLineTicks.value = noteEndPos;
   }
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+    setNextState,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const noteToAdd = {
       id: NoteId(crypto.randomUUID()),
@@ -110,6 +119,11 @@ export class AddNoteState
       executePreviewProcess: false,
       previewRequestId,
     };
+
+    if (this.applyImmediatelyAndExit) {
+      this.applyPreview = true;
+      setNextState(this.returnStateId, undefined);
+    }
   }
 
   process({

--- a/src/sing/sequencerStateMachine/states/addNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/addNoteState.ts
@@ -125,7 +125,7 @@ export class AddNoteState
     if (input.type === "mouseEvent") {
       const mouseButton = getButton(input.mouseEvent);
 
-      if (input.targetArea === "SequencerBody") {
+      if (input.targetArea === "Window") {
         if (input.mouseEvent.type === "mousemove") {
           this.currentCursorPos = input.cursorPos;
           this.innerContext.executePreviewProcess = true;

--- a/src/sing/sequencerStateMachine/states/addNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/addNoteState.ts
@@ -87,6 +87,7 @@ export class AddNoteState
     const noteEndPos = noteToAdd.position + noteToAdd.duration;
 
     context.previewNotes.value = [noteToAdd];
+    context.previewNoteIds.value = new Set([noteToAdd.id]);
     context.cursorState.value = "DRAW";
     context.guideLineTicks.value = noteEndPos;
     context.nowPreviewing.value = true;
@@ -165,6 +166,7 @@ export class AddNoteState
     }
 
     context.previewNotes.value = [];
+    context.previewNoteIds.value = new Set();
     context.cursorState.value = "UNSET";
     context.nowPreviewing.value = false;
   }

--- a/src/sing/sequencerStateMachine/states/drawPitchState.ts
+++ b/src/sing/sequencerStateMachine/states/drawPitchState.ts
@@ -168,7 +168,7 @@ export class DrawPitchState
     if (input.type === "mouseEvent") {
       const mouseButton = getButton(input.mouseEvent);
 
-      if (input.targetArea === "SequencerBody") {
+      if (input.targetArea === "Window") {
         if (input.mouseEvent.type === "mousemove") {
           this.currentCursorPos = input.cursorPos;
           this.innerContext.executePreviewProcess = true;

--- a/src/sing/sequencerStateMachine/states/drawPitchState.ts
+++ b/src/sing/sequencerStateMachine/states/drawPitchState.ts
@@ -118,7 +118,12 @@ export class DrawPitchState
     this.innerContext.prevCursorPos = this.currentCursorPos;
   }
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     context.previewPitchEdit.value = {
       type: "draw",
       data: [this.cursorPosAtStart.frequency],

--- a/src/sing/sequencerStateMachine/states/drawPitchToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/drawPitchToolIdleState.ts
@@ -12,7 +12,12 @@ export class DrawPitchToolIdleState
 {
   readonly id = "drawPitchToolIdle";
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     this.updateCursorState(context, context.isCommandOrCtrlKeyDown.value);
   }
 

--- a/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
@@ -1,13 +1,16 @@
 import { SetNextState, State } from "@/sing/stateMachine";
 import {
   Context,
-  executeNotesSelectionProcess,
   getGuideLineTicks,
   Input,
+  selectNotesInRange,
+  selectOnlyThisNoteAndPlayPreviewSound,
   SequencerStateDefinitions,
+  toggleNoteSelection,
 } from "@/sing/sequencerStateMachine/common";
 import { getButton, isSelfEventTarget } from "@/sing/viewHelper";
 import { isOnCommandOrCtrlKeyDown } from "@/store/utility";
+import { Note } from "@/store/type";
 
 export class EditNotesToolIdleState
   implements State<SequencerStateDefinitions, Input, Context>
@@ -70,7 +73,11 @@ export class EditNotesToolIdleState
             });
           }
         } else if (input.targetArea === "Note") {
-          executeNotesSelectionProcess(context, input.mouseEvent, input.note);
+          this.executeNotesSelectionProcess(
+            context,
+            input.mouseEvent,
+            input.note,
+          );
           setNextState("moveNote", {
             cursorPosAtStart: input.cursorPos,
             targetTrackId: selectedTrackId,
@@ -79,7 +86,11 @@ export class EditNotesToolIdleState
             returnStateId: this.id,
           });
         } else if (input.targetArea === "NoteLeftEdge") {
-          executeNotesSelectionProcess(context, input.mouseEvent, input.note);
+          this.executeNotesSelectionProcess(
+            context,
+            input.mouseEvent,
+            input.note,
+          );
           setNextState("resizeNoteLeft", {
             cursorPosAtStart: input.cursorPos,
             targetTrackId: selectedTrackId,
@@ -88,7 +99,11 @@ export class EditNotesToolIdleState
             returnStateId: this.id,
           });
         } else if (input.targetArea === "NoteRightEdge") {
-          executeNotesSelectionProcess(context, input.mouseEvent, input.note);
+          this.executeNotesSelectionProcess(
+            context,
+            input.mouseEvent,
+            input.note,
+          );
           setNextState("resizeNoteRight", {
             cursorPosAtStart: input.cursorPos,
             targetTrackId: selectedTrackId,
@@ -116,6 +131,20 @@ export class EditNotesToolIdleState
       context.cursorState.value = "UNSET";
     } else {
       context.cursorState.value = "DRAW";
+    }
+  }
+
+  private executeNotesSelectionProcess(
+    context: Context,
+    mouseEvent: MouseEvent,
+    mouseDownNote: Note,
+  ) {
+    if (mouseEvent.shiftKey) {
+      selectNotesInRange(context, mouseDownNote);
+    } else if (isOnCommandOrCtrlKeyDown(mouseEvent)) {
+      toggleNoteSelection(context, mouseDownNote);
+    } else if (!context.selectedNoteIds.value.has(mouseDownNote.id)) {
+      selectOnlyThisNoteAndPlayPreviewSound(context, mouseDownNote);
     }
   }
 }

--- a/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
@@ -17,7 +17,12 @@ export class EditNotesToolIdleState
 {
   readonly id = "editNotesToolIdle";
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     this.updateCursorState(
       context,
       context.isCommandOrCtrlKeyDown.value,
@@ -73,6 +78,7 @@ export class EditNotesToolIdleState
               cursorPosAtStart: input.cursorPos,
               targetTrackId: selectedTrackId,
               returnStateId: this.id,
+              applyImmediatelyAndExit: false,
             });
           }
         } else if (input.targetArea === "Note") {

--- a/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
@@ -44,7 +44,10 @@ export class EditNotesToolIdleState
       const mouseButton = getButton(input.mouseEvent);
       const selectedTrackId = context.selectedTrackId.value;
 
-      if (input.targetArea === "SequencerBody") {
+      if (
+        input.targetArea === "Window" &&
+        input.mouseEvent.type === "mousemove"
+      ) {
         context.guideLineTicks.value = getGuideLineTicks(
           input.cursorPos,
           context,

--- a/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
@@ -15,7 +15,11 @@ export class EditNotesToolIdleState
   readonly id = "editNotesToolIdle";
 
   onEnter(context: Context) {
-    this.updateCursorState(context, context.isCommandOrCtrlKeyDown.value);
+    this.updateCursorState(
+      context,
+      context.isCommandOrCtrlKeyDown.value,
+      context.isShiftKeyDown.value,
+    );
   }
 
   process({
@@ -31,6 +35,7 @@ export class EditNotesToolIdleState
       this.updateCursorState(
         context,
         isOnCommandOrCtrlKeyDown(input.keyboardEvent),
+        input.keyboardEvent.shiftKey,
       );
     } else if (input.type === "mouseEvent") {
       const mouseButton = getButton(input.mouseEvent);
@@ -100,9 +105,15 @@ export class EditNotesToolIdleState
     context.cursorState.value = "UNSET";
   }
 
-  private updateCursorState(context: Context, isCommandOrCtrlKeyDown: boolean) {
-    if (isCommandOrCtrlKeyDown) {
+  private updateCursorState(
+    context: Context,
+    isCommandOrCtrlKeyDown: boolean,
+    isShiftKeyDown: boolean,
+  ) {
+    if (isShiftKeyDown) {
       context.cursorState.value = "CROSSHAIR";
+    } else if (isCommandOrCtrlKeyDown) {
+      context.cursorState.value = "UNSET";
     } else {
       context.cursorState.value = "DRAW";
     }

--- a/src/sing/sequencerStateMachine/states/erasePitchState.ts
+++ b/src/sing/sequencerStateMachine/states/erasePitchState.ts
@@ -67,7 +67,12 @@ export class ErasePitchState
     context.previewPitchEdit.value = tempPitchEdit;
   }
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     context.previewPitchEdit.value = {
       type: "erase",
       startFrame: this.cursorPosAtStart.frame,

--- a/src/sing/sequencerStateMachine/states/erasePitchState.ts
+++ b/src/sing/sequencerStateMachine/states/erasePitchState.ts
@@ -109,7 +109,7 @@ export class ErasePitchState
     if (input.type === "mouseEvent") {
       const mouseButton = getButton(input.mouseEvent);
 
-      if (input.targetArea === "SequencerBody") {
+      if (input.targetArea === "Window") {
         if (input.mouseEvent.type === "mousemove") {
           this.currentCursorPos = input.cursorPos;
           this.innerContext.executePreviewProcess = true;

--- a/src/sing/sequencerStateMachine/states/erasePitchToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/erasePitchToolIdleState.ts
@@ -11,7 +11,12 @@ export class ErasePitchToolIdleState
 {
   readonly id = "erasePitchToolIdle";
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     context.cursorState.value = "UNSET";
   }
 

--- a/src/sing/sequencerStateMachine/states/moveNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/moveNoteState.ts
@@ -99,7 +99,12 @@ export class MoveNoteState
       this.innerContext.guideLineTicksAtStart + movingTicks;
   }
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const targetNotesArray = context.notesInSelectedTrack.value.filter(
       (value) => this.targetNoteIds.has(value.id),

--- a/src/sing/sequencerStateMachine/states/moveNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/moveNoteState.ts
@@ -150,7 +150,7 @@ export class MoveNoteState
     if (input.type === "mouseEvent") {
       const mouseButton = getButton(input.mouseEvent);
 
-      if (input.targetArea === "SequencerBody") {
+      if (input.targetArea === "Window") {
         if (input.mouseEvent.type === "mousemove") {
           this.currentCursorPos = input.cursorPos;
           this.innerContext.executePreviewProcess = true;

--- a/src/sing/sequencerStateMachine/states/moveNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/moveNoteState.ts
@@ -110,6 +110,7 @@ export class MoveNoteState
     }
 
     context.previewNotes.value = [...targetNotesArray];
+    context.previewNoteIds.value = new Set(this.targetNoteIds);
     context.cursorState.value = "MOVE";
     context.guideLineTicks.value = guideLineTicks;
     context.nowPreviewing.value = true;
@@ -192,6 +193,7 @@ export class MoveNoteState
     }
 
     context.previewNotes.value = [];
+    context.previewNoteIds.value = new Set();
     context.cursorState.value = "UNSET";
     context.nowPreviewing.value = false;
   }

--- a/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
@@ -106,6 +106,7 @@ export class ResizeNoteLeftState
     const mouseDownNote = getOrThrow(targetNotesMap, this.mouseDownNoteId);
 
     context.previewNotes.value = [...targetNotesArray];
+    context.previewNoteIds.value = new Set(this.targetNoteIds);
     context.cursorState.value = "EW_RESIZE";
     context.guideLineTicks.value = mouseDownNote.position;
     context.nowPreviewing.value = true;
@@ -186,6 +187,7 @@ export class ResizeNoteLeftState
     }
 
     context.previewNotes.value = [];
+    context.previewNoteIds.value = new Set();
     context.cursorState.value = "UNSET";
     context.nowPreviewing.value = false;
   }

--- a/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
@@ -146,7 +146,7 @@ export class ResizeNoteLeftState
     if (input.type === "mouseEvent") {
       const mouseButton = getButton(input.mouseEvent);
 
-      if (input.targetArea === "SequencerBody") {
+      if (input.targetArea === "Window") {
         if (input.mouseEvent.type === "mousemove") {
           this.currentCursorPos = input.cursorPos;
           this.innerContext.executePreviewProcess = true;

--- a/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
@@ -94,7 +94,12 @@ export class ResizeNoteLeftState
     context.guideLineTicks.value = newNotePos;
   }
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const targetNotesArray = context.notesInSelectedTrack.value.filter(
       (value) => this.targetNoteIds.has(value.id),

--- a/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
@@ -92,7 +92,12 @@ export class ResizeNoteRightState
     context.guideLineTicks.value = newNoteEndPos;
   }
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const targetNotesArray = context.notesInSelectedTrack.value.filter(
       (value) => this.targetNoteIds.has(value.id),

--- a/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
@@ -105,6 +105,7 @@ export class ResizeNoteRightState
     const noteEndPos = mouseDownNote.position + mouseDownNote.duration;
 
     context.previewNotes.value = [...targetNotesArray];
+    context.previewNoteIds.value = new Set(this.targetNoteIds);
     context.cursorState.value = "EW_RESIZE";
     context.guideLineTicks.value = noteEndPos;
     context.nowPreviewing.value = true;
@@ -187,6 +188,7 @@ export class ResizeNoteRightState
     }
 
     context.previewNotes.value = [];
+    context.previewNoteIds.value = new Set();
     context.cursorState.value = "UNSET";
     context.nowPreviewing.value = false;
   }

--- a/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
@@ -145,7 +145,7 @@ export class ResizeNoteRightState
     if (input.type === "mouseEvent") {
       const mouseButton = getButton(input.mouseEvent);
 
-      if (input.targetArea === "SequencerBody") {
+      if (input.targetArea === "Window") {
         if (input.mouseEvent.type === "mousemove") {
           this.currentCursorPos = input.cursorPos;
           this.innerContext.executePreviewProcess = true;

--- a/src/sing/sequencerStateMachine/states/selectNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/selectNotesToolIdleState.ts
@@ -17,7 +17,12 @@ export class SelectNotesToolIdleState
 {
   readonly id = "selectNotesToolIdle";
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     this.updateCursorState(context, context.isShiftKeyDown.value);
   }
 
@@ -102,6 +107,7 @@ export class SelectNotesToolIdleState
             cursorPosAtStart: input.cursorPos,
             targetTrackId: selectedTrackId,
             returnStateId: this.id,
+            applyImmediatelyAndExit: true,
           });
         }
       }

--- a/src/sing/sequencerStateMachine/states/selectNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/selectNotesToolIdleState.ts
@@ -36,7 +36,10 @@ export class SelectNotesToolIdleState
       const mouseButton = getButton(input.mouseEvent);
       const selectedTrackId = context.selectedTrackId.value;
 
-      if (input.targetArea === "SequencerBody") {
+      if (
+        input.targetArea === "Window" &&
+        input.mouseEvent.type === "mousemove"
+      ) {
         context.guideLineTicks.value = getGuideLineTicks(
           input.cursorPos,
           context,

--- a/src/sing/sequencerStateMachine/states/selectNotesWithRectState.ts
+++ b/src/sing/sequencerStateMachine/states/selectNotesWithRectState.ts
@@ -48,7 +48,12 @@ export class SelectNotesWithRectState
     };
   }
 
-  onEnter(context: Context) {
+  onEnter({
+    context,
+  }: {
+    context: Context;
+    setNextState: SetNextState<SequencerStateDefinitions>;
+  }) {
     this.updatePreviewRect(context);
 
     context.cursorState.value = "CROSSHAIR";

--- a/src/sing/sequencerStateMachine/states/selectNotesWithRectState.ts
+++ b/src/sing/sequencerStateMachine/states/selectNotesWithRectState.ts
@@ -68,7 +68,7 @@ export class SelectNotesWithRectState
     if (input.type === "mouseEvent") {
       const mouseButton = getButton(input.mouseEvent);
 
-      if (input.targetArea === "SequencerBody") {
+      if (input.targetArea === "Window") {
         if (input.mouseEvent.type === "mousemove") {
           this.currentCursorPos = input.cursorPos;
           this.updatePreviewRect(context);


### PR DESCRIPTION
## 内容

以下を行います。
- editNotesToolIdleStateのupdateCursorStateを修正（ aa0b5bdb71e78104fe6d695a41e0586894727ac0 ）
- `executeNotesSelectionProcess`を、`selectNotesInRange`、`toggleNoteSelection`、`selectOnlyThisNoteAndPlayPreviewSound`に分割（ 016265a8a62b9b8ddfe7b567332286d0d464ecd4 ）
- SequencerStateIdを追加し、ステート遷移時にコールバックを呼び出すようにする（ a64fb0cc4c15a3bb7a63b8d9b39732329507e1d3 ）
- InputのtargetAreaを修正（ 472da4121d7ab8040f6bb56f1a873a5f5e7dce9f ）
- refsにpreviewNoteIdsを追加（ eeb804183dcfb99fd888967dfdd92c71b5e65585 ）
- onEnterでもsetNextStateできるようにして、ノートの追加をすぐに適用できるようにする（ e34808d141c469eb7deae4a9deecc76d88859da8 ）

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2403

## その他
