### PR TITLE
feat: [project-sequencer-statemachine] previewNoteIdsを追加

### DIFF
--- a/src/composables/useSequencerStateMachine.ts
+++ b/src/composables/useSequencerStateMachine.ts
@@ -32,6 +32,7 @@ export const useSequencerStateMachine = (
   const refs: Refs = {
     nowPreviewing: ref(false),
     previewNotes: ref([]),
+    previewNoteIds: ref(new Set()),
     previewRectForRectSelect: ref(undefined),
     previewPitchEdit: ref(undefined),
     cursorState: ref("UNSET"),
@@ -51,6 +52,7 @@ export const useSequencerStateMachine = (
     stateMachine,
     nowPreviewing: computed(() => refs.nowPreviewing.value),
     previewNotes: computed(() => refs.previewNotes.value),
+    previewNoteIds: computed(() => refs.previewNoteIds.value),
     previewRectForRectSelect: computed(
       () => refs.previewRectForRectSelect.value,
     ),

--- a/src/sing/sequencerStateMachine/common.ts
+++ b/src/sing/sequencerStateMachine/common.ts
@@ -64,6 +64,7 @@ export type ComputedRefs = {
 export type Refs = {
   readonly nowPreviewing: Ref<boolean>;
   readonly previewNotes: Ref<Note[]>;
+  readonly previewNoteIds: Ref<Set<NoteId>>;
   readonly previewRectForRectSelect: Ref<Rect | undefined>;
   readonly previewPitchEdit: Ref<
     | { type: "draw"; data: number[]; startFrame: number }

--- a/src/sing/sequencerStateMachine/states/addNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/addNoteState.ts
@@ -87,6 +87,7 @@ export class AddNoteState
     const noteEndPos = noteToAdd.position + noteToAdd.duration;
 
     context.previewNotes.value = [noteToAdd];
+    context.previewNoteIds.value = new Set([noteToAdd.id]);
     context.cursorState.value = "DRAW";
     context.guideLineTicks.value = noteEndPos;
     context.nowPreviewing.value = true;
@@ -165,6 +166,7 @@ export class AddNoteState
     }
 
     context.previewNotes.value = [];
+    context.previewNoteIds.value = new Set();
     context.cursorState.value = "UNSET";
     context.nowPreviewing.value = false;
   }

--- a/src/sing/sequencerStateMachine/states/moveNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/moveNoteState.ts
@@ -110,6 +110,7 @@ export class MoveNoteState
     }
 
     context.previewNotes.value = [...targetNotesArray];
+    context.previewNoteIds.value = new Set(this.targetNoteIds);
     context.cursorState.value = "MOVE";
     context.guideLineTicks.value = guideLineTicks;
     context.nowPreviewing.value = true;
@@ -192,6 +193,7 @@ export class MoveNoteState
     }
 
     context.previewNotes.value = [];
+    context.previewNoteIds.value = new Set();
     context.cursorState.value = "UNSET";
     context.nowPreviewing.value = false;
   }

--- a/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
@@ -106,6 +106,7 @@ export class ResizeNoteLeftState
     const mouseDownNote = getOrThrow(targetNotesMap, this.mouseDownNoteId);
 
     context.previewNotes.value = [...targetNotesArray];
+    context.previewNoteIds.value = new Set(this.targetNoteIds);
     context.cursorState.value = "EW_RESIZE";
     context.guideLineTicks.value = mouseDownNote.position;
     context.nowPreviewing.value = true;
@@ -186,6 +187,7 @@ export class ResizeNoteLeftState
     }
 
     context.previewNotes.value = [];
+    context.previewNoteIds.value = new Set();
     context.cursorState.value = "UNSET";
     context.nowPreviewing.value = false;
   }

--- a/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
@@ -105,6 +105,7 @@ export class ResizeNoteRightState
     const noteEndPos = mouseDownNote.position + mouseDownNote.duration;
 
     context.previewNotes.value = [...targetNotesArray];
+    context.previewNoteIds.value = new Set(this.targetNoteIds);
     context.cursorState.value = "EW_RESIZE";
     context.guideLineTicks.value = noteEndPos;
     context.nowPreviewing.value = true;
@@ -187,6 +188,7 @@ export class ResizeNoteRightState
     }
 
     context.previewNotes.value = [];
+    context.previewNoteIds.value = new Set();
     context.cursorState.value = "UNSET";
     context.nowPreviewing.value = false;
   }


### PR DESCRIPTION
## 内容

以下のようなpreviewNotesからpreviewNoteIdsを算出する形
```ts
const previewNoteIds = computed(() => {
  return new Set(previewNotes.value.map((note) => note.id));
};
```
だと、previewNotesが更新されるたびにpreviewNoteIdsも更新されてしまうので、プレビュー開始時に1回だけ設定（更新）されるpreviewNoteIdsを追加します。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2403

## その他
