### PR TITLE
refactor: getAppVersion()をなくす

### DIFF
--- a/src/backend/browser/sandbox.ts
+++ b/src/backend/browser/sandbox.ts
@@ -57,13 +57,6 @@ function onReceivedIPCMsg(listeners: {
  * まだ開発中のため、Browser版の実装も同時に行えない場合は、メソッドを追加して throw new Error() する
  */
 export const api: Sandbox = {
-  getAppInfos() {
-    const appInfo = {
-      name: import.meta.env.VITE_APP_NAME,
-      version: import.meta.env.VITE_APP_VERSION,
-    };
-    return Promise.resolve(appInfo);
-  },
   async getTextAsset(textType) {
     const fileName = AssetTextFileNames[textType];
     const v = await fetch(toStaticPath(fileName));

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -333,15 +333,6 @@ const retryShowSaveDialogWhileSafeDir = async <
 
 // プロセス間通信
 registerIpcMainHandle<IpcMainHandle>({
-  GET_APP_INFOS: () => {
-    const name = app.getName();
-    const version = app.getVersion();
-    return {
-      name,
-      version,
-    };
-  },
-
   GET_TEXT_ASSET: async (_, textType) => {
     const fileName = path.join(__static, AssetTextFileNames[textType]);
     const text = await fs.promises.readFile(fileName, "utf-8");

--- a/src/backend/electron/preload.ts
+++ b/src/backend/electron/preload.ts
@@ -19,10 +19,6 @@ const ipcRendererInvokeProxy = new Proxy(
 ) as IpcRendererInvoke;
 
 const api: Sandbox = {
-  getAppInfos: async () => {
-    return await ipcRendererInvokeProxy.GET_APP_INFOS();
-  },
-
   getTextAsset: (textType) => {
     return ipcRendererInvokeProxy.GET_TEXT_ASSET(textType) as Promise<
       TextAsset[typeof textType]

--- a/src/components/Dialog/HelpDialog/HelpDialog.vue
+++ b/src/components/Dialog/HelpDialog/HelpDialog.vue
@@ -85,6 +85,7 @@ import { UpdateInfo as UpdateInfoObject, UrlString } from "@/type/preload";
 import { useStore } from "@/store";
 import { useFetchNewUpdateInfos } from "@/composables/useFetchNewUpdateInfos";
 import { createLogger } from "@/helpers/log";
+import { getAppInfos } from "@/domain/appInfo";
 
 type PageItem = {
   type: "item";
@@ -115,7 +116,7 @@ if (!import.meta.env.VITE_LATEST_UPDATE_INFOS_URL) {
   );
 }
 const newUpdateResult = useFetchNewUpdateInfos(
-  () => window.backend.getAppInfos().then((obj) => obj.version), // アプリのバージョン
+  () => getAppInfos().version,
   UrlString(import.meta.env.VITE_LATEST_UPDATE_INFOS_URL),
 );
 

--- a/src/components/Dialog/UpdateNotificationDialog/Container.vue
+++ b/src/components/Dialog/UpdateNotificationDialog/Container.vue
@@ -20,6 +20,7 @@ import UpdateNotificationDialog from "./Presentation.vue";
 import { useFetchNewUpdateInfos } from "@/composables/useFetchNewUpdateInfos";
 import { useStore } from "@/store";
 import { UrlString } from "@/type/preload";
+import { getAppInfos } from "@/domain/appInfo";
 
 const props = defineProps<{
   canOpenDialog: boolean; // ダイアログを開いても良いかどうか
@@ -44,9 +45,7 @@ if (!import.meta.env.VITE_LATEST_UPDATE_INFOS_URL) {
 
 // アプリのバージョンとスキップしたバージョンのうち、新しい方を返す
 const currentVersionGetter = async () => {
-  const appVersion = await window.backend
-    .getAppInfos()
-    .then((obj) => obj.version);
+  const appVersion = getAppInfos().version;
 
   await store.actions.WAIT_VUEX_READY({ timeout: 15000 });
   const skipUpdateVersion = store.state.skipUpdateVersion ?? "0.0.0";

--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -37,6 +37,7 @@ import { useStore } from "@/store";
 import { HotkeyAction, useHotkeyManager } from "@/plugins/hotkeyPlugin";
 import { useEngineIcons } from "@/composables/useEngineIcons";
 import HelpDialog from "@/components/Dialog/HelpDialog/HelpDialog.vue";
+import { getAppInfos } from "@/domain/appInfo";
 
 const props = defineProps<{
   /** 「ファイル」メニューのサブメニュー */
@@ -52,7 +53,6 @@ const props = defineProps<{
 const $q = useQuasar();
 const store = useStore();
 const { registerHotkeyWithCleanup } = useHotkeyManager();
-const currentVersion = ref("");
 
 /** 追加のバージョン情報。コミットハッシュなどを書ける。 */
 const extraVersionInfo = import.meta.env.VITE_EXTRA_VERSION_INFO;
@@ -77,9 +77,6 @@ const defaultEngineAltPortTo = computed<string | undefined>(() => {
   }
 });
 
-void window.backend.getAppInfos().then((obj) => {
-  currentVersion.value = obj.version;
-});
 const isMultiEngineOffMode = computed(() => store.state.isMultiEngineOffMode);
 const uiLocked = computed(() => store.getters.UI_LOCKED);
 const menubarLocked = computed(() => store.getters.MENUBAR_LOCKED);
@@ -96,7 +93,7 @@ const titleText = computed(
     (isEdited.value ? "*" : "") +
     (projectName.value != undefined ? projectName.value + " - " : "") +
     "VOICEVOX" +
-    (currentVersion.value ? " - Ver. " + currentVersion.value : "") +
+    (" - Ver. " + getAppInfos().version) +
     (extraVersionInfo ? ` (${extraVersionInfo})` : "") +
     (isMultiEngineOffMode.value ? " - マルチエンジンオフ" : "") +
     (defaultEngineAltPortTo.value != null

--- a/src/composables/useFetchNewUpdateInfos.ts
+++ b/src/composables/useFetchNewUpdateInfos.ts
@@ -8,7 +8,7 @@ import { UpdateInfo, UrlString, updateInfoSchema } from "@/type/preload";
  * あれば最新バージョンと、現在より新しいバージョンの情報を返す。
  */
 export const useFetchNewUpdateInfos = (
-  currentVersionGetter: () => Promise<string>,
+  currentVersionGetter: () => string | Promise<string>,
   newUpdateInfosUrl: UrlString,
 ) => {
   const result = ref<

--- a/src/domain/appInfo.ts
+++ b/src/domain/appInfo.ts
@@ -1,0 +1,7 @@
+/** アプリの情報を返す */
+export function getAppInfos() {
+  return {
+    name: import.meta.env.VITE_APP_NAME,
+    version: import.meta.env.VITE_APP_VERSION,
+  };
+}

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -28,6 +28,7 @@ import {
   showQuestionDialog,
 } from "@/components/Dialog/Dialog";
 import { uuid4 } from "@/helpers/random";
+import { getAppInfos } from "@/domain/appInfo";
 
 export const projectStoreState: ProjectStoreState = {
   savedLastCommandIds: { talk: null, song: null },
@@ -286,7 +287,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
           await context.actions.APPEND_RECENTLY_USED_PROJECT({
             filePath,
           });
-          const appInfos = await window.backend.getAppInfos();
+          const appVersion = getAppInfos().version;
           const {
             audioItems,
             audioKeys,
@@ -297,7 +298,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             trackOrder,
           } = context.state;
           const projectData: LatestProjectType = {
-            appVersion: appInfos.version,
+            appVersion,
             talk: {
               audioKeys,
               audioItems,

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -18,11 +18,6 @@ import { HotkeySettingType } from "@/domain/hotkeyAction";
  * invoke, handle
  */
 export type IpcIHData = {
-  GET_APP_INFOS: {
-    args: [];
-    return: AppInfos;
-  };
-
   GET_TEXT_ASSET: {
     args: [textType: keyof TextAsset];
     return: TextAsset[keyof TextAsset];

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -1,5 +1,4 @@
 import {
-  AppInfos,
   ConfigType,
   EngineDirValidationResult,
   EngineId,

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -70,7 +70,6 @@ export type TextAsset = {
 };
 
 export interface Sandbox {
-  getAppInfos(): Promise<AppInfos>;
   getTextAsset<K extends keyof TextAsset>(textType: K): Promise<TextAsset[K]>;
   getAltPortInfos(): Promise<AltPortInfos>;
   showSaveDirectoryDialog(obj: { title: string }): Promise<string | undefined>;


### PR DESCRIPTION
## 内容

たぶんwindow.backendからこの関数を省いても問題ないと思うので省き、ついでにipc通信からも省きます。

おそらく、最初期の実装だとelectron側から持ってこないといけなかった･･･？
今は直でVITEから得れば良い気がします。

## その他

- https://github.com/VOICEVOX/voicevox/pull/2521#discussion_r1957344395

のレビュー時に思い当たりました。