### PR TITLE
feat: [project-sequencer-statemachine] ダブルクリック時はaddNoteStateに遷移せずに直接ノート追加の処理を行うようにする

### DIFF
--- a/src/sing/sequencerStateMachine/states/addNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/addNoteState.ts
@@ -15,6 +15,7 @@ import {
   PREVIEW_SOUND_DURATION,
 } from "@/sing/viewHelper";
 import { clamp } from "@/sing/utility";
+import { uuid4 } from "@/helpers/random";
 
 export class AddNoteState
   implements State<SequencerStateDefinitions, Input, Context>
@@ -78,7 +79,7 @@ export class AddNoteState
   onEnter(context: Context) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const noteToAdd = {
-      id: NoteId(crypto.randomUUID()),
+      id: NoteId(uuid4()),
       position: Math.max(0, guideLineTicks),
       duration: context.snapTicks.value,
       noteNumber: clamp(this.cursorPosAtStart.noteNumber, 0, 127),

--- a/src/sing/sequencerStateMachine/states/selectNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/selectNotesToolIdleState.ts
@@ -18,6 +18,7 @@ import { isOnCommandOrCtrlKeyDown } from "@/store/utility";
 import { Note } from "@/store/type";
 import { NoteId } from "@/type/preload";
 import { clamp } from "@/sing/utility";
+import { uuid4 } from "@/helpers/random";
 
 export class SelectNotesToolIdleState
   implements State<SequencerStateDefinitions, Input, Context>
@@ -108,7 +109,7 @@ export class SelectNotesToolIdleState
 
           const guideLineTicks = getGuideLineTicks(input.cursorPos, context);
           const noteToAdd = {
-            id: NoteId(crypto.randomUUID()),
+            id: NoteId(uuid4()),
             position: Math.max(0, guideLineTicks),
             duration: context.snapTicks.value,
             noteNumber: clamp(input.cursorPos.noteNumber, 0, 127),


### PR DESCRIPTION
## 内容

ノート編集の選択優先ツールでダブルクリックしたときはノート追加になりますが、このノート追加では「ドラッグでノートの長さを決める」というのは行わずに、すぐにノートの追加を適用させる必要があります。
https://github.com/VOICEVOX/voicevox/blob/074bcec52dcb5a16e4c2acee702fc1bc7d9c061c/src/components/Sing/ScoreSequencer.vue#L1442-L1448

なので、ダブルクリック時はaddNoteStateに遷移せずに、直接ノート追加の処理を行うようにします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2403

## その他
