### PR TITLE
chore: backendから情報を同期している関数の名前をGETからPULLに変更

### DIFF
--- a/docs/res/エンジン再起動シーケンス図.md
+++ b/docs/res/エンジン再起動シーケンス図.md
@@ -16,7 +16,7 @@ flowchart LR
       939785 --> 494722["runtimeInfo.exportFile"]
     end
     subgraph 512074["Vuex.POST_ENGINE_START"]
-      623200["Vuex.GET_ALT_PORT_INFOS"] --> 225947["各エンジン"]
+      623200["Vuex.PULL_ALT_PORT_INFOS"] --> 225947["各エンジン"]
       subgraph 225947["各エンジン"]
         489573{" "} -->|"state==STARTING"| 445649["Vuex.START_WAITING_ENGINE"]
         445649 --> 722638["Vuex.FETCH_AND_SET_ENGINE_MANIFEST"]

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -121,7 +121,7 @@ onMounted(async () => {
   // エンジンの初期化開始
 
   // エンジン情報取得
-  await store.actions.GET_ENGINE_INFOS();
+  await store.actions.PULL_AND_INIT_ENGINE_INFOS();
 
   // URLパラメータに従ってマルチエンジンをオフにする
   const isMultiEngineOffMode = urlParams.get("isMultiEngineOffMode") === "true";

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -13,7 +13,10 @@ export const engineStoreState: EngineStoreState = {
 const { info, error } = createLogger("store/engine");
 
 export const engineStore = createPartialStore<EngineStoreTypes>({
-  /** backendのエンジン情報をstateに同期して初期化する。 */
+  /**
+   * backendのエンジン情報をstateに同期して初期化する。
+   * エンジンIDも同期する。
+   */
   PULL_AND_INIT_ENGINE_INFOS: {
     async action({ state, mutations }) {
       let engineInfos = await window.backend.engineInfos();
@@ -37,6 +40,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
+  /** backendのエンジン情報をstateに同期する。 */
   PULL_ENGINE_INFOS: {
     async action({ mutations }, { engineIds }) {
       const engineInfos = await window.backend.engineInfos();

--- a/src/store/engine.ts
+++ b/src/store/engine.ts
@@ -13,7 +13,8 @@ export const engineStoreState: EngineStoreState = {
 const { info, error } = createLogger("store/engine");
 
 export const engineStore = createPartialStore<EngineStoreTypes>({
-  GET_ENGINE_INFOS: {
+  /** backendのエンジン情報をstateに同期して初期化する。 */
+  PULL_AND_INIT_ENGINE_INFOS: {
     async action({ state, mutations }) {
       let engineInfos = await window.backend.engineInfos();
 
@@ -36,7 +37,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
-  GET_ONLY_ENGINE_INFOS: {
+  PULL_ENGINE_INFOS: {
     async action({ mutations }, { engineIds }) {
       const engineInfos = await window.backend.engineInfos();
       for (const engineInfo of engineInfos) {
@@ -64,7 +65,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
     },
   },
 
-  GET_ALT_PORT_INFOS: {
+  PULL_ALT_PORT_INFOS: {
     async action({ mutations }) {
       const altPortInfos = await window.backend.getAltPortInfos();
       mutations.SET_ALT_PORT_INFOS({ altPortInfos });
@@ -223,7 +224,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
         }),
       );
 
-      await actions.GET_ONLY_ENGINE_INFOS({ engineIds });
+      await actions.PULL_ENGINE_INFOS({ engineIds });
 
       const result = await actions.POST_ENGINE_START({
         engineIds,
@@ -235,7 +236,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
 
   POST_ENGINE_START: {
     async action({ state, actions }, { engineIds }) {
-      await actions.GET_ALT_PORT_INFOS();
+      await actions.PULL_ALT_PORT_INFOS();
       const result = await Promise.all(
         engineIds.map(async (engineId) => {
           if (state.engineStates[engineId] === "STARTING") {
@@ -355,11 +356,13 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
       }
     },
   },
+
   VALIDATE_ENGINE_DIR: {
     action: async (_, { engineDir }) => {
       return window.backend.validateEngineDir(engineDir);
     },
   },
+
   ADD_ENGINE_DIR: {
     action: async (_, { engineDir }) => {
       const registeredEngineDirs = await window.backend.getSetting(
@@ -371,6 +374,7 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
       ]);
     },
   },
+
   REMOVE_ENGINE_DIR: {
     action: async (_, { engineDir }) => {
       const registeredEngineDirs = await window.backend.getSetting(
@@ -382,16 +386,19 @@ export const engineStore = createPartialStore<EngineStoreTypes>({
       );
     },
   },
+
   INSTALL_VVPP_ENGINE: {
     action: async (_, path) => {
       return window.backend.installVvppEngine(path);
     },
   },
+
   UNINSTALL_VVPP_ENGINE: {
     action: async (_, engineId) => {
       return window.backend.uninstallVvppEngine(engineId);
     },
   },
+
   SET_ENGINE_MANIFEST: {
     mutation(
       state,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1596,7 +1596,7 @@ export type EngineStoreState = {
 };
 
 export type EngineStoreTypes = {
-  GET_ENGINE_INFOS: {
+  PULL_AND_INIT_ENGINE_INFOS: {
     action(): void;
   };
 
@@ -1604,7 +1604,7 @@ export type EngineStoreTypes = {
     mutation: { engineId: EngineId; engineInfo: EngineInfo };
   };
 
-  GET_ONLY_ENGINE_INFOS: {
+  PULL_ENGINE_INFOS: {
     action: (payload: { engineIds: EngineId[] }) => Promise<void>;
   };
 
@@ -1612,7 +1612,7 @@ export type EngineStoreTypes = {
     getter: EngineInfo[];
   };
 
-  GET_ALT_PORT_INFOS: {
+  PULL_ALT_PORT_INFOS: {
     action(): Promise<AltPortInfos>;
   };
 


### PR DESCRIPTION
## 内容

タイトルのとおりです。
対象の関数は３つだけでした。

## 関連 Issue

close #1020


## その他

こういう改善をどんどんやっていきたい。
