### PR TITLE
refactor: backendにあったファイル読み込み系統の関数を統一

### DIFF
--- a/src/backend/browser/sandbox.ts
+++ b/src/backend/browser/sandbox.ts
@@ -119,24 +119,17 @@ export const api: Sandbox = {
     });
   },
   async showImportFileDialog(obj: {
-    name?: string;
-    extensions?: string[];
     title: string;
+    name: string;
+    mimeType: string;
+    extensions: string[];
   }) {
     const fileHandle = await showOpenFilePickerImpl({
       multiple: false,
       fileTypes: [
         {
-          description: obj.name ?? "Text",
-          accept: obj.extensions
-            ? {
-                "application/octet-stream": obj.extensions.map(
-                  (ext) => `.${ext}`,
-                ),
-              }
-            : {
-                "plain/text": [".txt"],
-              },
+          description: obj.name,
+          accept: { [obj.mimeType]: obj.extensions.map((ext) => `.${ext}`) },
         },
       ],
     });

--- a/src/backend/browser/sandbox.ts
+++ b/src/backend/browser/sandbox.ts
@@ -99,7 +99,7 @@ export const api: Sandbox = {
       }
     });
   },
-  async showImportFileDialog(obj: {
+  async showOpenFileDialog(obj: {
     title: string;
     name: string;
     mimeType: string;

--- a/src/backend/browser/sandbox.ts
+++ b/src/backend/browser/sandbox.ts
@@ -82,12 +82,6 @@ export const api: Sandbox = {
   showSaveDirectoryDialog(obj: { title: string }) {
     return showOpenDirectoryDialogImpl(obj);
   },
-  showVvppOpenDialog(obj: { title: string; defaultPath?: string }) {
-    // NOTE: 今後接続先を変える手段としてVvppが使われるかもしれないので、そのタイミングで実装する
-    throw new Error(
-      `not implemented: showVvppOpenDialog, request: ${JSON.stringify(obj)}`,
-    );
-  },
   showOpenDirectoryDialog(obj: { title: string }) {
     return showOpenDirectoryDialogImpl(obj);
   },

--- a/src/backend/browser/sandbox.ts
+++ b/src/backend/browser/sandbox.ts
@@ -105,19 +105,6 @@ export const api: Sandbox = {
       }
     });
   },
-  async showProjectLoadDialog() {
-    return showOpenFilePickerImpl({
-      multiple: false,
-      fileTypes: [
-        {
-          description: "Voicevox Project File",
-          accept: {
-            "application/json": [".vvproj"],
-          },
-        },
-      ],
-    });
-  },
   async showImportFileDialog(obj: {
     title: string;
     name: string;

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -476,7 +476,7 @@ registerIpcMainHandle<IpcMainHandle>({
   SHOW_IMPORT_FILE_DIALOG: (_, { title, name, extensions }) => {
     return windowManager.showOpenDialogSync({
       title,
-      filters: [{ name: name ?? "Text", extensions: extensions ?? ["txt"] }],
+      filters: [{ name, extensions }],
       properties: ["openFile", "createDirectory", "treatPackageAsDirectory"],
     })?.[0];
   },
@@ -508,27 +508,34 @@ registerIpcMainHandle<IpcMainHandle>({
     appState.willQuit = true;
     windowManager.destroyWindow();
   },
+
   MINIMIZE_WINDOW: () => {
     windowManager.minimize();
   },
+
   TOGGLE_MAXIMIZE_WINDOW: () => {
     windowManager.toggleMaximizeWindow();
   },
+
   TOGGLE_FULLSCREEN: () => {
     windowManager.toggleFullScreen();
   },
+
   /** UIの拡大 */
   ZOOM_IN: () => {
     windowManager.zoomIn();
   },
+
   /** UIの縮小 */
   ZOOM_OUT: () => {
     windowManager.zoomOut();
   },
+
   /** UIの拡大率リセット */
   ZOOM_RESET: () => {
     windowManager.zoomReset();
   },
+
   OPEN_LOG_DIRECTORY: () => {
     void shell.openPath(app.getPath("logs"));
   },
@@ -567,6 +574,7 @@ registerIpcMainHandle<IpcMainHandle>({
   CHECK_FILE_EXISTS: (_, { file }) => {
     return fs.existsSync(file);
   },
+
   CHANGE_PIN_WINDOW: () => {
     windowManager.togglePinWindow();
   },

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -399,18 +399,6 @@ registerIpcMainHandle<IpcMainHandle>({
     return result.filePaths[0];
   },
 
-  SHOW_VVPP_OPEN_DIALOG: async (_, { title, defaultPath }) => {
-    const result = await windowManager.showOpenDialog({
-      title,
-      defaultPath,
-      filters: [
-        { name: "VOICEVOX Plugin Package", extensions: ["vvpp", "vvppp"] },
-      ],
-      properties: ["openFile", "createDirectory", "treatPackageAsDirectory"],
-    });
-    return result.filePaths[0];
-  },
-
   /**
    * ディレクトリ選択ダイアログを表示する。
    * 保存先として選ぶ場合は SHOW_SAVE_DIRECTORY_DIALOG を使うべき。
@@ -461,9 +449,10 @@ registerIpcMainHandle<IpcMainHandle>({
     });
   },
 
-  SHOW_IMPORT_FILE_DIALOG: (_, { title, name, extensions }) => {
+  SHOW_IMPORT_FILE_DIALOG: (_, { title, name, extensions, defaultPath }) => {
     return windowManager.showOpenDialogSync({
       title,
+      defaultPath,
       filters: [{ name, extensions }],
       properties: ["openFile", "createDirectory", "treatPackageAsDirectory"],
     })?.[0];

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -449,7 +449,7 @@ registerIpcMainHandle<IpcMainHandle>({
     });
   },
 
-  SHOW_IMPORT_FILE_DIALOG: (_, { title, name, extensions, defaultPath }) => {
+  SHOW_OPEN_FILE_DIALOG: (_, { title, name, extensions, defaultPath }) => {
     return windowManager.showOpenDialogSync({
       title,
       defaultPath,

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -445,18 +445,6 @@ registerIpcMainHandle<IpcMainHandle>({
     return result.filePath;
   },
 
-  SHOW_PROJECT_LOAD_DIALOG: async (_, { title }) => {
-    const result = await windowManager.showOpenDialog({
-      title,
-      filters: [{ name: "VOICEVOX Project file", extensions: ["vvproj"] }],
-      properties: ["openFile", "createDirectory", "treatPackageAsDirectory"],
-    });
-    if (result.canceled) {
-      return undefined;
-    }
-    return result.filePaths;
-  },
-
   SHOW_WARNING_DIALOG: (_, { title, message }) => {
     return windowManager.showMessageBox({
       type: "warning",

--- a/src/backend/electron/preload.ts
+++ b/src/backend/electron/preload.ts
@@ -52,7 +52,7 @@ const api: Sandbox = {
     });
   },
 
-  showImportFileDialog: ({ title, name, extensions, defaultPath }) => {
+  showOpenFileDialog: ({ title, name, extensions, defaultPath }) => {
     return ipcRendererInvokeProxy.SHOW_IMPORT_FILE_DIALOG({
       title,
       name,

--- a/src/backend/electron/preload.ts
+++ b/src/backend/electron/preload.ts
@@ -53,7 +53,7 @@ const api: Sandbox = {
   },
 
   showOpenFileDialog: ({ title, name, extensions, defaultPath }) => {
-    return ipcRendererInvokeProxy.SHOW_IMPORT_FILE_DIALOG({
+    return ipcRendererInvokeProxy.SHOW_OPEN_FILE_DIALOG({
       title,
       name,
       extensions,

--- a/src/backend/electron/preload.ts
+++ b/src/backend/electron/preload.ts
@@ -41,10 +41,6 @@ const api: Sandbox = {
     return ipcRendererInvokeProxy.SHOW_SAVE_DIRECTORY_DIALOG({ title });
   },
 
-  showVvppOpenDialog: ({ title, defaultPath }) => {
-    return ipcRendererInvokeProxy.SHOW_VVPP_OPEN_DIALOG({ title, defaultPath });
-  },
-
   showOpenDirectoryDialog: ({ title }) => {
     return ipcRendererInvokeProxy.SHOW_OPEN_DIRECTORY_DIALOG({ title });
   },
@@ -56,11 +52,12 @@ const api: Sandbox = {
     });
   },
 
-  showImportFileDialog: ({ title, name, extensions }) => {
+  showImportFileDialog: ({ title, name, extensions, defaultPath }) => {
     return ipcRendererInvokeProxy.SHOW_IMPORT_FILE_DIALOG({
       title,
       name,
       extensions,
+      defaultPath,
     });
   },
 

--- a/src/backend/electron/preload.ts
+++ b/src/backend/electron/preload.ts
@@ -56,10 +56,6 @@ const api: Sandbox = {
     });
   },
 
-  showProjectLoadDialog: ({ title }) => {
-    return ipcRendererInvokeProxy.SHOW_PROJECT_LOAD_DIALOG({ title });
-  },
-
   showImportFileDialog: ({ title, name, extensions }) => {
     return ipcRendererInvokeProxy.SHOW_IMPORT_FILE_DIALOG({
       title,

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -545,8 +545,11 @@ const selectEngineDir = async () => {
 
 const vvppFilePath = ref("");
 const selectVvppFile = async () => {
-  const path = await window.backend.showVvppOpenDialog({
+  const path = await window.backend.showImportFileDialog({
     title: "vvppファイルを選択",
+    name: "VOICEVOX Plugin Package",
+    mimeType: "application/octet-stream",
+    extensions: ["vvpp", "vvppp"],
     defaultPath: vvppFilePath.value,
   });
   if (path) {

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -545,7 +545,7 @@ const selectEngineDir = async () => {
 
 const vvppFilePath = ref("");
 const selectVvppFile = async () => {
-  const path = await window.backend.showImportFileDialog({
+  const path = await window.backend.showOpenFileDialog({
     title: "vvppファイルを選択",
     name: "VOICEVOX Plugin Package",
     mimeType: "application/octet-stream",

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2900,7 +2900,7 @@ export const audioCommandStore = transformCommandStore(
         async ({ state, mutations, actions, getters }, payload) => {
           let filePath: undefined | string;
           if (payload.type == "dialog") {
-            filePath = await window.backend.showImportFileDialog({
+            filePath = await window.backend.showOpenFileDialog({
               title: "セリフ読み込み",
               name: "Text",
               mimeType: "plain/text",

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2902,6 +2902,9 @@ export const audioCommandStore = transformCommandStore(
           if (payload.type == "dialog") {
             filePath = await window.backend.showImportFileDialog({
               title: "セリフ読み込み",
+              name: "Text",
+              mimeType: "plain/text",
+              extensions: ["txt"],
             });
             if (!filePath) return;
           } else if (payload.type == "path") {

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -173,7 +173,7 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
       async ({ actions, mutations, getters }, payload) => {
         let filePath: undefined | string;
         if (payload.type == "dialog") {
-          const ret = await window.backend.showImportFileDialog({
+          const ret = await window.backend.showOpenFileDialog({
             title: "プロジェクトファイルの選択",
             name: "VOICEVOX Project file",
             mimeType: "application/json",

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -173,8 +173,11 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
       async ({ actions, mutations, getters }, payload) => {
         let filePath: undefined | string;
         if (payload.type == "dialog") {
-          const ret = await window.backend.showProjectLoadDialog({
+          const ret = await window.backend.showImportFileDialog({
             title: "プロジェクトファイルの選択",
+            name: "VOICEVOX Project file",
+            mimeType: "application/json",
+            extensions: ["vvproj"],
           });
           if (ret == undefined || ret?.length == 0) {
             return false;

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -179,10 +179,10 @@ export const projectStore = createPartialStore<ProjectStoreTypes>({
             mimeType: "application/json",
             extensions: ["vvproj"],
           });
-          if (ret == undefined || ret?.length == 0) {
+          if (ret == undefined) {
             return false;
           }
-          filePath = ret[0];
+          filePath = ret;
         } else if (payload.type == "path") {
           filePath = payload.filePath;
         }

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -43,18 +43,20 @@ export type IpcIHData = {
     return?: string;
   };
 
-  SHOW_VVPP_OPEN_DIALOG: {
-    args: [obj: { title: string; defaultPath?: string }];
-    return?: string;
-  };
-
   SHOW_OPEN_DIRECTORY_DIALOG: {
     args: [obj: { title: string }];
     return?: string;
   };
 
   SHOW_IMPORT_FILE_DIALOG: {
-    args: [obj: { title: string; name: string; extensions: string[] }];
+    args: [
+      obj: {
+        title: string;
+        name: string;
+        extensions: string[];
+        defaultPath?: string;
+      },
+    ];
     return?: string;
   };
 

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -48,7 +48,7 @@ export type IpcIHData = {
     return?: string;
   };
 
-  SHOW_IMPORT_FILE_DIALOG: {
+  SHOW_OPEN_FILE_DIALOG: {
     args: [
       obj: {
         title: string;

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -54,7 +54,7 @@ export type IpcIHData = {
   };
 
   SHOW_IMPORT_FILE_DIALOG: {
-    args: [obj: { title: string; name?: string; extensions?: string[] }];
+    args: [obj: { title: string; name: string; extensions: string[] }];
     return?: string;
   };
 

--- a/src/type/ipc.ts
+++ b/src/type/ipc.ts
@@ -63,11 +63,6 @@ export type IpcIHData = {
     return?: string;
   };
 
-  SHOW_PROJECT_LOAD_DIALOG: {
-    args: [obj: { title: string }];
-    return?: string[];
-  };
-
   SHOW_WARNING_DIALOG: {
     args: [
       obj: {

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -80,7 +80,7 @@ export interface Sandbox {
     title: string;
     defaultPath?: string;
   }): Promise<string | undefined>;
-  showImportFileDialog(obj: {
+  showOpenFileDialog(obj: {
     title: string;
     name: string;
     mimeType: string;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -87,8 +87,9 @@ export interface Sandbox {
   showProjectLoadDialog(obj: { title: string }): Promise<string[] | undefined>;
   showImportFileDialog(obj: {
     title: string;
-    name?: string;
-    extensions?: string[];
+    name: string;
+    mimeType: string;
+    extensions: string[];
   }): Promise<string | undefined>;
   showExportFileDialog(obj: {
     title: string;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -84,7 +84,6 @@ export interface Sandbox {
     title: string;
     defaultPath?: string;
   }): Promise<string | undefined>;
-  showProjectLoadDialog(obj: { title: string }): Promise<string[] | undefined>;
   showImportFileDialog(obj: {
     title: string;
     name: string;

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -75,10 +75,6 @@ export interface Sandbox {
   getAltPortInfos(): Promise<AltPortInfos>;
   getInitialProjectFilePath(): Promise<string | undefined>;
   showSaveDirectoryDialog(obj: { title: string }): Promise<string | undefined>;
-  showVvppOpenDialog(obj: {
-    title: string;
-    defaultPath?: string;
-  }): Promise<string | undefined>;
   showOpenDirectoryDialog(obj: { title: string }): Promise<string | undefined>;
   showProjectSaveDialog(obj: {
     title: string;
@@ -89,6 +85,7 @@ export interface Sandbox {
     name: string;
     mimeType: string;
     extensions: string[];
+    defaultPath?: string;
   }): Promise<string | undefined>;
   showExportFileDialog(obj: {
     title: string;


### PR DESCRIPTION
## 内容

ファイル読み込み系統の関数を統一し、重複を減らします。

引数はこうしてみました。
```ts
title: string;
name: string;
mimeType: string;
extensions: string[];
defaultPath?: string;
```
mimeTypeはelectronバックエンドで使えず、defaultPathはブラウザバックエンドで使えません。
まあ共通化しちゃっていいかなぁと。

## 関連 Issue

close #2522


## その他

同様にファイル書き出し系のダイアログも統一できると思います。
といっても現状はSHOW_PROJECT_SAVE_DIALOGとSHOW_EXPORT_FILE_DIALOGだけかも。

やっぱりDRY原則は正しい気がします。
