### PR TITLE
fix(test): アップデート確認ダイアログのテストが落ちることがあるのを直す

### DIFF
--- a/src/components/Dialog/UpdateNotificationDialog/Container.vue
+++ b/src/components/Dialog/UpdateNotificationDialog/Container.vue
@@ -15,7 +15,7 @@
 
 <script setup lang="ts">
 import semver from "semver";
-import { computed, watch } from "vue";
+import { computed, watchEffect } from "vue";
 import UpdateNotificationDialog from "./Presentation.vue";
 import { useFetchNewUpdateInfos } from "@/composables/useFetchNewUpdateInfos";
 import { useStore } from "@/store";
@@ -74,15 +74,12 @@ const handleSkipThisVersionClick = (version: string) => {
 };
 
 // ダイアログを開くかどうか
-watch(
-  () => [props.canOpenDialog, newUpdateResult],
-  () => {
-    if (
-      props.canOpenDialog &&
-      newUpdateResult.value.status == "updateAvailable"
-    ) {
-      isDialogOpenComputed.value = true;
-    }
-  },
-);
+watchEffect(() => {
+  if (
+    props.canOpenDialog &&
+    newUpdateResult.value.status == "updateAvailable"
+  ) {
+    isDialogOpenComputed.value = true;
+  }
+});
 </script>


### PR DESCRIPTION
## 内容

タイトルのとおりです。

`newUpdateResult.value.status`だけが書き換わることがあり、deepにwatchしてなかった関係でアプデダイアログが開かなかったのが原因だと思われます。

大体の場合でうまく行ってたのはたぶん、タイミングによってはあとで`canOpenDialog`などが書き換わって偶然開かることもあった･･･んだと思います。

## その他
