### PR TITLE
refactor: VvppManagerをリファクタリング

### DIFF
--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -53,7 +53,7 @@ export class VvppManager {
   private tmpDir: string;
 
   private willDeleteEngineIds: Set<EngineId>;
-  private willReplaceEngineDirs: {
+  private willMoveEngineDirs: {
     from: string;
     to: string;
     engineId: EngineId;
@@ -65,11 +65,11 @@ export class VvppManager {
     this.vvppEngineDir = params.vvppEngineDir;
     this.tmpDir = params.tmpDir;
     this.willDeleteEngineIds = new Set();
-    this.willReplaceEngineDirs = [];
+    this.willMoveEngineDirs = [];
   }
 
   markWillMove(params: { from: string; to: string; engineId: EngineId }) {
-    this.willReplaceEngineDirs.push(params);
+    this.willMoveEngineDirs.push(params);
   }
 
   markWillDelete(engineId: EngineId) {
@@ -204,7 +204,7 @@ export class VvppManager {
     this.willDeleteEngineIds.clear();
 
     await Promise.all(
-      [...this.willReplaceEngineDirs].map(async ({ from, to, engineId }) => {
+      [...this.willMoveEngineDirs].map(async ({ from, to, engineId }) => {
         const deletingEngineDir = await this.getInstalledEngineDir(engineId);
         if (deletingEngineDir == undefined) {
           throw new Error("エンジンが見つかりませんでした。");
@@ -225,12 +225,12 @@ export class VvppManager {
         }
       }),
     );
-    this.willReplaceEngineDirs = [];
+    this.willMoveEngineDirs = [];
   }
 
   hasMarkedEngineDirs() {
     return (
-      this.willReplaceEngineDirs.length > 0 || this.willDeleteEngineIds.size > 0
+      this.willMoveEngineDirs.length > 0 || this.willDeleteEngineIds.size > 0
     );
   }
 }

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -183,12 +183,7 @@ export class VvppManager {
         }
 
         try {
-          await retry(() =>
-            fs.promises.rm(deletingEngineDir, {
-              recursive: true,
-              force: true,
-            }),
-          );
+          await deleteDirWithRetry(deletingEngineDir);
           log.info(`Engine ${engineId} deleted successfully.`);
         } catch (e) {
           log.error("Failed to delete engine directory: ", e);
@@ -209,15 +204,10 @@ export class VvppManager {
         }
 
         try {
-          await retry(() =>
-            fs.promises.rm(deletingEngineDir, {
-              recursive: true,
-              force: true,
-            }),
-          );
+          await deleteDirWithRetry(deletingEngineDir);
           log.info(`Engine ${engineId} deleted successfully.`);
 
-          await retry(() => moveFile(from, to));
+          await moveFileWithRetry({ from, to });
           log.info(`Renamed ${from} to ${to}`);
         } catch (e) {
           log.error("Failed to rename engine directory: ", e);
@@ -236,6 +226,20 @@ export class VvppManager {
       this.willReplaceEngineDirs.length > 0 || this.willDeleteEngineIds.size > 0
     );
   }
+}
+
+async function deleteDirWithRetry(dir: string) {
+  await retry(() =>
+    fs.promises.rm(dir, {
+      recursive: true,
+      force: true,
+    }),
+  );
+}
+
+async function moveFileWithRetry(params: { from: string; to: string }) {
+  const { from, to } = params;
+  await retry(() => moveFile(from, to));
 }
 
 async function retry(fn: () => Promise<void>) {

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -118,6 +118,10 @@ export class VvppManager {
     return true;
   }
 
+  private async lockAcquire(fn: () => Promise<void>) {
+    await this.lock.acquire(lockKey, () => fn());
+  }
+
   /**
    * 追加
    */
@@ -125,7 +129,7 @@ export class VvppManager {
     vvppPath: string,
     callbacks?: { onProgress?: ProgressCallback },
   ) {
-    await this.lock.acquire(lockKey, () => this._install(vvppPath, callbacks));
+    await this.lockAcquire(() => this._install(vvppPath, callbacks));
   }
   private async _install(
     vvppPath: string,
@@ -172,7 +176,7 @@ export class VvppManager {
   }
 
   async handleMarkedEngineDirs() {
-    await this.lock.acquire(lockKey, () => this._handleMarkedEngineDirs());
+    await this.lockAcquire(() => this._handleMarkedEngineDirs());
   }
   private async _handleMarkedEngineDirs() {
     await Promise.all(

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -94,7 +94,7 @@ export class VvppManager {
       (dir) => this.isEngineDirName(dir, engineId),
     );
     if (dirNames.length > 1) {
-      throw new Error("Multiple or no installed engine directories found.");
+      throw new Error("Multiple installed engine directories found.");
     } else if (dirNames.length == 0) {
       return undefined;
     }

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -137,7 +137,7 @@ export class VvppManager {
     const manifest = await new VvppFileExtractor({
       vvppLikeFilePath: vvppPath,
       outputDir: tmpEngineDir,
-      tmpDir: app.getPath("temp"),
+      tmpDir: this.tmpDir,
       callbacks,
     }).extract();
 

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -53,7 +53,11 @@ export class VvppManager {
   private tmpDir: string;
 
   private willDeleteEngineIds: Set<EngineId>;
-  private willReplaceEngineDirs: { from: string; to: string }[];
+  private willReplaceEngineDirs: {
+    from: string;
+    to: string;
+    engineId: EngineId;
+  }[];
 
   private lock = new AsyncLock();
 
@@ -64,11 +68,8 @@ export class VvppManager {
     this.willReplaceEngineDirs = [];
   }
 
-  markWillMove(from: string, to: string) {
-    this.willReplaceEngineDirs.push({
-      from,
-      to: path.join(this.vvppEngineDir, to),
-    });
+  markWillMove(params: { from: string; to: string; engineId: EngineId }) {
+    this.willReplaceEngineDirs.push(params);
   }
 
   markWillDelete(engineId: EngineId) {
@@ -84,8 +85,20 @@ export class VvppManager {
     return path.join(this.vvppEngineDir, this.toValidDirName(manifest));
   }
 
-  isEngineDirName(dir: string, manifest: MinimumEngineManifestType) {
-    return dir.endsWith(`+${manifest.uuid}`);
+  isEngineDirName(dir: string, engineId: EngineId) {
+    return dir.endsWith(`+${engineId}`);
+  }
+
+  async getInstalledEngineDir(engineId: EngineId) {
+    const dirNames = (await fs.promises.readdir(this.vvppEngineDir)).filter(
+      (dir) => this.isEngineDirName(dir, engineId),
+    );
+    if (dirNames.length > 1) {
+      throw new Error("Multiple or no installed engine directories found.");
+    } else if (dirNames.length == 0) {
+      return undefined;
+    }
+    return path.join(this.vvppEngineDir, dirNames[0]);
   }
 
   canUninstall(engineInfo: EngineInfo) {
@@ -124,27 +137,22 @@ export class VvppManager {
     const manifest = await new VvppFileExtractor({
       vvppLikeFilePath: vvppPath,
       outputDir: tmpEngineDir,
-      tmpDir: this.tmpDir,
+      tmpDir: app.getPath("temp"),
       callbacks,
     }).extract();
 
-    const dirName = this.toValidDirName(manifest);
-    const engineDirectory = path.join(this.vvppEngineDir, dirName);
-    const oldEngineDirName = (
-      await fs.promises.readdir(this.vvppEngineDir)
-    ).find((dir) => {
-      return this.isEngineDirName(dir, manifest);
-    });
-    if (oldEngineDirName) {
-      this.markWillMove(tmpEngineDir, dirName);
+    await this.applyPermissions(tmpEngineDir, manifest.command);
+
+    const hasOldEngine = await this.hasOldEngine(manifest.uuid);
+    const engineDir = this.buildEngineDirPath(manifest);
+    if (hasOldEngine) {
+      this.markWillMove({
+        from: tmpEngineDir,
+        to: engineDir,
+        engineId: manifest.uuid,
+      });
     } else {
-      await moveFile(tmpEngineDir, engineDirectory);
-    }
-    if (!isWindows) {
-      await fs.promises.chmod(
-        path.join(engineDirectory, manifest.command),
-        "755",
-      );
+      await moveFile(tmpEngineDir, engineDir);
     }
   }
 
@@ -153,67 +161,70 @@ export class VvppManager {
     return path.join(vvppEngineDir, ".tmp", nonce);
   }
 
+  private async applyPermissions(engineDirectory: string, commandPath: string) {
+    if (!isWindows) {
+      await fs.promises.chmod(path.join(engineDirectory, commandPath), "755");
+    }
+  }
+
+  private async hasOldEngine(engineId: EngineId) {
+    return (await this.getInstalledEngineDir(engineId)) != undefined;
+  }
+
   async handleMarkedEngineDirs() {
     await this.lock.acquire(lockKey, () => this._handleMarkedEngineDirs());
   }
   private async _handleMarkedEngineDirs() {
     await Promise.all(
       [...this.willDeleteEngineIds].map(async (engineId) => {
-        let deletingEngineDir: string | undefined = undefined;
-        for (const engineDir of await fs.promises.readdir(this.vvppEngineDir)) {
-          if (engineDir.endsWith("+" + engineId)) {
-            deletingEngineDir = path.join(this.vvppEngineDir, engineDir);
-            break;
-          }
-        }
-        if (deletingEngineDir == null) {
+        const deletingEngineDir = await this.getInstalledEngineDir(engineId);
+        if (deletingEngineDir == undefined) {
           throw new Error("エンジンが見つかりませんでした。");
         }
 
-        for (let i = 0; i < 5; i++) {
-          try {
-            await fs.promises.rm(deletingEngineDir, {
+        try {
+          await retry(() =>
+            fs.promises.rm(deletingEngineDir, {
               recursive: true,
               force: true,
-            });
-            log.info(`Engine ${engineId} deleted successfully.`);
-            break;
-          } catch (e) {
-            if (i === 4) {
-              log.error(e);
-              dialog.showErrorBox(
-                "エンジン削除エラー",
-                `エンジンの削除に失敗しました。エンジンのフォルダを手動で削除してください。\n${deletingEngineDir}\nエラー内容: ${errorToMessage(e)}`,
-              );
-            } else {
-              log.error("Failed to delete engine directory: ", e, ", retrying");
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-            }
-          }
+            }),
+          );
+          log.info(`Engine ${engineId} deleted successfully.`);
+        } catch (e) {
+          log.error("Failed to delete engine directory: ", e);
+          dialog.showErrorBox(
+            "エンジン削除エラー",
+            `エンジンの削除に失敗しました。エンジンのフォルダを手動で削除してください。\n${deletingEngineDir}\nエラー内容: ${errorToMessage(e)}`,
+          );
         }
       }),
     );
     this.willDeleteEngineIds.clear();
+
     await Promise.all(
-      [...this.willReplaceEngineDirs].map(async ({ from, to }) => {
-        for (let i = 0; i < 5; i++) {
-          try {
-            await fs.promises.rm(to, { recursive: true });
-            await moveFile(from, to);
-            log.info(`Renamed ${from} to ${to}`);
-            break;
-          } catch (e) {
-            if (i === 4) {
-              log.error(e);
-              dialog.showErrorBox(
-                "エンジン追加エラー",
-                `エンジンの追加に失敗しました。エンジンのフォルダを手動で移動してください。\n${from}\nエラー内容: ${errorToMessage(e)}`,
-              );
-            } else {
-              log.error("Failed to rename engine directory: ", e, ", retrying");
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-            }
-          }
+      [...this.willReplaceEngineDirs].map(async ({ from, to, engineId }) => {
+        const deletingEngineDir = await this.getInstalledEngineDir(engineId);
+        if (deletingEngineDir == undefined) {
+          throw new Error("エンジンが見つかりませんでした。");
+        }
+
+        try {
+          await retry(() =>
+            fs.promises.rm(deletingEngineDir, {
+              recursive: true,
+              force: true,
+            }),
+          );
+          log.info(`Engine ${engineId} deleted successfully.`);
+
+          await retry(() => moveFile(from, to));
+          log.info(`Renamed ${from} to ${to}`);
+        } catch (e) {
+          log.error("Failed to rename engine directory: ", e);
+          dialog.showErrorBox(
+            "エンジン追加エラー",
+            `エンジンの追加に失敗しました。エンジンのフォルダを手動で移動してください。\n${from} -> ${to}\nエラー内容: ${errorToMessage(e)}`,
+          );
         }
       }),
     );
@@ -224,6 +235,23 @@ export class VvppManager {
     return (
       this.willReplaceEngineDirs.length > 0 || this.willDeleteEngineIds.size > 0
     );
+  }
+}
+
+async function retry(fn: () => Promise<void>) {
+  const maxRetries = 5;
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      await fn();
+      break;
+    } catch (e) {
+      if (i === maxRetries - 1) {
+        throw e;
+      } else {
+        log.warn(`Retrying... (${i + 1}/${maxRetries}):`);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
   }
 }
 

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -145,7 +145,7 @@ export class VvppManager {
       callbacks,
     }).extract();
 
-    await this.applyPermissions(tmpEngineDir, manifest.command);
+    await this.applyExecutablePermissions(tmpEngineDir, manifest.command);
 
     const hasOldEngine = await this.hasOldEngine(manifest.uuid);
     const engineDir = this.buildEngineDirPath(manifest);
@@ -165,7 +165,10 @@ export class VvppManager {
     return path.join(vvppEngineDir, ".tmp", nonce);
   }
 
-  private async applyPermissions(engineDirectory: string, commandPath: string) {
+  private async applyExecutablePermissions(
+    engineDirectory: string,
+    commandPath: string,
+  ) {
     if (!isWindows) {
       await fs.promises.chmod(path.join(engineDirectory, commandPath), "755");
     }

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -118,7 +118,7 @@ export class VvppManager {
     return true;
   }
 
-  private async lockAcquire(fn: () => Promise<void>) {
+  private async withLockAcquired(fn: () => Promise<void>) {
     await this.lock.acquire(lockKey, () => fn());
   }
 
@@ -129,7 +129,7 @@ export class VvppManager {
     vvppPath: string,
     callbacks?: { onProgress?: ProgressCallback },
   ) {
-    await this.lockAcquire(() => this._install(vvppPath, callbacks));
+    await this.withLockAcquired(() => this._install(vvppPath, callbacks));
   }
   private async _install(
     vvppPath: string,
@@ -179,7 +179,7 @@ export class VvppManager {
   }
 
   async handleMarkedEngineDirs() {
-    await this.lockAcquire(() => this._handleMarkedEngineDirs());
+    await this.withLockAcquired(() => this._handleMarkedEngineDirs());
   }
   private async _handleMarkedEngineDirs() {
     await Promise.all(

--- a/src/backend/electron/manager/vvppManager.ts
+++ b/src/backend/electron/manager/vvppManager.ts
@@ -24,6 +24,8 @@ export const isVvppFile = (filePath: string) => {
 
 const lockKey = "lock-key-for-vvpp-manager";
 
+type MoveParams = { from: string; to: string; engineId: EngineId };
+
 // # 軽い概要
 //
 // フォルダ名："エンジン名+UUID"
@@ -53,11 +55,7 @@ export class VvppManager {
   private tmpDir: string;
 
   private willDeleteEngineIds: Set<EngineId>;
-  private willMoveEngineDirs: {
-    from: string;
-    to: string;
-    engineId: EngineId;
-  }[];
+  private willMoveEngineDirs: MoveParams[];
 
   private lock = new AsyncLock();
 
@@ -68,7 +66,7 @@ export class VvppManager {
     this.willMoveEngineDirs = [];
   }
 
-  markWillMove(params: { from: string; to: string; engineId: EngineId }) {
+  markWillMove(params: MoveParams) {
     this.willMoveEngineDirs.push(params);
   }
 


### PR DESCRIPTION
## 内容

VvppManagerをリファクタリングしてみました。
markしてhandleする機構上、これ以上は割と難しそうかも。

ついでにバグを２つ直してます。

* パーミッションを変更してから移動するようにした
	* 以前は移動してからパーミッション変更してた
	* markで移動を予約した後はパーミッションを変更してないので、おそらくバグってた
* 移動の際に削除するエンジンディレクトリを、`to`ディレクトリではなく毎回取得するようにした
	* 前はtoディレクトリのものを消していた
	* エンジンIDそのままに名が変わったときなどはディレクトリが変わるので、toディレクトリを消すだけではダメなときもある

いずれも関数化して処理を整理していくと割と問題が見えてきたので、関数に切り分けていくのは大事だなと改めて思いました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2547

の続き

## その他
