### PR TITLE
chore: errorToMessageの文面をいい感じにし、テストも追加する

### DIFF
--- a/tests/unit/lib/errorHelper.spec.ts
+++ b/tests/unit/lib/errorHelper.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { errorToMessage } from "@/helpers/errorHelper";
+
+describe("errorToMessage", () => {
+  it("Errorインスタンス", () => {
+    const input = new Error("error instance");
+    const expected = "error instance";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("SyntaxErrorインスタンス", () => {
+    const input = new SyntaxError("syntax error instance");
+    const expected = "SyntaxError: syntax error instance";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("自作エラーインスタンス", () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "CustomError";
+      }
+    }
+    const input = new CustomError("custom error instance");
+    const expected = "CustomError: custom error instance";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("AggregateErrorインスタンス", () => {
+    const input = new AggregateError(
+      [new Error("error1"), new Error("error2")],
+      "aggregate error",
+    );
+    const expected = "aggregate error\nerror1\nerror2";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("cause付きエラーインスタンス", () => {
+    const input = new Error("error instance", { cause: new Error("cause") });
+    const expected = "error instance\ncause";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("文字列エラー", () => {
+    const input = "string error";
+    const expected = "Unknown Error: string error";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("オブジェクトエラー", () => {
+    const input = { key: "value" };
+    const expected = 'Unknown Error: {"key":"value"}';
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("不明なエラー", () => {
+    const input = undefined;
+    const expected = "Unknown Error: undefined";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox/issues/1086#issuecomment-2672437285 で考えたことを実装してみました。
ダイアログでそのままメッセージを表示することを前提に、errorToMessageを少しいい感じにしています。

例えば`new Error("エラーメッセージはあれこれです")`を突っ込むと文字列は
`エラーメッセージはあれこれです`
になります。

例えば`new AggregateError[Error("エラーメッセージ1"), Error("エラーメッセージ2")]`を突っ込むと文字列は
```
エラーメッセージ1
エラーメッセージ2
```
になります。

たぶん[Promise.allSettled](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)の結果を良い感じにエラーハンドリングできる関数を用意しておけば更に便利なはず。
エラーメッセージをちゃんと整えれば。

## 関連 Issue

ref #1086 

## その他

@sevenc-nanashi さんが[discordで言ってた](https://discord.com/channels/879570910208733277/893889888208977960/1343167964920287315)`DisplayableError`は一旦無しにして、ダイアログを表示しないといけないとこはどんなエラーが来てもダイアログを表示する感じはどうかなぁと。
実装したほうが良さそうだったらちょっと検討します。