### PR TITLE
fix: PitchLineの初期化をonMountedOrActivatedで行っていなかったので修正

### DIFF
--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -280,43 +280,37 @@ let initialized = false;
 
 const asyncLock = new AsyncLock({ maxPending: 1 });
 
-watch(
-  [singingGuidesInSelectedTrack, tempos, tpqn],
-  async () => {
-    asyncLock.acquire(
-      "originalPitch",
-      async () => {
-        if (initialized) {
-          await updateOriginalPitchLineDataMap();
-        }
-      },
-      (err) => {
-        if (err != undefined) {
-          warn(`An error occurred.`, err);
-        }
-      },
-    );
-  }
-);
+watch([singingGuidesInSelectedTrack, tempos, tpqn], async () => {
+  asyncLock.acquire(
+    "originalPitch",
+    async () => {
+      if (initialized) {
+        await updateOriginalPitchLineDataMap();
+      }
+    },
+    (err) => {
+      if (err != undefined) {
+        warn(`An error occurred.`, err);
+      }
+    },
+  );
+});
 
-watch(
-  [pitchEditData, previewPitchEdit, tempos, tpqn],
-  async () => {
-    asyncLock.acquire(
-      "pitchEdit",
-      async () => {
-        if (initialized) {
-          await updatePitchEditLineDataMap();
-        }
-      },
-      (err) => {
-        if (err != undefined) {
-          warn(`An error occurred.`, err);
-        }
-      },
-    );
-  }
-);
+watch([pitchEditData, previewPitchEdit, tempos, tpqn], async () => {
+  asyncLock.acquire(
+    "pitchEdit",
+    async () => {
+      if (initialized) {
+        await updatePitchEditLineDataMap();
+      }
+    },
+    (err) => {
+      if (err != undefined) {
+        warn(`An error occurred.`, err);
+      }
+    },
+  );
+});
 
 watch(isDark, () => {
   renderInNextFrame = true;

--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -296,8 +296,7 @@ watch(
         }
       },
     );
-  },
-  { immediate: true },
+  }
 );
 
 watch(
@@ -316,8 +315,7 @@ watch(
         }
       },
     );
-  },
-  { immediate: true },
+  }
 );
 
 watch(isDark, () => {


### PR DESCRIPTION
## 内容

`PitchLine`の初期化を`onMountedOrActivated`で行っていなかったので修正します。
（ピッチを表示した状態でソング→トーク→ソングと切り替えるとエラーになるのを修正します）

また、以下も行います。
- トーク/ソングの切り替えでPIXI（WebGL）のオブジェクトを破棄しないように（維持するように）する
  - `onMountedOrActivated`から`onMounted`に変更
  - 問題なく動くのと、パフォーマンスにも影響しないと思うので

## その他
