### PR TITLE
chore: DisplayableErrorを追加し、テストも追加する

### DIFF
--- a/src/helpers/errorHelper.ts
+++ b/src/helpers/errorHelper.ts
@@ -69,8 +69,14 @@ export const errorToMessages = (
     for (const e of errors) {
       if (e instanceof Error) {
         let message = "";
-        if (!["Error", "AggregateError", "DisplayableError"].includes(e.name)) {
-          message += `${e.name}: `;
+        if (
+          !(
+            e.constructor === Error ||
+            e instanceof AggregateError ||
+            e instanceof DisplayableError
+          )
+        ) {
+          message += `${e.constructor.name}: `;
         }
         message += e.message;
         messages.push(message);

--- a/src/helpers/errorHelper.ts
+++ b/src/helpers/errorHelper.ts
@@ -1,5 +1,3 @@
-import { UnreachableError } from "@/type/utility";
-
 /** 入力がnullかundefinedの場合エラーを投げ、それ以外の場合は入力をそのまま返す */
 export const ensureNotNullish = <T>(
   value: T | null | undefined,
@@ -40,13 +38,14 @@ export const errorToMessages = (
   };
 
   function flattenErrors(e: unknown): unknown[] {
+    const errors = [e];
     if (e instanceof AggregateError) {
-      return [e, ...e.errors.flatMap(flattenErrors)];
+      errors.push(...e.errors.flatMap(flattenErrors));
     }
-    if (e instanceof Error) {
-      return [e, ...(e.cause ? flattenErrors(e.cause) : [])];
+    if (e instanceof Error && e.cause) {
+      errors.push(...flattenErrors(e.cause));
     }
-    return [e];
+    return errors;
   }
 
   function splitErrors(errors: unknown[]): {

--- a/src/helpers/errorHelper.ts
+++ b/src/helpers/errorHelper.ts
@@ -53,16 +53,15 @@ export const errorToMessages = (
     displayable: unknown[];
     internal: unknown[];
   } {
-    let displayableCount = errors.findIndex(
-      (e) => !(e instanceof DisplayableError),
+    const firstInternalErrorIndex = errors.findIndex(
+      (error) => !(error instanceof DisplayableError),
     );
-    if (displayableCount === -1) {
-      displayableCount = errors.length;
-    }
+    const splitIndex =
+      firstInternalErrorIndex === -1 ? errors.length : firstInternalErrorIndex;
 
     return {
-      displayable: errors.slice(0, displayableCount),
-      internal: errors.slice(displayableCount),
+      displayable: errors.slice(0, splitIndex),
+      internal: errors.slice(splitIndex),
     };
   }
 

--- a/src/helpers/errorHelper.ts
+++ b/src/helpers/errorHelper.ts
@@ -76,7 +76,7 @@ export const errorToMessages = (
             e instanceof DisplayableError
           )
         ) {
-          message += `${e.constructor.name}: `;
+          message += `${e.name}: `;
         }
         message += e.message;
         messages.push(message);

--- a/tests/unit/lib/errorHelper.spec.ts
+++ b/tests/unit/lib/errorHelper.spec.ts
@@ -95,4 +95,13 @@ describe("errorToMessage", () => {
       "displayable error instance\n（内部エラーメッセージ）\ncause\ndisplayable cause";
     expect(errorToMessage(input)).toEqual(expected);
   });
+
+  it("CustomDisplayableErrorインスタンス", () => {
+    class CustomDisplayableError extends DisplayableError {}
+    const input = new CustomDisplayableError(
+      "custom displayable error instance",
+    );
+    const expected = "custom displayable error instance";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
 });

--- a/tests/unit/lib/errorHelper.spec.ts
+++ b/tests/unit/lib/errorHelper.spec.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { errorToMessage } from "@/helpers/errorHelper";
+import { DisplayableError, errorToMessage } from "@/helpers/errorHelper";
 
 describe("errorToMessage", () => {
   it("Errorインスタンス", () => {
     const input = new Error("error instance");
-    const expected = "error instance";
+    const expected = "（内部エラーメッセージ）\nerror instance";
     expect(errorToMessage(input)).toEqual(expected);
   });
 
   it("SyntaxErrorインスタンス", () => {
     const input = new SyntaxError("syntax error instance");
-    const expected = "SyntaxError: syntax error instance";
+    const expected =
+      "（内部エラーメッセージ）\nSyntaxError: syntax error instance";
     expect(errorToMessage(input)).toEqual(expected);
   });
 
@@ -22,7 +23,8 @@ describe("errorToMessage", () => {
       }
     }
     const input = new CustomError("custom error instance");
-    const expected = "CustomError: custom error instance";
+    const expected =
+      "（内部エラーメッセージ）\nCustomError: custom error instance";
     expect(errorToMessage(input)).toEqual(expected);
   });
 
@@ -31,31 +33,66 @@ describe("errorToMessage", () => {
       [new Error("error1"), new Error("error2")],
       "aggregate error",
     );
-    const expected = "aggregate error\nerror1\nerror2";
+    const expected =
+      "（内部エラーメッセージ）\naggregate error\nerror1\nerror2";
     expect(errorToMessage(input)).toEqual(expected);
   });
 
   it("cause付きエラーインスタンス", () => {
     const input = new Error("error instance", { cause: new Error("cause") });
-    const expected = "error instance\ncause";
+    const expected = "（内部エラーメッセージ）\nerror instance\ncause";
     expect(errorToMessage(input)).toEqual(expected);
   });
 
   it("文字列エラー", () => {
     const input = "string error";
-    const expected = "Unknown Error: string error";
+    const expected = "（内部エラーメッセージ）\nUnknown Error: string error";
     expect(errorToMessage(input)).toEqual(expected);
   });
 
   it("オブジェクトエラー", () => {
     const input = { key: "value" };
-    const expected = 'Unknown Error: {"key":"value"}';
+    const expected = '（内部エラーメッセージ）\nUnknown Error: {"key":"value"}';
     expect(errorToMessage(input)).toEqual(expected);
   });
 
   it("不明なエラー", () => {
     const input = undefined;
-    const expected = "Unknown Error: undefined";
+    const expected = "（内部エラーメッセージ）\nUnknown Error: undefined";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("DisplayableErrorインスタンス", () => {
+    const input = new DisplayableError("displayable error instance");
+    const expected = "displayable error instance";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("DisplayableError -> Error", () => {
+    const input = new DisplayableError("displayable error instance", {
+      cause: new Error("cause"),
+    });
+    const expected =
+      "displayable error instance\n（内部エラーメッセージ）\ncause";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("DisplayableError -> DisplayableError", () => {
+    const input = new DisplayableError("displayable error instance", {
+      cause: new DisplayableError("displayable cause"),
+    });
+    const expected = "displayable error instance\ndisplayable cause";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("DisplayableError -> Error -> DisplayableError", () => {
+    const input = new DisplayableError("displayable error instance", {
+      cause: new Error("cause", {
+        cause: new DisplayableError("displayable cause"),
+      }),
+    });
+    const expected =
+      "displayable error instance\n（内部エラーメッセージ）\ncause\ndisplayable cause";
     expect(errorToMessage(input)).toEqual(expected);
   });
 });

--- a/tests/unit/lib/errorHelper.spec.ts
+++ b/tests/unit/lib/errorHelper.spec.ts
@@ -34,7 +34,7 @@ describe("errorToMessage", () => {
       "aggregate error",
     );
     const expected =
-      "（内部エラーメッセージ）\nAggregateError: aggregate error\nerror1\nerror2";
+      "（内部エラーメッセージ）\naggregate error\nerror1\nerror2";
     expect(errorToMessage(input)).toEqual(expected);
   });
 

--- a/tests/unit/lib/errorHelper.spec.ts
+++ b/tests/unit/lib/errorHelper.spec.ts
@@ -34,7 +34,7 @@ describe("errorToMessage", () => {
       "aggregate error",
     );
     const expected =
-      "（内部エラーメッセージ）\naggregate error\nerror1\nerror2";
+      "（内部エラーメッセージ）\nAggregateError: aggregate error\nerror1\nerror2";
     expect(errorToMessage(input)).toEqual(expected);
   });
 

--- a/tests/unit/lib/errorHelper.spec.ts
+++ b/tests/unit/lib/errorHelper.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { errorToMessage } from "@/helpers/errorHelper";
+
+describe("errorToMessage", () => {
+  it("Errorインスタンス", () => {
+    const input = new Error("error instance");
+    const expected = "error instance";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("SyntaxErrorインスタンス", () => {
+    const input = new SyntaxError("syntax error instance");
+    const expected = "SyntaxError: syntax error instance";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("自作エラーインスタンス", () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "CustomError";
+      }
+    }
+    const input = new CustomError("custom error instance");
+    const expected = "CustomError: custom error instance";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("AggregateErrorインスタンス", () => {
+    const input = new AggregateError(
+      [new Error("error1"), new Error("error2")],
+      "aggregate error",
+    );
+    const expected = "aggregate error\nerror1\nerror2";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("cause付きエラーインスタンス", () => {
+    const input = new Error("error instance", { cause: new Error("cause") });
+    const expected = "error instance\ncause";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("文字列エラー", () => {
+    const input = "string error";
+    const expected = "Unknown Error: string error";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("オブジェクトエラー", () => {
+    const input = { key: "value" };
+    const expected = 'Unknown Error: {"key":"value"}';
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+
+  it("不明なエラー", () => {
+    const input = undefined;
+    const expected = "Unknown Error: undefined";
+    expect(errorToMessage(input)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## 内容

errorToMessageを改造し、
DisplayableError以外のエラーは`（内部エラーメッセージ）`として、
DisplayableErrorのエラーはユーザー向けのメッセージとして文字列化するようにします。

ついでにAggregateErrorやcauseなどもメッセージ化できるようにします。

- https://github.com/VOICEVOX/voicevox/pull/2556

の改造版で、DisplayableErrorも追加します。

## 関連 Issue

ref #2556

## その他

都合が良かったので`errorToMessages`も作りました。
IPC通信を通すときはこっちを使い、`displayable`なものと`internal`なものを分離してシリアライズ化して通信し、`new DisplayableError(displayable, { cause: new Error(internal) })`とする予定です。

ちなみに`DisplayableError`以外の名前を検討したけど良いのが見つかりませんでした。
AIくんは`UserError`推しだけど、これだとユーザー入力のエラーに見える。。
https://chatgpt.com/share/67bc5a21-71d0-8008-9711-c532c1d300b3
https://x.com/i/grok/share/bNQSK5cxxKMj7M2OvYcZbSZUn