### PR TITLE
fix: 不要な`window-all-closed`イベントリスナーを削除する

### DIFF
--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -302,11 +302,6 @@ app.on("web-contents-created", (_e, contents) => {
   });
 });
 
-app.on("window-all-closed", () => {
-  log.info("All windows closed. Quitting app");
-  app.quit();
-});
-
 // Called before window closing
 app.on("before-quit", async (event) => {
   if (!appState.willQuit) {


### PR DESCRIPTION
## 内容

[`window-all-closed`](https://www.electronjs.org/ja/docs/latest/api/app#%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88-window-all-closed)が必要なさそうなので削除します。


## 関連 Issue

https://github.com/VOICEVOX/voicevox/pull/2563#issuecomment-2686319614