### PR TITLE
fix(build): ビルド時にlinux x64のエンジンを使うように

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           # Linux CPU
           - artifact_name: linux-cpu-prepackage
             artifact_path: dist_electron/linux-unpacked
-            voicevox_engine_asset_name: linux-cpu
+            voicevox_engine_asset_name: linux-cpu-x64
             package_name: voicevox-cpu
             compressed_artifact_name: voicevox-linux-cpu
             app_asar_dir: prepackage/resources

--- a/public/updateInfos.json
+++ b/public/updateInfos.json
@@ -9,17 +9,21 @@
       "バグ修正"
     ],
     "contributors": [
-      "sevenc-nanashi",
-      "romot-co",
+      "aoirint",
+      "Hiroshiba",
+      "HyodaKazuaki",
+      "jdkfx",
+      "madosuki",
       "MT224244",
       "nanae772",
-      "madosuki",
-      "sabonerune",
       "raa0121",
-      "takusea",
-      "jdkfx",
+      "romot-co",
+      "sabonerune",
+      "sevenc-nanashi",
+      "shunjilin",
       "sigprogramming",
-      "Hiroshiba"
+      "takana-v",
+      "takusea"
     ]
   },
   {


### PR DESCRIPTION
## 内容

arm64のエンジンをダウンロードしようとしていたのでx64のを使うようにしてみました。

- https://github.com/VOICEVOX/voicevox/issues/2575

を解決します。

## 関連 Issue

close #2575

- https://github.com/VOICEVOX/voicevox_project/discussions/60

## その他

arm64版のlinuxエディタを作るとか、x64用の名前に今のうちに変更するかとかも考えたのですが、どっちも一旦なしにしました。
もしarm64版linuxエディタ作るなら命名はmacOSのに倣って、x64のはx64に、arm64のはarm64と書くのが良さそう。

![image](https://github.com/user-attachments/assets/ad5c337d-3b90-4c68-bf70-73baa4cf1545)
