### PR TITLE
refactor: ステートのprivateメソッドを下の方に移動

### DIFF
--- a/src/sing/sequencerStateMachine/states/addNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/addNoteState.ts
@@ -50,32 +50,6 @@ export class AddNoteState
     this.applyPreview = false;
   }
 
-  private previewAdd(context: Context) {
-    if (this.innerContext == undefined) {
-      throw new Error("innerContext is undefined.");
-    }
-    const noteToAdd = this.innerContext.noteToAdd;
-    const snapTicks = context.snapTicks.value;
-    const dragTicks = this.currentCursorPos.ticks - this.cursorPosAtStart.ticks;
-    const noteDuration = Math.round(dragTicks / snapTicks) * snapTicks;
-    const noteEndPos = noteToAdd.position + noteDuration;
-    const previewNotes = context.previewNotes.value;
-
-    const editedNotes = new Map<NoteId, Note>();
-    for (const note of previewNotes) {
-      const duration = Math.max(snapTicks, noteDuration);
-      if (note.duration !== duration) {
-        editedNotes.set(note.id, { ...note, duration });
-      }
-    }
-    if (editedNotes.size !== 0) {
-      context.previewNotes.value = previewNotes.map((value) => {
-        return editedNotes.get(value.id) ?? value;
-      });
-    }
-    context.guideLineTicks.value = noteEndPos;
-  }
-
   onEnter(context: Context) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const noteToAdd = {
@@ -168,5 +142,31 @@ export class AddNoteState
     context.previewNotes.value = [];
     context.cursorState.value = "UNSET";
     context.previewMode.value = "IDLE";
+  }
+
+  private previewAdd(context: Context) {
+    if (this.innerContext == undefined) {
+      throw new Error("innerContext is undefined.");
+    }
+    const noteToAdd = this.innerContext.noteToAdd;
+    const snapTicks = context.snapTicks.value;
+    const dragTicks = this.currentCursorPos.ticks - this.cursorPosAtStart.ticks;
+    const noteDuration = Math.round(dragTicks / snapTicks) * snapTicks;
+    const noteEndPos = noteToAdd.position + noteDuration;
+    const previewNotes = context.previewNotes.value;
+
+    const editedNotes = new Map<NoteId, Note>();
+    for (const note of previewNotes) {
+      const duration = Math.max(snapTicks, noteDuration);
+      if (note.duration !== duration) {
+        editedNotes.set(note.id, { ...note, duration });
+      }
+    }
+    if (editedNotes.size !== 0) {
+      context.previewNotes.value = previewNotes.map((value) => {
+        return editedNotes.get(value.id) ?? value;
+      });
+    }
+    context.guideLineTicks.value = noteEndPos;
   }
 }

--- a/src/sing/sequencerStateMachine/states/drawPitchState.ts
+++ b/src/sing/sequencerStateMachine/states/drawPitchState.ts
@@ -47,77 +47,6 @@ export class DrawPitchState
     this.applyPreview = false;
   }
 
-  private previewDrawPitch(context: Context) {
-    if (this.innerContext == undefined) {
-      throw new Error("innerContext is undefined.");
-    }
-    if (context.previewPitchEdit.value == undefined) {
-      throw new Error("previewPitchEdit.value is undefined.");
-    }
-    if (context.previewPitchEdit.value.type !== "draw") {
-      throw new Error("previewPitchEdit.value.type is not draw.");
-    }
-    const cursorFrame = this.currentCursorPos.frame;
-    const cursorFrequency = this.currentCursorPos.frequency;
-    const prevCursorFrame = this.innerContext.prevCursorPos.frame;
-    const prevCursorFrequency = this.innerContext.prevCursorPos.frequency;
-    if (cursorFrame < 0) {
-      return;
-    }
-    const tempPitchEdit = {
-      ...context.previewPitchEdit.value,
-      data: [...context.previewPitchEdit.value.data],
-    };
-
-    if (cursorFrame < tempPitchEdit.startFrame) {
-      const numOfFramesToUnshift = tempPitchEdit.startFrame - cursorFrame;
-      tempPitchEdit.data = createArray(numOfFramesToUnshift, () => 0).concat(
-        tempPitchEdit.data,
-      );
-      tempPitchEdit.startFrame = cursorFrame;
-    }
-
-    const lastFrame = tempPitchEdit.startFrame + tempPitchEdit.data.length - 1;
-    if (cursorFrame > lastFrame) {
-      const numOfFramesToPush = cursorFrame - lastFrame;
-      tempPitchEdit.data = tempPitchEdit.data.concat(
-        createArray(numOfFramesToPush, () => 0),
-      );
-    }
-
-    if (cursorFrame === prevCursorFrame) {
-      const i = cursorFrame - tempPitchEdit.startFrame;
-      tempPitchEdit.data[i] = cursorFrequency;
-    } else if (cursorFrame < prevCursorFrame) {
-      for (let i = cursorFrame; i <= prevCursorFrame; i++) {
-        tempPitchEdit.data[i - tempPitchEdit.startFrame] = Math.exp(
-          linearInterpolation(
-            cursorFrame,
-            Math.log(cursorFrequency),
-            prevCursorFrame,
-            Math.log(prevCursorFrequency),
-            i,
-          ),
-        );
-      }
-    } else {
-      for (let i = prevCursorFrame; i <= cursorFrame; i++) {
-        tempPitchEdit.data[i - tempPitchEdit.startFrame] = Math.exp(
-          linearInterpolation(
-            prevCursorFrame,
-            Math.log(prevCursorFrequency),
-            cursorFrame,
-            Math.log(cursorFrequency),
-            i,
-          ),
-        );
-      }
-    }
-
-    context.previewPitchEdit.value = tempPitchEdit;
-    this.innerContext.prevCursorPos = this.currentCursorPos;
-  }
-
   onEnter(context: Context) {
     context.previewPitchEdit.value = {
       type: "draw",
@@ -217,5 +146,76 @@ export class DrawPitchState
     context.previewPitchEdit.value = undefined;
     context.cursorState.value = "UNSET";
     context.previewMode.value = "IDLE";
+  }
+
+  private previewDrawPitch(context: Context) {
+    if (this.innerContext == undefined) {
+      throw new Error("innerContext is undefined.");
+    }
+    if (context.previewPitchEdit.value == undefined) {
+      throw new Error("previewPitchEdit.value is undefined.");
+    }
+    if (context.previewPitchEdit.value.type !== "draw") {
+      throw new Error("previewPitchEdit.value.type is not draw.");
+    }
+    const cursorFrame = this.currentCursorPos.frame;
+    const cursorFrequency = this.currentCursorPos.frequency;
+    const prevCursorFrame = this.innerContext.prevCursorPos.frame;
+    const prevCursorFrequency = this.innerContext.prevCursorPos.frequency;
+    if (cursorFrame < 0) {
+      return;
+    }
+    const tempPitchEdit = {
+      ...context.previewPitchEdit.value,
+      data: [...context.previewPitchEdit.value.data],
+    };
+
+    if (cursorFrame < tempPitchEdit.startFrame) {
+      const numOfFramesToUnshift = tempPitchEdit.startFrame - cursorFrame;
+      tempPitchEdit.data = createArray(numOfFramesToUnshift, () => 0).concat(
+        tempPitchEdit.data,
+      );
+      tempPitchEdit.startFrame = cursorFrame;
+    }
+
+    const lastFrame = tempPitchEdit.startFrame + tempPitchEdit.data.length - 1;
+    if (cursorFrame > lastFrame) {
+      const numOfFramesToPush = cursorFrame - lastFrame;
+      tempPitchEdit.data = tempPitchEdit.data.concat(
+        createArray(numOfFramesToPush, () => 0),
+      );
+    }
+
+    if (cursorFrame === prevCursorFrame) {
+      const i = cursorFrame - tempPitchEdit.startFrame;
+      tempPitchEdit.data[i] = cursorFrequency;
+    } else if (cursorFrame < prevCursorFrame) {
+      for (let i = cursorFrame; i <= prevCursorFrame; i++) {
+        tempPitchEdit.data[i - tempPitchEdit.startFrame] = Math.exp(
+          linearInterpolation(
+            cursorFrame,
+            Math.log(cursorFrequency),
+            prevCursorFrame,
+            Math.log(prevCursorFrequency),
+            i,
+          ),
+        );
+      }
+    } else {
+      for (let i = prevCursorFrame; i <= cursorFrame; i++) {
+        tempPitchEdit.data[i - tempPitchEdit.startFrame] = Math.exp(
+          linearInterpolation(
+            prevCursorFrame,
+            Math.log(prevCursorFrequency),
+            cursorFrame,
+            Math.log(cursorFrequency),
+            i,
+          ),
+        );
+      }
+    }
+
+    context.previewPitchEdit.value = tempPitchEdit;
+    this.innerContext.prevCursorPos = this.currentCursorPos;
   }
 }

--- a/src/sing/sequencerStateMachine/states/erasePitchState.ts
+++ b/src/sing/sequencerStateMachine/states/erasePitchState.ts
@@ -41,32 +41,6 @@ export class ErasePitchState
     this.applyPreview = false;
   }
 
-  private previewErasePitch(context: Context) {
-    if (this.innerContext == undefined) {
-      throw new Error("innerContext is undefined.");
-    }
-    if (context.previewPitchEdit.value == undefined) {
-      throw new Error("previewPitchEdit.value is undefined.");
-    }
-    if (context.previewPitchEdit.value.type !== "erase") {
-      throw new Error("previewPitchEdit.value.type is not erase.");
-    }
-    const cursorFrame = Math.max(0, this.currentCursorPos.frame);
-    const tempPitchEdit = { ...context.previewPitchEdit.value };
-
-    if (tempPitchEdit.startFrame > cursorFrame) {
-      tempPitchEdit.frameLength += tempPitchEdit.startFrame - cursorFrame;
-      tempPitchEdit.startFrame = cursorFrame;
-    }
-
-    const lastFrame = tempPitchEdit.startFrame + tempPitchEdit.frameLength - 1;
-    if (lastFrame < cursorFrame) {
-      tempPitchEdit.frameLength += cursorFrame - lastFrame;
-    }
-
-    context.previewPitchEdit.value = tempPitchEdit;
-  }
-
   onEnter(context: Context) {
     context.previewPitchEdit.value = {
       type: "erase",
@@ -148,5 +122,31 @@ export class ErasePitchState
     context.previewPitchEdit.value = undefined;
     context.cursorState.value = "UNSET";
     context.previewMode.value = "IDLE";
+  }
+
+  private previewErasePitch(context: Context) {
+    if (this.innerContext == undefined) {
+      throw new Error("innerContext is undefined.");
+    }
+    if (context.previewPitchEdit.value == undefined) {
+      throw new Error("previewPitchEdit.value is undefined.");
+    }
+    if (context.previewPitchEdit.value.type !== "erase") {
+      throw new Error("previewPitchEdit.value.type is not erase.");
+    }
+    const cursorFrame = Math.max(0, this.currentCursorPos.frame);
+    const tempPitchEdit = { ...context.previewPitchEdit.value };
+
+    if (tempPitchEdit.startFrame > cursorFrame) {
+      tempPitchEdit.frameLength += tempPitchEdit.startFrame - cursorFrame;
+      tempPitchEdit.startFrame = cursorFrame;
+    }
+
+    const lastFrame = tempPitchEdit.startFrame + tempPitchEdit.frameLength - 1;
+    if (lastFrame < cursorFrame) {
+      tempPitchEdit.frameLength += cursorFrame - lastFrame;
+    }
+
+    context.previewPitchEdit.value = tempPitchEdit;
   }
 }

--- a/src/sing/sequencerStateMachine/states/moveNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/moveNoteState.ts
@@ -57,48 +57,6 @@ export class MoveNoteState
     this.applyPreview = false;
   }
 
-  private previewMove(context: Context) {
-    if (this.innerContext == undefined) {
-      throw new Error("innerContext is undefined.");
-    }
-    const snapTicks = context.snapTicks.value;
-    const previewNotes = context.previewNotes.value;
-    const targetNotesAtStart = this.innerContext.targetNotesAtStart;
-    const mouseDownNote = getOrThrow(targetNotesAtStart, this.mouseDownNoteId);
-    const dragTicks = this.currentCursorPos.ticks - this.cursorPosAtStart.ticks;
-    const notePos = mouseDownNote.position;
-    const newNotePos =
-      Math.round((notePos + dragTicks) / snapTicks) * snapTicks;
-    const movingTicks = newNotePos - notePos;
-    const movingSemitones =
-      this.currentCursorPos.noteNumber - this.cursorPosAtStart.noteNumber;
-
-    const editedNotes = new Map<NoteId, Note>();
-    for (const note of previewNotes) {
-      const targetNoteAtStart = getOrThrow(targetNotesAtStart, note.id);
-      const position = Math.max(0, targetNoteAtStart.position + movingTicks);
-      const noteNumber = clamp(
-        targetNoteAtStart.noteNumber + movingSemitones,
-        0,
-        127,
-      );
-
-      if (note.position !== position || note.noteNumber !== noteNumber) {
-        editedNotes.set(note.id, { ...note, noteNumber, position });
-      }
-    }
-
-    if (editedNotes.size !== 0) {
-      context.previewNotes.value = previewNotes.map((value) => {
-        return editedNotes.get(value.id) ?? value;
-      });
-      this.innerContext.edited = true;
-    }
-
-    context.guideLineTicks.value =
-      this.innerContext.guideLineTicksAtStart + movingTicks;
-  }
-
   onEnter(context: Context) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const targetNotesArray = context.notesInSelectedTrack.value.filter(
@@ -194,5 +152,47 @@ export class MoveNoteState
     context.previewNotes.value = [];
     context.cursorState.value = "UNSET";
     context.previewMode.value = "IDLE";
+  }
+
+  private previewMove(context: Context) {
+    if (this.innerContext == undefined) {
+      throw new Error("innerContext is undefined.");
+    }
+    const snapTicks = context.snapTicks.value;
+    const previewNotes = context.previewNotes.value;
+    const targetNotesAtStart = this.innerContext.targetNotesAtStart;
+    const mouseDownNote = getOrThrow(targetNotesAtStart, this.mouseDownNoteId);
+    const dragTicks = this.currentCursorPos.ticks - this.cursorPosAtStart.ticks;
+    const notePos = mouseDownNote.position;
+    const newNotePos =
+      Math.round((notePos + dragTicks) / snapTicks) * snapTicks;
+    const movingTicks = newNotePos - notePos;
+    const movingSemitones =
+      this.currentCursorPos.noteNumber - this.cursorPosAtStart.noteNumber;
+
+    const editedNotes = new Map<NoteId, Note>();
+    for (const note of previewNotes) {
+      const targetNoteAtStart = getOrThrow(targetNotesAtStart, note.id);
+      const position = Math.max(0, targetNoteAtStart.position + movingTicks);
+      const noteNumber = clamp(
+        targetNoteAtStart.noteNumber + movingSemitones,
+        0,
+        127,
+      );
+
+      if (note.position !== position || note.noteNumber !== noteNumber) {
+        editedNotes.set(note.id, { ...note, noteNumber, position });
+      }
+    }
+
+    if (editedNotes.size !== 0) {
+      context.previewNotes.value = previewNotes.map((value) => {
+        return editedNotes.get(value.id) ?? value;
+      });
+      this.innerContext.edited = true;
+    }
+
+    context.guideLineTicks.value =
+      this.innerContext.guideLineTicksAtStart + movingTicks;
   }
 }

--- a/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
@@ -57,43 +57,6 @@ export class ResizeNoteLeftState
     this.applyPreview = false;
   }
 
-  private previewResizeLeft(context: Context) {
-    if (this.innerContext == undefined) {
-      throw new Error("innerContext is undefined.");
-    }
-    const snapTicks = context.snapTicks.value;
-    const previewNotes = context.previewNotes.value;
-    const targetNotesAtStart = this.innerContext.targetNotesAtStart;
-    const mouseDownNote = getOrThrow(targetNotesAtStart, this.mouseDownNoteId);
-    const dragTicks = this.currentCursorPos.ticks - this.cursorPosAtStart.ticks;
-    const notePos = mouseDownNote.position;
-    const newNotePos =
-      Math.round((notePos + dragTicks) / snapTicks) * snapTicks;
-    const movingTicks = newNotePos - notePos;
-
-    const editedNotes = new Map<NoteId, Note>();
-    for (const note of previewNotes) {
-      const targetNoteAtStart = getOrThrow(targetNotesAtStart, note.id);
-      const notePos = targetNoteAtStart.position;
-      const noteEndPos =
-        targetNoteAtStart.position + targetNoteAtStart.duration;
-      const position = clamp(notePos + movingTicks, 0, noteEndPos - snapTicks);
-      const duration = noteEndPos - position;
-
-      if (note.position !== position || note.duration !== duration) {
-        editedNotes.set(note.id, { ...note, position, duration });
-      }
-    }
-    if (editedNotes.size !== 0) {
-      context.previewNotes.value = previewNotes.map((value) => {
-        return editedNotes.get(value.id) ?? value;
-      });
-      this.innerContext.edited = true;
-    }
-
-    context.guideLineTicks.value = newNotePos;
-  }
-
   onEnter(context: Context) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const targetNotesArray = context.notesInSelectedTrack.value.filter(
@@ -188,5 +151,42 @@ export class ResizeNoteLeftState
     context.previewNotes.value = [];
     context.cursorState.value = "UNSET";
     context.previewMode.value = "IDLE";
+  }
+
+  private previewResizeLeft(context: Context) {
+    if (this.innerContext == undefined) {
+      throw new Error("innerContext is undefined.");
+    }
+    const snapTicks = context.snapTicks.value;
+    const previewNotes = context.previewNotes.value;
+    const targetNotesAtStart = this.innerContext.targetNotesAtStart;
+    const mouseDownNote = getOrThrow(targetNotesAtStart, this.mouseDownNoteId);
+    const dragTicks = this.currentCursorPos.ticks - this.cursorPosAtStart.ticks;
+    const notePos = mouseDownNote.position;
+    const newNotePos =
+      Math.round((notePos + dragTicks) / snapTicks) * snapTicks;
+    const movingTicks = newNotePos - notePos;
+
+    const editedNotes = new Map<NoteId, Note>();
+    for (const note of previewNotes) {
+      const targetNoteAtStart = getOrThrow(targetNotesAtStart, note.id);
+      const notePos = targetNoteAtStart.position;
+      const noteEndPos =
+        targetNoteAtStart.position + targetNoteAtStart.duration;
+      const position = clamp(notePos + movingTicks, 0, noteEndPos - snapTicks);
+      const duration = noteEndPos - position;
+
+      if (note.position !== position || note.duration !== duration) {
+        editedNotes.set(note.id, { ...note, position, duration });
+      }
+    }
+    if (editedNotes.size !== 0) {
+      context.previewNotes.value = previewNotes.map((value) => {
+        return editedNotes.get(value.id) ?? value;
+      });
+      this.innerContext.edited = true;
+    }
+
+    context.guideLineTicks.value = newNotePos;
   }
 }

--- a/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
@@ -56,42 +56,6 @@ export class ResizeNoteRightState
     this.applyPreview = false;
   }
 
-  private previewResizeRight(context: Context) {
-    if (this.innerContext == undefined) {
-      throw new Error("innerContext is undefined.");
-    }
-    const snapTicks = context.snapTicks.value;
-    const previewNotes = context.previewNotes.value;
-    const targetNotesAtStart = this.innerContext.targetNotesAtStart;
-    const mouseDownNote = getOrThrow(targetNotesAtStart, this.mouseDownNoteId);
-    const dragTicks = this.currentCursorPos.ticks - this.cursorPosAtStart.ticks;
-    const noteEndPos = mouseDownNote.position + mouseDownNote.duration;
-    const newNoteEndPos =
-      Math.round((noteEndPos + dragTicks) / snapTicks) * snapTicks;
-    const movingTicks = newNoteEndPos - noteEndPos;
-
-    const editedNotes = new Map<NoteId, Note>();
-    for (const note of previewNotes) {
-      const targetNoteAtStart = getOrThrow(targetNotesAtStart, note.id);
-      const notePos = targetNoteAtStart.position;
-      const noteEndPos =
-        targetNoteAtStart.position + targetNoteAtStart.duration;
-      const duration = Math.max(snapTicks, noteEndPos + movingTicks - notePos);
-
-      if (note.duration !== duration) {
-        editedNotes.set(note.id, { ...note, duration });
-      }
-    }
-    if (editedNotes.size !== 0) {
-      context.previewNotes.value = previewNotes.map((value) => {
-        return editedNotes.get(value.id) ?? value;
-      });
-      this.innerContext.edited = true;
-    }
-
-    context.guideLineTicks.value = newNoteEndPos;
-  }
-
   onEnter(context: Context) {
     const guideLineTicks = getGuideLineTicks(this.cursorPosAtStart, context);
     const targetNotesArray = context.notesInSelectedTrack.value.filter(
@@ -189,5 +153,41 @@ export class ResizeNoteRightState
     context.previewNotes.value = [];
     context.cursorState.value = "UNSET";
     context.previewMode.value = "IDLE";
+  }
+
+  private previewResizeRight(context: Context) {
+    if (this.innerContext == undefined) {
+      throw new Error("innerContext is undefined.");
+    }
+    const snapTicks = context.snapTicks.value;
+    const previewNotes = context.previewNotes.value;
+    const targetNotesAtStart = this.innerContext.targetNotesAtStart;
+    const mouseDownNote = getOrThrow(targetNotesAtStart, this.mouseDownNoteId);
+    const dragTicks = this.currentCursorPos.ticks - this.cursorPosAtStart.ticks;
+    const noteEndPos = mouseDownNote.position + mouseDownNote.duration;
+    const newNoteEndPos =
+      Math.round((noteEndPos + dragTicks) / snapTicks) * snapTicks;
+    const movingTicks = newNoteEndPos - noteEndPos;
+
+    const editedNotes = new Map<NoteId, Note>();
+    for (const note of previewNotes) {
+      const targetNoteAtStart = getOrThrow(targetNotesAtStart, note.id);
+      const notePos = targetNoteAtStart.position;
+      const noteEndPos =
+        targetNoteAtStart.position + targetNoteAtStart.duration;
+      const duration = Math.max(snapTicks, noteEndPos + movingTicks - notePos);
+
+      if (note.duration !== duration) {
+        editedNotes.set(note.id, { ...note, duration });
+      }
+    }
+    if (editedNotes.size !== 0) {
+      context.previewNotes.value = previewNotes.map((value) => {
+        return editedNotes.get(value.id) ?? value;
+      });
+      this.innerContext.edited = true;
+    }
+
+    context.guideLineTicks.value = newNoteEndPos;
   }
 }

--- a/src/sing/sequencerStateMachine/states/selectNotesWithRectState.ts
+++ b/src/sing/sequencerStateMachine/states/selectNotesWithRectState.ts
@@ -34,20 +34,6 @@ export class SelectNotesWithRectState
     this.additive = false;
   }
 
-  private updatePreviewRect(context: Context) {
-    const startX = Math.min(this.cursorPosAtStart.x, this.currentCursorPos.x);
-    const endX = Math.max(this.cursorPosAtStart.x, this.currentCursorPos.x);
-    const startY = Math.min(this.cursorPosAtStart.y, this.currentCursorPos.y);
-    const endY = Math.max(this.cursorPosAtStart.y, this.currentCursorPos.y);
-
-    context.previewRectForRectSelect.value = {
-      x: startX,
-      y: startY,
-      width: Math.max(1, endX - startX),
-      height: Math.max(1, endY - startY),
-    };
-  }
-
   onEnter(context: Context) {
     this.updatePreviewRect(context);
 
@@ -123,5 +109,19 @@ export class SelectNotesWithRectState
     context.previewRectForRectSelect.value = undefined;
     context.cursorState.value = "UNSET";
     context.previewMode.value = "IDLE";
+  }
+
+  private updatePreviewRect(context: Context) {
+    const startX = Math.min(this.cursorPosAtStart.x, this.currentCursorPos.x);
+    const endX = Math.max(this.cursorPosAtStart.x, this.currentCursorPos.x);
+    const startY = Math.min(this.cursorPosAtStart.y, this.currentCursorPos.y);
+    const endY = Math.max(this.cursorPosAtStart.y, this.currentCursorPos.y);
+
+    context.previewRectForRectSelect.value = {
+      x: startX,
+      y: startY,
+      width: Math.max(1, endX - startX),
+      height: Math.max(1, endY - startY),
+    };
   }
 }

--- a/src/sing/viewHelper.ts
+++ b/src/sing/viewHelper.ts
@@ -131,23 +131,6 @@ export type PreviewMode =
   | "SELECT_NOTES_WITH_RECT"
   | "EDIT_NOTE_LYRIC";
 
-// マウスダウン時の振る舞い
-export const mouseDownBehaviorSchema = z.enum([
-  "IGNORE",
-  "DESELECT_ALL",
-  "ADD_NOTE",
-  "START_RECT_SELECT",
-  "DRAW_PITCH",
-  "ERASE_PITCH",
-]);
-export type MouseDownBehavior = z.infer<typeof mouseDownBehaviorSchema>;
-
-// ダブルクリック時の振る舞い
-export const mouseDoubleClickBehaviorSchema = z.enum(["IGNORE", "ADD_NOTE"]);
-export type MouseDoubleClickBehavior = z.infer<
-  typeof mouseDoubleClickBehaviorSchema
->;
-
 export function getButton(event: MouseEvent): MouseButton {
   // macOSの場合、Ctrl+クリックは右クリック
   if (isMac && event.button === 0 && event.ctrlKey) {


### PR DESCRIPTION
## 内容

ステートのprivateメソッドを下の方に移動します。（移動のみ）

また、使われていない型の削除もついでに行います。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2403

## その他
