### PR TITLE
build: インストール時にVOICEVOX-CPU-ARCH.AppImageからVOICEVOX.AppImageにrenameするようにする

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -319,12 +319,11 @@ FIRST_ARCHIVE=${ARCHIVE_NAME_LIST[0]}
 APPIMAGE="VOICEVOX.AppImage"
 OUT_APPIMAGE_NAME=$("${COMMAND_7Z}" l -slt -ba "${FIRST_ARCHIVE}" | grep 'Path = ' | head -n1 | sed 's/Path = \(.*\)/\1/')
 if [ "$OUT_APPIMAGE_NAME" != "$APPIMAGE" ]; then
-    if ! cp "$OUT_APPIMAGE_NAME" "$APPIMAGE"; then
+    if ! mv "$OUT_APPIMAGE_NAME" "$APPIMAGE"; then
         echo "Failed rename a AppImage file."
         rm "$OUT_APPIMAGE_NAME"
         exit 1
     fi
-    rm "$OUT_APPIMAGE_NAME"
 fi
 chmod +x "${APPIMAGE}"
 

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -316,8 +316,16 @@ echo "[+] Extracting archive..."
 FIRST_ARCHIVE=${ARCHIVE_NAME_LIST[0]}
 "${COMMAND_7Z}" x "${FIRST_ARCHIVE}" -y
 
-# Get AppImage filename from 7z archive
-APPIMAGE=$("${COMMAND_7Z}" l -slt -ba "${FIRST_ARCHIVE}" | grep 'Path = ' | head -n1 | sed 's/Path = \(.*\)/\1/')
+APPIMAGE="VOICEVOX.AppImage"
+OUT_APPIMAGE_NAME=$("${COMMAND_7Z}" l -slt -ba "${FIRST_ARCHIVE}" | grep 'Path = ' | head -n1 | sed 's/Path = \(.*\)/\1/')
+if [ "$OUT_APPIMAGE_NAME" != "$APPIMAGE" ]; then
+    if ! cp "$OUT_APPIMAGE_NAME" "$APPIMAGE"; then
+        echo "Failed rename a AppImage file."
+        rm "$OUT_APPIMAGE_NAME"
+        exit 1
+    fi
+    rm "$OUT_APPIMAGE_NAME"
+fi
 chmod +x "${APPIMAGE}"
 
 # Dump version

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -318,13 +318,9 @@ FIRST_ARCHIVE=${ARCHIVE_NAME_LIST[0]}
 
 # Rename
 APPIMAGE="VOICEVOX.AppImage"
-OUT_APPIMAGE_NAME=$("${COMMAND_7Z}" l -slt -ba "${FIRST_ARCHIVE}" | grep 'Path = ' | head -n1 | sed 's/Path = \(.*\)/\1/')
-if [ "$OUT_APPIMAGE_NAME" != "$APPIMAGE" ]; then
-    if ! mv "$OUT_APPIMAGE_NAME" "$APPIMAGE"; then
-        echo "Failed rename a AppImage file."
-        rm "$OUT_APPIMAGE_NAME"
-        exit 1
-    fi
+EXTRACTED_APPIMAGE_NAME=$("${COMMAND_7Z}" l -slt -ba "${FIRST_ARCHIVE}" | grep 'Path = ' | head -n1 | sed 's/Path = \(.*\)/\1/')
+if [ "$EXTRACTED_APPIMAGE_NAME" != "$APPIMAGE" ]; then
+    mv "$EXTRACTED_APPIMAGE_NAME" "$APPIMAGE"
 fi
 chmod +x "${APPIMAGE}"
 

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -316,6 +316,7 @@ echo "[+] Extracting archive..."
 FIRST_ARCHIVE=${ARCHIVE_NAME_LIST[0]}
 "${COMMAND_7Z}" x "${FIRST_ARCHIVE}" -y
 
+# Rename
 APPIMAGE="VOICEVOX.AppImage"
 OUT_APPIMAGE_NAME=$("${COMMAND_7Z}" l -slt -ba "${FIRST_ARCHIVE}" | grep 'Path = ' | head -n1 | sed 's/Path = \(.*\)/\1/')
 if [ "$OUT_APPIMAGE_NAME" != "$APPIMAGE" ]; then


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox/issues/2577 でLinux版のCPU版がX64とARM64の両方提供されることになり、7zファイルを展開するとVOICEVOX-CPU-ARCH_NAME.AppImageが出力される。
それまでは.voicevox下に配置されるのはVOICEVOX.AppImageだったのでアップデート時に上書きできるようにインストール時にrename処理を追加しました。  

X64は、`VERSION=0.24.0-dev NAME=linux-cpu-x64-appimage bash build/installer_linux.sh`  
ARM64は、`VERSION=0.24.0-dev NAME=linux-cpu-arm64-appimage bash build/installer_linux.sh`  
で試せます。

## 関連 Issue
close #2587
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
