### PR TITLE
chore: typosのバージョンを管理

### DIFF
--- a/tools/downloadTypos.mts
+++ b/tools/downloadTypos.mts
@@ -27,6 +27,9 @@ const CPU_ARCHITECTURE = {
 const BINARY_BASE_PATH = resolve(import.meta.dirname, "..", "vendored");
 // typosのバイナリを格納するディレクトリ
 const TYPOS_DIRECTORY_PATH = resolve(BINARY_BASE_PATH, "typos");
+// typosのバージョンを保存しておくテキストファイル
+const TYPOS_VERSION_FILE_NAME = "version.txt";
+
 const TYPOS_VERSION = "v1.30.0";
 
 // 各OSとアーキテクチャに対応するtyposバイナリのターゲットトリプル
@@ -113,7 +116,7 @@ async function needsDownloadTypos(): Promise<boolean> {
   // TYPOS_BINARY_PATHが存在する場合、typosのバージョンをチェック
   if (await exists(TYPOS_DIRECTORY_PATH)) {
     const currentVersion = await fs
-      .readFile(resolve(TYPOS_DIRECTORY_PATH, ".typos-version"), "utf-8")
+      .readFile(resolve(TYPOS_DIRECTORY_PATH, TYPOS_VERSION_FILE_NAME), "utf-8")
       .catch((error: NodeJS.ErrnoException) => {
         if (error.code === "ENOENT") {
           return ""; // バージョンファイルが存在しない場合は空文字列を返却
@@ -193,8 +196,8 @@ async function downloadAndUnarchive({ url }: { url: string }) {
   }
 
   // typosのバージョンを保存
-  const versionFile = resolve(TYPOS_DIRECTORY_PATH, ".typos-version");
-  await fs.writeFile(versionFile, `${TYPOS_VERSION}`);
+  const versionFile = resolve(TYPOS_DIRECTORY_PATH, TYPOS_VERSION_FILE_NAME);
+  await fs.writeFile(versionFile, TYPOS_VERSION);
 
   // 解凍後に圧縮ファイルを削除
   await fs.rm(compressedFilePath);

--- a/tools/downloadTypos.mts
+++ b/tools/downloadTypos.mts
@@ -219,7 +219,7 @@ async function downloadAndUnarchive({ url }: { url: string }) {
 
 /**
  * /vendored/typos ディレクトリから不要なドキュメントを削除する関数
- * ダウンロード・解凍後に実行される
+ * ダウンロード・解凍後に実行する
  */
 async function removeTyposDocumentation() {
   const typosDocDirPath = join(TYPOS_DIRECTORY_PATH, "doc");

--- a/tools/downloadTypos.mts
+++ b/tools/downloadTypos.mts
@@ -112,7 +112,7 @@ function getBinaryURL() {
  * Typosのダウンロードが必要か判定する関数
  * @returns {Promise<boolean>} Typosのダウンロードが必要か
  */
-async function needsDownloadTypos(): Promise<boolean> {
+async function shouldDownloadTypos(): Promise<boolean> {
   // TYPOS_BINARY_PATHが存在する場合、typosのバージョンをチェック
   if (await exists(TYPOS_DIRECTORY_PATH)) {
     const currentVersion = await fs
@@ -149,7 +149,7 @@ async function needsDownloadTypos(): Promise<boolean> {
  * バイナリをダウンロードして解凍し、実行権限を付与する関数
  */
 async function downloadAndUnarchive({ url }: { url: string }) {
-  if (!(await needsDownloadTypos())) {
+  if (!(await shouldDownloadTypos())) {
     console.log("typos already downloaded");
     return;
   }


### PR DESCRIPTION
## 内容
表題の通り、typosのバージョンを管理できるようにしました。
私の手元の環境(Windows, Linux(WSL))で動作確認はしています。

実装方法としては #2585 に書いていただいている方針です。

> 今URLを入れてるところをtar.gzについてるtriplet（x86_64-pc-windows-msvc）だけにして、
バージョンを定数としてURLの外に出して、
URLをバージョンとtripletから生成するようにして、
バージョンの書いたテキストファイルをtyposの隣に置くようにして、
ダウンロード時に更新チェック

注意点としてはバージョンを書いたテキストファイル(`.typos-version`)が存在しない場合は再ダウンロードが行われるようになっています。

## 関連 Issue
close #2585 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
