### PR TITLE
refactor: download7z.ts, downloadTypos.tsで使われていたpath.resolveをpath.joinに置き換える

### DIFF
--- a/tools/download7z.ts
+++ b/tools/download7z.ts
@@ -7,7 +7,7 @@ import { arch } from "os";
 import path from "path";
 import { retryFetch } from "./helper.mjs";
 
-const distPath = path.resolve(import.meta.dirname, "..", "vendored", "7z");
+const distPath = path.join(import.meta.dirname, "..", "vendored", "7z");
 let url;
 let filesToExtract;
 
@@ -19,7 +19,7 @@ switch (process.platform) {
     // Actionsでインストーラーを動かすことはできないので、単独で配布されている7zr.exeを使い、
     // 7z形式で圧縮されている7za.exeを展開する。
     const sevenzrUrl = "https://www.7-zip.org/a/7zr.exe";
-    const sevenzrPath = path.resolve(distPath, "7zr.exe");
+    const sevenzrPath = path.join(distPath, "7zr.exe");
     if (!fs.existsSync(sevenzrPath)) {
       console.log("Downloading 7zr from " + sevenzrUrl);
       const res = await retryFetch(sevenzrUrl);
@@ -82,13 +82,13 @@ if (!res.ok) {
   throw new Error(`Failed to download binary: ${res.statusText}`);
 }
 const buffer = await res.arrayBuffer();
-const sevenZipPath = path.resolve(distPath, path.basename(url));
+const sevenZipPath = path.join(distPath, path.basename(url));
 await fs.promises.writeFile(sevenZipPath, Buffer.from(buffer));
 
 console.log("Extracting 7z");
 const extractor = url.endsWith(".7z")
   ? spawnSync(
-      path.resolve(distPath, "7zr.exe"),
+      path.join(distPath, "7zr.exe"),
       ["x", "-y", "-o" + distPath, sevenZipPath, ...filesToExtract],
       {
         stdio: ["ignore", "inherit", "inherit"],

--- a/tools/downloadTypos.ts
+++ b/tools/downloadTypos.ts
@@ -4,7 +4,7 @@
 import { exec } from "child_process";
 import { promisify } from "util";
 import { platform, arch } from "os";
-import { join, resolve } from "path";
+import { join } from "path";
 import fsSync from "fs";
 import fs from "fs/promises";
 import { Readable } from "stream";
@@ -24,9 +24,9 @@ const CPU_ARCHITECTURE = {
   ARM: "aarch64",
 };
 // ダウンロードしたバイナリを格納するディレクトリ
-const BINARY_BASE_PATH = resolve(import.meta.dirname, "..", "vendored");
+const BINARY_BASE_PATH = join(import.meta.dirname, "..", "vendored");
 // typosのバイナリを格納するディレクトリ
-const TYPOS_DIRECTORY_PATH = resolve(BINARY_BASE_PATH, "typos");
+const TYPOS_DIRECTORY_PATH = join(BINARY_BASE_PATH, "typos");
 // typosのバージョンを保存しておくテキストファイル
 const TYPOS_VERSION_FILE_NAME = "version.txt";
 
@@ -118,10 +118,7 @@ async function shouldDownloadTypos(): Promise<boolean> {
   }
 
   // TYPOS_BINARY_PATHが存在する場合、typosのバージョンをチェック
-  const versionFilePath = resolve(
-    TYPOS_DIRECTORY_PATH,
-    TYPOS_VERSION_FILE_NAME,
-  );
+  const versionFilePath = join(TYPOS_DIRECTORY_PATH, TYPOS_VERSION_FILE_NAME);
   if (!(await exists(versionFilePath))) {
     return true;
   }
@@ -146,7 +143,7 @@ async function prepareTyposDirectory() {
   if (await exists(TYPOS_DIRECTORY_PATH)) {
     const files = await fs.readdir(TYPOS_DIRECTORY_PATH);
     await Promise.all(
-      files.map((file) => fs.unlink(resolve(TYPOS_DIRECTORY_PATH, file))),
+      files.map((file) => fs.unlink(join(TYPOS_DIRECTORY_PATH, file))),
     );
   } else {
     // 無い場合は新規作成する
@@ -207,10 +204,7 @@ async function downloadAndUnarchive({ url }: { url: string }) {
   }
 
   // typosのバージョンを保存
-  const versionFilePath = resolve(
-    TYPOS_DIRECTORY_PATH,
-    TYPOS_VERSION_FILE_NAME,
-  );
+  const versionFilePath = join(TYPOS_DIRECTORY_PATH, TYPOS_VERSION_FILE_NAME);
   await fs.writeFile(versionFilePath, TYPOS_VERSION);
 
   // 解凍後に圧縮ファイルを削除

--- a/tools/downloadTypos.ts
+++ b/tools/downloadTypos.ts
@@ -2,14 +2,14 @@
  * OSに合ったtyposのバイナリをダウンロードするスクリプト。
  */
 import { exec } from "child_process";
-import { promisify } from "util";
-import { platform, arch } from "os";
-import { join } from "path";
 import fsSync from "fs";
 import fs from "fs/promises";
+import { arch, platform } from "os";
+import { join } from "path";
 import { Readable } from "stream";
-import { ReadableStream } from "stream/web";
 import { pipeline } from "stream/promises";
+import { ReadableStream } from "stream/web";
+import { promisify } from "util";
 import { retryFetch } from "./helper.mjs";
 
 // OS名を定義するオブジェクト


### PR DESCRIPTION
## 内容
#2602 に対する一部対応です。
以下の2つのファイルはpath.joinに置き換えても問題無さそうだったので修正しました。

- download7z.ts
- downloadsTypos.ts

置き換えが必要である理由は上記issueに書かれている以下の通りです。

> VOICEVOXエディタ内では、path.join（パスの連結）で問題ない箇所でよくpath.resolve（パスの解決）が行われています。
path.resolveは後ろに絶対パスがあった時に予想外の挙動をするので危ない気がします。

```node
join("hoge/fuga", "/piyo.txt")
-> hoge\fuga\piyo.txt

resolve("hoge/fuga", "/piyo.txt")
-> C:\piyo.txt
```

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
#2602
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
