### PR TITLE
fix: 再生位置のハイライトが動かなかったのを修正

### DIFF
--- a/src/components/Talk/AudioDetail.vue
+++ b/src/components/Talk/AudioDetail.vue
@@ -308,6 +308,10 @@ const scrollToActivePoint = () => {
   }
 };
 
+const currentTimeGetter = computed(
+  () => store.getters.ACTIVE_AUDIO_ELEM_CURRENT_TIME_GETTER,
+);
+
 let requestId: number | undefined;
 watch(nowPlaying, async (newState) => {
   if (newState) {
@@ -317,10 +321,10 @@ watch(nowPlaying, async (newState) => {
     // 現在再生されているaudio elementの再生時刻を描画毎に取得(監視)し、
     // それに合わせてフォーカスするアクセント句を変えていく
     const focusAccentPhrase = () => {
-      const currentTime = store.getters.ACTIVE_AUDIO_ELEM_CURRENT_TIME;
-      if (currentTime == undefined) {
+      if (currentTimeGetter.value == undefined) {
         throw new Error("currentTime === undefined)");
       }
+      const currentTime = currentTimeGetter.value();
       const playingAccentPhraseIndex =
         accentPhraseOffsets.findIndex(
           (currentOffset) => currentTime < currentOffset,

--- a/src/components/Talk/AudioDetail.vue
+++ b/src/components/Talk/AudioDetail.vue
@@ -308,23 +308,21 @@ const scrollToActivePoint = () => {
   }
 };
 
-const currentTimeGetter = computed(
-  () => store.getters.ACTIVE_AUDIO_ELEM_CURRENT_TIME_GETTER,
-);
-
 let requestId: number | undefined;
 watch(nowPlaying, async (newState) => {
   if (newState) {
     const accentPhraseOffsets = await store.actions.GET_AUDIO_PLAY_OFFSETS({
       audioKey: props.activeAudioKey,
     });
+    const currentTimeGetter =
+      store.getters.ACTIVE_AUDIO_ELEM_CURRENT_TIME_GETTER;
     // 現在再生されているaudio elementの再生時刻を描画毎に取得(監視)し、
     // それに合わせてフォーカスするアクセント句を変えていく
     const focusAccentPhrase = () => {
-      if (currentTimeGetter.value == undefined) {
-        throw new Error("currentTime === undefined)");
+      if (currentTimeGetter == undefined) {
+        throw new Error("currentTimeGetter == undefined");
       }
-      const currentTime = currentTimeGetter.value();
+      const currentTime = currentTimeGetter();
       const playingAccentPhraseIndex =
         accentPhraseOffsets.findIndex(
           (currentOffset) => currentTime < currentOffset,

--- a/src/components/Talk/AudioDetail.vue
+++ b/src/components/Talk/AudioDetail.vue
@@ -319,10 +319,10 @@ watch(nowPlaying, async (newState) => {
     // 現在再生されているaudio elementの再生時刻を描画毎に取得(監視)し、
     // それに合わせてフォーカスするアクセント句を変えていく
     const focusAccentPhrase = () => {
-      if (currentTimeGetter == undefined) {
-        throw new Error("currentTimeGetter == undefined");
-      }
       const currentTime = currentTimeGetter();
+      if (currentTime == undefined) {
+        throw new Error("currentTime == undefined");
+      }
       const playingAccentPhraseIndex =
         accentPhraseOffsets.findIndex(
           (currentOffset) => currentTime < currentOffset,

--- a/src/store/audioPlayer.ts
+++ b/src/store/audioPlayer.ts
@@ -24,9 +24,10 @@ export const audioPlayerStoreState: AudioPlayerStoreState = {
 export const audioPlayerStore = createPartialStore<AudioPlayerStoreTypes>({
   ACTIVE_AUDIO_ELEM_CURRENT_TIME_GETTER: {
     getter: (state) => {
-      return state._activeAudioKey != undefined
-        ? () => getAudioElement().currentTime
-        : undefined;
+      return () =>
+        state._activeAudioKey != undefined
+          ? getAudioElement().currentTime
+          : undefined;
     },
   },
 

--- a/src/store/audioPlayer.ts
+++ b/src/store/audioPlayer.ts
@@ -22,10 +22,10 @@ export const audioPlayerStoreState: AudioPlayerStoreState = {
 };
 
 export const audioPlayerStore = createPartialStore<AudioPlayerStoreTypes>({
-  ACTIVE_AUDIO_ELEM_CURRENT_TIME: {
+  ACTIVE_AUDIO_ELEM_CURRENT_TIME_GETTER: {
     getter: (state) => {
       return state._activeAudioKey != undefined
-        ? getAudioElement().currentTime
+        ? () => getAudioElement().currentTime
         : undefined;
     },
   },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -720,8 +720,8 @@ export type AudioPlayerStoreState = {
 };
 
 export type AudioPlayerStoreTypes = {
-  ACTIVE_AUDIO_ELEM_CURRENT_TIME: {
-    getter: number | undefined;
+  ACTIVE_AUDIO_ELEM_CURRENT_TIME_GETTER: {
+    getter: (() => number) | undefined;
   };
 
   NOW_PLAYING: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -721,7 +721,7 @@ export type AudioPlayerStoreState = {
 
 export type AudioPlayerStoreTypes = {
   ACTIVE_AUDIO_ELEM_CURRENT_TIME_GETTER: {
-    getter: (() => number) | undefined;
+    getter: () => number | undefined;
   };
 
   NOW_PLAYING: {


### PR DESCRIPTION
## 内容

ACTIVE_AUDIO_ELEM_CURRENT_TIMEがcurrentTimeを返すコールバックを返すようにします。
設計をひっくり返すレベルのリファクタをしないといけない可能性はある...

## 関連 Issue

- close: #2620 

## スクリーンショット・動画など

（なし）

## その他

（なし）