### PR TITLE
fix: 無くなったフレーズのピッチやボリュームを削除していなかったので修正

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2515,11 +2515,14 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           }
         }
 
-        // 無くなったフレーズのシーケンスを削除する
+        // 無くなったフレーズのピッチなどのデータとシーケンスを削除する
         for (const phraseKey of disappearedPhraseKeys) {
           const phraseSequenceId = getPhraseSequenceId(phraseKey);
           if (phraseSequenceId != undefined) {
             deleteSequence(phraseSequenceId);
+          }
+          for (let i = stages.length - 1; i >= 0; i--) {
+            stages[i].deleteExecutionResult(phraseKey);
           }
         }
 


### PR DESCRIPTION
## 内容

フレーズが無くなったときにシーケンスのみが削除されていて、フレーズに紐づくピッチやボリュームなどのデータが残り続けていたので、それらもシーケンスと一緒に削除するように修正します。

## その他