### PR TITLE
refactor: ヘルプダイアログを除くcomputed+@update:modelValueパターンで開くダイアログをdefineModelを使うようにする

### DIFF
--- a/src/components/Dialog/AcceptDialog/AcceptDialog.stories.ts
+++ b/src/components/Dialog/AcceptDialog/AcceptDialog.stories.ts
@@ -6,7 +6,7 @@ import AcceptDialog from "./AcceptDialog.vue";
 const meta: Meta<typeof AcceptDialog> = {
   component: AcceptDialog,
   args: {
-    modelValue: false,
+    dialogOpened: false,
     title: "タイトル",
     heading: "見出し",
     terms: "# 見出し1\n文章文章文章\n## 見出し2\n文章文章文章",
@@ -14,6 +14,7 @@ const meta: Meta<typeof AcceptDialog> = {
     acceptLabel: "承諾",
     onAccept: fn(),
     onReject: fn(),
+    "onUpdate:dialogOpened": fn(),
   },
   tags: ["!autodocs"], // ダイアログ系はautodocsのプレビューが正しく表示されないので無効化
 };
@@ -24,7 +25,7 @@ type Story = StoryObj<typeof meta>;
 export const Opened: Story = {
   name: "開いている",
   args: {
-    modelValue: true,
+    dialogOpened: true,
   },
 };
 

--- a/src/components/Dialog/AcceptDialog/AcceptDialog.stories.ts
+++ b/src/components/Dialog/AcceptDialog/AcceptDialog.stories.ts
@@ -12,7 +12,6 @@ const meta: Meta<typeof AcceptDialog> = {
     terms: "# 見出し1\n文章文章文章\n## 見出し2\n文章文章文章",
     rejectLabel: "拒否",
     acceptLabel: "承諾",
-    "onUpdate:modelValue": fn(),
     onAccept: fn(),
     onReject: fn(),
   },

--- a/src/components/Dialog/AcceptDialog/AcceptDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptDialog.vue
@@ -67,7 +67,7 @@ import { useMarkdownIt } from "@/plugins/markdownItPlugin";
 import BaseDocumentView from "@/components/Base/BaseDocumentView.vue";
 import BaseScrollArea from "@/components/Base/BaseScrollArea.vue";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 const props = defineProps<{
   title: string;
   heading: string;

--- a/src/components/Dialog/AcceptDialog/AcceptDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <QDialog
-    v-model="modelValueComputed"
+    v-model="dialogOpened"
     maximized
     transitionShow="jump-up"
     transitionHide="jump-down"
@@ -67,8 +67,8 @@ import { useMarkdownIt } from "@/plugins/markdownItPlugin";
 import BaseDocumentView from "@/components/Base/BaseDocumentView.vue";
 import BaseScrollArea from "@/components/Base/BaseScrollArea.vue";
 
+const dialogOpened = defineModel<boolean>({ default: false });
 const props = defineProps<{
-  modelValue: boolean;
   title: string;
   heading: string;
   terms: string;
@@ -76,16 +76,10 @@ const props = defineProps<{
   acceptLabel: string;
 }>();
 
-const emit = defineEmits<{
-  "update:modelValue": [value: boolean];
+defineEmits<{
   reject: [];
   accept: [];
 }>();
-
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
 
 const md = useMarkdownIt();
 const termsHtml = computed(() => md.render(props.terms));

--- a/src/components/Dialog/AcceptDialog/AcceptRetrieveTelemetryDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptRetrieveTelemetryDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <AcceptDialog
-    v-model="modelValueComputed"
+    v-model="dialogOpened"
     title="使いやすさ向上のためのお願い"
     rejectLabel="拒否"
     acceptLabel="許可"
@@ -20,30 +20,20 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted } from "vue";
+import { ref, onMounted } from "vue";
 import AcceptDialog from "./AcceptDialog.vue";
 import { useStore } from "@/store";
 
-const props = defineProps<{
-  modelValue: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
-}>();
+const dialogOpened = defineModel<boolean>({ default: false });
 
 const store = useStore();
-
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
 
 const handler = (acceptRetrieveTelemetry: boolean) => {
   void store.actions.SET_ACCEPT_RETRIEVE_TELEMETRY({
     acceptRetrieveTelemetry: acceptRetrieveTelemetry ? "Accepted" : "Refused",
   });
 
-  modelValueComputed.value = false;
+  dialogOpened.value = false;
 };
 
 const privacyPolicy = ref("");

--- a/src/components/Dialog/AcceptDialog/AcceptRetrieveTelemetryDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptRetrieveTelemetryDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <AcceptDialog
-    v-model="dialogOpened"
+    v-model:dialogOpened="dialogOpened"
     title="使いやすさ向上のためのお願い"
     rejectLabel="拒否"
     acceptLabel="許可"
@@ -24,7 +24,7 @@ import { ref, onMounted } from "vue";
 import AcceptDialog from "./AcceptDialog.vue";
 import { useStore } from "@/store";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 
 const store = useStore();
 

--- a/src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <AcceptDialog
-    v-model="dialogOpened"
+    v-model:dialogOpened="dialogOpened"
     title="利用規約に関するお知らせ"
     rejectLabel="同意せずに終了"
     acceptLabel="同意して使用開始"
@@ -20,7 +20,7 @@ import { ref, onMounted } from "vue";
 import AcceptDialog from "./AcceptDialog.vue";
 import { useStore } from "@/store";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 
 const store = useStore();
 

--- a/src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
+++ b/src/components/Dialog/AcceptDialog/AcceptTermsDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <AcceptDialog
-    v-model="modelValueComputed"
+    v-model="dialogOpened"
     title="利用規約に関するお知らせ"
     rejectLabel="同意せずに終了"
     acceptLabel="同意して使用開始"
@@ -16,23 +16,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted } from "vue";
+import { ref, onMounted } from "vue";
 import AcceptDialog from "./AcceptDialog.vue";
 import { useStore } from "@/store";
 
-const props = defineProps<{
-  modelValue: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
-}>();
+const dialogOpened = defineModel<boolean>({ default: false });
 
 const store = useStore();
-
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
 
 const handler = (acceptTerms: boolean) => {
   void store.actions.SET_ACCEPT_TERMS({
@@ -44,7 +34,7 @@ const handler = (acceptTerms: boolean) => {
     });
   }
 
-  modelValueComputed.value = false;
+  dialogOpened.value = false;
 };
 
 const terms = ref("");

--- a/src/components/Dialog/AllDialog.vue
+++ b/src/components/Dialog/AllDialog.vue
@@ -1,29 +1,35 @@
 <template>
   <AcceptRetrieveTelemetryDialog
-    v-model="isAcceptRetrieveTelemetryDialogOpenComputed"
+    v-model:dialogOpened="isAcceptRetrieveTelemetryDialogOpenComputed"
   />
-  <AcceptTermsDialog v-model="isAcceptTermsDialogOpenComputed" />
-  <SettingDialog v-model="isSettingDialogOpenComputed" />
-  <HotkeySettingDialog v-model="isHotkeySettingDialogOpenComputed" />
-  <ToolBarCustomDialog v-model="isToolbarSettingDialogOpenComputed" />
+  <AcceptTermsDialog v-model:dialogOpened="isAcceptTermsDialogOpenComputed" />
+  <SettingDialog v-model:dialogOpened="isSettingDialogOpenComputed" />
+  <HotkeySettingDialog
+    v-model:dialoOpened="isHotkeySettingDialogOpenComputed"
+  />
+  <ToolBarCustomDialog
+    v-model:dialogOpened="isToolbarSettingDialogOpenComputed"
+  />
   <CharacterOrderDialog
     v-if="orderedAllCharacterInfos.length > 0"
-    v-model="isCharacterOrderDialogOpenComputed"
+    v-model:dialogOpened="isCharacterOrderDialogOpenComputed"
     :characterInfos="orderedAllCharacterInfos"
   />
   <DefaultStyleListDialog
     v-if="orderedTalkCharacterInfos.length > 0"
-    v-model="isDefaultStyleSelectDialogOpenComputed"
+    v-model:dialogOpened="isDefaultStyleSelectDialogOpenComputed"
     :characterInfos="orderedTalkCharacterInfos"
   />
-  <DictionaryManageDialog v-model="isDictionaryManageDialogOpenComputed" />
-  <EngineManageDialog v-model="isEngineManageDialogOpenComputed" />
+  <DictionaryManageDialog
+    v-model:dialogOpened="isDictionaryManageDialogOpenComputed"
+  />
+  <EngineManageDialog v-model:dialogOpened="isEngineManageDialogOpenComputed" />
   <UpdateNotificationDialogContainer
     :canOpenDialog="canOpenNotificationDialog"
   />
-  <ExportSongAudioDialog v-model="isExportSongAudioDialogOpen" />
+  <ExportSongAudioDialog v-model:dialogOpened="isExportSongAudioDialogOpen" />
   <ImportSongProjectDialog v-model="isImportSongProjectDialogOpenComputed" />
-  <PresetManageDialog v-model="isPresetManageDialogOpenComputed" />
+  <PresetManageDialog v-model:dialogOpened="isPresetManageDialogOpenComputed" />
 </template>
 
 <script setup lang="ts">

--- a/src/components/Dialog/AllDialog.vue
+++ b/src/components/Dialog/AllDialog.vue
@@ -5,7 +5,7 @@
   <AcceptTermsDialog v-model:dialogOpened="isAcceptTermsDialogOpenComputed" />
   <SettingDialog v-model:dialogOpened="isSettingDialogOpenComputed" />
   <HotkeySettingDialog
-    v-model:dialoOpened="isHotkeySettingDialogOpenComputed"
+    v-model:dialogOpened="isHotkeySettingDialogOpenComputed"
   />
   <ToolBarCustomDialog
     v-model:dialogOpened="isToolbarSettingDialogOpenComputed"

--- a/src/components/Dialog/CharacterOrderDialog.vue
+++ b/src/components/Dialog/CharacterOrderDialog.vue
@@ -112,26 +112,12 @@ import { CharacterInfo, SpeakerId, StyleId, StyleInfo } from "@/type/preload";
 
 const dialogOpened = defineModel<boolean>({ default: false });
 const props = defineProps<{
-  // modelValue: boolean;
   characterInfos: CharacterInfo[];
 }>();
-
-/*
-const emit = defineEmits<{
-  (event: "update:modelValue", value: boolean): void;
-}>();
-*/
 
 const $q = useQuasar();
 
 const store = useStore();
-
-/*
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
-*/
 
 const characterInfosMap = computed(() => {
   const map: { [key: SpeakerId]: CharacterInfo } = {};
@@ -258,7 +244,6 @@ const closeDialog = () => {
     characterOrder.value.map((info) => info.metas.speakerUuid),
   );
   stop();
-  // modelValueComputed.value = false;
   dialogOpened.value = false;
 };
 

--- a/src/components/Dialog/CharacterOrderDialog.vue
+++ b/src/components/Dialog/CharacterOrderDialog.vue
@@ -110,7 +110,7 @@ import CharacterTryListenCard from "./CharacterTryListenCard.vue";
 import { useStore } from "@/store";
 import { CharacterInfo, SpeakerId, StyleId, StyleInfo } from "@/type/preload";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 const props = defineProps<{
   characterInfos: CharacterInfo[];
 }>();

--- a/src/components/Dialog/CharacterOrderDialog.vue
+++ b/src/components/Dialog/CharacterOrderDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <QDialog
-    v-model="modelValueComputed"
+    v-model="dialogOpened"
     maximized
     transitionShow="jump-up"
     transitionHide="jump-down"
@@ -110,23 +110,28 @@ import CharacterTryListenCard from "./CharacterTryListenCard.vue";
 import { useStore } from "@/store";
 import { CharacterInfo, SpeakerId, StyleId, StyleInfo } from "@/type/preload";
 
+const dialogOpened = defineModel<boolean>({ default: false });
 const props = defineProps<{
-  modelValue: boolean;
+  // modelValue: boolean;
   characterInfos: CharacterInfo[];
 }>();
 
+/*
 const emit = defineEmits<{
   (event: "update:modelValue", value: boolean): void;
 }>();
+*/
 
 const $q = useQuasar();
 
 const store = useStore();
 
+/*
 const modelValueComputed = computed({
   get: () => props.modelValue,
   set: (val) => emit("update:modelValue", val),
 });
+*/
 
 const characterInfosMap = computed(() => {
   const map: { [key: SpeakerId]: CharacterInfo } = {};
@@ -157,47 +162,42 @@ const selectCharacterWithChangePortrait = (speakerUuid: SpeakerId) => {
 const characterOrder = ref<CharacterInfo[]>([]);
 
 // ダイアログが開かれたときに初期値を求める
-watch(
-  () => props.modelValue,
-  async (newValue, oldValue) => {
-    if (!oldValue && newValue) {
-      // 新しいキャラクター
-      newCharacters.value = await store.actions.GET_NEW_CHARACTERS();
+watch(dialogOpened, async (newValue, oldValue) => {
+  if (!oldValue && newValue) {
+    // 新しいキャラクター
+    newCharacters.value = await store.actions.GET_NEW_CHARACTERS();
 
-      // サンプルの順番、新しいキャラクターは上に
-      sampleCharacterOrder.value = [
-        ...newCharacters.value,
-        ...props.characterInfos
-          .filter(
-            (info) => !newCharacters.value.includes(info.metas.speakerUuid),
-          )
-          .map((info) => info.metas.speakerUuid),
-      ];
+    // サンプルの順番、新しいキャラクターは上に
+    sampleCharacterOrder.value = [
+      ...newCharacters.value,
+      ...props.characterInfos
+        .filter((info) => !newCharacters.value.includes(info.metas.speakerUuid))
+        .map((info) => info.metas.speakerUuid),
+    ];
 
-      selectedCharacter.value = sampleCharacterOrder.value[0];
+    selectedCharacter.value = sampleCharacterOrder.value[0];
 
-      // 保存済みのキャラクターリストを取得
-      // FIXME: 不明なキャラを無視しているので、不明キャラの順番が保存時にリセットされてしまう
-      characterOrder.value = store.state.userCharacterOrder
-        .map((speakerUuid) => characterInfosMap.value[speakerUuid])
-        .filter((info) => info != undefined);
+    // 保存済みのキャラクターリストを取得
+    // FIXME: 不明なキャラを無視しているので、不明キャラの順番が保存時にリセットされてしまう
+    characterOrder.value = store.state.userCharacterOrder
+      .map((speakerUuid) => characterInfosMap.value[speakerUuid])
+      .filter((info) => info != undefined);
 
-      // 含まれていないキャラクターを足す
-      const notIncludesCharacterInfos = props.characterInfos.filter(
-        (characterInfo) =>
-          !characterOrder.value.find(
-            (characterInfoInList) =>
-              characterInfoInList.metas.speakerUuid ===
-              characterInfo.metas.speakerUuid,
-          ),
-      );
-      characterOrder.value = [
-        ...characterOrder.value,
-        ...notIncludesCharacterInfos,
-      ];
-    }
-  },
-);
+    // 含まれていないキャラクターを足す
+    const notIncludesCharacterInfos = props.characterInfos.filter(
+      (characterInfo) =>
+        !characterOrder.value.find(
+          (characterInfoInList) =>
+            characterInfoInList.metas.speakerUuid ===
+            characterInfo.metas.speakerUuid,
+        ),
+    );
+    characterOrder.value = [
+      ...characterOrder.value,
+      ...notIncludesCharacterInfos,
+    ];
+  }
+});
 
 // draggable用
 const keyOfCharacterOrderItem = (item: CharacterInfo) => item.metas.speakerUuid;
@@ -258,7 +258,8 @@ const closeDialog = () => {
     characterOrder.value.map((info) => info.metas.speakerUuid),
   );
   stop();
-  modelValueComputed.value = false;
+  // modelValueComputed.value = false;
+  dialogOpened.value = false;
 };
 
 const portrait = ref<string | undefined>(

--- a/src/components/Dialog/DefaultStyleListDialog.vue
+++ b/src/components/Dialog/DefaultStyleListDialog.vue
@@ -5,7 +5,7 @@
       selectedStyleIndexes[selectedCharacterInfo.metas.speakerUuid] !==
         undefined
     "
-    v-model:modelValue="showStyleSelectDialog"
+    v-model:dialogOpened="showStyleSelectDialog"
     v-model:selectedStyleIndex="
       selectedStyleIndexes[selectedCharacterInfo.metas.speakerUuid]
     "
@@ -107,7 +107,7 @@ import { useStore } from "@/store";
 import { DEFAULT_STYLE_NAME } from "@/store/utility";
 import { CharacterInfo, SpeakerId, StyleInfo } from "@/type/preload";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 
 const props = defineProps<{
   characterInfos: CharacterInfo[];

--- a/src/components/Dialog/DefaultStyleListDialog.vue
+++ b/src/components/Dialog/DefaultStyleListDialog.vue
@@ -5,7 +5,7 @@
       selectedStyleIndexes[selectedCharacterInfo.metas.speakerUuid] !==
         undefined
     "
-    v-model:isOpen="showStyleSelectDialog"
+    v-model:modelValue="showStyleSelectDialog"
     v-model:selectedStyleIndex="
       selectedStyleIndexes[selectedCharacterInfo.metas.speakerUuid]
     "

--- a/src/components/Dialog/DefaultStyleListDialog.vue
+++ b/src/components/Dialog/DefaultStyleListDialog.vue
@@ -110,23 +110,10 @@ import { CharacterInfo, SpeakerId, StyleInfo } from "@/type/preload";
 const dialogOpened = defineModel<boolean>({ default: false });
 
 const props = defineProps<{
-  // modelValue: boolean;
   characterInfos: CharacterInfo[];
 }>();
-/*
-const emit = defineEmits<{
-  (e: "update:modelValue", val: boolean): void;
-}>();
-*/
 
 const store = useStore();
-
-/*
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
-*/
 
 // 選択中のキャラクター
 const selectedCharacter = ref(props.characterInfos[0].metas.speakerUuid);

--- a/src/components/Dialog/DefaultStyleListDialog.vue
+++ b/src/components/Dialog/DefaultStyleListDialog.vue
@@ -12,7 +12,7 @@
     :characterInfo="selectedCharacterInfo"
   />
   <QDialog
-    v-model="modelValueComputed"
+    v-model="dialogOpened"
     maximized
     transitionShow="jump-up"
     transitionHide="jump-down"
@@ -106,20 +106,27 @@ import DefaultStyleSelectDialog from "./DefaultStyleSelectDialog.vue";
 import { useStore } from "@/store";
 import { DEFAULT_STYLE_NAME } from "@/store/utility";
 import { CharacterInfo, SpeakerId, StyleInfo } from "@/type/preload";
+
+const dialogOpened = defineModel<boolean>({ default: false });
+
 const props = defineProps<{
-  modelValue: boolean;
+  // modelValue: boolean;
   characterInfos: CharacterInfo[];
 }>();
+/*
 const emit = defineEmits<{
   (e: "update:modelValue", val: boolean): void;
 }>();
+*/
 
 const store = useStore();
 
+/*
 const modelValueComputed = computed({
   get: () => props.modelValue,
   set: (val) => emit("update:modelValue", val),
 });
+*/
 
 // 選択中のキャラクター
 const selectedCharacter = ref(props.characterInfos[0].metas.speakerUuid);
@@ -157,7 +164,7 @@ const selectedStyles = computed(() => {
 });
 
 // ダイアログが開かれたときに初期値を求める
-watch([() => props.modelValue], async ([newValue]) => {
+watch([dialogOpened], async ([newValue]) => {
   if (newValue) {
     speakerWithMultipleStyles.value = store.state.userCharacterOrder
       .map((speakerUuid) => characterInfosMap.value[speakerUuid])
@@ -208,7 +215,7 @@ const closeDialog = () => {
     ),
   );
   stop();
-  modelValueComputed.value = false;
+  dialogOpened.value = false;
 };
 const openStyleSelectDialog = (characterInfo: CharacterInfo) => {
   stop();

--- a/src/components/Dialog/DefaultStyleSelectDialog.vue
+++ b/src/components/Dialog/DefaultStyleSelectDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <QDialog
-    v-model="isOpenComputed"
+    v-model="dialogOpened"
     maximized
     transitionShow="none"
     transitionHide="none"
@@ -129,14 +129,14 @@ import {
   StyleInfo,
 } from "@/type/preload";
 
+const dialogOpened = defineModel<boolean>({ default: false });
+
 const props = defineProps<{
-  isOpen: boolean;
   selectedStyleIndex: number;
   characterInfo: CharacterInfo;
 }>();
 
 const emit = defineEmits<{
-  (e: "update:isOpen", value: boolean): void;
   (e: "update:selectedStyleIndex", value: number): void;
 }>();
 
@@ -144,18 +144,13 @@ const $q = useQuasar();
 
 const store = useStore();
 
-const isOpenComputed = computed({
-  get: () => props.isOpen,
-  set: (val) => emit("update:isOpen", val),
-});
-
 const firstSelectedStyleIndex = ref(0);
 const isModified = computed(() => {
   return firstSelectedStyleIndex.value !== props.selectedStyleIndex;
 });
 
 // ダイアログが開かれたときに初期値を求める
-watch([() => props.isOpen], async ([newValue]) => {
+watch([dialogOpened], async ([newValue]) => {
   if (newValue) {
     firstSelectedStyleIndex.value = props.selectedStyleIndex;
   }
@@ -232,7 +227,7 @@ const closeDialog = () => {
   ]);
 
   stop();
-  isOpenComputed.value = false;
+  dialogOpened.value = false;
 };
 </script>
 

--- a/src/components/Dialog/DefaultStyleSelectDialog.vue
+++ b/src/components/Dialog/DefaultStyleSelectDialog.vue
@@ -129,7 +129,7 @@ import {
   StyleInfo,
 } from "@/type/preload";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 
 const props = defineProps<{
   selectedStyleIndex: number;

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <QDialog
-    v-model="dictionaryManageDialogOpenedComputed"
+    v-model="dialogOpened"
     maximized
     transitionShow="jump-up"
     transitionHide="jump-down"
@@ -169,19 +169,10 @@ import {
 
 const defaultDictPriority = 5;
 
-const props = defineProps<{
-  modelValue: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "update:modelValue", v: boolean): void;
-}>();
+const dialogOpened = defineModel<boolean>({ default: false });
 
 const store = useStore();
 
-const dictionaryManageDialogOpenedComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
 const uiLocked = ref(false); // ダイアログ内でstore.getters.UI_LOCKEDは常にtrueなので独自に管理
 
 // word-list の要素のうち、どの要素がホバーされているか
@@ -212,7 +203,7 @@ const loadingDictProcess = async () => {
       message: "エンジンの再起動をお試しください。",
     });
     if (result === "OK") {
-      dictionaryManageDialogOpenedComputed.value = false;
+      dialogOpened.value = false;
     }
   }
   loadingDictState.value = "synchronizing";
@@ -226,7 +217,7 @@ const loadingDictProcess = async () => {
   }
   loadingDictState.value = null;
 };
-watch(dictionaryManageDialogOpenedComputed, async (newValue) => {
+watch(dialogOpened, async (newValue) => {
   if (newValue) {
     await loadingDictProcess();
     toInitialState();
@@ -421,7 +412,7 @@ const toWordEditingState = () => {
 };
 // ダイアログが閉じている状態
 const toDialogClosedState = () => {
-  dictionaryManageDialogOpenedComputed.value = false;
+  dialogOpened.value = false;
 };
 
 provide(dictionaryManageDialogContextKey, {

--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -169,7 +169,7 @@ import {
 
 const defaultDictPriority = 5;
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 
 const store = useStore();
 

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <QDialog
-    v-model="engineManageDialogOpenedComputed"
+    v-model="dialogOpened"
     maximized
     transitionShow="jump-up"
     transitionHide="jump-down"
@@ -281,19 +281,10 @@ import { useEngineIcons } from "@/composables/useEngineIcons";
 
 type EngineLoaderType = "dir" | "vvpp";
 
-const props = defineProps<{
-  modelValue: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "update:modelValue", val: boolean): void;
-}>();
+const dialogOpened = defineModel<boolean>();
 
 const store = useStore();
 
-const engineManageDialogOpenedComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
 const uiLockedState = ref<null | "addingEngine" | "deletingEngine">(null); // ダイアログ内でstore.getters.UI_LOCKEDは常にtrueなので独自に管理
 const uiLocked = computed(() => uiLockedState.value != null);
 const isAddingEngine = ref(false);
@@ -586,7 +577,7 @@ const toAddEngineState = () => {
 };
 // ダイアログが閉じている状態
 const toDialogClosedState = () => {
-  engineManageDialogOpenedComputed.value = false;
+  dialogOpened.value = false;
   isAddingEngine.value = false;
 };
 </script>

--- a/src/components/Dialog/EngineManageDialog.vue
+++ b/src/components/Dialog/EngineManageDialog.vue
@@ -281,7 +281,7 @@ import { useEngineIcons } from "@/composables/useEngineIcons";
 
 type EngineLoaderType = "dir" | "vvpp";
 
-const dialogOpened = defineModel<boolean>();
+const dialogOpened = defineModel<boolean>("dialogOpened");
 
 const store = useStore();
 

--- a/src/components/Dialog/ExportSongAudioDialog/Container.vue
+++ b/src/components/Dialog/ExportSongAudioDialog/Container.vue
@@ -1,5 +1,8 @@
 <template>
-  <Presentation v-model="modelValue" @exportAudio="handleExportAudio" />
+  <Presentation
+    v-model:dialogOpened="dialogOpened"
+    @exportAudio="handleExportAudio"
+  />
 </template>
 
 <script setup lang="ts">
@@ -12,7 +15,7 @@ defineOptions({
   name: "ExportSongAudioDialog",
 });
 
-const modelValue = defineModel<boolean>();
+const dialogOpened = defineModel<boolean>("dialogOpened");
 const store = useStore();
 
 const handleExportAudio = async (

--- a/src/components/Dialog/ExportSongAudioDialog/Presentation.vue
+++ b/src/components/Dialog/ExportSongAudioDialog/Presentation.vue
@@ -1,5 +1,5 @@
 <template>
-  <QDialog ref="dialogRef" v-model="modelValue">
+  <QDialog ref="dialogRef" v-model="dialogOpened">
     <QCard class="q-py-sm q-px-md dialog-card">
       <QCardSection>
         <div class="text-h5">音声書き出し</div>
@@ -99,7 +99,7 @@ import { SongExportSetting, TrackParameters } from "@/store/type";
 export type ExportTarget = "master" | "stem";
 const { dialogRef, onDialogOK, onDialogCancel } = useDialogPluginComponent();
 
-const modelValue = defineModel<boolean>();
+const dialogOpened = defineModel<boolean>("dialogOpened");
 const emit = defineEmits<{
   /** 音声をエクスポートするときに呼ばれる */
   exportAudio: [exportTarget: ExportTarget, setting: SongExportSetting];
@@ -177,7 +177,7 @@ const handleExportTrack = () => {
 // キャンセルボタンクリック時
 const handleCancel = () => {
   onDialogCancel();
-  modelValue.value = false;
+  dialogOpened.value = false;
 };
 </script>
 

--- a/src/components/Dialog/HotkeyRecordingDialog.vue
+++ b/src/components/Dialog/HotkeyRecordingDialog.vue
@@ -84,7 +84,7 @@
 import { computed } from "vue";
 import { HotkeyCombination } from "@/domain/hotkeyAction";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 const props = defineProps<{
   lastAction: string;
   lastRecord: HotkeyCombination;

--- a/src/components/Dialog/HotkeyRecordingDialog.vue
+++ b/src/components/Dialog/HotkeyRecordingDialog.vue
@@ -1,11 +1,10 @@
 <template>
   <QDialog
+    v-model="dialogOpened"
     noEscDismiss
     noShake
     transitionShow="none"
     transitionHide="none"
-    :modelValue="isHotkeyDialogOpened"
-    @update:modelValue="closeHotkeyDialog"
   >
     <QCard class="q-py-sm q-px-md">
       <QCardSection align="center">
@@ -85,15 +84,14 @@
 import { computed } from "vue";
 import { HotkeyCombination } from "@/domain/hotkeyAction";
 
+const dialogOpened = defineModel<boolean>();
 const props = defineProps<{
-  isHotkeyDialogOpened: boolean;
   lastAction: string;
   lastRecord: HotkeyCombination;
   duplicatedHotkey?: { action: string };
 }>();
 
 const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
   (e: "deleteHotkey", action: string): void;
   (
     e: "changeHotkeySettings",
@@ -112,7 +110,7 @@ const confirmBtnEnabled = computed(() => {
 });
 
 const closeHotkeyDialog = () => {
-  emit("update:modelValue", false);
+  dialogOpened.value = false;
 };
 
 const changeHotkeyAndClose = () => {

--- a/src/components/Dialog/HotkeyRecordingDialog.vue
+++ b/src/components/Dialog/HotkeyRecordingDialog.vue
@@ -84,7 +84,7 @@
 import { computed } from "vue";
 import { HotkeyCombination } from "@/domain/hotkeyAction";
 
-const dialogOpened = defineModel<boolean>();
+const dialogOpened = defineModel<boolean>({ default: false });
 const props = defineProps<{
   lastAction: string;
   lastRecord: HotkeyCombination;

--- a/src/components/Dialog/HotkeySettingDialog.vue
+++ b/src/components/Dialog/HotkeySettingDialog.vue
@@ -109,7 +109,7 @@
   </QDialog>
 
   <HotkeyRecordingDialog
-    v-model="isHotkeyDialogOpened"
+    v-model:dialogOpened="isHotkeyDialogOpened"
     :lastAction
     :lastRecord
     :duplicatedHotkey
@@ -134,7 +134,7 @@ import {
 } from "@/domain/hotkeyAction";
 import { isMac } from "@/helpers/platform";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 
 const store = useStore();
 

--- a/src/components/Dialog/HotkeySettingDialog.vue
+++ b/src/components/Dialog/HotkeySettingDialog.vue
@@ -134,7 +134,7 @@ import {
 } from "@/domain/hotkeyAction";
 import { isMac } from "@/helpers/platform";
 
-const dialogOpened = defineModel<boolean>();
+const dialogOpened = defineModel<boolean>({ default: false });
 
 const store = useStore();
 

--- a/src/components/Dialog/HotkeySettingDialog.vue
+++ b/src/components/Dialog/HotkeySettingDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <QDialog
-    v-model="hotkeySettingDialogOpenComputed"
+    v-model="dialogOpened"
     maximized
     transitionShow="jump-up"
     transitionHide="jump-down"
@@ -38,7 +38,7 @@
             flat
             icon="close"
             color="display"
-            @click="hotkeySettingDialogOpenComputed = false"
+            @click="dialogOpened = false"
           />
         </QToolbar>
       </QHeader>
@@ -109,7 +109,7 @@
   </QDialog>
 
   <HotkeyRecordingDialog
-    :isHotkeyDialogOpened
+    v-model="isHotkeyDialogOpened"
     :lastAction
     :lastRecord
     :duplicatedHotkey
@@ -134,19 +134,9 @@ import {
 } from "@/domain/hotkeyAction";
 import { isMac } from "@/helpers/platform";
 
-const props = defineProps<{
-  modelValue: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "update:modelValue", val: boolean): void;
-}>();
+const dialogOpened = defineModel<boolean>();
 
 const store = useStore();
-
-const hotkeySettingDialogOpenComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
 
 const isHotkeyDialogOpened = ref(false);
 

--- a/src/components/Dialog/PresetManageDialog.vue
+++ b/src/components/Dialog/PresetManageDialog.vue
@@ -176,7 +176,7 @@ import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 import { debounce } from "@/helpers/timer";
 import { UnreachableError } from "@/type/utility";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 
 const store = useStore();
 const { isDefaultPresetKey } = useDefaultPreset();

--- a/src/components/Dialog/PresetManageDialog.vue
+++ b/src/components/Dialog/PresetManageDialog.vue
@@ -176,7 +176,7 @@ import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 import { debounce } from "@/helpers/timer";
 import { UnreachableError } from "@/type/utility";
 
-const dialogOpened = defineModel<boolean>();
+const dialogOpened = defineModel<boolean>({ default: false });
 
 const store = useStore();
 const { isDefaultPresetKey } = useDefaultPreset();

--- a/src/components/Dialog/SettingDialog/FileNameTemplateDialog.stories.ts
+++ b/src/components/Dialog/SettingDialog/FileNameTemplateDialog.stories.ts
@@ -23,6 +23,7 @@ const meta: Meta<typeof FileNameTemplateDialog> = {
     fileNameBuilder: buildAudioFileNameFromRawData,
     extension: ".wav",
     "onUpdate:template": fn(),
+    "onUpdate:modelValue": fn(),
   },
   tags: ["!autodocs"], // ダイアログ系はautodocsのプレビューが正しく表示されないので無効化
 };
@@ -114,7 +115,7 @@ export const Save: Story = {
 
     // 確定とダイアログを閉じるイベントが呼ばれる
     await expect(args["onUpdate:template"]).toBeCalledWith("$連番$");
-    await expect(args["modelValue"]).toBeFalsy();
+    await expect(args["onUpdate:modelValue"]).toBeCalledWith(false);
   },
 };
 
@@ -144,7 +145,7 @@ export const Close: Story = {
 
     // ダイアログを閉じるイベントが呼ばれる、確定イベントは呼ばれない
     await expect(args["onUpdate:template"]).not.toBeCalled();
-    await expect(args["modelValue"]).toBeFalsy();
+    await expect(args["onUpdate:modelValue"]).toBeCalledWith(false);
   },
 };
 

--- a/src/components/Dialog/SettingDialog/FileNameTemplateDialog.stories.ts
+++ b/src/components/Dialog/SettingDialog/FileNameTemplateDialog.stories.ts
@@ -23,7 +23,6 @@ const meta: Meta<typeof FileNameTemplateDialog> = {
     fileNameBuilder: buildAudioFileNameFromRawData,
     extension: ".wav",
     "onUpdate:template": fn(),
-    "onUpdate:openDialog": fn(),
   },
   tags: ["!autodocs"], // ダイアログ系はautodocsのプレビューが正しく表示されないので無効化
 };
@@ -33,8 +32,11 @@ type Story = StoryObj<typeof meta>;
 
 export const Opened: Story = {
   name: "開いている",
+  // 対象のコンポーネントでconst foo = defineModel()と変数名を指定していてもStorybookではmodelValueという名前になっている
+  // ref: https://github.com/storybookjs/storybook/blob/next/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/define-model/component.vue
+  // ref: https://github.com/storybookjs/storybook/blob/next/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/DefineModel.stories.ts
   args: {
-    openDialog: true,
+    modelValue: true,
   },
 };
 
@@ -112,7 +114,7 @@ export const Save: Story = {
 
     // 確定とダイアログを閉じるイベントが呼ばれる
     await expect(args["onUpdate:template"]).toBeCalledWith("$連番$");
-    await expect(args["onUpdate:openDialog"]).toBeCalledWith(false);
+    await expect(args["modelValue"]).toBeFalsy();
   },
 };
 
@@ -142,7 +144,7 @@ export const Close: Story = {
 
     // ダイアログを閉じるイベントが呼ばれる、確定イベントは呼ばれない
     await expect(args["onUpdate:template"]).not.toBeCalled();
-    await expect(args["onUpdate:openDialog"]).toBeCalledWith(false);
+    await expect(args["modelValue"]).toBeFalsy();
   },
 };
 
@@ -150,6 +152,6 @@ export const Closed: Story = {
   name: "閉じている",
   tags: ["skip-screenshot"],
   args: {
-    openDialog: false,
+    modelValue: false,
   },
 };

--- a/src/components/Dialog/SettingDialog/FileNameTemplateDialog.stories.ts
+++ b/src/components/Dialog/SettingDialog/FileNameTemplateDialog.stories.ts
@@ -23,7 +23,7 @@ const meta: Meta<typeof FileNameTemplateDialog> = {
     fileNameBuilder: buildAudioFileNameFromRawData,
     extension: ".wav",
     "onUpdate:template": fn(),
-    "onUpdate:modelValue": fn(),
+    "onUpdate:dialogOpened": fn(),
   },
   tags: ["!autodocs"], // ダイアログ系はautodocsのプレビューが正しく表示されないので無効化
 };
@@ -33,11 +33,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Opened: Story = {
   name: "開いている",
-  // 対象のコンポーネントでconst foo = defineModel()と変数名を指定していてもStorybookではmodelValueという名前になっている
-  // ref: https://github.com/storybookjs/storybook/blob/next/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/define-model/component.vue
-  // ref: https://github.com/storybookjs/storybook/blob/next/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/DefineModel.stories.ts
   args: {
-    modelValue: true,
+    dialogOpened: true,
   },
 };
 
@@ -115,7 +112,7 @@ export const Save: Story = {
 
     // 確定とダイアログを閉じるイベントが呼ばれる
     await expect(args["onUpdate:template"]).toBeCalledWith("$連番$");
-    await expect(args["onUpdate:modelValue"]).toBeCalledWith(false);
+    await expect(args["onUpdate:dialogOpened"]).toBeCalledWith(false);
   },
 };
 
@@ -145,7 +142,7 @@ export const Close: Story = {
 
     // ダイアログを閉じるイベントが呼ばれる、確定イベントは呼ばれない
     await expect(args["onUpdate:template"]).not.toBeCalled();
-    await expect(args["onUpdate:modelValue"]).toBeCalledWith(false);
+    await expect(args["onUpdate:dialogOpened"]).toBeCalledWith(false);
   },
 };
 
@@ -153,6 +150,6 @@ export const Closed: Story = {
   name: "閉じている",
   tags: ["skip-screenshot"],
   args: {
-    modelValue: false,
+    dialogOpened: false,
   },
 };

--- a/src/components/Dialog/SettingDialog/FileNameTemplateDialog.vue
+++ b/src/components/Dialog/SettingDialog/FileNameTemplateDialog.vue
@@ -77,7 +77,7 @@ import { QInput } from "quasar";
 import { replaceTagIdToTagString, sanitizeFileName } from "@/store/utility";
 import { UnreachableError } from "@/type/utility";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 const props = defineProps<{
   /** デフォルトのテンプレート */
   defaultTemplate: string;

--- a/src/components/Dialog/SettingDialog/FileNameTemplateDialog.vue
+++ b/src/components/Dialog/SettingDialog/FileNameTemplateDialog.vue
@@ -1,9 +1,5 @@
 <template>
-  <QDialog
-    :modelValue="props.openDialog"
-    @update:modelValue="updateOpenDialog"
-    @beforeShow="initializeInput"
-  >
+  <QDialog v-model="dialogOpened" @beforeShow="initializeInput">
     <QCard class="q-pa-md dialog-card">
       <QCardSection>
         <div class="text-h5">書き出しファイル名パターン</div>
@@ -58,7 +54,7 @@
             outline
             textColor="display"
             class="text-no-wrap text-bold q-mr-sm col-2"
-            @click="updateOpenDialog(false)"
+            @click="dialogOpened = false"
           />
           <QBtn
             label="確定"
@@ -81,9 +77,8 @@ import { QInput } from "quasar";
 import { replaceTagIdToTagString, sanitizeFileName } from "@/store/utility";
 import { UnreachableError } from "@/type/utility";
 
+const dialogOpened = defineModel<boolean>({ default: false });
 const props = defineProps<{
-  /** ダイアログが開いているかどうか */
-  openDialog: boolean;
   /** デフォルトのテンプレート */
   defaultTemplate: string;
   /** 使用可能なタグ */
@@ -97,11 +92,9 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: "update:openDialog", val: boolean): void;
   (e: "update:template", val: string): void;
 }>();
 
-const updateOpenDialog = (isOpen: boolean) => emit("update:openDialog", isOpen);
 const updateFileNamePattern = (pattern: string) =>
   emit("update:template", pattern);
 
@@ -185,7 +178,7 @@ const submit = async () => {
   }
 
   updateFileNamePattern(temporaryTemplate.value);
-  updateOpenDialog(false);
+  dialogOpened.value = false;
 };
 </script>
 

--- a/src/components/Dialog/SettingDialog/SettingDialog.vue
+++ b/src/components/Dialog/SettingDialog/SettingDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <QDialog
-    v-model="settingDialogOpenedComputed"
+    v-model="dialogOpened"
     maximized
     allowFocusOutside
     transitionShow="jump-up"
@@ -22,7 +22,7 @@
               icon="close"
               color="display"
               aria-label="設定を閉じる"
-              @click="settingDialogOpenedComputed = false"
+              @click="dialogOpened = false"
             />
           </QToolbar>
         </QHeader>
@@ -507,20 +507,10 @@ import { isProduction } from "@/helpers/platform";
 
 type SamplingRateOption = EngineSettingType["outputSamplingRate"];
 
-const props = defineProps<{
-  modelValue: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "update:modelValue", val: boolean): void;
-}>();
+const dialogOpened = defineModel<boolean>();
 
 const store = useStore();
 const { warn } = createLogger("SettingDialog");
-
-const settingDialogOpenedComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
 
 const engineUseGpu = computed({
   get: () => {

--- a/src/components/Dialog/SettingDialog/SettingDialog.vue
+++ b/src/components/Dialog/SettingDialog/SettingDialog.vue
@@ -218,7 +218,7 @@
                 </QSlideTransition>
 
                 <FileNameTemplateDialog
-                  v-model:openDialog="showAudioFilePatternEditDialog"
+                  v-model="showAudioFilePatternEditDialog"
                   :savedTemplate="audioFileNamePattern"
                   :defaultTemplate="DEFAULT_AUDIO_FILE_NAME_TEMPLATE"
                   :availableTags="[
@@ -236,7 +236,7 @@
                   "
                 />
                 <FileNameTemplateDialog
-                  v-model:openDialog="showSongTrackAudioFilePatternEditDialog"
+                  v-model="showSongTrackAudioFilePatternEditDialog"
                   :savedTemplate="songTrackFileNamePattern"
                   :defaultTemplate="DEFAULT_SONG_AUDIO_FILE_NAME_TEMPLATE"
                   :availableTags="[

--- a/src/components/Dialog/SettingDialog/SettingDialog.vue
+++ b/src/components/Dialog/SettingDialog/SettingDialog.vue
@@ -218,7 +218,7 @@
                 </QSlideTransition>
 
                 <FileNameTemplateDialog
-                  v-model="showAudioFilePatternEditDialog"
+                  v-model:dialogOpened="showAudioFilePatternEditDialog"
                   :savedTemplate="audioFileNamePattern"
                   :defaultTemplate="DEFAULT_AUDIO_FILE_NAME_TEMPLATE"
                   :availableTags="[
@@ -236,7 +236,7 @@
                   "
                 />
                 <FileNameTemplateDialog
-                  v-model="showSongTrackAudioFilePatternEditDialog"
+                  v-model:dialogOpened="showSongTrackAudioFilePatternEditDialog"
                   :savedTemplate="songTrackFileNamePattern"
                   :defaultTemplate="DEFAULT_SONG_AUDIO_FILE_NAME_TEMPLATE"
                   :availableTags="[
@@ -507,7 +507,7 @@ import { isProduction } from "@/helpers/platform";
 
 type SamplingRateOption = EngineSettingType["outputSamplingRate"];
 
-const dialogOpened = defineModel<boolean>();
+const dialogOpened = defineModel<boolean>("dialogOpened");
 
 const store = useStore();
 const { warn } = createLogger("SettingDialog");

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -112,7 +112,7 @@ import { useStore } from "@/store";
 import { ToolbarButtonTagType, ToolbarSettingType } from "@/type/preload";
 import { getToolbarButtonName } from "@/store/utility";
 
-const dialogOpened = defineModel<boolean>();
+const dialogOpened = defineModel<boolean>({ default: false });
 
 const store = useStore();
 

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -112,7 +112,7 @@ import { useStore } from "@/store";
 import { ToolbarButtonTagType, ToolbarSettingType } from "@/type/preload";
 import { getToolbarButtonName } from "@/store/utility";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 
 const store = useStore();
 

--- a/src/components/Dialog/ToolBarCustomDialog.vue
+++ b/src/components/Dialog/ToolBarCustomDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <QDialog
-    v-model="ToolBarCustomDialogOpenComputed"
+    v-model="dialogOpened"
     maximized
     transitionShow="jump-up"
     transitionHide="jump-down"
@@ -112,12 +112,7 @@ import { useStore } from "@/store";
 import { ToolbarButtonTagType, ToolbarSettingType } from "@/type/preload";
 import { getToolbarButtonName } from "@/store/utility";
 
-const props = defineProps<{
-  modelValue: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "update:modelValue", val: boolean): void;
-}>();
+const dialogOpened = defineModel<boolean>();
 
 const store = useStore();
 
@@ -170,11 +165,6 @@ const usableButtonsDesc: Record<ToolbarButtonTagType, string> = {
   EMPTY:
     "これはボタンではありません。レイアウトの調整に使います。また、実際には表示されません。",
 };
-
-const ToolBarCustomDialogOpenComputed = computed({
-  get: () => props.modelValue || isChanged.value,
-  set: (val) => emit("update:modelValue", val),
-});
 
 const isChanged = computed(() => {
   const nowSetting = store.state.toolbarSetting;
@@ -235,11 +225,11 @@ const finishOrNotDialog = async () => {
     if (result === "OK") {
       toolbarButtons.value = [...store.state.toolbarSetting];
       selectedButton.value = toolbarButtons.value[0];
-      ToolBarCustomDialogOpenComputed.value = false;
+      dialogOpened.value = false;
     }
   } else {
     selectedButton.value = toolbarButtons.value[0];
-    ToolBarCustomDialogOpenComputed.value = false;
+    dialogOpened.value = false;
   }
 };
 </script>

--- a/src/components/Dialog/UpdateNotificationDialog/Container.vue
+++ b/src/components/Dialog/UpdateNotificationDialog/Container.vue
@@ -79,7 +79,7 @@ const stopWatchEffect = watchEffect(() => {
     newUpdateResult.value.status == "updateAvailable"
   ) {
     isDialogOpenComputed.value = true;
-    stopWatchEffect();
+    stopWatchEffect(); // ダイアログを再表示させない
   }
 });
 </script>

--- a/src/components/Dialog/UpdateNotificationDialog/Container.vue
+++ b/src/components/Dialog/UpdateNotificationDialog/Container.vue
@@ -6,7 +6,7 @@
 <template>
   <UpdateNotificationDialog
     v-if="newUpdateResult.status == 'updateAvailable'"
-    v-model="isDialogOpenComputed"
+    v-model:dialogOpened="isDialogOpenComputed"
     :latestVersion="newUpdateResult.latestVersion"
     :newUpdateInfos="newUpdateResult.newUpdateInfos"
     @skipThisVersionClick="handleSkipThisVersionClick"

--- a/src/components/Dialog/UpdateNotificationDialog/Container.vue
+++ b/src/components/Dialog/UpdateNotificationDialog/Container.vue
@@ -73,12 +73,13 @@ const handleSkipThisVersionClick = (version: string) => {
 };
 
 // ダイアログを開くかどうか
-watchEffect(() => {
+const stopWatchEffect = watchEffect(() => {
   if (
     props.canOpenDialog &&
     newUpdateResult.value.status == "updateAvailable"
   ) {
     isDialogOpenComputed.value = true;
+    stopWatchEffect();
   }
 });
 </script>

--- a/src/components/Dialog/UpdateNotificationDialog/Presentation.vue
+++ b/src/components/Dialog/UpdateNotificationDialog/Presentation.vue
@@ -72,7 +72,7 @@
 <script setup lang="ts">
 import { UpdateInfo } from "@/type/preload";
 
-const dialogOpened = defineModel<boolean>({ default: false });
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
 const props = defineProps<{
   /** 公開されている最新のバージョン */
   latestVersion: string;

--- a/src/components/Dialog/UpdateNotificationDialog/Presentation.vue
+++ b/src/components/Dialog/UpdateNotificationDialog/Presentation.vue
@@ -1,5 +1,5 @@
 <template>
-  <QDialog v-model="modelValueComputed">
+  <QDialog v-model="dialogOpened">
     <QCard class="q-py-sm q-px-md dialog-card">
       <QCardSection>
         <div class="text-h5">アップデートのお知らせ</div>
@@ -70,31 +70,22 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
 import { UpdateInfo } from "@/type/preload";
 
+const dialogOpened = defineModel<boolean>({ default: false });
 const props = defineProps<{
-  /** ダイアログの表示状態 */
-  modelValue: boolean;
   /** 公開されている最新のバージョン */
   latestVersion: string;
   /** 表示するアップデート情報 */
   newUpdateInfos: UpdateInfo[];
 }>();
 const emit = defineEmits<{
-  /** ダイアログの表示状態が変わるときに呼ばれる */
-  (e: "update:modelValue", value: boolean): void;
   /** スキップするときに呼ばれる */
   (e: "skipThisVersionClick", version: string): void;
 }>();
 
-const modelValueComputed = computed({
-  get: () => props.modelValue,
-  set: (val) => emit("update:modelValue", val),
-});
-
 const closeUpdateNotificationDialog = () => {
-  modelValueComputed.value = false;
+  dialogOpened.value = false;
 };
 
 const openOfficialWebsite = () => {

--- a/src/components/Dialog/UpdateNotificationDialog/index.stories.ts
+++ b/src/components/Dialog/UpdateNotificationDialog/index.stories.ts
@@ -6,7 +6,7 @@ import Presentation from "./Presentation.vue";
 const meta: Meta<typeof Presentation> = {
   component: Presentation,
   args: {
-    modelValue: false,
+    dialogOpened: false,
     latestVersion: "1.0.0",
     newUpdateInfos: [
       {
@@ -20,7 +20,7 @@ const meta: Meta<typeof Presentation> = {
         contributors: ["これは表示されないはず"],
       },
     ],
-    "onUpdate:modelValue": fn(),
+    "onUpdate:dialogOpened": fn(),
     onSkipThisVersionClick: fn(),
   },
   tags: ["!autodocs"], // ダイアログ系はautodocsのプレビューが正しく表示されないので無効化
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof meta>;
 export const Opened: Story = {
   name: "開いている",
   args: {
-    modelValue: true,
+    dialogOpened: true,
   },
 };
 
@@ -46,7 +46,7 @@ export const Close: Story = {
     await userEvent.click(button);
 
     // ダイアログを閉じるイベントが呼ばれる
-    await expect(args["onUpdate:modelValue"]).toBeCalledWith(false);
+    await expect(args["onUpdate:dialogOpened"]).toBeCalledWith(false);
   },
 };
 
@@ -66,7 +66,7 @@ export const SkipThisVersion: Story = {
     // スキップイベントが呼ばれる
     await expect(args["onSkipThisVersionClick"]).toBeCalledWith("1.0.0");
     // ダイアログを閉じるイベントが呼ばれる
-    await expect(args["onUpdate:modelValue"]).toBeCalledWith(false);
+    await expect(args["onUpdate:dialogOpened"]).toBeCalledWith(false);
   },
 };
 
@@ -89,7 +89,7 @@ export const OpenOfficialSite: Story = {
       "_blank",
     );
     // ダイアログを閉じるイベントが呼ばれる
-    await expect(args["onUpdate:modelValue"]).toBeCalledWith(false);
+    await expect(args["onUpdate:dialogOpened"]).toBeCalledWith(false);
   },
 };
 


### PR DESCRIPTION
## 内容

基本的にはdefineModelを使うように置き換えただけです。
留意点としては `const dialogOpened = defineModel<boolean>({ default: false })` していてもStorybookではmodeValueとして扱われます。
それとアップデート通知ダイアログが閉じれないバグを見つけてついでに修正してあります。

ヘルプダイアログについてissueが立っているのとこのPRの変更量がそれなりに多いので、このPRがマージされた後にやりたいと思います。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
