### PR TITLE
fix: ヘルプダイアログが無限に開けるのを修正 #2610

### DIFF
--- a/src/components/Dialog/AllDialog.vue
+++ b/src/components/Dialog/AllDialog.vue
@@ -30,6 +30,7 @@
   <ExportSongAudioDialog v-model:dialogOpened="isExportSongAudioDialogOpen" />
   <ImportSongProjectDialog v-model="isImportSongProjectDialogOpenComputed" />
   <PresetManageDialog v-model:dialogOpened="isPresetManageDialogOpenComputed" />
+  <HelpDialog v-model="isHelpDialogOpenComputed" />
 </template>
 
 <script setup lang="ts">
@@ -47,6 +48,7 @@ import UpdateNotificationDialogContainer from "@/components/Dialog/UpdateNotific
 import ImportSongProjectDialog from "@/components/Dialog/ImportSongProjectDialog.vue";
 import ExportSongAudioDialog from "@/components/Dialog/ExportSongAudioDialog/Container.vue";
 import PresetManageDialog from "@/components/Dialog/PresetManageDialog.vue";
+import HelpDialog from "@/components/Dialog/HelpDialog/HelpDialog.vue";
 import { useStore } from "@/store";
 import { filterCharacterInfosByStyleType } from "@/store/utility";
 
@@ -185,6 +187,15 @@ const isPresetManageDialogOpenComputed = computed({
   set: (val) =>
     store.actions.SET_DIALOG_OPEN({
       isPresetManageDialogOpen: val,
+    }),
+});
+
+// ヘルプダイアログ
+const isHelpDialogOpenComputed = computed({
+  get: () => store.state.isHelpDialogOpen,
+  set: (val) =>
+    store.actions.SET_DIALOG_OPEN({
+      isHelpDialogOpen: val,
     }),
 });
 </script>

--- a/src/components/Dialog/HelpDialog/HelpDialog.vue
+++ b/src/components/Dialog/HelpDialog/HelpDialog.vue
@@ -32,7 +32,7 @@
               icon="close"
               color="display"
               aria-label="ヘルプを閉じる"
-              @click="closeDialog"
+              @click="onDialogOK"
             />
           </QToolbar>
         </QHeader>
@@ -103,10 +103,6 @@ type PageData = PageItem | PageSeparator;
 
 const { dialogRef, onDialogOK } = useDialogPluginComponent();
 defineEmits([...useDialogPluginComponent.emits]);
-
-const closeDialog = () => {
-  onDialogOK();
-};
 
 // エディタのアップデート確認
 const store = useStore();

--- a/src/components/Dialog/HelpDialog/HelpDialog.vue
+++ b/src/components/Dialog/HelpDialog/HelpDialog.vue
@@ -32,7 +32,7 @@
               icon="close"
               color="display"
               aria-label="ヘルプを閉じる"
-              @click="onDialogOK"
+              @click="closeDialog"
             />
           </QToolbar>
         </QHeader>
@@ -102,6 +102,11 @@ type PageSeparator = {
 type PageData = PageItem | PageSeparator;
 
 const { dialogRef, onDialogOK } = useDialogPluginComponent();
+defineEmits([...useDialogPluginComponent.emits]);
+
+const closeDialog = () => {
+  onDialogOK();
+};
 
 // エディタのアップデート確認
 const store = useStore();

--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -28,7 +28,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
-import { useQuasar, Dialog } from "quasar";
+import { useQuasar } from "quasar";
 import { MenuItemData, MenuItemRoot } from "../type";
 import MenuButton from "../MenuButton.vue";
 import TitleBarButtons from "./TitleBarButtons.vue";

--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -36,7 +36,6 @@ import TitleBarEditorSwitcher from "./TitleBarEditorSwitcher.vue";
 import { useStore } from "@/store";
 import { HotkeyAction, useHotkeyManager } from "@/plugins/hotkeyPlugin";
 import { useEngineIcons } from "@/composables/useEngineIcons";
-import HelpDialog from "@/components/Dialog/HelpDialog/HelpDialog.vue";
 import { getAppInfos } from "@/domain/appInfo";
 
 const props = defineProps<{
@@ -544,8 +543,8 @@ const menudata = computed<MenuItemData[]>(() => [
     label: "ヘルプ",
     onClick: () => {
       closeAllDialog();
-      Dialog.create({
-        component: HelpDialog,
+      void store.actions.SET_DIALOG_OPEN({
+        isHelpDialogOpen: true,
       });
     },
     disableWhenUiLocked: false,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -2029,6 +2029,7 @@ export type DialogStates = {
   isExportSongAudioDialogOpen: boolean;
   isImportSongProjectDialogOpen: boolean;
   isPresetManageDialogOpen: boolean;
+  isHelpDialogOpen: boolean;
 };
 
 export type UiStoreTypes = {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -79,6 +79,7 @@ export const uiStoreState: UiStoreState = {
   isExportSongAudioDialogOpen: false,
   isImportSongProjectDialogOpen: false,
   isPresetManageDialogOpen: false,
+  isHelpDialogOpen: false,
   isMaximized: false,
   isPinned: false,
   isFullscreen: false,


### PR DESCRIPTION
## 内容
UIロックとアンロックを自動で行うためにALL_DIALOGで開く方式に戻します。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #2610 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
