### PR TITLE
chore: eslintにvitestプラグインを追加

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -217,7 +217,7 @@ export default defineConfigWithVueTs(
         { sameNameShorthand: "always" },
       ],
       "vue/v-on-event-hyphenation": ["error", "never", { autofix: true }],
-      "progressPlugin/activate":
+      "progress/activate":
         process.env.ESLINT_FILE_PROGRESS === "1" ? "error" : "off",
       "vitest/expect-expect": ["error", { assertFunctionNames: ["expect*"] }],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,8 +11,8 @@ import {
   vueTsConfigs,
 } from "@vue/eslint-config-typescript";
 import { configs as tsConfigs, parser as tsParser } from "typescript-eslint";
-import progress from "eslint-plugin-file-progress";
-import gitignore from "eslint-config-flat-gitignore";
+import progressPlugin from "eslint-plugin-file-progress";
+import gitignoreConfig from "eslint-config-flat-gitignore";
 import vitestPlugin from "@vitest/eslint-plugin";
 import voicevoxPlugin from "./eslint-plugin/index.mjs";
 
@@ -92,7 +92,7 @@ export default defineConfigWithVueTs(
     name: "voicevox/defaults/plugins",
     plugins: {
       import: importPlugin,
-      progress,
+      progressPlugin,
     },
   },
 
@@ -117,7 +117,7 @@ export default defineConfigWithVueTs(
     },
   },
 
-  gitignore(),
+  gitignoreConfig(),
 
   ...pluginConfig(vuePlugin.configs["flat/recommended"]),
   ...pluginConfig("eslint:recommended", js.configs.recommended),
@@ -217,7 +217,7 @@ export default defineConfigWithVueTs(
         { sameNameShorthand: "always" },
       ],
       "vue/v-on-event-hyphenation": ["error", "never", { autofix: true }],
-      "progress/activate":
+      "progressPlugin/activate":
         process.env.ESLINT_FILE_PROGRESS === "1" ? "error" : "off",
       "vitest/expect-expect": ["error", { assertFunctionNames: ["expect*"] }],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -92,7 +92,7 @@ export default defineConfigWithVueTs(
     name: "voicevox/defaults/plugins",
     plugins: {
       import: importPlugin,
-      progressPlugin,
+      progress: progressPlugin,
     },
   },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ import {
 import { configs as tsConfigs, parser as tsParser } from "typescript-eslint";
 import progress from "eslint-plugin-file-progress";
 import gitignore from "eslint-config-flat-gitignore";
+import vitestPlugin from "@vitest/eslint-plugin";
 import voicevoxPlugin from "./eslint-plugin/index.mjs";
 
 /**
@@ -124,6 +125,7 @@ export default defineConfigWithVueTs(
   ...pluginConfig(vueTsConfigs.recommended.toConfigArray()),
   ...pluginConfig(voicevoxPlugin.configs.all),
   ...pluginConfig(storybookPlugin.configs["flat/recommended"]),
+  ...pluginConfig(vitestPlugin.configs.recommended),
 
   {
     name: "voicevox/type-checked/typescript",
@@ -217,6 +219,7 @@ export default defineConfigWithVueTs(
       "vue/v-on-event-hyphenation": ["error", "never", { autofix: true }],
       "progress/activate":
         process.env.ESLINT_FILE_PROGRESS === "1" ? "error" : "off",
+      "vitest/expect-expect": ["error", { assertFunctionNames: ["expect*"] }],
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@typescript-eslint/utils": "8.26.0",
     "@vitejs/plugin-vue": "5.2.1",
     "@vitest/browser": "3.0.7",
+    "@vitest/eslint-plugin": "1.1.38",
     "@vitest/ui": "3.0.7",
     "@voicevox/eslint-plugin": "file:./eslint-plugin",
     "@vue/eslint-config-prettier": "10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@vitest/browser':
         specifier: 3.0.7
         version: 3.0.7(@types/node@22.13.9)(playwright@1.50.1)(typescript@5.8.2)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(sass-embedded@1.85.1)(tsx@4.19.3))(vitest@3.0.7)
+      '@vitest/eslint-plugin':
+        specifier: 1.1.38
+        version: 1.1.38(@typescript-eslint/utils@8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7)
       '@vitest/ui':
         specifier: 3.0.7
         version: 3.0.7(vitest@3.0.7)
@@ -1638,6 +1641,19 @@ packages:
       safaridriver:
         optional: true
       webdriverio:
+        optional: true
+
+  '@vitest/eslint-plugin@1.1.38':
+    resolution: {integrity: sha512-KcOTZyVz8RiM5HyriiDVrP1CyBGuhRxle+lBsmSs6NTJEO/8dKVAq+f5vQzHj1/Kc7bYXSDO6yBe62Zx0t5iaw==}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.24.0
+      eslint: '>= 8.57.0'
+      typescript: '>= 5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vitest:
         optional: true
 
   '@vitest/expect@2.0.5':
@@ -6657,6 +6673,14 @@ snapshots:
       - typescript
       - utf-8-validate
       - vite
+
+  '@vitest/eslint-plugin@1.1.38(@typescript-eslint/utils@8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7)':
+    dependencies:
+      '@typescript-eslint/utils': 8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
+      eslint: 9.21.0(jiti@2.4.2)
+    optionalDependencies:
+      typescript: 5.8.2
+      vitest: 3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/browser@3.0.7)(@vitest/ui@3.0.7)(happy-dom@17.2.2)(jiti@2.4.2)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(sass-embedded@1.85.1)(tsx@4.19.3)
 
   '@vitest/expect@2.0.5':
     dependencies:

--- a/tests/unit/backend/electron/vvppFile.node.spec.ts
+++ b/tests/unit/backend/electron/vvppFile.node.spec.ts
@@ -24,7 +24,7 @@ test("正しいVVPPファイルからエンジンを切り出せる", async () =
     outputDir,
     tmpDir,
   }).extract();
-  assertIsEngineDir(outputDir);
+  expectIsEngineDir(outputDir);
 });
 
 test("分割されたVVPPファイルからエンジンを切り出せる", async () => {
@@ -41,7 +41,7 @@ test("分割されたVVPPファイルからエンジンを切り出せる", asyn
     outputDir,
     tmpDir,
   }).extract();
-  assertIsEngineDir(outputDir);
+  expectIsEngineDir(outputDir);
 });
 
 test.each([
@@ -71,7 +71,7 @@ function buildOutputDir() {
 /**
  * エンジンディレクトリであることを確認する。
  */
-function assertIsEngineDir(vvppEngineDir: string) {
+function expectIsEngineDir(vvppEngineDir: string) {
   const files = fs.readdirSync(vvppEngineDir, { recursive: true });
   const manifestExists = files.some(
     (file) =>

--- a/tests/unit/components/help/HelpMarkdownViewSection.spec.ts
+++ b/tests/unit/components/help/HelpMarkdownViewSection.spec.ts
@@ -4,6 +4,7 @@ import HelpMarkdownViewSection from "@/components/Dialog/HelpDialog/HelpMarkdown
 import { markdownItPlugin } from "@/plugins/markdownItPlugin";
 
 describe("HelpMarkdownViewSection.vue", () => {
+  // eslint-disable-next-line vitest/expect-expect
   it("can mount", () => {
     mount(HelpMarkdownViewSection, {
       global: {

--- a/tests/unit/lib/hotkeyManager.spec.ts
+++ b/tests/unit/lib/hotkeyManager.spec.ts
@@ -47,6 +47,7 @@ const createHotkeyManager = (): {
   };
 };
 
+// eslint-disable-next-line vitest/expect-expect
 it("registerできる", () => {
   const { hotkeyManager } = createHotkeyManager();
   hotkeyManager.register({


### PR DESCRIPTION
## 内容

タイトルのとおりです。公式から提供されてたので追加してみました。
今のテストだと「テストはexpectが１つ以上含まれてるべき」ルールに引っかかってるのがいくつかあったので、とりあえず対処しています。

## 関連 Issue

ref: https://github.com/VOICEVOX/voicevox/issues/2627

## その他

ぶっちゃけ恩恵はあまりない気がします。
nodeのtestをimportしてたときにエラーにするみたいなのも入ってて、初学者の助けになるかもしれない･･･？
https://github.com/vitest-dev/eslint-plugin-vitest/