### PR TITLE
chore(tests): vitestのimportを明示的にする

### DIFF
--- a/tests/unit/backend/browser/fakePath.spec.ts
+++ b/tests/unit/backend/browser/fakePath.spec.ts
@@ -1,3 +1,4 @@
+import { it, expect } from "vitest";
 import { isFakePath, createFakePath } from "@/backend/browser/fakePath";
 
 it.each([

--- a/tests/unit/backend/common/configManager.spec.ts
+++ b/tests/unit/backend/common/configManager.spec.ts
@@ -1,3 +1,4 @@
+import { vi, it, expect, afterEach } from "vitest";
 import pastConfigs from "./pastConfigs";
 import configBugDefaultPreset1996 from "./pastConfigs/0.19.1-bug_default_preset.json";
 import { BaseConfigManager } from "@/backend/common/ConfigManager";

--- a/tests/unit/backend/electron/VvppManager.node.spec.ts
+++ b/tests/unit/backend/electron/VvppManager.node.spec.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { beforeEach, expect, test } from "vitest";
+import { beforeAll, afterAll, beforeEach, expect, test } from "vitest";
 import { createVvppFile } from "./helper";
 import { EngineId, MinimumEngineManifestType } from "@/type/preload";
 import VvppManager from "@/backend/electron/manager/vvppManager";

--- a/tests/unit/backend/electron/fileHelper.node.spec.ts
+++ b/tests/unit/backend/electron/fileHelper.node.spec.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { test, expect, beforeAll, afterAll } from "vitest";
+import { beforeAll, afterAll, describe, expect, test } from "vitest";
 import { writeFileSafely } from "@/backend/electron/fileHelper";
 import { uuid4 } from "@/helpers/random";
 

--- a/tests/unit/backend/electron/vvppFile.node.spec.ts
+++ b/tests/unit/backend/electron/vvppFile.node.spec.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import path from "path";
 import fs from "fs";
-import { test, afterAll, beforeAll } from "vitest";
+import { afterAll, beforeAll, expect, test } from "vitest";
 import { createVvppFile } from "./helper";
 import { VvppFileExtractor } from "@/backend/electron/vvppFile";
 import { uuid4 } from "@/helpers/random";

--- a/tests/unit/components/help/HelpMarkdownViewSection.spec.ts
+++ b/tests/unit/components/help/HelpMarkdownViewSection.spec.ts
@@ -1,5 +1,5 @@
 import { mount, flushPromises } from "@vue/test-utils";
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import HelpMarkdownViewSection from "@/components/Dialog/HelpDialog/HelpMarkdownViewSection.vue";
 import { markdownItPlugin } from "@/plugins/markdownItPlugin";
 

--- a/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
+++ b/tests/unit/composable/useFetchNewUpdateInfos.spec.ts
@@ -1,3 +1,4 @@
+import { vi, it, expect } from "vitest";
 import { Ref } from "vue";
 import { UpdateInfo, UrlString } from "@/type/preload";
 import { useFetchNewUpdateInfos } from "@/composables/useFetchNewUpdateInfos";

--- a/tests/unit/composable/useModifierKey.spec.ts
+++ b/tests/unit/composable/useModifierKey.spec.ts
@@ -1,3 +1,4 @@
+import { it, expect, describe } from "vitest";
 import { mount } from "@vue/test-utils";
 import { Ref } from "vue";
 import {

--- a/tests/unit/domain/defaultEngine/latetDefaultEngine.spec.ts
+++ b/tests/unit/domain/defaultEngine/latetDefaultEngine.spec.ts
@@ -1,3 +1,4 @@
+import { vi, expect, test } from "vitest";
 import latestDefaultEngineInfos from "./latestDefaultEngineInfos.json";
 import { fetchLatestDefaultEngineInfo } from "@/domain/defaultEngine/latetDefaultEngine";
 

--- a/tests/unit/domain/hotkeyAction.spec.ts
+++ b/tests/unit/domain/hotkeyAction.spec.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import {
   getDefaultHotkeySettings,
   hotkeyActionNameSchema,

--- a/tests/unit/domain/japanese.spec.ts
+++ b/tests/unit/domain/japanese.spec.ts
@@ -1,3 +1,4 @@
+import { it, expect, describe, test } from "vitest";
 import {
   createKanaRegex,
   convertHiraToKana,

--- a/tests/unit/domain/project.spec.ts
+++ b/tests/unit/domain/project.spec.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { beforeEach, describe, expect, test } from "vitest";
 import { migrateProjectFileObject } from "@/domain/project";
 import { EngineId, SpeakerId, StyleId } from "@/type/preload";
 import { resetMockMode } from "@/helpers/random";

--- a/tests/unit/domain/sing/applyPhonemeTimingEdit.spec.ts
+++ b/tests/unit/domain/sing/applyPhonemeTimingEdit.spec.ts
@@ -1,3 +1,4 @@
+import { it, expect, describe } from "vitest";
 import { uuid4 } from "@/helpers/random";
 import { FramePhoneme } from "@/openapi";
 import {

--- a/tests/unit/domain/sing/shouldPlayTracks.spec.ts
+++ b/tests/unit/domain/sing/shouldPlayTracks.spec.ts
@@ -1,3 +1,4 @@
+import { it, expect, describe } from "vitest";
 import { uuid4 } from "@/helpers/random";
 import { createDefaultTrack, shouldPlayTracks } from "@/sing/domain";
 import { Track } from "@/store/type";

--- a/tests/unit/lib/cloneWithUnwrapProxy.spec.ts
+++ b/tests/unit/lib/cloneWithUnwrapProxy.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "vitest";
+import { expect, test } from "vitest";
 import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 
 const original = { a: 1, b: { c: 2 } };

--- a/tests/unit/mock/engineMock/index.spec.ts
+++ b/tests/unit/mock/engineMock/index.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, test } from "vitest";
 import { hash } from "../../utils";
 import { resetMockMode } from "@/helpers/random";
 import { createOpenAPIEngineMock } from "@/mock/engineMock";

--- a/tests/unit/store/command.spec.ts
+++ b/tests/unit/store/command.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, expect, test } from "vitest";
 import { store } from "@/store";
 import { AudioKey } from "@/type/preload";
 import { resetMockMode, uuid4 } from "@/helpers/random";

--- a/tests/unit/store/immerPatchUtility.spec.ts
+++ b/tests/unit/store/immerPatchUtility.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { enableMapSet, enablePatches, Immer, Patch } from "immer";
 import { applyPatches } from "@/store/immerPatchUtility";
 

--- a/tests/unit/store/singing.spec.ts
+++ b/tests/unit/store/singing.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, expect, test } from "vitest";
 import { store } from "@/store";
 import { TrackId } from "@/type/preload";
 import { resetMockMode, uuid4 } from "@/helpers/random";

--- a/tests/unit/store/utility.spec.ts
+++ b/tests/unit/store/utility.spec.ts
@@ -1,3 +1,4 @@
+import { it, expect, describe, test } from "vitest";
 import { AccentPhrase, Mora } from "@/openapi";
 import {
   CharacterInfo,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "baseUrl": ".",
-    "types": ["vitest/globals"],
     "paths": {
       "@/*": ["src/*"]
     },


### PR DESCRIPTION
## 内容

ESLintの実行環境における挙動の不整合を解消するため、以下の修正を行いました。  
- 各テストファイルにおいて、vitestのグローバル変数（it, expect, describe, test, vi, afterEach など）を明示的にimportするよう変更しました。  
- tsconfig.jsonから "types": ["vitest/globals"] の記述を削除し、設定の一貫性を図りました。

これでplaywright系のときは明示的import・vitestのときは省いても良いというバランスだったのが、全部明示的に変わるので一貫性は上がったはず･･･！
（あと間違いも減る･･･････気がする。）

## 関連 Issue

close #2627  
ref #2628

## スクリーンショット・動画など

特になし

## その他

このプルリクエストは、ローカル環境でpnpm run lint実行時に発生するエラーの原因を調査した結果、ESLintとtsconfigの設定不整合が原因であると判明したため、その対策として行いました。  
テスト実行時の環境差異によるエラー発生を防止し、開発環境の一貫性を保つことを目的としています。
