### PR TITLE
refactor(MenuBar): subMenuDataのpropsを統合

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1,14 +1,9 @@
 <template>
   <ErrorBoundary>
     <TooltipProvider disableHoverableContent :delayDuration="500">
-      <!-- TODO: subMenuDataのpropsを分けず、１つにまとめて渡す -->
       <MenuBar
         v-if="openedEditor != undefined"
-        :fileSubMenuData="subMenuData.file"
-        :editSubMenuData="subMenuData.edit"
-        :viewSubMenuData="subMenuData.view"
-        :engineSubMenuData="subMenuData.engine"
-        :settingSubMenuData="subMenuData.setting"
+        :subMenus="subMenuData"
         :editor="openedEditor"
       />
       <KeepAlive>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -3,7 +3,7 @@
     <TooltipProvider disableHoverableContent :delayDuration="500">
       <MenuBar
         v-if="openedEditor != undefined"
-        :subMenus="subMenuData"
+        :subMenuData
         :editor="openedEditor"
       />
       <KeepAlive>

--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -32,6 +32,7 @@
 import { ref, computed, watch } from "vue";
 import { useQuasar } from "quasar";
 import { MenuItemButton, MenuItemData, MenuItemRoot } from "../type";
+import { MenuBarCategory } from "./menuBarData";
 import MenuButton from "../MenuButton.vue";
 import TitleBarButtons from "./TitleBarButtons.vue";
 import TitleBarEditorSwitcher from "./TitleBarEditorSwitcher.vue";
@@ -39,16 +40,8 @@ import { useStore } from "@/store";
 import { getAppInfos } from "@/domain/appInfo";
 
 const props = defineProps<{
-  /** 「ファイル」メニューのサブメニュー */
-  fileSubMenuData: MenuItemData[];
-  /** 「編集」メニューのサブメニュー */
-  editSubMenuData: MenuItemData[];
-  /** 「表示」メニューのサブメニュー */
-  viewSubMenuData: MenuItemData[];
-  /** 「エンジン」メニューのサブメニュー */
-  engineSubMenuData: MenuItemData[];
-  /** 「設定」メニューのサブメニュー */
-  settingSubMenuData: MenuItemData[];
+  /** メニューバーの全サブメニューデータ */
+  subMenus: Record<MenuBarCategory, MenuItemData[]>;
   /** エディタの種類 */
   editor: "talk" | "song";
 }>();
@@ -105,36 +98,36 @@ const menudata = computed<(MenuItemButton | MenuItemRoot)[]>(() => [
   {
     type: "root",
     label: "ファイル",
-    subMenu: props.fileSubMenuData,
-    disabled: props.fileSubMenuData.length === 0,
+    subMenu: props.subMenus.file,
+    disabled: props.subMenus.file.length === 0,
     disableWhenUiLocked: false,
   },
   {
     type: "root",
     label: "編集",
-    subMenu: props.editSubMenuData,
-    disabled: props.editSubMenuData.length === 0,
+    subMenu: props.subMenus.edit,
+    disabled: props.subMenus.edit.length === 0,
     disableWhenUiLocked: false,
   },
   {
     type: "root",
     label: "表示",
-    subMenu: props.viewSubMenuData,
-    disabled: props.viewSubMenuData.length === 0,
+    subMenu: props.subMenus.view,
+    disabled: props.subMenus.view.length === 0,
     disableWhenUiLocked: false,
   },
   {
     type: "root",
     label: "エンジン",
-    subMenu: props.engineSubMenuData,
-    disabled: props.engineSubMenuData.length === 0,
+    subMenu: props.subMenus.engine,
+    disabled: props.subMenus.engine.length === 0,
     disableWhenUiLocked: false,
   },
   {
     type: "root",
     label: "設定",
-    subMenu: props.settingSubMenuData,
-    disabled: props.settingSubMenuData.length === 0,
+    subMenu: props.subMenus.setting,
+    disabled: props.subMenus.setting.length === 0,
     disableWhenUiLocked: false,
   },
   {

--- a/src/components/Menu/MenuBar/MenuBar.vue
+++ b/src/components/Menu/MenuBar/MenuBar.vue
@@ -32,8 +32,8 @@
 import { ref, computed, watch } from "vue";
 import { useQuasar } from "quasar";
 import { MenuItemButton, MenuItemData, MenuItemRoot } from "../type";
-import { MenuBarCategory } from "./menuBarData";
 import MenuButton from "../MenuButton.vue";
+import { MenuBarCategory } from "./menuBarData";
 import TitleBarButtons from "./TitleBarButtons.vue";
 import TitleBarEditorSwitcher from "./TitleBarEditorSwitcher.vue";
 import { useStore } from "@/store";
@@ -41,7 +41,7 @@ import { getAppInfos } from "@/domain/appInfo";
 
 const props = defineProps<{
   /** メニューバーの全サブメニューデータ */
-  subMenus: Record<MenuBarCategory, MenuItemData[]>;
+  subMenuData: Record<MenuBarCategory, MenuItemData[]>;
   /** エディタの種類 */
   editor: "talk" | "song";
 }>();
@@ -98,36 +98,36 @@ const menudata = computed<(MenuItemButton | MenuItemRoot)[]>(() => [
   {
     type: "root",
     label: "ファイル",
-    subMenu: props.subMenus.file,
-    disabled: props.subMenus.file.length === 0,
+    subMenu: props.subMenuData.file,
+    disabled: props.subMenuData.file.length === 0,
     disableWhenUiLocked: false,
   },
   {
     type: "root",
     label: "編集",
-    subMenu: props.subMenus.edit,
-    disabled: props.subMenus.edit.length === 0,
+    subMenu: props.subMenuData.edit,
+    disabled: props.subMenuData.edit.length === 0,
     disableWhenUiLocked: false,
   },
   {
     type: "root",
     label: "表示",
-    subMenu: props.subMenus.view,
-    disabled: props.subMenus.view.length === 0,
+    subMenu: props.subMenuData.view,
+    disabled: props.subMenuData.view.length === 0,
     disableWhenUiLocked: false,
   },
   {
     type: "root",
     label: "エンジン",
-    subMenu: props.subMenus.engine,
-    disabled: props.subMenus.engine.length === 0,
+    subMenu: props.subMenuData.engine,
+    disabled: props.subMenuData.engine.length === 0,
     disableWhenUiLocked: false,
   },
   {
     type: "root",
     label: "設定",
-    subMenu: props.subMenus.setting,
-    disabled: props.subMenus.setting.length === 0,
+    subMenu: props.subMenuData.setting,
+    disabled: props.subMenuData.setting.length === 0,
     disableWhenUiLocked: false,
   },
   {

--- a/src/components/Menu/MenuBar/menuBarData.ts
+++ b/src/components/Menu/MenuBar/menuBarData.ts
@@ -3,7 +3,7 @@ import { MenuItemData } from "@/components/Menu/type";
 import { flatWithSeparator } from "@/helpers/arrayHelper";
 import { objectEntries, objectFromEntries } from "@/helpers/typedEntries";
 
-type MenuBarCategory = "file" | "edit" | "view" | "engine" | "setting";
+export type MenuBarCategory = "file" | "edit" | "view" | "engine" | "setting"; // exportを追加
 
 const menuItemStructure = {
   file: ["audioExport", "externalProject", "project"],


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/2632

を解決してみました。

## 関連 Issue

fix #2632


## その他

clineとgemini-2.5-pro-expを使ってみたら、解決まで達成できました。
（ちょっと型周りはごたついていたので修正したけど）

プロンプトこんな感じ：

openai:o1でplan
```
このissueを解決してください。

（issue内容コピペ）

↓プルリクエスト #2596 はこちらです。

（プルリクエストのコメントを全部展開した状態でwebページをコピペ）

まずはhiho_docs/introduction.mdも読んでください。
そのあとissueを解決するための要件定義書をhoge.mdに書いてください。
```

gemini-2.5-pro-expでact
```
実行時、要件定義書のタスクリストを埋めながら進行してください。
```

終わったあと、App.vue内でunrefしていたので
```
ここでunrefしているのを消すリファクタリングをしてください。

（該当コードコピペ）
```