### PR TITLE
refactor: selectPriorPhrase関数のインターフェースを変更

### DIFF
--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -467,7 +467,7 @@ export function toSortedPhraseRanges<K extends string>(
  */
 export function selectPriorPhrase<K extends string>(
   phraseRanges: Map<K, PhraseRange>,
-  position: number,
+  playheadPosition: number,
 ): K {
   if (phraseRanges.size === 0) {
     throw new Error("phraseRanges.size is 0.");
@@ -475,8 +475,8 @@ export function selectPriorPhrase<K extends string>(
   // 再生位置が含まれるPhrase
   for (const [phraseKey, phraseRange] of phraseRanges) {
     if (
-      phraseRange.startTicks <= position &&
-      position <= phraseRange.endTicks
+      phraseRange.startTicks <= playheadPosition &&
+      playheadPosition <= phraseRange.endTicks
     ) {
       return phraseKey;
     }
@@ -485,7 +485,7 @@ export function selectPriorPhrase<K extends string>(
   const sortedPhraseRanges = toSortedPhraseRanges(phraseRanges);
   // 再生位置より後のPhrase
   for (const [phraseKey, phraseRange] of sortedPhraseRanges) {
-    if (phraseRange.startTicks > position) {
+    if (phraseRange.startTicks > playheadPosition) {
       return phraseKey;
     }
   }

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -449,7 +449,7 @@ export type PhraseRange = {
   endTicks: number;
 };
 
-export function toSortedPhrases<K extends string>(
+export function toSortedPhraseRanges<K extends string>(
   phraseRanges: Map<K, PhraseRange>,
 ) {
   return [...phraseRanges.entries()].sort((a, b) => {
@@ -459,7 +459,7 @@ export function toSortedPhrases<K extends string>(
 
 /**
  * 次にレンダリングするべきPhraseを探す。
- * phrasesが空の場合はエラー
+ * phraseRangesが空の場合はエラー
  * 優先順：
  * - 再生位置が含まれるPhrase
  * - 再生位置より後のPhrase
@@ -482,7 +482,7 @@ export function selectPriorPhrase<K extends string>(
     }
   }
 
-  const sortedPhraseRanges = toSortedPhrases(phraseRanges);
+  const sortedPhraseRanges = toSortedPhraseRanges(phraseRanges);
   // 再生位置より後のPhrase
   for (const [phraseKey, phraseRange] of sortedPhraseRanges) {
     if (phraseRange.startTicks > position) {

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -98,6 +98,7 @@ import {
   calculateHash,
   createArray,
   createPromiseThatResolvesWhen,
+  getLast,
   linearInterpolation,
   round,
 } from "@/sing/utility";
@@ -2604,10 +2605,23 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           if (startRenderingRequested() || stopRenderingRequested()) {
             return;
           }
-          const [phraseKey, phrase] = selectPriorPhrase(
-            phrasesToBeRendered,
+          const phraseKey = selectPriorPhrase(
+            new Map(
+              [...phrasesToBeRendered.entries()].map(([phraseKey, phrase]) => {
+                const phraseFirstNote = phrase.notes[0];
+                const phraseLastNote = getLast(phrase.notes);
+                return [
+                  phraseKey,
+                  {
+                    startTicks: phraseFirstNote.position,
+                    endTicks: phraseLastNote.position + phraseLastNote.duration,
+                  },
+                ];
+              }),
+            ),
             playheadPosition.value,
           );
+          const phrase = getOrThrow(phrasesToBeRendered, phraseKey);
           phrasesToBeRendered.delete(phraseKey);
 
           mutations.SET_STATE_TO_PHRASE({

--- a/tests/unit/lib/selectPriorPhrase.spec.ts
+++ b/tests/unit/lib/selectPriorPhrase.spec.ts
@@ -1,52 +1,23 @@
 import { it, expect } from "vitest";
-import { Phrase, PhraseKey, PhraseState } from "@/store/type";
-import {
-  DEFAULT_BPM,
-  DEFAULT_TPQN,
-  selectPriorPhrase,
-  tickToSecond,
-} from "@/sing/domain";
-import { NoteId, TrackId } from "@/type/preload";
-import { uuid4 } from "@/helpers/random";
+import { PhraseKey } from "@/store/type";
+import { DEFAULT_TPQN, PhraseRange, selectPriorPhrase } from "@/sing/domain";
 
-const trackId = TrackId("00000000-0000-0000-0000-000000000000");
-
-const createPhrase = (
-  firstRestDuration: number,
-  start: number,
-  end: number,
-  state: PhraseState,
-): Phrase => {
+const createPhraseRange = (start: number, end: number): PhraseRange => {
   return {
-    trackId,
-    firstRestDuration: firstRestDuration * DEFAULT_TPQN,
-    notes: [
-      {
-        id: NoteId(uuid4()),
-        position: start * DEFAULT_TPQN,
-        duration: (end - start) * DEFAULT_TPQN,
-        noteNumber: 60,
-        lyric: "ド",
-      },
-    ],
-    startTime: tickToSecond(
-      start * DEFAULT_TPQN - firstRestDuration * DEFAULT_TPQN,
-      [{ position: 0, bpm: DEFAULT_BPM }],
-      DEFAULT_TPQN,
-    ),
-    state,
+    startTicks: start * DEFAULT_TPQN,
+    endTicks: end * DEFAULT_TPQN,
   };
 };
-const basePhrases = new Map<PhraseKey, Phrase>([
-  [PhraseKey("1"), createPhrase(0, 0, 1, "WAITING_TO_BE_RENDERED")],
-  [PhraseKey("2"), createPhrase(0, 1, 2, "WAITING_TO_BE_RENDERED")],
-  [PhraseKey("3"), createPhrase(0, 2, 3, "WAITING_TO_BE_RENDERED")],
-  [PhraseKey("4"), createPhrase(0, 3, 4, "WAITING_TO_BE_RENDERED")],
-  [PhraseKey("5"), createPhrase(0, 4, 5, "WAITING_TO_BE_RENDERED")],
+const basePhraseRanges = new Map<PhraseKey, PhraseRange>([
+  [PhraseKey("1"), createPhraseRange(0, 1)],
+  [PhraseKey("2"), createPhraseRange(1, 2)],
+  [PhraseKey("3"), createPhraseRange(2, 3)],
+  [PhraseKey("4"), createPhraseRange(3, 4)],
+  [PhraseKey("5"), createPhraseRange(4, 5)],
 ]);
 
 it("しっかり優先順位に従って探している", () => {
-  const phrases = structuredClone(basePhrases);
+  const phraseRanges = structuredClone(basePhraseRanges);
   const position = 2.5 * DEFAULT_TPQN;
   for (const expectation of [
     // 再生位置が含まれるPhrase
@@ -58,17 +29,13 @@ it("しっかり優先順位に従って探している", () => {
     "1", // 早い方
     "2", // 遅い方
   ]) {
-    const [key] = selectPriorPhrase(phrases, position);
+    const key = selectPriorPhrase(phraseRanges, position);
     expect(key).toEqual(expectation);
-    if (key == undefined) {
-      // 型アサーションのためにthrowを使う
-      throw new Error("key is undefined");
-    }
-    phrases.delete(key);
+    phraseRanges.delete(key);
   }
 
   // もう再生可能なPhraseがないのでthrow
   expect(() => {
-    selectPriorPhrase(phrases, position);
-  }).toThrow("Received empty phrases");
+    selectPriorPhrase(phraseRanges, position);
+  }).toThrow("phraseRanges.size is 0.");
 });


### PR DESCRIPTION
## 内容

selectPriorPhrase関数のインターフェースを変更します。
- `Phrase`ではなく`PhraseRange`を渡すように
- `[phraseKey, phrase]`ではなく`phraseKey`を返すように

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2261

## その他
レンダリング処理の変更をしやすくするために行っています。