### PR TITLE
refactor: ソングのレンダリング関係の型と関数を移動

### DIFF
--- a/src/sing/songTrackRendering.ts
+++ b/src/sing/songTrackRendering.ts
@@ -1,0 +1,367 @@
+import {
+  EditorFrameAudioQuery,
+  EditorFrameAudioQueryKey,
+  Note,
+  Phrase,
+  PhraseKey,
+  Singer,
+  SingingPitchKey,
+  SingingVoiceKey,
+  SingingVolumeKey,
+  Tempo,
+  Track,
+} from "@/store/type";
+import { calculateHash, linearInterpolation } from "@/sing/utility";
+import {
+  calculatePhraseKey,
+  decibelToLinear,
+  getNoteDuration,
+  secondToTick,
+  tickToSecond,
+} from "@/sing/domain";
+import { FramePhoneme, Note as NoteForRequestToEngine } from "@/openapi";
+import { EngineId, TrackId } from "@/type/preload";
+
+/**
+ * フレーズレンダリングに必要なデータのスナップショット
+ */
+export type SnapshotForPhraseRender = Readonly<{
+  tpqn: number;
+  tempos: Tempo[];
+  tracks: Map<TrackId, Track>;
+  engineFrameRates: Map<EngineId, number>;
+  editorFrameRate: number;
+}>;
+
+/**
+ * クエリの生成に必要なデータ
+ */
+export type QuerySource = Readonly<{
+  engineId: EngineId;
+  engineFrameRate: number;
+  tpqn: number;
+  tempos: Tempo[];
+  firstRestDuration: number;
+  notes: Note[];
+  keyRangeAdjustment: number;
+}>;
+
+/**
+ * 歌唱ピッチの生成に必要なデータ
+ */
+export type SingingPitchSource = Readonly<{
+  engineId: EngineId;
+  engineFrameRate: number;
+  tpqn: number;
+  tempos: Tempo[];
+  firstRestDuration: number;
+  notes: Note[];
+  keyRangeAdjustment: number;
+  queryForPitchGeneration: EditorFrameAudioQuery;
+}>;
+
+/**
+ * 歌唱ボリュームの生成に必要なデータ
+ */
+export type SingingVolumeSource = Readonly<{
+  engineId: EngineId;
+  engineFrameRate: number;
+  tpqn: number;
+  tempos: Tempo[];
+  firstRestDuration: number;
+  notes: Note[];
+  keyRangeAdjustment: number;
+  volumeRangeAdjustment: number;
+  queryForVolumeGeneration: EditorFrameAudioQuery;
+}>;
+
+/**
+ * 歌唱音声の合成に必要なデータ
+ */
+export type SingingVoiceSource = Readonly<{
+  singer: Singer;
+  queryForSingingVoiceSynthesis: EditorFrameAudioQuery;
+}>;
+
+/**
+ * リクエスト用のノーツ（と休符）を作成する。
+ */
+export const createNotesForRequestToEngine = (
+  firstRestDuration: number,
+  lastRestDurationSeconds: number,
+  notes: Note[],
+  tempos: Tempo[],
+  tpqn: number,
+  frameRate: number,
+) => {
+  const notesForRequestToEngine: NoteForRequestToEngine[] = [];
+
+  // 先頭の休符を変換
+  const firstRestStartSeconds = tickToSecond(
+    notes[0].position - firstRestDuration,
+    tempos,
+    tpqn,
+  );
+  const firstRestStartFrame = Math.round(firstRestStartSeconds * frameRate);
+  const firstRestEndSeconds = tickToSecond(notes[0].position, tempos, tpqn);
+  const firstRestEndFrame = Math.round(firstRestEndSeconds * frameRate);
+  notesForRequestToEngine.push({
+    key: undefined,
+    frameLength: firstRestEndFrame - firstRestStartFrame,
+    lyric: "",
+  });
+
+  // ノートを変換
+  for (const note of notes) {
+    const noteOnSeconds = tickToSecond(note.position, tempos, tpqn);
+    const noteOnFrame = Math.round(noteOnSeconds * frameRate);
+    const noteOffSeconds = tickToSecond(
+      note.position + note.duration,
+      tempos,
+      tpqn,
+    );
+    const noteOffFrame = Math.round(noteOffSeconds * frameRate);
+    notesForRequestToEngine.push({
+      id: note.id,
+      key: note.noteNumber,
+      frameLength: noteOffFrame - noteOnFrame,
+      lyric: note.lyric,
+    });
+  }
+
+  // 末尾に休符を追加
+  const lastRestFrameLength = Math.round(lastRestDurationSeconds * frameRate);
+  notesForRequestToEngine.push({
+    key: undefined,
+    frameLength: lastRestFrameLength,
+    lyric: "",
+  });
+
+  // frameLengthが1以上になるようにする
+  for (let i = 0; i < notesForRequestToEngine.length; i++) {
+    const frameLength = notesForRequestToEngine[i].frameLength;
+    const frameToShift = Math.max(0, 1 - frameLength);
+    notesForRequestToEngine[i].frameLength += frameToShift;
+    if (i < notesForRequestToEngine.length - 1) {
+      notesForRequestToEngine[i + 1].frameLength -= frameToShift;
+    }
+  }
+
+  return notesForRequestToEngine;
+};
+
+export const shiftKeyOfNotes = (
+  notes: NoteForRequestToEngine[],
+  keyShift: number,
+) => {
+  for (const note of notes) {
+    if (note.key != undefined) {
+      note.key += keyShift;
+    }
+  }
+};
+
+export const getPhonemes = (query: EditorFrameAudioQuery) => {
+  return query.phonemes.map((value) => value.phoneme).join(" ");
+};
+
+export const shiftPitch = (f0: number[], pitchShift: number) => {
+  for (let i = 0; i < f0.length; i++) {
+    f0[i] *= Math.pow(2, pitchShift / 12);
+  }
+};
+
+export const shiftVolume = (volume: number[], volumeShift: number) => {
+  for (let i = 0; i < volume.length; i++) {
+    volume[i] *= decibelToLinear(volumeShift);
+  }
+};
+
+/**
+ * 末尾のpauの区間のvolumeを0にする。（歌とpauの呼吸音が重ならないようにする）
+ * fadeOutDurationSecondsが0の場合は即座にvolumeを0にする。
+ */
+export const muteLastPauSection = (
+  volume: number[],
+  phonemes: FramePhoneme[],
+  frameRate: number,
+  fadeOutDurationSeconds: number,
+) => {
+  const lastPhoneme = phonemes.at(-1);
+  if (lastPhoneme == undefined || lastPhoneme.phoneme !== "pau") {
+    throw new Error("No pau exists at the end.");
+  }
+
+  let lastPauStartFrame = 0;
+  for (let i = 0; i < phonemes.length - 1; i++) {
+    lastPauStartFrame += phonemes[i].frameLength;
+  }
+
+  const lastPauFrameLength = lastPhoneme.frameLength;
+  let fadeOutFrameLength = Math.round(fadeOutDurationSeconds * frameRate);
+  fadeOutFrameLength = Math.max(0, fadeOutFrameLength);
+  fadeOutFrameLength = Math.min(lastPauFrameLength, fadeOutFrameLength);
+
+  // フェードアウト処理を行う
+  if (fadeOutFrameLength === 1) {
+    volume[lastPauStartFrame] *= 0.5;
+  } else {
+    for (let i = 0; i < fadeOutFrameLength; i++) {
+      volume[lastPauStartFrame + i] *= linearInterpolation(
+        0,
+        1,
+        fadeOutFrameLength - 1,
+        0,
+        i,
+      );
+    }
+  }
+  // 音量を0にする
+  for (let i = fadeOutFrameLength; i < lastPauFrameLength; i++) {
+    volume[lastPauStartFrame + i] = 0;
+  }
+};
+
+export const calculateQueryKey = async (querySource: QuerySource) => {
+  const hash = await calculateHash(querySource);
+  return EditorFrameAudioQueryKey(hash);
+};
+
+export const calculateSingingPitchKey = async (
+  singingPitchSource: SingingPitchSource,
+) => {
+  const hash = await calculateHash(singingPitchSource);
+  return SingingPitchKey(hash);
+};
+
+export const calculateSingingVolumeKey = async (
+  singingVolumeSource: SingingVolumeSource,
+) => {
+  const hash = await calculateHash(singingVolumeSource);
+  return SingingVolumeKey(hash);
+};
+
+export const calculateSingingVoiceKey = async (
+  singingVoiceSource: SingingVoiceSource,
+) => {
+  const hash = await calculateHash(singingVoiceSource);
+  return SingingVoiceKey(hash);
+};
+
+const calcPhraseFirstRestDuration = (
+  prevPhraseLastNote: Note | undefined,
+  phraseFirstNote: Note,
+  phraseFirstRestMinDurationSeconds: number,
+  tempos: Tempo[],
+  tpqn: number,
+) => {
+  const quarterNoteDuration = getNoteDuration(4, tpqn);
+  let phraseFirstRestDuration: number | undefined = undefined;
+
+  // 実際のフレーズ先頭の休符の長さを調べる
+  if (prevPhraseLastNote == undefined) {
+    if (phraseFirstNote.position === 0) {
+      // 1小節目の最初から始まっているフレーズの場合は、
+      // とりあえず4分音符の長さをフレーズ先頭の休符の長さにする
+      phraseFirstRestDuration = quarterNoteDuration;
+    } else {
+      phraseFirstRestDuration = phraseFirstNote.position;
+    }
+  } else {
+    const prevPhraseLastNoteEndPos =
+      prevPhraseLastNote.position + prevPhraseLastNote.duration;
+    phraseFirstRestDuration =
+      phraseFirstNote.position - prevPhraseLastNoteEndPos;
+  }
+  // 4分音符の長さ以下にする
+  phraseFirstRestDuration = Math.min(
+    phraseFirstRestDuration,
+    quarterNoteDuration,
+  );
+  // 最小の長さ以上にする
+  phraseFirstRestDuration = Math.max(
+    phraseFirstRestDuration,
+    phraseFirstNote.position -
+      secondToTick(
+        tickToSecond(phraseFirstNote.position, tempos, tpqn) -
+          phraseFirstRestMinDurationSeconds,
+        tempos,
+        tpqn,
+      ),
+  );
+  // 1tick以上にする
+  phraseFirstRestDuration = Math.max(1, phraseFirstRestDuration);
+
+  return phraseFirstRestDuration;
+};
+
+const calculatePhraseStartTime = (
+  phraseFirstRestDuration: number,
+  phraseNotes: Note[],
+  tempos: Tempo[],
+  tpqn: number,
+) => {
+  return tickToSecond(
+    phraseNotes[0].position - phraseFirstRestDuration,
+    tempos,
+    tpqn,
+  );
+};
+
+export const generatePhrases = async (
+  notes: Note[],
+  tempos: Tempo[],
+  tpqn: number,
+  phraseFirstRestMinDurationSeconds: number,
+  trackId: TrackId,
+) => {
+  const generatedPhrases = new Map<PhraseKey, Phrase>();
+
+  let phraseNotes: Note[] = [];
+  let prevPhraseLastNote: Note | undefined = undefined;
+
+  for (let i = 0; i < notes.length; i++) {
+    const note = notes[i];
+    const nextNote = notes.at(i + 1);
+    const currentNoteEndPos = note.position + note.duration;
+
+    phraseNotes.push(note);
+
+    // ノートが途切れていたら別のフレーズにする
+    if (nextNote == undefined || currentNoteEndPos !== nextNote.position) {
+      const phraseFirstNote = phraseNotes[0];
+      const phraseFirstRestDuration = calcPhraseFirstRestDuration(
+        prevPhraseLastNote,
+        phraseFirstNote,
+        phraseFirstRestMinDurationSeconds,
+        tempos,
+        tpqn,
+      );
+      const phraseStartTime = calculatePhraseStartTime(
+        phraseFirstRestDuration,
+        phraseNotes,
+        tempos,
+        tpqn,
+      );
+      const phraseKey = await calculatePhraseKey({
+        firstRestDuration: phraseFirstRestDuration,
+        notes: phraseNotes,
+        startTime: phraseStartTime,
+        trackId,
+      });
+      generatedPhrases.set(phraseKey, {
+        firstRestDuration: phraseFirstRestDuration,
+        notes: phraseNotes,
+        startTime: phraseStartTime,
+        state: "WAITING_TO_BE_RENDERED",
+        trackId,
+      });
+
+      if (nextNote != undefined) {
+        prevPhraseLastNote = phraseNotes.at(-1);
+        phraseNotes = [];
+      }
+    }
+  }
+  return generatedPhrases;
+};

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -42,7 +42,7 @@ import {
   StyleId,
   TrackId,
 } from "@/type/preload";
-import { FramePhoneme, Note as NoteForRequestToEngine } from "@/openapi";
+import { Note as NoteForRequestToEngine } from "@/openapi";
 import { ResultError, getValueOrThrow } from "@/type/result";
 import {
   AudioEvent,
@@ -71,7 +71,6 @@ import {
   tickToSecond,
   VALUE_INDICATING_NO_DATA,
   isValidPitchEditData,
-  calculatePhraseKey,
   isValidTempos,
   isValidTimeSignatures,
   isValidTpqn,
@@ -84,7 +83,6 @@ import {
   isValidTrack,
   isTracksEmpty,
   shouldPlayTracks,
-  decibelToLinear,
   applyPitchEdit,
   calcPhraseStartFrames,
   calcPhraseEndFrames,
@@ -95,10 +93,8 @@ import {
 import { getOverlappingNoteIds } from "@/sing/storeHelper";
 import {
   AnimationTimer,
-  calculateHash,
   createArray,
   createPromiseThatResolvesWhen,
-  linearInterpolation,
   round,
 } from "@/sing/utility";
 import { getWorkaroundKeyRangeAdjustment } from "@/sing/workaroundKeyRangeAdjustment";
@@ -121,19 +117,26 @@ import {
   ufProjectToMultiFile,
   ufProjectToSingleFile,
 } from "@/sing/utaformatixProject/utils";
+import {
+  calculateQueryKey,
+  calculateSingingPitchKey,
+  calculateSingingVoiceKey,
+  calculateSingingVolumeKey,
+  createNotesForRequestToEngine,
+  generatePhrases,
+  getPhonemes,
+  muteLastPauSection,
+  QuerySource,
+  shiftKeyOfNotes,
+  shiftPitch,
+  shiftVolume,
+  SingingPitchSource,
+  SingingVoiceSource,
+  SingingVolumeSource,
+  SnapshotForPhraseRender,
+} from "@/sing/songTrackRendering";
 
 const logger = createLogger("store/singing");
-
-/**
- * フレーズレンダリングに必要なデータのスナップショット
- */
-type SnapshotForPhraseRender = Readonly<{
-  tpqn: number;
-  tempos: Tempo[];
-  tracks: Map<TrackId, Track>;
-  engineFrameRates: Map<EngineId, number>;
-  editorFrameRate: number;
-}>;
 
 type PhraseRenderStageId =
   | "queryGeneration"
@@ -175,218 +178,6 @@ type PhraseRenderStage = Readonly<{
     snapshot: SnapshotForPhraseRender,
   ) => Promise<void>;
 }>;
-
-/**
- * クエリの生成に必要なデータ
- */
-type QuerySource = Readonly<{
-  engineId: EngineId;
-  engineFrameRate: number;
-  tpqn: number;
-  tempos: Tempo[];
-  firstRestDuration: number;
-  notes: Note[];
-  keyRangeAdjustment: number;
-}>;
-
-/**
- * 歌唱ピッチの生成に必要なデータ
- */
-type SingingPitchSource = Readonly<{
-  engineId: EngineId;
-  engineFrameRate: number;
-  tpqn: number;
-  tempos: Tempo[];
-  firstRestDuration: number;
-  notes: Note[];
-  keyRangeAdjustment: number;
-  queryForPitchGeneration: EditorFrameAudioQuery;
-}>;
-
-/**
- * 歌唱ボリュームの生成に必要なデータ
- */
-type SingingVolumeSource = Readonly<{
-  engineId: EngineId;
-  engineFrameRate: number;
-  tpqn: number;
-  tempos: Tempo[];
-  firstRestDuration: number;
-  notes: Note[];
-  keyRangeAdjustment: number;
-  volumeRangeAdjustment: number;
-  queryForVolumeGeneration: EditorFrameAudioQuery;
-}>;
-
-/**
- * 歌唱音声の合成に必要なデータ
- */
-type SingingVoiceSource = Readonly<{
-  singer: Singer;
-  queryForSingingVoiceSynthesis: EditorFrameAudioQuery;
-}>;
-
-/**
- * リクエスト用のノーツ（と休符）を作成する。
- */
-const createNotesForRequestToEngine = (
-  firstRestDuration: number,
-  lastRestDurationSeconds: number,
-  notes: Note[],
-  tempos: Tempo[],
-  tpqn: number,
-  frameRate: number,
-) => {
-  const notesForRequestToEngine: NoteForRequestToEngine[] = [];
-
-  // 先頭の休符を変換
-  const firstRestStartSeconds = tickToSecond(
-    notes[0].position - firstRestDuration,
-    tempos,
-    tpqn,
-  );
-  const firstRestStartFrame = Math.round(firstRestStartSeconds * frameRate);
-  const firstRestEndSeconds = tickToSecond(notes[0].position, tempos, tpqn);
-  const firstRestEndFrame = Math.round(firstRestEndSeconds * frameRate);
-  notesForRequestToEngine.push({
-    key: undefined,
-    frameLength: firstRestEndFrame - firstRestStartFrame,
-    lyric: "",
-  });
-
-  // ノートを変換
-  for (const note of notes) {
-    const noteOnSeconds = tickToSecond(note.position, tempos, tpqn);
-    const noteOnFrame = Math.round(noteOnSeconds * frameRate);
-    const noteOffSeconds = tickToSecond(
-      note.position + note.duration,
-      tempos,
-      tpqn,
-    );
-    const noteOffFrame = Math.round(noteOffSeconds * frameRate);
-    notesForRequestToEngine.push({
-      id: note.id,
-      key: note.noteNumber,
-      frameLength: noteOffFrame - noteOnFrame,
-      lyric: note.lyric,
-    });
-  }
-
-  // 末尾に休符を追加
-  const lastRestFrameLength = Math.round(lastRestDurationSeconds * frameRate);
-  notesForRequestToEngine.push({
-    key: undefined,
-    frameLength: lastRestFrameLength,
-    lyric: "",
-  });
-
-  // frameLengthが1以上になるようにする
-  for (let i = 0; i < notesForRequestToEngine.length; i++) {
-    const frameLength = notesForRequestToEngine[i].frameLength;
-    const frameToShift = Math.max(0, 1 - frameLength);
-    notesForRequestToEngine[i].frameLength += frameToShift;
-    if (i < notesForRequestToEngine.length - 1) {
-      notesForRequestToEngine[i + 1].frameLength -= frameToShift;
-    }
-  }
-
-  return notesForRequestToEngine;
-};
-
-const shiftKeyOfNotes = (notes: NoteForRequestToEngine[], keyShift: number) => {
-  for (const note of notes) {
-    if (note.key != undefined) {
-      note.key += keyShift;
-    }
-  }
-};
-
-const getPhonemes = (query: EditorFrameAudioQuery) => {
-  return query.phonemes.map((value) => value.phoneme).join(" ");
-};
-
-const shiftPitch = (f0: number[], pitchShift: number) => {
-  for (let i = 0; i < f0.length; i++) {
-    f0[i] *= Math.pow(2, pitchShift / 12);
-  }
-};
-
-const shiftVolume = (volume: number[], volumeShift: number) => {
-  for (let i = 0; i < volume.length; i++) {
-    volume[i] *= decibelToLinear(volumeShift);
-  }
-};
-
-/**
- * 末尾のpauの区間のvolumeを0にする。（歌とpauの呼吸音が重ならないようにする）
- * fadeOutDurationSecondsが0の場合は即座にvolumeを0にする。
- */
-const muteLastPauSection = (
-  volume: number[],
-  phonemes: FramePhoneme[],
-  frameRate: number,
-  fadeOutDurationSeconds: number,
-) => {
-  const lastPhoneme = phonemes.at(-1);
-  if (lastPhoneme == undefined || lastPhoneme.phoneme !== "pau") {
-    throw new Error("No pau exists at the end.");
-  }
-
-  let lastPauStartFrame = 0;
-  for (let i = 0; i < phonemes.length - 1; i++) {
-    lastPauStartFrame += phonemes[i].frameLength;
-  }
-
-  const lastPauFrameLength = lastPhoneme.frameLength;
-  let fadeOutFrameLength = Math.round(fadeOutDurationSeconds * frameRate);
-  fadeOutFrameLength = Math.max(0, fadeOutFrameLength);
-  fadeOutFrameLength = Math.min(lastPauFrameLength, fadeOutFrameLength);
-
-  // フェードアウト処理を行う
-  if (fadeOutFrameLength === 1) {
-    volume[lastPauStartFrame] *= 0.5;
-  } else {
-    for (let i = 0; i < fadeOutFrameLength; i++) {
-      volume[lastPauStartFrame + i] *= linearInterpolation(
-        0,
-        1,
-        fadeOutFrameLength - 1,
-        0,
-        i,
-      );
-    }
-  }
-  // 音量を0にする
-  for (let i = fadeOutFrameLength; i < lastPauFrameLength; i++) {
-    volume[lastPauStartFrame + i] = 0;
-  }
-};
-
-const calculateQueryKey = async (querySource: QuerySource) => {
-  const hash = await calculateHash(querySource);
-  return EditorFrameAudioQueryKey(hash);
-};
-
-const calculateSingingPitchKey = async (
-  singingPitchSource: SingingPitchSource,
-) => {
-  const hash = await calculateHash(singingPitchSource);
-  return SingingPitchKey(hash);
-};
-
-const calculateSingingVolumeKey = async (
-  singingVolumeSource: SingingVolumeSource,
-) => {
-  const hash = await calculateHash(singingVolumeSource);
-  return SingingVolumeKey(hash);
-};
-
-const calculateSingingVoiceKey = async (
-  singingVoiceSource: SingingVoiceSource,
-) => {
-  const hash = await calculateHash(singingVoiceSource);
-  return SingingVoiceKey(hash);
-};
 
 const generateAudioEvents = async (
   audioContext: BaseAudioContext,
@@ -1708,127 +1499,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           ),
           editorFrameRate: state.editorFrameRate,
         } as const;
-      };
-
-      const calcPhraseFirstRestDuration = (
-        prevPhraseLastNote: Note | undefined,
-        phraseFirstNote: Note,
-        phraseFirstRestMinDurationSeconds: number,
-        tempos: Tempo[],
-        tpqn: number,
-      ) => {
-        const quarterNoteDuration = getNoteDuration(4, tpqn);
-        let phraseFirstRestDuration: number | undefined = undefined;
-
-        // 実際のフレーズ先頭の休符の長さを調べる
-        if (prevPhraseLastNote == undefined) {
-          if (phraseFirstNote.position === 0) {
-            // 1小節目の最初から始まっているフレーズの場合は、
-            // とりあえず4分音符の長さをフレーズ先頭の休符の長さにする
-            phraseFirstRestDuration = quarterNoteDuration;
-          } else {
-            phraseFirstRestDuration = phraseFirstNote.position;
-          }
-        } else {
-          const prevPhraseLastNoteEndPos =
-            prevPhraseLastNote.position + prevPhraseLastNote.duration;
-          phraseFirstRestDuration =
-            phraseFirstNote.position - prevPhraseLastNoteEndPos;
-        }
-        // 4分音符の長さ以下にする
-        phraseFirstRestDuration = Math.min(
-          phraseFirstRestDuration,
-          quarterNoteDuration,
-        );
-        // 最小の長さ以上にする
-        phraseFirstRestDuration = Math.max(
-          phraseFirstRestDuration,
-          phraseFirstNote.position -
-            secondToTick(
-              tickToSecond(phraseFirstNote.position, tempos, tpqn) -
-                phraseFirstRestMinDurationSeconds,
-              tempos,
-              tpqn,
-            ),
-        );
-        // 1tick以上にする
-        phraseFirstRestDuration = Math.max(1, phraseFirstRestDuration);
-
-        return phraseFirstRestDuration;
-      };
-
-      const calculatePhraseStartTime = (
-        phraseFirstRestDuration: number,
-        phraseNotes: Note[],
-        tempos: Tempo[],
-        tpqn: number,
-      ) => {
-        return tickToSecond(
-          phraseNotes[0].position - phraseFirstRestDuration,
-          tempos,
-          tpqn,
-        );
-      };
-
-      const generatePhrases = async (
-        notes: Note[],
-        tempos: Tempo[],
-        tpqn: number,
-        phraseFirstRestMinDurationSeconds: number,
-        trackId: TrackId,
-      ) => {
-        const generatedPhrases = new Map<PhraseKey, Phrase>();
-
-        let phraseNotes: Note[] = [];
-        let prevPhraseLastNote: Note | undefined = undefined;
-
-        for (let i = 0; i < notes.length; i++) {
-          const note = notes[i];
-          const nextNote = notes.at(i + 1);
-          const currentNoteEndPos = note.position + note.duration;
-
-          phraseNotes.push(note);
-
-          // ノートが途切れていたら別のフレーズにする
-          if (
-            nextNote == undefined ||
-            currentNoteEndPos !== nextNote.position
-          ) {
-            const phraseFirstNote = phraseNotes[0];
-            const phraseFirstRestDuration = calcPhraseFirstRestDuration(
-              prevPhraseLastNote,
-              phraseFirstNote,
-              phraseFirstRestMinDurationSeconds,
-              tempos,
-              tpqn,
-            );
-            const phraseStartTime = calculatePhraseStartTime(
-              phraseFirstRestDuration,
-              phraseNotes,
-              tempos,
-              tpqn,
-            );
-            const phraseKey = await calculatePhraseKey({
-              firstRestDuration: phraseFirstRestDuration,
-              notes: phraseNotes,
-              startTime: phraseStartTime,
-              trackId,
-            });
-            generatedPhrases.set(phraseKey, {
-              firstRestDuration: phraseFirstRestDuration,
-              notes: phraseNotes,
-              startTime: phraseStartTime,
-              state: "WAITING_TO_BE_RENDERED",
-              trackId,
-            });
-
-            if (nextNote != undefined) {
-              prevPhraseLastNote = phraseNotes.at(-1);
-              phraseNotes = [];
-            }
-          }
-        }
-        return generatedPhrases;
       };
 
       const generateQuerySource = (


### PR DESCRIPTION
## 内容

ソングのレンダリング関係の型と関数を、`singing.ts`から`songTrackRendering.ts`に移動します。（移動のみ）
（変更が必要なものは残しています）

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2261

## その他
レンダリング関係はすべて`songTrackRendering.ts`に移動する予定です。