### PR TITLE
chore(docs): preview-pagesのURLを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pnpm run storybook
 ```
 
 main ブランチの Storybook は[VOICEVOX/preview-pages](https://github.com/VOICEVOX/preview-pages)から確認できます。  
-<https://voicevox.github.io/preview-pages/preview/branch-main/storybook/index.html>
+<https://voicevox.github.io/preview-pages/preview/editor/branch-main/storybook/index.html>
 
 ### ブラウザ版の実行（開発中）
 
@@ -107,7 +107,7 @@ pnpm run browser:serve
 ```
 
 また、main ブランチのビルド結果が[VOICEVOX/preview-pages](https://github.com/VOICEVOX/preview-pages)にデプロイされています。  
-<https://voicevox.github.io/preview-pages/preview/branch-main/editor/index.html>  
+<https://voicevox.github.io/preview-pages/preview/editor/branch-main/editor/index.html>  
 今はローカル PC 上で音声合成エンジンを起動する必要があります。
 
 ## ビルド


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/preview-pages/issues/24

以降readmeからのリンクが途絶えていたっぽいので修正しました。

## その他
