### PR TITLE
refactor: generateQuerySourceなどの関数をsongTrackRendering.tsに移動

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -83,7 +83,6 @@ import {
   isValidTrack,
   isTracksEmpty,
   shouldPlayTracks,
-  applyPitchEdit,
   calcPhraseStartFrames,
   calcPhraseEndFrames,
   toEntirePhonemeTimings,
@@ -124,6 +123,10 @@ import {
   calculateSingingVolumeKey,
   createNotesForRequestToEngine,
   generatePhrases,
+  generateQuerySource,
+  generateSingingPitchSource,
+  generateSingingVoiceSource,
+  generateSingingVolumeSource,
   getPhonemes,
   muteLastPauSection,
   QuerySource,
@@ -173,7 +176,6 @@ type PhraseRenderStage = Readonly<{
    * @param context コンテキスト
    */
   execute: (
-    trackId: TrackId,
     phraseKey: PhraseKey,
     snapshot: SnapshotForPhraseRender,
   ) => Promise<void>;
@@ -1501,31 +1503,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         } as const;
       };
 
-      const generateQuerySource = (
-        trackId: TrackId,
-        phraseKey: PhraseKey,
-        snapshot: SnapshotForPhraseRender,
-      ): QuerySource => {
-        const track = getOrThrow(snapshot.tracks, trackId);
-        if (track.singer == undefined) {
-          throw new Error("track.singer is undefined.");
-        }
-        const engineFrameRate = getOrThrow(
-          snapshot.engineFrameRates,
-          track.singer.engineId,
-        );
-        const phrase = getOrThrow(state.phrases, phraseKey);
-        return {
-          engineId: track.singer.engineId,
-          engineFrameRate,
-          tpqn: snapshot.tpqn,
-          tempos: snapshot.tempos,
-          firstRestDuration: phrase.firstRestDuration,
-          notes: phrase.notes,
-          keyRangeAdjustment: track.keyRangeAdjustment,
-        };
-      };
-
       const fetchQuery = async (
         engineId: EngineId,
         engineFrameRate: number,
@@ -1597,7 +1574,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           }
           const phrase = getOrThrow(state.phrases, phraseKey);
           const phraseQueryKey = phrase.queryKey;
-          const querySource = generateQuerySource(trackId, phraseKey, snapshot);
+          const querySource = generateQuerySource(phrase, snapshot);
           const queryKey = await calculateQueryKey(querySource);
           return phraseQueryKey == undefined || phraseQueryKey !== queryKey;
         },
@@ -1613,11 +1590,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           }
         },
         execute: async (
-          trackId: TrackId,
           phraseKey: PhraseKey,
           snapshot: SnapshotForPhraseRender,
         ) => {
-          const querySource = generateQuerySource(trackId, phraseKey, snapshot);
+          let phrase = getOrThrow(state.phrases, phraseKey);
+          const querySource = generateQuerySource(phrase, snapshot);
           const queryKey = await calculateQueryKey(querySource);
 
           let query = queryCache.get(queryKey);
@@ -1630,7 +1607,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             queryCache.set(queryKey, query);
           }
 
-          const phrase = getOrThrow(state.phrases, phraseKey);
+          phrase = getOrThrow(state.phrases, phraseKey);
           const phraseQueryKey = phrase.queryKey;
           if (phraseQueryKey != undefined) {
             throw new Error("The previous query has not been removed.");
@@ -1638,37 +1615,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           mutations.SET_PHRASE_QUERY({ queryKey, query });
           mutations.SET_QUERY_KEY_TO_PHRASE({ phraseKey, queryKey });
         },
-      };
-
-      const generateSingingPitchSource = (
-        trackId: TrackId,
-        phraseKey: PhraseKey,
-        snapshot: SnapshotForPhraseRender,
-      ): SingingPitchSource => {
-        const track = getOrThrow(snapshot.tracks, trackId);
-        if (track.singer == undefined) {
-          throw new Error("track.singer is undefined.");
-        }
-        const phrase = getOrThrow(state.phrases, phraseKey);
-        if (phrase.queryKey == undefined) {
-          throw new Error("phrase.queryKey is undefined.");
-        }
-
-        const query = getOrThrow(state.phraseQueries, phrase.queryKey);
-
-        const clonedQuery = cloneWithUnwrapProxy(query);
-
-        // TODO: 音素タイミングの編集データの適用を行うようにする
-        return {
-          engineId: track.singer.engineId,
-          engineFrameRate: query.frameRate,
-          tpqn: snapshot.tpqn,
-          tempos: snapshot.tempos,
-          firstRestDuration: phrase.firstRestDuration,
-          notes: phrase.notes,
-          keyRangeAdjustment: track.keyRangeAdjustment,
-          queryForPitchGeneration: clonedQuery,
-        };
       };
 
       const generateSingingPitch = async (
@@ -1714,10 +1660,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             return false;
           }
           const phrase = getOrThrow(state.phrases, phraseKey);
+          const query = getOrThrow(state.phraseQueries, phrase.queryKey);
           const phraseSingingPitchKey = phrase.singingPitchKey;
           const singingPitchSource = generateSingingPitchSource(
-            trackId,
-            phraseKey,
+            query,
+            phrase,
             snapshot,
           );
           const singingPitchKey =
@@ -1741,13 +1688,14 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           }
         },
         execute: async (
-          trackId: TrackId,
           phraseKey: PhraseKey,
           snapshot: SnapshotForPhraseRender,
         ) => {
+          let phrase = getOrThrow(state.phrases, phraseKey);
+          const query = getOrThrow(state.phraseQueries, phrase.queryKey);
           const singingPitchSource = generateSingingPitchSource(
-            trackId,
-            phraseKey,
+            query,
+            phrase,
             snapshot,
           );
           const singingPitchKey =
@@ -1762,7 +1710,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             singingPitchCache.set(singingPitchKey, singingPitch);
           }
 
-          const phrase = getOrThrow(state.phrases, phraseKey);
+          phrase = getOrThrow(state.phrases, phraseKey);
           const phraseSingingPitchKey = phrase.singingPitchKey;
           if (phraseSingingPitchKey != undefined) {
             throw new Error("The previous singing pitch has not been removed.");
@@ -1773,54 +1721,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             singingPitchKey,
           });
         },
-      };
-
-      const generateSingingVolumeSource = (
-        trackId: TrackId,
-        phraseKey: PhraseKey,
-        snapshot: SnapshotForPhraseRender,
-      ): SingingVolumeSource => {
-        const track = getOrThrow(snapshot.tracks, trackId);
-        if (track.singer == undefined) {
-          throw new Error("track.singer is undefined.");
-        }
-        const phrase = getOrThrow(state.phrases, phraseKey);
-        if (phrase.queryKey == undefined) {
-          throw new Error("phrase.queryKey is undefined.");
-        }
-        if (phrase.singingPitchKey == undefined) {
-          throw new Error("phrase.singingPitchKey is undefined.");
-        }
-
-        const query = getOrThrow(state.phraseQueries, phrase.queryKey);
-        const singingPitch = getOrThrow(
-          state.phraseSingingPitches,
-          phrase.singingPitchKey,
-        );
-
-        const clonedQuery = cloneWithUnwrapProxy(query);
-        const clonedSingingPitch = cloneWithUnwrapProxy(singingPitch);
-
-        clonedQuery.f0 = clonedSingingPitch;
-
-        applyPitchEdit(
-          clonedQuery,
-          phrase.startTime,
-          track.pitchEditData,
-          snapshot.editorFrameRate,
-        );
-
-        return {
-          engineId: track.singer.engineId,
-          engineFrameRate: query.frameRate,
-          tpqn: snapshot.tpqn,
-          tempos: snapshot.tempos,
-          firstRestDuration: phrase.firstRestDuration,
-          notes: phrase.notes,
-          keyRangeAdjustment: track.keyRangeAdjustment,
-          volumeRangeAdjustment: track.volumeRangeAdjustment,
-          queryForVolumeGeneration: clonedQuery,
-        };
       };
 
       const generateSingingVolume = async (
@@ -1874,14 +1774,20 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           if (track.singer == undefined) {
             return false;
           }
+          const phrase = getOrThrow(state.phrases, phraseKey);
+          const query = getOrThrow(state.phraseQueries, phrase.queryKey);
+          const singingPitch = getOrThrow(
+            state.phraseSingingPitches,
+            phrase.singingPitchKey,
+          );
           const singingVolumeSource = generateSingingVolumeSource(
-            trackId,
-            phraseKey,
+            query,
+            singingPitch,
+            phrase,
             snapshot,
           );
           const singingVolumeKey =
             await calculateSingingVolumeKey(singingVolumeSource);
-          const phrase = getOrThrow(state.phrases, phraseKey);
           const phraseSingingVolumeKey = phrase.singingVolumeKey;
           return (
             phraseSingingVolumeKey == undefined ||
@@ -1902,13 +1808,19 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           }
         },
         execute: async (
-          trackId: TrackId,
           phraseKey: PhraseKey,
           snapshot: SnapshotForPhraseRender,
         ) => {
+          let phrase = getOrThrow(state.phrases, phraseKey);
+          const query = getOrThrow(state.phraseQueries, phrase.queryKey);
+          const singingPitch = getOrThrow(
+            state.phraseSingingPitches,
+            phrase.singingPitchKey,
+          );
           const singingVolumeSource = generateSingingVolumeSource(
-            trackId,
-            phraseKey,
+            query,
+            singingPitch,
+            phrase,
             snapshot,
           );
           const singingVolumeKey =
@@ -1923,7 +1835,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             singingVolumeCache.set(singingVolumeKey, singingVolume);
           }
 
-          const phrase = getOrThrow(state.phrases, phraseKey);
+          phrase = getOrThrow(state.phrases, phraseKey);
           const phraseSingingVolumeKey = phrase.singingVolumeKey;
           if (phraseSingingVolumeKey != undefined) {
             throw new Error(
@@ -1939,56 +1851,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             singingVolumeKey,
           });
         },
-      };
-
-      const generateSingingVoiceSource = (
-        trackId: TrackId,
-        phraseKey: PhraseKey,
-        snapshot: SnapshotForPhraseRender,
-      ): SingingVoiceSource => {
-        const track = getOrThrow(snapshot.tracks, trackId);
-        if (track.singer == undefined) {
-          throw new Error("track.singer is undefined.");
-        }
-        const phrase = getOrThrow(state.phrases, phraseKey);
-        if (phrase.queryKey == undefined) {
-          throw new Error("phrase.queryKey is undefined.");
-        }
-        if (phrase.singingPitchKey == undefined) {
-          throw new Error("phrase.singingPitchKey is undefined.");
-        }
-        if (phrase.singingVolumeKey == undefined) {
-          throw new Error("phrase.singingVolumeKey is undefined.");
-        }
-
-        const query = getOrThrow(state.phraseQueries, phrase.queryKey);
-        const singingPitch = getOrThrow(
-          state.phraseSingingPitches,
-          phrase.singingPitchKey,
-        );
-        const singingVolume = getOrThrow(
-          state.phraseSingingVolumes,
-          phrase.singingVolumeKey,
-        );
-
-        const clonedQuery = cloneWithUnwrapProxy(query);
-        const clonedSingingPitch = cloneWithUnwrapProxy(singingPitch);
-        const clonedSingingVolume = cloneWithUnwrapProxy(singingVolume);
-
-        clonedQuery.f0 = clonedSingingPitch;
-        clonedQuery.volume = clonedSingingVolume;
-
-        applyPitchEdit(
-          clonedQuery,
-          phrase.startTime,
-          track.pitchEditData,
-          snapshot.editorFrameRate,
-        );
-
-        return {
-          singer: track.singer,
-          queryForSingingVoiceSynthesis: clonedQuery,
-        };
       };
 
       const synthesizeSingingVoice = async (
@@ -2031,14 +1893,25 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           if (track.singer == undefined) {
             return false;
           }
+          const phrase = getOrThrow(state.phrases, phraseKey);
+          const query = getOrThrow(state.phraseQueries, phrase.queryKey);
+          const singingPitch = getOrThrow(
+            state.phraseSingingPitches,
+            phrase.singingPitchKey,
+          );
+          const singingVolume = getOrThrow(
+            state.phraseSingingVolumes,
+            phrase.singingVolumeKey,
+          );
           const singingVoiceSource = generateSingingVoiceSource(
-            trackId,
-            phraseKey,
+            query,
+            singingPitch,
+            singingVolume,
+            phrase,
             snapshot,
           );
           const singingVoiceKey =
             await calculateSingingVoiceKey(singingVoiceSource);
-          const phrase = getOrThrow(state.phrases, phraseKey);
           const phraseSingingVoiceKey = phrase.singingVoiceKey;
           return (
             phraseSingingVoiceKey == undefined ||
@@ -2057,13 +1930,24 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           }
         },
         execute: async (
-          trackId: TrackId,
           phraseKey: PhraseKey,
           snapshot: SnapshotForPhraseRender,
         ) => {
+          let phrase = getOrThrow(state.phrases, phraseKey);
+          const query = getOrThrow(state.phraseQueries, phrase.queryKey);
+          const singingPitch = getOrThrow(
+            state.phraseSingingPitches,
+            phrase.singingPitchKey,
+          );
+          const singingVolume = getOrThrow(
+            state.phraseSingingVolumes,
+            phrase.singingVolumeKey,
+          );
           const singingVoiceSource = generateSingingVoiceSource(
-            trackId,
-            phraseKey,
+            query,
+            singingPitch,
+            singingVolume,
+            phrase,
             snapshot,
           );
           const singingVoiceKey =
@@ -2078,7 +1962,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             singingVoiceCache.set(singingVoiceKey, singingVoice);
           }
 
-          const phrase = getOrThrow(state.phrases, phraseKey);
+          phrase = getOrThrow(state.phrases, phraseKey);
           const phraseSingingVoiceKey = phrase.singingVoiceKey;
           if (phraseSingingVoiceKey != undefined) {
             throw new Error("The previous singing voice has not been removed.");
@@ -2287,7 +2171,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
 
           try {
             // フレーズのレンダリングを行う
-            const trackId = phrase.trackId;
             const startStageId = getOrThrow(renderStartStageIds, phraseKey);
             const startStageIndex = stages.findIndex((value) => {
               return value.id === startStageId;
@@ -2299,7 +2182,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               stages[i].deleteExecutionResult(phraseKey);
             }
             for (let i = startStageIndex; i < stages.length; i++) {
-              await stages[i].execute(trackId, phraseKey, snapshot);
+              await stages[i].execute(phraseKey, snapshot);
             }
 
             // シーケンスが存在する場合、シーケンスを削除する


### PR DESCRIPTION
## 内容

以下の関数をsongTrackRendering.tsに移動します。（移動とインターフェースの変更を行います）
- generateQuerySource
- generateSingingPitchSource
- generateSingingVolumeSource
- generateSingingVoiceSource



## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2261

## その他
