### PR TITLE
refactor: generatePhrases関数をリファクタリング

### DIFF
--- a/src/sing/songTrackRendering.ts
+++ b/src/sing/songTrackRendering.ts
@@ -11,7 +11,7 @@ import {
   Tempo,
   Track,
 } from "@/store/type";
-import { calculateHash, linearInterpolation } from "@/sing/utility";
+import { calculateHash, getPrev, linearInterpolation } from "@/sing/utility";
 import {
   calculatePhraseKey,
   decibelToLinear,
@@ -20,7 +20,8 @@ import {
   tickToSecond,
 } from "@/sing/domain";
 import { FramePhoneme, Note as NoteForRequestToEngine } from "@/openapi";
-import { EngineId, TrackId } from "@/type/preload";
+import { EngineId, NoteId, TrackId } from "@/type/preload";
+import { getOrThrow } from "@/helpers/mapHelper";
 
 /**
  * フレーズレンダリングに必要なデータのスナップショット
@@ -29,6 +30,7 @@ export type SnapshotForPhraseRender = Readonly<{
   tpqn: number;
   tempos: Tempo[];
   tracks: Map<TrackId, Track>;
+  trackOverlappingNoteIds: Map<TrackId, Set<NoteId>>;
   engineFrameRates: Map<EngineId, number>;
   editorFrameRate: number;
 }>;
@@ -308,60 +310,114 @@ const calculatePhraseStartTime = (
   );
 };
 
-export const generatePhrases = async (
-  notes: Note[],
-  tempos: Tempo[],
-  tpqn: number,
-  phraseFirstRestMinDurationSeconds: number,
-  trackId: TrackId,
-) => {
-  const generatedPhrases = new Map<PhraseKey, Phrase>();
+/**
+ * トラックのノーツからフレーズごとのノーツを抽出する。
+ */
+const extractPhraseNotes = (trackNotes: Note[]) => {
+  const phraseNotes: Note[][] = [];
+  let currentPhraseNotes: Note[] = [];
 
-  let phraseNotes: Note[] = [];
-  let prevPhraseLastNote: Note | undefined = undefined;
-
-  for (let i = 0; i < notes.length; i++) {
-    const note = notes[i];
-    const nextNote = notes.at(i + 1);
+  for (let i = 0; i < trackNotes.length; i++) {
+    const note = trackNotes[i];
+    const nextNote = trackNotes.at(i + 1);
     const currentNoteEndPos = note.position + note.duration;
 
-    phraseNotes.push(note);
+    currentPhraseNotes.push(note);
 
     // ノートが途切れていたら別のフレーズにする
     if (nextNote == undefined || currentNoteEndPos !== nextNote.position) {
-      const phraseFirstNote = phraseNotes[0];
-      const phraseFirstRestDuration = calcPhraseFirstRestDuration(
-        prevPhraseLastNote,
-        phraseFirstNote,
-        phraseFirstRestMinDurationSeconds,
-        tempos,
-        tpqn,
-      );
-      const phraseStartTime = calculatePhraseStartTime(
-        phraseFirstRestDuration,
-        phraseNotes,
-        tempos,
-        tpqn,
-      );
-      const phraseKey = await calculatePhraseKey({
-        firstRestDuration: phraseFirstRestDuration,
-        notes: phraseNotes,
-        startTime: phraseStartTime,
-        trackId,
-      });
-      generatedPhrases.set(phraseKey, {
-        firstRestDuration: phraseFirstRestDuration,
-        notes: phraseNotes,
-        startTime: phraseStartTime,
-        state: "WAITING_TO_BE_RENDERED",
-        trackId,
-      });
-
-      if (nextNote != undefined) {
-        prevPhraseLastNote = phraseNotes.at(-1);
-        phraseNotes = [];
-      }
+      phraseNotes.push([...currentPhraseNotes]);
+      currentPhraseNotes = [];
     }
   }
-  return generatedPhrases;
+
+  return phraseNotes;
+};
+
+/**
+ * フレーズごとのノーツからフレーズを生成する。
+ */
+const createPhrasesFromNotes = async (
+  phraseNotesList: Note[][],
+  trackId: TrackId,
+  snapshot: SnapshotForPhraseRender,
+  firstRestMinDurationSeconds: number,
+) => {
+  const phrases = new Map<PhraseKey, Phrase>();
+
+  for (let i = 0; i < phraseNotesList.length; i++) {
+    const phraseNotes = phraseNotesList[i];
+    const phraseFirstNote = phraseNotes[0];
+    const prevPhraseNotes = getPrev(phraseNotesList, i);
+    const prevPhraseLastNote = prevPhraseNotes?.at(-1);
+
+    const phraseFirstRestDuration = calcPhraseFirstRestDuration(
+      prevPhraseLastNote,
+      phraseFirstNote,
+      firstRestMinDurationSeconds,
+      snapshot.tempos,
+      snapshot.tpqn,
+    );
+    const phraseStartTime = calculatePhraseStartTime(
+      phraseFirstRestDuration,
+      phraseNotes,
+      snapshot.tempos,
+      snapshot.tpqn,
+    );
+    const phraseKey = await calculatePhraseKey({
+      firstRestDuration: phraseFirstRestDuration,
+      notes: phraseNotes,
+      startTime: phraseStartTime,
+      trackId,
+    });
+    phrases.set(phraseKey, {
+      firstRestDuration: phraseFirstRestDuration,
+      notes: phraseNotes,
+      startTime: phraseStartTime,
+      state: "WAITING_TO_BE_RENDERED",
+      trackId,
+    });
+  }
+
+  return phrases;
+};
+
+/**
+ * 各トラックのノーツからフレーズを生成する。
+ * 重なっているノートはフレーズには含まれない。
+ */
+export const generatePhrases = async (
+  snapshot: SnapshotForPhraseRender,
+  firstRestMinDurationSeconds: number,
+) => {
+  const phrases = new Map<PhraseKey, Phrase>();
+
+  for (const [trackId, track] of snapshot.tracks) {
+    // 重なっているノートを除く
+    const overlappingNoteIds = getOrThrow(
+      snapshot.trackOverlappingNoteIds,
+      trackId,
+    );
+    const trackNotes = track.notes.filter(
+      (value) => !overlappingNoteIds.has(value.id),
+    );
+
+    // トラックのノーツからフレーズごとのノーツを抽出
+    const phraseNotesList = extractPhraseNotes(trackNotes);
+
+    // フレーズごとのノーツからフレーズを生成
+    const trackPhrases = await createPhrasesFromNotes(
+      phraseNotesList,
+      trackId,
+      snapshot,
+      firstRestMinDurationSeconds,
+    );
+
+    // 結果をマージ
+    for (const [key, phrase] of trackPhrases) {
+      phrases.set(key, phrase);
+    }
+  }
+
+  return phrases;
 };

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2127,34 +2127,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
 
         const renderStartStageIds = new Map<PhraseKey, PhraseRenderStageId>();
 
-        // 重なっているノートを削除する
-        const filteredTrackNotes = new Map<TrackId, Note[]>();
-        for (const [trackId, track] of snapshot.tracks) {
-          const overlappingNoteIds = getOrThrow(
-            snapshot.trackOverlappingNoteIds,
-            trackId,
-          );
-          const filteredNotes = track.notes.filter(
-            (value) => !overlappingNoteIds.has(value.id),
-          );
-          filteredTrackNotes.set(trackId, filteredNotes);
-        }
-
-        // ノーツからフレーズを生成する
-        const generatedPhrases = new Map<PhraseKey, Phrase>();
-        for (const trackId of snapshot.tracks.keys()) {
-          const filteredNotes = getOrThrow(filteredTrackNotes, trackId);
-          const phrases = await generatePhrases(
-            filteredNotes,
-            snapshot.tempos,
-            snapshot.tpqn,
-            firstRestMinDurationSeconds,
-            trackId,
-          );
-          for (const [phraseKey, phrase] of phrases) {
-            generatedPhrases.set(phraseKey, phrase);
-          }
-        }
+        // 各トラックのノーツからフレーズを生成する
+        const generatedPhrases = await generatePhrases(
+          snapshot,
+          firstRestMinDurationSeconds,
+        );
 
         const mergedPhrases = new Map<PhraseKey, Phrase>();
         const newlyCreatedPhraseKeys = new Set<PhraseKey>();


### PR DESCRIPTION
## 内容

`generatePhrases` 関数のリファクタリングを行います。

- 単一トラックではなく全トラックのノーツを受け取り、そのノーツからフレーズを生成するように
  - `notes`, `tempos` など個別の引数ではなく、必要な情報をまとめた `snapshot` オブジェクトを受け取るように変更
- 重なっているノート（`trackOverlappingNoteIds` に含まれるノート）を除外する処理を `generatePhrases` 関数内に移動
- トラックのノーツをフレーズ単位に分割する処理を `extractPhraseNotes` 関数として切り出し
- フレーズごとのノーツからフレーズを生成する処理を `createPhrasesFromNotes` 関数として切り出し

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2261

## その他
