### PR TITLE
ci: Ubuntu 22.04に更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
             linux_artifact_name: "VOICEVOX.${ext}"
             linux_executable_name: voicevox
             linux_appimage_7z_name: VOICEVOX.AppImage
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           # Linux CPU (x64)
           - artifact_name: linux-cpu-x64-prepackage
             artifact_path: dist_electron/linux-unpacked
@@ -72,7 +72,7 @@ jobs:
             linux_artifact_name: "VOICEVOX.${version}-x64.${ext}"
             linux_executable_name: voicevox
             linux_appimage_7z_name: VOICEVOX-CPU-X64.AppImage
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           # Linux CPU (arm64)
           - artifact_name: linux-cpu-arm64-prepackage
             artifact_path: dist_electron/linux-arm64-unpacked


### PR DESCRIPTION
## 内容
GitHub Actionsのworkflowで使用していたubuntu-20.04をubuntu-22.04に更新しました。
20.04がサポート終了となり、CIが失敗していたための対応です。

## 関連 Issue
close #2646

## スクリーンショット・動画など
（なし）

## その他
- 参考: [過去の20.04関連PR](https://github.com/VOICEVOX/voicevox/pull/2066)
- 20.04でのみ発生していた問題も今後は発生しなくなります。
