### PR TITLE
refactor: generateQueryなどの関数をsongTrackRendering.tsに移動

### DIFF
--- a/src/sing/songTrackRendering.ts
+++ b/src/sing/songTrackRendering.ts
@@ -92,7 +92,7 @@ export type SingingVoiceSource = Readonly<{
   queryForSingingVoiceSynthesis: EditorFrameAudioQuery;
 }>;
 
-export type VoicevoxEngineApi = Readonly<{
+export type EngineSongApi = Readonly<{
   fetchFrameAudioQuery: (args: {
     engineId: EngineId;
     styleId: StyleId;
@@ -599,7 +599,7 @@ export const generateSingingVoiceSource = (
 export const generateQuery = async (
   querySource: QuerySource,
   config: SongTrackRenderingConfig,
-  voicevoxEngineApi: VoicevoxEngineApi,
+  engineSongApi: EngineSongApi,
 ) => {
   const notesForRequestToEngine = createNotesForRequestToEngine(
     querySource.firstRestDuration,
@@ -612,7 +612,7 @@ export const generateQuery = async (
 
   shiftKeyOfNotes(notesForRequestToEngine, -querySource.keyRangeAdjustment);
 
-  const query = await voicevoxEngineApi.fetchFrameAudioQuery({
+  const query = await engineSongApi.fetchFrameAudioQuery({
     engineId: querySource.engineId,
     styleId: config.singingTeacherStyleId,
     engineFrameRate: querySource.engineFrameRate,
@@ -630,7 +630,7 @@ export const generateQuery = async (
 export const generateSingingPitch = async (
   singingPitchSource: SingingPitchSource,
   config: SongTrackRenderingConfig,
-  voicevoxEngineApi: VoicevoxEngineApi,
+  engineSongApi: EngineSongApi,
 ) => {
   const notesForRequestToEngine = createNotesForRequestToEngine(
     singingPitchSource.firstRestDuration,
@@ -647,7 +647,7 @@ export const generateSingingPitch = async (
     -singingPitchSource.keyRangeAdjustment,
   );
 
-  const singingPitch = await voicevoxEngineApi.fetchSingFrameF0({
+  const singingPitch = await engineSongApi.fetchSingFrameF0({
     notes: notesForRequestToEngine,
     query: queryForPitchGeneration,
     engineId: singingPitchSource.engineId,
@@ -664,7 +664,7 @@ export const generateSingingPitch = async (
 export const generateSingingVolume = async (
   singingVolumeSource: SingingVolumeSource,
   config: SongTrackRenderingConfig,
-  voicevoxEngineApi: VoicevoxEngineApi,
+  engineSongApi: EngineSongApi,
 ) => {
   const notesForRequestToEngine = createNotesForRequestToEngine(
     singingVolumeSource.firstRestDuration,
@@ -685,7 +685,7 @@ export const generateSingingVolume = async (
     -singingVolumeSource.keyRangeAdjustment,
   );
 
-  const singingVolume = await voicevoxEngineApi.fetchSingFrameVolume({
+  const singingVolume = await engineSongApi.fetchSingFrameVolume({
     notes: notesForRequestToEngine,
     query: queryForVolumeGeneration,
     engineId: singingVolumeSource.engineId,
@@ -707,9 +707,9 @@ export const generateSingingVolume = async (
 
 export const synthesizeSingingVoice = async (
   singingVoiceSource: SingingVoiceSource,
-  voicevoxEngineApi: VoicevoxEngineApi,
+  engineSongApi: EngineSongApi,
 ) => {
-  const singingVoice = await voicevoxEngineApi.frameSynthesis({
+  const singingVoice = await engineSongApi.frameSynthesis({
     query: singingVoiceSource.queryForSingingVoiceSynthesis,
     engineId: singingVoiceSource.singer.engineId,
     styleId: singingVoiceSource.singer.styleId,

--- a/src/sing/songTrackRendering.ts
+++ b/src/sing/songTrackRendering.ts
@@ -23,9 +23,12 @@ import {
   tickToSecond,
 } from "@/sing/domain";
 import { FramePhoneme, Note as NoteForRequestToEngine } from "@/openapi";
-import { EngineId, NoteId, TrackId } from "@/type/preload";
+import { EngineId, NoteId, StyleId, TrackId } from "@/type/preload";
 import { getOrThrow } from "@/helpers/mapHelper";
 import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
+import { createLogger } from "@/helpers/log";
+
+const logger = createLogger("sing/songTrackRendering");
 
 /**
  * フレーズレンダリングに必要なデータのスナップショット
@@ -89,10 +92,46 @@ export type SingingVoiceSource = Readonly<{
   queryForSingingVoiceSynthesis: EditorFrameAudioQuery;
 }>;
 
+export type VoicevoxEngineApi = Readonly<{
+  fetchFrameAudioQuery: (args: {
+    engineId: EngineId;
+    styleId: StyleId;
+    engineFrameRate: number;
+    notes: NoteForRequestToEngine[];
+  }) => Promise<EditorFrameAudioQuery>;
+
+  fetchSingFrameF0: (args: {
+    notes: NoteForRequestToEngine[];
+    query: EditorFrameAudioQuery;
+    engineId: EngineId;
+    styleId: StyleId;
+  }) => Promise<number[]>;
+
+  fetchSingFrameVolume: (args: {
+    notes: NoteForRequestToEngine[];
+    query: EditorFrameAudioQuery;
+    engineId: EngineId;
+    styleId: StyleId;
+  }) => Promise<number[]>;
+
+  frameSynthesis: (args: {
+    query: EditorFrameAudioQuery;
+    engineId: EngineId;
+    styleId: StyleId;
+  }) => Promise<Blob>;
+}>;
+
+export type SongTrackRenderingConfig = Readonly<{
+  singingTeacherStyleId: StyleId;
+  firstRestMinDurationSeconds: number;
+  lastRestDurationSeconds: number;
+  fadeOutDurationSeconds: number;
+}>;
+
 /**
  * リクエスト用のノーツ（と休符）を作成する。
  */
-export const createNotesForRequestToEngine = (
+const createNotesForRequestToEngine = (
   firstRestDuration: number,
   lastRestDurationSeconds: number,
   notes: Note[],
@@ -156,10 +195,7 @@ export const createNotesForRequestToEngine = (
   return notesForRequestToEngine;
 };
 
-export const shiftKeyOfNotes = (
-  notes: NoteForRequestToEngine[],
-  keyShift: number,
-) => {
+const shiftKeyOfNotes = (notes: NoteForRequestToEngine[], keyShift: number) => {
   for (const note of notes) {
     if (note.key != undefined) {
       note.key += keyShift;
@@ -171,13 +207,13 @@ export const getPhonemes = (query: EditorFrameAudioQuery) => {
   return query.phonemes.map((value) => value.phoneme).join(" ");
 };
 
-export const shiftPitch = (f0: number[], pitchShift: number) => {
+const shiftPitch = (f0: number[], pitchShift: number) => {
   for (let i = 0; i < f0.length; i++) {
     f0[i] *= Math.pow(2, pitchShift / 12);
   }
 };
 
-export const shiftVolume = (volume: number[], volumeShift: number) => {
+const shiftVolume = (volume: number[], volumeShift: number) => {
   for (let i = 0; i < volume.length; i++) {
     volume[i] *= decibelToLinear(volumeShift);
   }
@@ -187,7 +223,7 @@ export const shiftVolume = (volume: number[], volumeShift: number) => {
  * 末尾のpauの区間のvolumeを0にする。（歌とpauの呼吸音が重ならないようにする）
  * fadeOutDurationSecondsが0の場合は即座にvolumeを0にする。
  */
-export const muteLastPauSection = (
+const muteLastPauSection = (
   volume: number[],
   phonemes: FramePhoneme[],
   frameRate: number,
@@ -558,4 +594,128 @@ export const generateSingingVoiceSource = (
     singer: track.singer,
     queryForSingingVoiceSynthesis: clonedQuery,
   };
+};
+
+export const generateQuery = async (
+  querySource: QuerySource,
+  config: SongTrackRenderingConfig,
+  voicevoxEngineApi: VoicevoxEngineApi,
+) => {
+  const notesForRequestToEngine = createNotesForRequestToEngine(
+    querySource.firstRestDuration,
+    config.lastRestDurationSeconds,
+    querySource.notes,
+    querySource.tempos,
+    querySource.tpqn,
+    querySource.engineFrameRate,
+  );
+
+  shiftKeyOfNotes(notesForRequestToEngine, -querySource.keyRangeAdjustment);
+
+  const query = await voicevoxEngineApi.fetchFrameAudioQuery({
+    engineId: querySource.engineId,
+    styleId: config.singingTeacherStyleId,
+    engineFrameRate: querySource.engineFrameRate,
+    notes: notesForRequestToEngine,
+  });
+
+  shiftPitch(query.f0, querySource.keyRangeAdjustment);
+
+  const phonemes = getPhonemes(query);
+  logger.info(`Generated query. phonemes: ${phonemes}`);
+
+  return query;
+};
+
+export const generateSingingPitch = async (
+  singingPitchSource: SingingPitchSource,
+  config: SongTrackRenderingConfig,
+  voicevoxEngineApi: VoicevoxEngineApi,
+) => {
+  const notesForRequestToEngine = createNotesForRequestToEngine(
+    singingPitchSource.firstRestDuration,
+    config.lastRestDurationSeconds,
+    singingPitchSource.notes,
+    singingPitchSource.tempos,
+    singingPitchSource.tpqn,
+    singingPitchSource.engineFrameRate,
+  );
+  const queryForPitchGeneration = singingPitchSource.queryForPitchGeneration;
+
+  shiftKeyOfNotes(
+    notesForRequestToEngine,
+    -singingPitchSource.keyRangeAdjustment,
+  );
+
+  const singingPitch = await voicevoxEngineApi.fetchSingFrameF0({
+    notes: notesForRequestToEngine,
+    query: queryForPitchGeneration,
+    engineId: singingPitchSource.engineId,
+    styleId: config.singingTeacherStyleId,
+  });
+
+  shiftPitch(singingPitch, singingPitchSource.keyRangeAdjustment);
+
+  logger.info(`Generated singing pitch.`);
+
+  return singingPitch;
+};
+
+export const generateSingingVolume = async (
+  singingVolumeSource: SingingVolumeSource,
+  config: SongTrackRenderingConfig,
+  voicevoxEngineApi: VoicevoxEngineApi,
+) => {
+  const notesForRequestToEngine = createNotesForRequestToEngine(
+    singingVolumeSource.firstRestDuration,
+    config.lastRestDurationSeconds,
+    singingVolumeSource.notes,
+    singingVolumeSource.tempos,
+    singingVolumeSource.tpqn,
+    singingVolumeSource.engineFrameRate,
+  );
+  const queryForVolumeGeneration = singingVolumeSource.queryForVolumeGeneration;
+
+  shiftKeyOfNotes(
+    notesForRequestToEngine,
+    -singingVolumeSource.keyRangeAdjustment,
+  );
+  shiftPitch(
+    queryForVolumeGeneration.f0,
+    -singingVolumeSource.keyRangeAdjustment,
+  );
+
+  const singingVolume = await voicevoxEngineApi.fetchSingFrameVolume({
+    notes: notesForRequestToEngine,
+    query: queryForVolumeGeneration,
+    engineId: singingVolumeSource.engineId,
+    styleId: config.singingTeacherStyleId,
+  });
+
+  shiftVolume(singingVolume, singingVolumeSource.volumeRangeAdjustment);
+  muteLastPauSection(
+    singingVolume,
+    queryForVolumeGeneration.phonemes,
+    singingVolumeSource.engineFrameRate,
+    config.fadeOutDurationSeconds,
+  );
+
+  logger.info(`Generated singing volume.`);
+
+  return singingVolume;
+};
+
+export const synthesizeSingingVoice = async (
+  singingVoiceSource: SingingVoiceSource,
+  voicevoxEngineApi: VoicevoxEngineApi,
+) => {
+  const singingVoice = await voicevoxEngineApi.frameSynthesis({
+    query: singingVoiceSource.queryForSingingVoiceSynthesis,
+    engineId: singingVoiceSource.singer.engineId,
+    styleId: singingVoiceSource.singer.styleId,
+  });
+
+  logger.info(`Generated singing voice.`);
+
+  return singingVoice;
 };

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -134,7 +134,7 @@ import {
   SnapshotForPhraseRender,
   SongTrackRenderingConfig,
   synthesizeSingingVoice,
-  VoicevoxEngineApi,
+  EngineSongApi,
 } from "@/sing/songTrackRendering";
 
 const logger = createLogger("store/singing");
@@ -1478,7 +1478,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         firstRestMinDurationSeconds: 0.12,
       };
 
-      const voicevoxEngineApi: VoicevoxEngineApi = {
+      const engineSongApi: EngineSongApi = {
         fetchFrameAudioQuery: async (args) => {
           return await actions.FETCH_SING_FRAME_AUDIO_QUERY(args);
         },
@@ -1559,7 +1559,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           if (query != undefined) {
             logger.info(`Loaded query from cache.`);
           } else {
-            query = await generateQuery(querySource, config, voicevoxEngineApi);
+            query = await generateQuery(querySource, config, engineSongApi);
             const phonemes = getPhonemes(query);
             logger.info(`Generated query. phonemes: ${phonemes}`);
             queryCache.set(queryKey, query);
@@ -1635,7 +1635,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             singingPitch = await generateSingingPitch(
               singingPitchSource,
               config,
-              voicevoxEngineApi,
+              engineSongApi,
             );
             logger.info(`Generated singing pitch.`);
             singingPitchCache.set(singingPitchKey, singingPitch);
@@ -1724,7 +1724,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             singingVolume = await generateSingingVolume(
               singingVolumeSource,
               config,
-              voicevoxEngineApi,
+              engineSongApi,
             );
             logger.info(`Generated singing volume.`);
             singingVolumeCache.set(singingVolumeKey, singingVolume);
@@ -1825,7 +1825,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           } else {
             singingVoice = await synthesizeSingingVoice(
               singingVoiceSource,
-              voicevoxEngineApi,
+              engineSongApi,
             );
             logger.info(`Generated singing voice.`);
             singingVoiceCache.set(singingVoiceKey, singingVoice);
@@ -1875,7 +1875,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       };
 
       const render = async () => {
-        const firstRestMinDurationSeconds = 0.12;
         const snapshot = createSnapshot();
 
         const renderStartStageIds = new Map<PhraseKey, PhraseRenderStageId>();
@@ -1883,7 +1882,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         // 各トラックのノーツからフレーズを生成する
         const generatedPhrases = await generatePhrases(
           snapshot,
-          firstRestMinDurationSeconds,
+          config.firstRestMinDurationSeconds,
         );
 
         const mergedPhrases = new Map<PhraseKey, Phrase>();

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1472,7 +1472,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
   RENDER: {
     async action({ state, getters, mutations, actions }) {
       const config: SongTrackRenderingConfig = {
-        singingTeacherStyleId: StyleId(6000),
+        singingTeacherStyleId: StyleId(6000), // TODO: UIで設定できるようにする
         lastRestDurationSeconds: 0.5,
         fadeOutDurationSeconds: 0.15,
         firstRestMinDurationSeconds: 0.12,


### PR DESCRIPTION
## 内容

以下の関数をsongTrackRendering.tsに移動します。（移動とインターフェースの変更を行います）

- generateQuery
- generateSingingPitch
- generateSingingVolume
- synthesizeSingingVoice

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2261

## その他
