### PR TITLE
refactor: シーケンス周りの処理をリファクタリング

### DIFF
--- a/src/components/Sing/SequencerPhraseIndicator.vue
+++ b/src/components/Sing/SequencerPhraseIndicator.vue
@@ -19,7 +19,7 @@ const classNames: Record<PhraseState, string> = {
   WAITING_TO_BE_RENDERED: "waiting-to-be-rendered",
   NOW_RENDERING: "now-rendering",
   COULD_NOT_RENDER: "could-not-render",
-  PLAYABLE: "playable",
+  RENDERED: "rendered",
 };
 const className = computed(() => {
   const phrase = getOrThrow(store.state.phrases, props.phraseKey);
@@ -114,7 +114,7 @@ const className = computed(() => {
   );
 }
 
-.playable {
+.rendered {
   visibility: hidden;
 }
 </style>

--- a/src/sing/oldSongTrackRendering.ts
+++ b/src/sing/oldSongTrackRendering.ts
@@ -26,9 +26,6 @@ import { FramePhoneme, Note as NoteForRequestToEngine } from "@/openapi";
 import { EngineId, NoteId, StyleId, TrackId } from "@/type/preload";
 import { getOrThrow } from "@/helpers/mapHelper";
 import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
-import { createLogger } from "@/helpers/log";
-
-const logger = createLogger("sing/songTrackRendering");
 
 /**
  * フレーズレンダリングに必要なデータのスナップショット
@@ -621,9 +618,6 @@ export const generateQuery = async (
 
   shiftPitch(query.f0, querySource.keyRangeAdjustment);
 
-  const phonemes = getPhonemes(query);
-  logger.info(`Generated query. phonemes: ${phonemes}`);
-
   return query;
 };
 
@@ -655,8 +649,6 @@ export const generateSingingPitch = async (
   });
 
   shiftPitch(singingPitch, singingPitchSource.keyRangeAdjustment);
-
-  logger.info(`Generated singing pitch.`);
 
   return singingPitch;
 };
@@ -700,8 +692,6 @@ export const generateSingingVolume = async (
     config.fadeOutDurationSeconds,
   );
 
-  logger.info(`Generated singing volume.`);
-
   return singingVolume;
 };
 
@@ -714,8 +704,6 @@ export const synthesizeSingingVoice = async (
     engineId: singingVoiceSource.singer.engineId,
     styleId: singingVoiceSource.singer.styleId,
   });
-
-  logger.info(`Generated singing voice.`);
 
   return singingVoice;
 };

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -138,6 +138,7 @@ import {
   // 一時的なインポート：SongTrackRenderer の統合が完了するまで、oldSongTrackRendering モジュールを使用する
   // TODO: SongTrackRenderer の統合が完了したら、このインポートを削除する
 } from "@/sing/oldSongTrackRendering";
+import { UnreachableError } from "@/type/utility";
 
 const logger = createLogger("store/singing");
 
@@ -264,7 +265,7 @@ const offlineRenderTracks = async (
   }
 
   for (const phrase of phrases.values()) {
-    if (phrase.singingVoiceKey == undefined || phrase.state !== "PLAYABLE") {
+    if (phrase.singingVoiceKey == undefined || phrase.state !== "RENDERED") {
       continue;
     }
     const singingVoice = getOrThrow(singingVoices, phrase.singingVoiceKey);
@@ -302,6 +303,17 @@ const offlineRenderTracks = async (
   return audioBuffer;
 };
 
+type PhraseSequenceInfo =
+  | {
+      readonly type: "note";
+      readonly sequenceId: SequenceId;
+    }
+  | {
+      readonly type: "audio";
+      readonly sequenceId: SequenceId;
+      readonly singingVoiceKey: SingingVoiceKey;
+    };
+
 let audioContext: AudioContext | undefined;
 let transport: Transport | undefined;
 let previewSynth: PolySynth | undefined;
@@ -327,6 +339,7 @@ if (window.AudioContext) {
 
 const playheadPosition = ref(0); // 単位はtick
 const phraseSingingVoices = new Map<SingingVoiceKey, SingingVoice>();
+const phraseSequenceInfos = new Map<PhraseKey, PhraseSequenceInfo>();
 const sequences = new Map<SequenceId, Sequence & { trackId: TrackId }>();
 const animationTimer = new AnimationTimer();
 
@@ -405,6 +418,16 @@ const deleteSequence = (sequenceId: SequenceId) => {
 };
 
 /**
+ * シーケンスが登録されているかどうかを確認する。
+ *
+ * @param sequenceId シーケンスID。
+ * @returns シーケンスが登録されている場合はtrue、そうでない場合はfalse。
+ */
+const isRegisteredSequence = (sequenceId: SequenceId) => {
+  return sequences.has(sequenceId);
+};
+
+/**
  * ノートシーケンスを生成する。
  */
 const generateNoteSequence = (
@@ -445,6 +468,108 @@ const generateAudioSequence = async (
     audioEvents,
     trackId,
   };
+};
+
+/**
+ * フレーズのシーケンスを更新する。
+ */
+const updatePhraseSequences = (
+  phrases: Map<PhraseKey, Phrase>,
+  phraseSingingVoices: Map<SingingVoiceKey, SingingVoice>,
+  tempos: Tempo[],
+  tpqn: number,
+) => {
+  // シーケンスの削除を行う
+  for (const [phraseKey, sequenceInfo] of phraseSequenceInfos) {
+    const phrase = phrases.get(phraseKey);
+
+    let needToDelete = false;
+
+    // シーケンスの削除が必要かどうかを判断する
+    if (phrase == undefined) {
+      needToDelete = true;
+    } else if (
+      phrase.state === "RENDERED" &&
+      (sequenceInfo.type !== "audio" ||
+        sequenceInfo.singingVoiceKey !== phrase.singingVoiceKey)
+    ) {
+      needToDelete = true;
+    } else if (phrase.state !== "RENDERED" && sequenceInfo.type !== "note") {
+      needToDelete = true;
+    }
+
+    // シーケンスの削除が必要な場合は、シーケンスを削除する
+    // TODO: ピッチを編集したときは行わないようにする
+    if (needToDelete) {
+      phraseSequenceInfos.delete(phraseKey);
+      if (isRegisteredSequence(sequenceInfo.sequenceId)) {
+        deleteSequence(sequenceInfo.sequenceId);
+        logger.info(`Deleted sequence. ID: ${sequenceInfo.sequenceId}`);
+      }
+    }
+  }
+
+  // シーケンスの生成と登録を行う
+  for (const [phraseKey, phrase] of phrases) {
+    if (phraseSequenceInfos.has(phraseKey)) {
+      // 既にシーケンスが登録されている場合はcontinue
+      continue;
+    }
+
+    const newSequenceId = SequenceId(uuid4());
+
+    // フレーズの状態が"RENDERED"の場合はオーディオシーケンスを生成し、
+    // "RENDERED"でない場合はノートシーケンスを生成して、登録する
+    if (phrase.state === "RENDERED") {
+      if (phrase.singingVoiceKey == undefined) {
+        throw new UnreachableError("phrase.singingVoiceKey is undefined.");
+      }
+      const singingVoice = getOrThrow(
+        phraseSingingVoices,
+        phrase.singingVoiceKey,
+      );
+
+      phraseSequenceInfos.set(phraseKey, {
+        type: "audio",
+        sequenceId: newSequenceId,
+        singingVoiceKey: phrase.singingVoiceKey,
+      });
+
+      const audioSequencePromise = generateAudioSequence(
+        phrase.startTime,
+        singingVoice,
+        phrase.trackId,
+      );
+
+      // Promiseが解決されたときに、フレーズと紐づいているシーケンスの情報が変わっているか確認し、
+      // 変わっていなければシーケンスを登録する
+      void audioSequencePromise.then((audioSequence) => {
+        const sequenceInfo = phraseSequenceInfos.get(phraseKey);
+        if (
+          sequenceInfo != undefined &&
+          sequenceInfo.sequenceId === newSequenceId
+        ) {
+          registerSequence(newSequenceId, audioSequence);
+          logger.info(`Registered audio sequence. ID: ${newSequenceId}`);
+        }
+      });
+    } else {
+      phraseSequenceInfos.set(phraseKey, {
+        type: "note",
+        sequenceId: newSequenceId,
+      });
+
+      const noteSequence = generateNoteSequence(
+        phrase.notes,
+        tempos,
+        tpqn,
+        phrase.trackId,
+      );
+
+      registerSequence(newSequenceId, noteSequence);
+      logger.info(`Registered note sequence. ID: ${newSequenceId}`);
+    }
+  }
 };
 
 /**
@@ -1072,23 +1197,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const phrase = getOrThrow(state.phrases, phraseKey);
 
       phrase.singingVoiceKey = singingVoiceKey;
-    },
-  },
-
-  SET_SEQUENCE_ID_TO_PHRASE: {
-    mutation(
-      state,
-      {
-        phraseKey,
-        sequenceId,
-      }: {
-        phraseKey: PhraseKey;
-        sequenceId: SequenceId | undefined;
-      },
-    ) {
-      const phrase = getOrThrow(state.phrases, phraseKey);
-
-      phrase.sequenceId = sequenceId;
     },
   },
 
@@ -1858,24 +1966,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const startRenderingRequested = () => state.startRenderingRequested;
       const stopRenderingRequested = () => state.stopRenderingRequested;
 
-      /**
-       * フレーズが持つシーケンスのIDを取得する。
-       * @param phraseKey フレーズのキー
-       * @returns シーケンスID
-       */
-      const getPhraseSequenceId = (phraseKey: PhraseKey) => {
-        return getOrThrow(state.phrases, phraseKey).sequenceId;
-      };
-
-      /**
-       * フレーズが持つ歌声のキーを取得する。
-       * @param phraseKey フレーズのキー
-       * @returns 歌声のキー
-       */
-      const getPhraseSingingVoiceKey = (phraseKey: PhraseKey) => {
-        return getOrThrow(state.phrases, phraseKey).singingVoiceKey;
-      };
-
       const render = async () => {
         const snapshot = createSnapshot();
 
@@ -1943,17 +2033,13 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             if (renderStartStageIds.has(phraseKey)) {
               phrase.state = "WAITING_TO_BE_RENDERED";
             } else {
-              phrase.state = "PLAYABLE";
+              phrase.state = "RENDERED";
             }
           }
         }
 
         // 無くなったフレーズのピッチなどのデータとシーケンスを削除する
         for (const phraseKey of disappearedPhraseKeys) {
-          const phraseSequenceId = getPhraseSequenceId(phraseKey);
-          if (phraseSequenceId != undefined) {
-            deleteSequence(phraseSequenceId);
-          }
           for (let i = stages.length - 1; i >= 0; i--) {
             stages[i].deleteExecutionResult(phraseKey);
           }
@@ -1962,38 +2048,15 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         // state.phrasesを更新する
         mutations.SET_PHRASES({ phrases: mergedPhrases });
 
+        // フレーズのシーケンスを更新する
+        updatePhraseSequences(
+          state.phrases,
+          phraseSingingVoices,
+          snapshot.tempos,
+          snapshot.tpqn,
+        );
+
         logger.info("Phrases updated.");
-
-        // シンガーが設定されていないフレーズとレンダリング未完了のフレーズが
-        // プレビュー音で再生されるようにする
-        for (const [phraseKey, phrase] of state.phrases.entries()) {
-          if (
-            phrase.state === "SINGER_IS_NOT_SET" ||
-            phrase.state === "WAITING_TO_BE_RENDERED"
-          ) {
-            // シーケンスが存在する場合は、シーケンスを削除する
-            // TODO: ピッチを編集したときは行わないようにする
-            const phraseSequenceId = getPhraseSequenceId(phraseKey);
-            if (phraseSequenceId != undefined) {
-              deleteSequence(phraseSequenceId);
-              mutations.SET_SEQUENCE_ID_TO_PHRASE({
-                phraseKey,
-                sequenceId: undefined,
-              });
-            }
-
-            // ノートシーケンスを生成して登録し、プレビュー音が鳴るようにする
-            const sequenceId = SequenceId(uuid4());
-            const noteSequence = generateNoteSequence(
-              phrase.notes,
-              snapshot.tempos,
-              snapshot.tpqn,
-              phrase.trackId,
-            );
-            registerSequence(sequenceId, noteSequence);
-            mutations.SET_SEQUENCE_ID_TO_PHRASE({ phraseKey, sequenceId });
-          }
-        }
 
         // 各フレーズのレンダリングを行い、レンダリングされた音声が再生されるようにする
         const phrasesToBeRendered = new Map(
@@ -2021,7 +2084,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             ),
             playheadPosition.value,
           );
-          const phrase = getOrThrow(phrasesToBeRendered, phraseKey);
           phrasesToBeRendered.delete(phraseKey);
 
           mutations.SET_STATE_TO_PHRASE({
@@ -2045,38 +2107,18 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
               await stages[i].execute(phraseKey, snapshot);
             }
 
-            // シーケンスが存在する場合、シーケンスを削除する
-            const phraseSequenceId = getPhraseSequenceId(phraseKey);
-            if (phraseSequenceId != undefined) {
-              deleteSequence(phraseSequenceId);
-              mutations.SET_SEQUENCE_ID_TO_PHRASE({
-                phraseKey,
-                sequenceId: undefined,
-              });
-            }
-
-            // オーディオシーケンスを生成して登録する
-            const singingVoiceKey = getPhraseSingingVoiceKey(phraseKey);
-            if (singingVoiceKey == undefined) {
-              throw new Error("singingVoiceKey is undefined.");
-            }
-            const singingVoice = getOrThrow(
-              phraseSingingVoices,
-              singingVoiceKey,
-            );
-            const sequenceId = SequenceId(uuid4());
-            const audioSequence = await generateAudioSequence(
-              phrase.startTime,
-              singingVoice,
-              phrase.trackId,
-            );
-            registerSequence(sequenceId, audioSequence);
-            mutations.SET_SEQUENCE_ID_TO_PHRASE({ phraseKey, sequenceId });
-
             mutations.SET_STATE_TO_PHRASE({
               phraseKey,
-              phraseState: "PLAYABLE",
+              phraseState: "RENDERED",
             });
+
+            // フレーズのシーケンスを更新する
+            updatePhraseSequences(
+              state.phrases,
+              phraseSingingVoices,
+              snapshot.tempos,
+              snapshot.tpqn,
+            );
           } catch (error) {
             mutations.SET_STATE_TO_PHRASE({
               phraseKey,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -766,7 +766,7 @@ export type PhraseState =
   | "WAITING_TO_BE_RENDERED"
   | "NOW_RENDERING"
   | "COULD_NOT_RENDER"
-  | "PLAYABLE";
+  | "RENDERED";
 
 /**
  * エディタ用のFrameAudioQuery
@@ -830,7 +830,6 @@ export type Phrase = {
   singingPitchKey?: SingingPitchKey;
   singingVolumeKey?: SingingVolumeKey;
   singingVoiceKey?: SingingVoiceKey;
-  sequenceId?: SequenceId;
   trackId: TrackId; // NOTE: state.tracksと同期していないので使用する際は注意
 };
 
@@ -1076,13 +1075,6 @@ export type SingingStoreTypes = {
     mutation: {
       phraseKey: PhraseKey;
       singingVoiceKey: SingingVoiceKey | undefined;
-    };
-  };
-
-  SET_SEQUENCE_ID_TO_PHRASE: {
-    mutation: {
-      phraseKey: PhraseKey;
-      sequenceId: SequenceId | undefined;
     };
   };
 


### PR DESCRIPTION
## 内容

フレーズのシーケンスを登録・削除する処理を`RENDER`actionの外に出して、`state.phrases`に合わせてシーケンスの登録・削除が行われるようにします。

また、それに合わせて`PLAYABLE`を`RENDERED`に変更します。
（フレーズの音声合成が完了した時点で`phrase.state`が`RENDERED`になるようにします）

ついでに、以下も行います。
- ログ出力が`singing.ts`と`songTrackRendering.ts`の両方で行われていたので、`singing.ts`のみで行うように

## その他
