### PR TITLE
feat: 音素タイミング編集データをプロジェクトで保持するようにする

### DIFF
--- a/src/domain/project/index.ts
+++ b/src/domain/project/index.ts
@@ -311,6 +311,13 @@ export const migrateProjectFileObject = async (
     }
   }
 
+  if (semver.satisfies(projectAppVersion, "<0.24.0", semverSatisfiesOptions)) {
+    // 音素タイミング編集値の追加
+    for (const trackId in projectData.song.tracks) {
+      projectData.song.tracks[trackId].phonemeTimingEditData = {};
+    }
+  }
+
   // Validation check
   // トークはvalidateTalkProjectで検証する
   // ソングはSET_SCOREの中の`isValidScore`関数で検証される

--- a/src/domain/project/schema.ts
+++ b/src/domain/project/schema.ts
@@ -85,6 +85,11 @@ export const singerSchema = z.object({
   styleId: styleIdSchema,
 });
 
+export const phonemeTimingEditSchema = z.object({
+  phonemeIndexInNote: z.number(), // ノート内での音素の順番
+  offsetSeconds: z.number(), // 単位は秒
+});
+
 export const trackSchema = z.object({
   name: z.string(),
   singer: singerSchema.optional(),
@@ -92,6 +97,10 @@ export const trackSchema = z.object({
   volumeRangeAdjustment: z.number(), // 声量調整量
   notes: z.array(noteSchema),
   pitchEditData: z.array(z.number()), // 値の単位はHzで、データが無いところはVALUE_INDICATING_NO_DATAの値
+  phonemeTimingEditData: z.record(
+    noteIdSchema,
+    z.array(phonemeTimingEditSchema),
+  ), // 音素タイミングの編集データはノートと紐づけて保持
 
   solo: z.boolean(),
   mute: z.boolean(),

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -9,6 +9,7 @@ import {
   PhraseKey,
   Track,
   EditorFrameAudioQuery,
+  PhonemeTimingEditData,
 } from "@/store/type";
 import { FramePhoneme } from "@/openapi";
 import { NoteId, TrackId } from "@/type/preload";
@@ -382,6 +383,7 @@ export function createDefaultTrack(): Track {
     volumeRangeAdjustment: 0,
     notes: [],
     pitchEditData: [],
+    phonemeTimingEditData: new Map(),
 
     solo: false,
     mute: false,
@@ -514,13 +516,6 @@ type PhonemeTiming = {
   endFrame: number;
   phoneme: string;
 };
-
-export type PhonemeTimingEdit = {
-  phonemeIndexInNote: number;
-  offsetSeconds: number;
-};
-
-export type PhonemeTimingEditData = Map<NoteId, PhonemeTimingEdit[]>;
 
 /**
  * 音素列を音素タイミング列に変換する。

--- a/src/sing/utility.ts
+++ b/src/sing/utility.ts
@@ -138,6 +138,10 @@ export const recordToMap = <K extends string, V>(record: Record<K, V>) => {
   return new Map(entries);
 };
 
+export const mapToRecord = <K extends string, V>(map: Map<K, V>) => {
+  return Object.fromEntries(map) as Record<K, V>;
+};
+
 export function linearInterpolation(
   x1: number,
   y1: number,

--- a/src/sing/utility.ts
+++ b/src/sing/utility.ts
@@ -1,3 +1,5 @@
+import { UnreachableError } from "@/type/utility";
+
 export type Rect = {
   x: number;
   y: number;
@@ -123,6 +125,18 @@ export function createArray<T>(
 ) {
   return Array.from({ length }, (_, i) => generateElementFn(i));
 }
+
+export const recordToMap = <K extends string, V>(record: Record<K, V>) => {
+  const keys = Object.keys(record) as K[];
+  const entries = keys.map((key) => {
+    const value = record[key];
+    if (value == undefined) {
+      throw new UnreachableError("value is undefined.");
+    }
+    return [key, value] as const;
+  });
+  return new Map(entries);
+};
 
 export function linearInterpolation(
   x1: number,

--- a/src/store/project/index.ts
+++ b/src/store/project/index.ts
@@ -11,6 +11,7 @@ import {
   AudioItem,
   ProjectStoreState,
   ProjectStoreTypes,
+  Track,
 } from "@/store/type";
 import { TrackId } from "@/type/preload";
 import path from "@/helpers/path";
@@ -73,14 +74,23 @@ const applySongProjectToStore = async (
   await actions.SET_TIME_SIGNATURES({ timeSignatures });
   await actions.SET_TRACKS({
     tracks: new Map(
-      trackOrder.map((trackId) => {
+      trackOrder.map((trackId): [TrackId, Track] => {
         const track = tracks[trackId];
         if (!track) throw new Error("track == undefined");
         return [
           trackId,
           {
-            ...track,
+            name: track.name,
+            singer: track.singer,
+            keyRangeAdjustment: track.keyRangeAdjustment,
+            volumeRangeAdjustment: track.volumeRangeAdjustment,
+            notes: track.notes,
+            pitchEditData: track.pitchEditData,
             phonemeTimingEditData: recordToMap(track.phonemeTimingEditData),
+            solo: track.solo,
+            mute: track.mute,
+            gain: track.gain,
+            pan: track.pan,
           },
         ];
       }),

--- a/src/store/project/index.ts
+++ b/src/store/project/index.ts
@@ -34,6 +34,7 @@ import {
   showQuestionDialog,
 } from "@/components/Dialog/Dialog";
 import { uuid4 } from "@/helpers/random";
+import { recordToMap } from "@/sing/utility";
 
 export const projectStoreState: ProjectStoreState = {
   savedLastCommandIds: { talk: null, song: null },
@@ -75,7 +76,13 @@ const applySongProjectToStore = async (
       trackOrder.map((trackId) => {
         const track = tracks[trackId];
         if (!track) throw new Error("track == undefined");
-        return [trackId, track];
+        return [
+          trackId,
+          {
+            ...track,
+            phonemeTimingEditData: recordToMap(track.phonemeTimingEditData),
+          },
+        ];
       }),
     ),
   });

--- a/src/store/project/saveProjectHelper.ts
+++ b/src/store/project/saveProjectHelper.ts
@@ -51,8 +51,17 @@ export async function writeProjectFile(
           return [
             trackId,
             {
-              ...track,
+              name: track.name,
+              singer: track.singer,
+              keyRangeAdjustment: track.keyRangeAdjustment,
+              volumeRangeAdjustment: track.volumeRangeAdjustment,
+              notes: track.notes,
+              pitchEditData: track.pitchEditData,
               phonemeTimingEditData: mapToRecord(track.phonemeTimingEditData),
+              solo: track.solo,
+              mute: track.mute,
+              gain: track.gain,
+              pan: track.pan,
             },
           ];
         }),

--- a/src/store/project/saveProjectHelper.ts
+++ b/src/store/project/saveProjectHelper.ts
@@ -3,6 +3,7 @@ import { showErrorDialog } from "@/components/Dialog/Dialog";
 import { getAppInfos } from "@/domain/appInfo";
 import { LatestProjectType } from "@/domain/project/schema";
 import { DisplayableError } from "@/helpers/errorHelper";
+import { mapToRecord } from "@/sing/utility";
 import { ResultError } from "@/type/result";
 
 export async function promptProjectSaveFilePath(
@@ -45,7 +46,17 @@ export async function writeProjectFile(
       tpqn,
       tempos,
       timeSignatures,
-      tracks: Object.fromEntries(tracks),
+      tracks: Object.fromEntries(
+        [...tracks.entries()].map(([trackId, track]) => {
+          return [
+            trackId,
+            {
+              ...track,
+              phonemeTimingEditData: mapToRecord(track.phonemeTimingEditData),
+            },
+          ];
+        }),
+      ),
       trackOrder,
     },
   };

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -3476,17 +3476,27 @@ export const singingCommandStore = transformCommandStore(
             getters.SELECTED_TRACK_ID,
           );
 
-          const filteredTracks = trackIndexes.map((trackIndex) => {
+          const filteredTracks = trackIndexes.map((trackIndex): Track => {
             const track = tracks[trackIndex];
             if (!track) {
               throw new Error("Track not found.");
             }
+            const rawTrack = toRaw(selectedTrack);
             return {
-              ...toRaw(selectedTrack),
-              notes: track.notes.map((note) => ({
+              name: rawTrack.name,
+              singer: rawTrack.singer,
+              keyRangeAdjustment: rawTrack.keyRangeAdjustment,
+              volumeRangeAdjustment: rawTrack.volumeRangeAdjustment,
+              notes: rawTrack.notes.map((note) => ({
                 ...note,
                 id: NoteId(uuid4()),
               })),
+              pitchEditData: rawTrack.pitchEditData,
+              phonemeTimingEditData: rawTrack.phonemeTimingEditData,
+              solo: rawTrack.solo,
+              mute: rawTrack.mute,
+              gain: rawTrack.gain,
+              pan: rawTrack.pan,
             };
           });
 
@@ -3513,21 +3523,29 @@ export const singingCommandStore = transformCommandStore(
             throw new Error("TPQN does not match. Must be converted.");
           }
 
-          const filteredTracks = trackIndexes.map((trackIndex) => {
+          const filteredTracks = trackIndexes.map((trackIndex): Track => {
             const track = tracks[trackOrder[trackIndex]];
             if (!track) {
               throw new Error("Track not found.");
             }
             const rawTrack = toRaw(track);
             return {
-              ...rawTrack,
+              name: rawTrack.name,
+              singer: rawTrack.singer,
+              keyRangeAdjustment: rawTrack.keyRangeAdjustment,
+              volumeRangeAdjustment: rawTrack.volumeRangeAdjustment,
               notes: rawTrack.notes.map((note) => ({
                 ...note,
                 id: NoteId(uuid4()),
               })),
+              pitchEditData: rawTrack.pitchEditData,
               phonemeTimingEditData: recordToMap(
                 rawTrack.phonemeTimingEditData,
               ),
+              solo: rawTrack.solo,
+              mute: rawTrack.mute,
+              gain: rawTrack.gain,
+              pan: rawTrack.pan,
             };
           });
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -93,6 +93,7 @@ import {
   AnimationTimer,
   createArray,
   createPromiseThatResolvesWhen,
+  recordToMap,
   round,
 } from "@/sing/utility";
 import { getWorkaroundKeyRangeAdjustment } from "@/sing/workaroundKeyRangeAdjustment";
@@ -3517,12 +3518,16 @@ export const singingCommandStore = transformCommandStore(
             if (!track) {
               throw new Error("Track not found.");
             }
+            const rawTrack = toRaw(track);
             return {
-              ...toRaw(track),
-              notes: track.notes.map((note) => ({
+              ...rawTrack,
+              notes: rawTrack.notes.map((note) => ({
                 ...note,
                 id: NoteId(uuid4()),
               })),
+              phonemeTimingEditData: recordToMap(
+                rawTrack.phonemeTimingEditData,
+              ),
             };
           });
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -66,10 +66,10 @@ import {
 import {
   LatestProjectType,
   noteSchema,
+  phonemeTimingEditSchema,
   singerSchema,
   tempoSchema,
   timeSignatureSchema,
-  trackSchema,
 } from "@/domain/project/schema";
 import { HotkeySettingType } from "@/domain/hotkeyAction";
 import {
@@ -759,7 +759,24 @@ export type Note = z.infer<typeof noteSchema>;
 
 export type Singer = z.infer<typeof singerSchema>;
 
-export type Track = z.infer<typeof trackSchema>;
+export type Track = {
+  name: string;
+  singer?: Singer;
+  keyRangeAdjustment: number; // 音域調整量
+  volumeRangeAdjustment: number; // 声量調整量
+  notes: Note[];
+  pitchEditData: number[]; // 値の単位はHzで、データが無いところはVALUE_INDICATING_NO_DATAの値
+  phonemeTimingEditData: Map<NoteId, PhonemeTimingEdit[]>;
+
+  solo: boolean;
+  mute: boolean;
+  gain: number;
+  pan: number;
+};
+
+export type PhonemeTimingEdit = z.infer<typeof phonemeTimingEditSchema>;
+
+export type PhonemeTimingEditData = Map<NoteId, PhonemeTimingEdit[]>;
 
 export type PhraseState =
   | "SINGER_IS_NOT_SET"

--- a/tests/unit/domain/__snapshots__/project.spec.ts.snap
+++ b/tests/unit/domain/__snapshots__/project.spec.ts.snap
@@ -29,6 +29,7 @@ exports[`migrateProjectFileObject > v0.14.11 1`] = `
         "name": "無名トラック",
         "notes": [],
         "pan": 0,
+        "phonemeTimingEditData": {},
         "pitchEditData": [],
         "singer": undefined,
         "solo": false,

--- a/tests/unit/domain/sing/applyPhonemeTimingEdit.spec.ts
+++ b/tests/unit/domain/sing/applyPhonemeTimingEdit.spec.ts
@@ -1,12 +1,9 @@
 import { it, expect, describe } from "vitest";
 import { uuid4 } from "@/helpers/random";
 import { FramePhoneme } from "@/openapi";
-import {
-  applyPhonemeTimingEditAndAdjust,
-  PhonemeTimingEdit,
-} from "@/sing/domain";
+import { applyPhonemeTimingEditAndAdjust } from "@/sing/domain";
 import { createArray } from "@/sing/utility";
-import { EditorFrameAudioQuery } from "@/store/type";
+import { EditorFrameAudioQuery, PhonemeTimingEdit } from "@/store/type";
 import { NoteId } from "@/type/preload";
 
 const frameRate = 93.75;


### PR DESCRIPTION
## 内容

以下を行います。
- `Track`に`phonemeTimingEditData`を追加
- `phonemeTimingEditData`をプロジェクトファイルに保存するように
- ひとまず0.24.0で実装される想定でマイグレーション処理を追加
- ユニットテストのスナップショットを更新
- ユーティリティー関数として`recordToMap`関数と`mapToRecord`関数を追加

ついでに、以下も行います。
- `PhonemeTimingEdit`型と`PhonemeTimingEditData`型を`src/store/type.ts`に移動

## 設計

- 編集データの持ち方は https://github.com/VOICEVOX/voicevox/issues/2261#issuecomment-2476100761 の通り
- プロジェクトファイルではRecord型で保持して、`store.state`ではMap型で保持

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2261

## その他
