### PR TITLE
refactor: プロジェクトファイル関連の型と関数をdomainディレクトリの外に出す

### DIFF
--- a/src/components/Dialog/ImportSongProjectDialog.vue
+++ b/src/components/Dialog/ImportSongProjectDialog.vue
@@ -102,7 +102,7 @@ import { useStore } from "@/store";
 import { createLogger } from "@/helpers/log";
 import { ExhaustiveError } from "@/type/utility";
 import { IsEqual } from "@/type/utility";
-import { LatestProjectType } from "@/domain/project/schema";
+import { LatestProjectType } from "@/infrastructures/projectFile/type";
 import { DEFAULT_TRACK_NAME } from "@/sing/domain";
 
 const { dialogRef, onDialogOK, onDialogCancel } = useDialogPluginComponent();

--- a/src/components/Sing/ChangeValueDialog/TempoChangeDialog.vue
+++ b/src/components/Sing/ChangeValueDialog/TempoChangeDialog.vue
@@ -22,7 +22,7 @@
 import { QInput, useDialogPluginComponent } from "quasar";
 import { ref } from "vue";
 import CommonDialog from "./CommonDialog.vue";
-import { Tempo } from "@/store/type";
+import { Tempo } from "@/domain/project/type";
 import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 
 const modelValue = defineModel<boolean>();

--- a/src/components/Sing/ChangeValueDialog/TimeSignatureChangeDialog.vue
+++ b/src/components/Sing/ChangeValueDialog/TimeSignatureChangeDialog.vue
@@ -39,7 +39,7 @@
 import { useDialogPluginComponent } from "quasar";
 import { ref } from "vue";
 import CommonDialog from "./CommonDialog.vue";
-import { TimeSignature } from "@/store/type";
+import { TimeSignature } from "@/domain/project/type";
 import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 import { BEAT_TYPES } from "@/sing/domain";
 

--- a/src/components/Sing/CharacterMenuButton/SelectedCharacter.vue
+++ b/src/components/Sing/CharacterMenuButton/SelectedCharacter.vue
@@ -38,7 +38,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { Singer } from "@/store/type";
+import { Singer } from "@/domain/project/type";
 import { CharacterInfo } from "@/type/preload";
 import { getStyleDescription } from "@/sing/viewHelper";
 

--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -247,7 +247,7 @@ import ContextMenu, {
   ContextMenuItemData,
 } from "@/components/Menu/ContextMenu/Container.vue";
 import { useStore } from "@/store";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import {
   getEndTicksOfPhrase,
   getNoteDuration,

--- a/src/components/Sing/SequencerGrid/Presentation.vue
+++ b/src/components/Sing/SequencerGrid/Presentation.vue
@@ -118,7 +118,7 @@ import {
   keyInfos,
   tickToBaseX,
 } from "@/sing/viewHelper";
-import { TimeSignature } from "@/store/type";
+import { TimeSignature } from "@/domain/project/type";
 import { useSequencerGrid } from "@/composables/useSequencerGridPattern";
 import { getNoteDuration, measureNumberToTick } from "@/sing/domain";
 

--- a/src/components/Sing/SequencerLyricInput.vue
+++ b/src/components/Sing/SequencerLyricInput.vue
@@ -22,7 +22,7 @@
 import { computed, nextTick, ref, watch } from "vue";
 import { useStore } from "@/store";
 import { tickToBaseX, noteNumberToBaseY } from "@/sing/viewHelper";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 
 const props = defineProps<{
   editingLyricNote: Note;

--- a/src/components/Sing/SequencerNote.vue
+++ b/src/components/Sing/SequencerNote.vue
@@ -66,7 +66,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { useStore } from "@/store";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import {
   getKeyBaseHeight,
   tickToBaseX,

--- a/src/components/Sing/SequencerRuler/Container.vue
+++ b/src/components/Sing/SequencerRuler/Container.vue
@@ -22,7 +22,7 @@
 import { computed } from "vue";
 import Presentation from "./Presentation.vue";
 import { useStore } from "@/store";
-import { Tempo, TimeSignature } from "@/store/type";
+import { Tempo, TimeSignature } from "@/domain/project/type";
 
 defineOptions({
   name: "SequencerRuler",

--- a/src/components/Sing/SequencerRuler/Presentation.vue
+++ b/src/components/Sing/SequencerRuler/Presentation.vue
@@ -122,7 +122,7 @@ import {
   tickToMeasureNumber,
 } from "@/sing/domain";
 import { baseXToTick, tickToBaseX } from "@/sing/viewHelper";
-import { Tempo, TimeSignature } from "@/store/type";
+import { Tempo, TimeSignature } from "@/domain/project/type";
 import ContextMenu, {
   ContextMenuItemData,
 } from "@/components/Menu/ContextMenu/Presentation.vue";

--- a/src/components/Sing/SequencerShadowNote.vue
+++ b/src/components/Sing/SequencerShadowNote.vue
@@ -15,7 +15,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@/store";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import {
   getKeyBaseHeight,
   tickToBaseX,

--- a/src/composables/useSequencerGridPattern.ts
+++ b/src/composables/useSequencerGridPattern.ts
@@ -1,6 +1,6 @@
 import { computed, Ref } from "vue";
 import { tickToBaseX } from "@/sing/viewHelper";
-import { TimeSignature } from "@/store/type";
+import { TimeSignature } from "@/domain/project/type";
 
 const beatWidth = (
   timeSignature: TimeSignature,

--- a/src/domain/project/schema.ts
+++ b/src/domain/project/schema.ts
@@ -1,17 +1,15 @@
 import { z } from "zod";
 
 import {
-  audioKeySchema,
   engineIdSchema,
   noteIdSchema,
   presetKeySchema,
   speakerIdSchema,
   styleIdSchema,
-  trackIdSchema,
 } from "@/type/preload";
 
 // トーク系のスキーマ
-const moraSchema = z.object({
+export const moraSchema = z.object({
   text: z.string(),
   vowel: z.string(),
   vowelLength: z.number(),
@@ -20,14 +18,14 @@ const moraSchema = z.object({
   consonantLength: z.number().optional(),
 });
 
-const accentPhraseSchema = z.object({
+export const accentPhraseSchema = z.object({
   moras: z.array(moraSchema),
   accent: z.number(),
   pauseMora: moraSchema.optional(),
   isInterrogative: z.boolean().optional(),
 });
 
-const audioQuerySchema = z.object({
+export const audioQuerySchema = z.object({
   accentPhrases: z.array(accentPhraseSchema),
   speedScale: z.number(),
   pitchScale: z.number(),
@@ -41,14 +39,14 @@ const audioQuerySchema = z.object({
   kana: z.string().optional(),
 });
 
-const morphingInfoSchema = z.object({
+export const morphingInfoSchema = z.object({
   rate: z.number(),
   targetEngineId: engineIdSchema,
   targetSpeakerId: speakerIdSchema,
   targetStyleId: styleIdSchema,
 });
 
-const audioItemSchema = z.object({
+export const audioItemSchema = z.object({
   text: z.string(),
   voice: z.object({
     engineId: engineIdSchema,
@@ -97,33 +95,10 @@ export const trackSchema = z.object({
   volumeRangeAdjustment: z.number(), // 声量調整量
   notes: z.array(noteSchema),
   pitchEditData: z.array(z.number()), // 値の単位はHzで、データが無いところはVALUE_INDICATING_NO_DATAの値
-  phonemeTimingEditData: z.record(
-    noteIdSchema,
-    z.array(phonemeTimingEditSchema),
-  ), // 音素タイミングの編集データはノートと紐づけて保持
+  phonemeTimingEditData: z.map(noteIdSchema, z.array(phonemeTimingEditSchema)), // 音素タイミングの編集データはノートと紐づけて保持
 
   solo: z.boolean(),
   mute: z.boolean(),
   gain: z.number(),
   pan: z.number(),
 });
-
-// プロジェクトファイルのスキーマ
-export const projectSchema = z.object({
-  appVersion: z.string(),
-  talk: z.object({
-    // description: "Attribute keys of audioItems.",
-    audioKeys: z.array(audioKeySchema),
-    // description: "VOICEVOX states per cell",
-    audioItems: z.record(audioKeySchema, audioItemSchema),
-  }),
-  song: z.object({
-    tpqn: z.number(),
-    tempos: z.array(tempoSchema),
-    timeSignatures: z.array(timeSignatureSchema),
-    tracks: z.record(trackIdSchema, trackSchema),
-    trackOrder: z.array(trackIdSchema),
-  }),
-});
-
-export type LatestProjectType = z.infer<typeof projectSchema>;

--- a/src/domain/project/type.ts
+++ b/src/domain/project/type.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+import {
+  noteSchema,
+  phonemeTimingEditSchema,
+  singerSchema,
+  tempoSchema,
+  timeSignatureSchema,
+  trackSchema,
+} from "@/domain/project/schema";
+import { NoteId } from "@/type/preload";
+
+export type Tempo = z.infer<typeof tempoSchema>;
+
+export type TimeSignature = z.infer<typeof timeSignatureSchema>;
+
+export type Note = z.infer<typeof noteSchema>;
+
+export type Singer = z.infer<typeof singerSchema>;
+
+export type Track = z.infer<typeof trackSchema>;
+
+export type PhonemeTimingEdit = z.infer<typeof phonemeTimingEditSchema>;
+
+export type PhonemeTimingEditData = Map<NoteId, PhonemeTimingEdit[]>;

--- a/src/infrastructures/projectFile/migration.ts
+++ b/src/infrastructures/projectFile/migration.ts
@@ -1,12 +1,8 @@
-/**
- * プロジェクトファイル関連のコード
- */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 import semver from "semver";
 
-import { LatestProjectType, projectSchema } from "./schema";
 import { AccentPhrase } from "@/openapi";
 import { EngineId, StyleId, TrackId, Voice } from "@/type/preload";
 import {
@@ -17,65 +13,12 @@ import {
   DEFAULT_TRACK_NAME,
 } from "@/sing/domain";
 import { uuid4 } from "@/helpers/random";
+import { projectFileSchema } from "@/infrastructures/projectFile/schema";
+import { ProjectFileFormatError } from "@/infrastructures/projectFile/type";
+import { validateTalkProject } from "@/infrastructures/projectFile/validation";
 
 const DEFAULT_SAMPLING_RATE = 24000;
 
-/**
- * プロジェクトファイルのフォーマットエラー
- * FIXME: Result型にする
- */
-export class ProjectFileFormatError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ProjectFileFormatError";
-  }
-}
-
-const validateTalkProject = (talkProject: LatestProjectType["talk"]) => {
-  if (
-    !talkProject.audioKeys.every(
-      (audioKey) => audioKey in talkProject.audioItems,
-    )
-  ) {
-    throw new Error(
-      "Every audioKey in audioKeys should be a key of audioItems",
-    );
-  }
-  if (
-    !talkProject.audioKeys.every(
-      (audioKey) => talkProject.audioItems[audioKey]?.voice != undefined,
-    )
-  ) {
-    throw new Error('Every audioItem should have a "voice" attribute.');
-  }
-  if (
-    !talkProject.audioKeys.every(
-      (audioKey) =>
-        talkProject.audioItems[audioKey]?.voice.engineId != undefined,
-    )
-  ) {
-    throw new Error('Every voice should have a "engineId" attribute.');
-  }
-  // FIXME: assert engineId is registered
-  if (
-    !talkProject.audioKeys.every(
-      (audioKey) =>
-        talkProject.audioItems[audioKey]?.voice.speakerId != undefined,
-    )
-  ) {
-    throw new Error('Every voice should have a "speakerId" attribute.');
-  }
-  if (
-    !talkProject.audioKeys.every(
-      (audioKey) =>
-        talkProject.audioItems[audioKey]?.voice.styleId != undefined,
-    )
-  ) {
-    throw new Error('Every voice should have a "styleId" attribute.');
-  }
-};
-
-// TODO: マイグレーション（とファイルの最初のeslint-disable）を別ファイルに移す
 /**
  * プロジェクトファイルのマイグレーション
  */
@@ -321,7 +264,7 @@ export const migrateProjectFileObject = async (
   // Validation check
   // トークはvalidateTalkProjectで検証する
   // ソングはSET_SCOREの中の`isValidScore`関数で検証される
-  const parsedProjectData = projectSchema.parse(projectData);
+  const parsedProjectData = projectFileSchema.parse(projectData);
   validateTalkProject(parsedProjectData.talk);
 
   return parsedProjectData;

--- a/src/infrastructures/projectFile/schema.ts
+++ b/src/infrastructures/projectFile/schema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import { audioKeySchema, noteIdSchema, trackIdSchema } from "@/type/preload";
+import {
+  audioItemSchema,
+  noteSchema,
+  phonemeTimingEditSchema,
+  singerSchema,
+  tempoSchema,
+  timeSignatureSchema,
+} from "@/domain/project/schema";
+
+// シリアライズ（JSON.stringify）可能なトラックのスキーマ
+export const serializableTrackSchema = z.object({
+  name: z.string(),
+  singer: singerSchema.optional(),
+  keyRangeAdjustment: z.number(),
+  volumeRangeAdjustment: z.number(),
+  notes: z.array(noteSchema),
+  pitchEditData: z.array(z.number()),
+  phonemeTimingEditData: z.record(
+    noteIdSchema,
+    z.array(phonemeTimingEditSchema),
+  ),
+  solo: z.boolean(),
+  mute: z.boolean(),
+  gain: z.number(),
+  pan: z.number(),
+});
+
+// プロジェクトファイルのスキーマ
+export const projectFileSchema = z.object({
+  appVersion: z.string(),
+  talk: z.object({
+    // description: "Attribute keys of audioItems.",
+    audioKeys: z.array(audioKeySchema),
+    // description: "VOICEVOX states per cell",
+    audioItems: z.record(audioKeySchema, audioItemSchema),
+  }),
+  song: z.object({
+    tpqn: z.number(),
+    tempos: z.array(tempoSchema),
+    timeSignatures: z.array(timeSignatureSchema),
+    tracks: z.record(trackIdSchema, serializableTrackSchema),
+    trackOrder: z.array(trackIdSchema),
+  }),
+});

--- a/src/infrastructures/projectFile/type.ts
+++ b/src/infrastructures/projectFile/type.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import {
+  projectFileSchema,
+  serializableTrackSchema,
+} from "@/infrastructures/projectFile/schema";
+
+export type SerializableTrack = z.infer<typeof serializableTrackSchema>;
+
+export type LatestProjectType = z.infer<typeof projectFileSchema>;
+
+/**
+ * プロジェクトファイルのフォーマットエラー
+ * FIXME: Result型にする
+ */
+export class ProjectFileFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProjectFileFormatError";
+  }
+}

--- a/src/infrastructures/projectFile/validation.ts
+++ b/src/infrastructures/projectFile/validation.ts
@@ -1,0 +1,45 @@
+import { LatestProjectType } from "@/infrastructures/projectFile/type";
+
+export const validateTalkProject = (talkProject: LatestProjectType["talk"]) => {
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) => audioKey in talkProject.audioItems,
+    )
+  ) {
+    throw new Error(
+      "Every audioKey in audioKeys should be a key of audioItems",
+    );
+  }
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) => talkProject.audioItems[audioKey]?.voice != undefined,
+    )
+  ) {
+    throw new Error('Every audioItem should have a "voice" attribute.');
+  }
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) =>
+        talkProject.audioItems[audioKey]?.voice.engineId != undefined,
+    )
+  ) {
+    throw new Error('Every voice should have a "engineId" attribute.');
+  }
+  // FIXME: assert engineId is registered
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) =>
+        talkProject.audioItems[audioKey]?.voice.speakerId != undefined,
+    )
+  ) {
+    throw new Error('Every voice should have a "speakerId" attribute.');
+  }
+  if (
+    !talkProject.audioKeys.every(
+      (audioKey) =>
+        talkProject.audioItems[audioKey]?.voice.styleId != undefined,
+    )
+  ) {
+    throw new Error('Every voice should have a "styleId" attribute.');
+  }
+};

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -1,18 +1,20 @@
 import { calculateHash, getLast, getNext, getPrev, isSorted } from "./utility";
 import { convertLongVowel, moraPattern } from "@/domain/japanese";
 import {
-  Note,
   Phrase,
   PhraseSource,
-  Tempo,
-  TimeSignature,
   PhraseKey,
-  Track,
   EditorFrameAudioQuery,
-  PhonemeTimingEditData,
 } from "@/store/type";
 import { FramePhoneme } from "@/openapi";
 import { NoteId, TrackId } from "@/type/preload";
+import {
+  Note,
+  PhonemeTimingEditData,
+  Tempo,
+  TimeSignature,
+  Track,
+} from "@/domain/project/type";
 
 // TODO: 後でdomain/type.tsに移す
 export type MeasuresBeats = {

--- a/src/sing/sequencerStateMachine/common.ts
+++ b/src/sing/sequencerStateMachine/common.ts
@@ -7,8 +7,9 @@ import {
   PreviewMode,
 } from "@/sing/viewHelper";
 import { Store } from "@/store";
-import { Note, SequencerEditTarget } from "@/store/type";
+import { SequencerEditTarget } from "@/store/type";
 import { NoteId, TrackId } from "@/type/preload";
+import { Note } from "@/domain/project/type";
 
 export type PositionOnSequencer = {
   readonly x: number;

--- a/src/sing/sequencerStateMachine/states/addNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/addNoteState.ts
@@ -8,7 +8,7 @@ import {
   SequencerStateDefinitions,
 } from "@/sing/sequencerStateMachine/common";
 import { NoteId, TrackId } from "@/type/preload";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import {
   getButton,
   getDoremiFromNoteNumber,

--- a/src/sing/sequencerStateMachine/states/editLyricState.ts
+++ b/src/sing/sequencerStateMachine/states/editLyricState.ts
@@ -6,7 +6,7 @@ import {
   SequencerStateDefinitions,
 } from "@/sing/sequencerStateMachine/common";
 import { NoteId, TrackId } from "@/type/preload";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import { splitLyricsByMoras } from "@/sing/domain";
 
 export class EditLyricState

--- a/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/editNotesToolIdleState.ts
@@ -10,7 +10,7 @@ import {
 } from "@/sing/sequencerStateMachine/common";
 import { getButton, isSelfEventTarget } from "@/sing/viewHelper";
 import { isOnCommandOrCtrlKeyDown } from "@/store/utility";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 
 export class EditNotesToolIdleState
   implements State<SequencerStateDefinitions, Input, Context>

--- a/src/sing/sequencerStateMachine/states/moveNoteState.ts
+++ b/src/sing/sequencerStateMachine/states/moveNoteState.ts
@@ -2,7 +2,7 @@ import { getOrThrow } from "@/helpers/mapHelper";
 import { State, SetNextState } from "@/sing/stateMachine";
 import { clamp } from "@/sing/utility";
 import { getButton, PREVIEW_SOUND_DURATION } from "@/sing/viewHelper";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import { TrackId, NoteId } from "@/type/preload";
 import {
   Context,

--- a/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteLeftState.ts
@@ -1,7 +1,7 @@
 import { getOrThrow } from "@/helpers/mapHelper";
 import { State, SetNextState } from "@/sing/stateMachine";
 import { getButton, PREVIEW_SOUND_DURATION } from "@/sing/viewHelper";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import { TrackId, NoteId } from "@/type/preload";
 import {
   Context,

--- a/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
+++ b/src/sing/sequencerStateMachine/states/resizeNoteRightState.ts
@@ -9,7 +9,7 @@ import {
   PositionOnSequencer,
   SequencerStateDefinitions,
 } from "@/sing/sequencerStateMachine/common";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import { getOrThrow } from "@/helpers/mapHelper";
 
 export class ResizeNoteRightState

--- a/src/sing/sequencerStateMachine/states/selectNotesToolIdleState.ts
+++ b/src/sing/sequencerStateMachine/states/selectNotesToolIdleState.ts
@@ -15,7 +15,7 @@ import {
   PREVIEW_SOUND_DURATION,
 } from "@/sing/viewHelper";
 import { isOnCommandOrCtrlKeyDown } from "@/store/utility";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 import { NoteId } from "@/type/preload";
 import { clamp } from "@/sing/utility";
 import { uuid4 } from "@/helpers/random";

--- a/src/sing/songTrackRendering.ts
+++ b/src/sing/songTrackRendering.ts
@@ -1,17 +1,13 @@
 import {
   EditorFrameAudioQuery,
   EditorFrameAudioQueryKey,
-  Note,
   PhraseKey,
-  Singer,
   SingingPitch,
   SingingPitchKey,
   SingingVoice,
   SingingVoiceKey,
   SingingVolume,
   SingingVolumeKey,
-  Tempo,
-  Track,
 } from "@/store/type";
 import {
   calculateHash,
@@ -31,6 +27,7 @@ import {
 import { FramePhoneme, Note as NoteForRequestToEngine } from "@/openapi";
 import { EngineId, NoteId, StyleId, TrackId } from "@/type/preload";
 import { getOrThrow } from "@/helpers/mapHelper";
+import { Note, Singer, Tempo, Track } from "@/domain/project/type";
 
 /**
  * レンダリングに必要なデータのスナップショット

--- a/src/sing/storeHelper.ts
+++ b/src/sing/storeHelper.ts
@@ -1,5 +1,5 @@
 import { NoteId } from "@/type/preload";
-import { Note } from "@/store/type";
+import { Note } from "@/domain/project/type";
 
 export function getOverlappingNoteIds(notes: Note[]): Set<NoteId> {
   const events: {

--- a/src/sing/utaformatixProject/common.ts
+++ b/src/sing/utaformatixProject/common.ts
@@ -1,4 +1,4 @@
-import { Tempo, TimeSignature, Track } from "@/store/type";
+import { Tempo, TimeSignature, Track } from "@/domain/project/type";
 
 export type VoicevoxScore = {
   tracks: Track[];

--- a/src/sing/utaformatixProject/toVoicevox.ts
+++ b/src/sing/utaformatixProject/toVoicevox.ts
@@ -3,7 +3,7 @@ import { VoicevoxScore } from "./common";
 import { DEFAULT_TPQN, createDefaultTrack } from "@/sing/domain";
 import { getDoremiFromNoteNumber } from "@/sing/viewHelper";
 import { NoteId } from "@/type/preload";
-import { Note, Tempo, TimeSignature, Track } from "@/store/type";
+import { Note, Tempo, TimeSignature, Track } from "@/domain/project/type";
 import { uuid4 } from "@/helpers/random";
 
 /** UtaformatixのプロジェクトをVoicevoxの楽譜データに変換する */

--- a/src/sing/workaroundKeyRangeAdjustment.ts
+++ b/src/sing/workaroundKeyRangeAdjustment.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger } from "@/helpers/log";
-import { Singer } from "@/store/type";
+import { Singer } from "@/domain/project/type";
 import { CharacterInfo, EngineId } from "@/type/preload";
 
 const logger = createLogger("sing/workaroundKeyRangeAdjustment");

--- a/src/store/project/index.ts
+++ b/src/store/project/index.ts
@@ -11,16 +11,12 @@ import {
   AudioItem,
   ProjectStoreState,
   ProjectStoreTypes,
-  Track,
 } from "@/store/type";
 import { TrackId } from "@/type/preload";
 import path from "@/helpers/path";
 import { getValueOrThrow, ResultError } from "@/type/result";
-import { LatestProjectType } from "@/domain/project/schema";
-import {
-  migrateProjectFileObject,
-  ProjectFileFormatError,
-} from "@/domain/project";
+import { LatestProjectType } from "@/infrastructures/projectFile/type";
+import { ProjectFileFormatError } from "@/infrastructures/projectFile/type";
 import {
   createDefaultTempo,
   createDefaultTimeSignature,
@@ -36,6 +32,8 @@ import {
 } from "@/components/Dialog/Dialog";
 import { uuid4 } from "@/helpers/random";
 import { recordToMap } from "@/sing/utility";
+import { Track } from "@/domain/project/type";
+import { migrateProjectFileObject } from "@/infrastructures/projectFile/migration";
 
 export const projectStoreState: ProjectStoreState = {
   savedLastCommandIds: { talk: null, song: null },

--- a/src/store/project/index.ts
+++ b/src/store/project/index.ts
@@ -75,6 +75,7 @@ const applySongProjectToStore = async (
       trackOrder.map((trackId): [TrackId, Track] => {
         const track = tracks[trackId];
         if (!track) throw new Error("track == undefined");
+        // TODO: トラックの変換処理を関数化する
         return [
           trackId,
           {

--- a/src/store/project/saveProjectHelper.ts
+++ b/src/store/project/saveProjectHelper.ts
@@ -1,7 +1,7 @@
 import { ActionContext } from "../type";
 import { showErrorDialog } from "@/components/Dialog/Dialog";
 import { getAppInfos } from "@/domain/appInfo";
-import { LatestProjectType } from "@/domain/project/schema";
+import { LatestProjectType } from "@/infrastructures/projectFile/type";
 import { DisplayableError } from "@/helpers/errorHelper";
 import { mapToRecord } from "@/sing/utility";
 import { ResultError } from "@/type/result";

--- a/src/store/project/saveProjectHelper.ts
+++ b/src/store/project/saveProjectHelper.ts
@@ -48,6 +48,7 @@ export async function writeProjectFile(
       timeSignatures,
       tracks: Object.fromEntries(
         [...tracks.entries()].map(([trackId, track]) => {
+          // TODO: トラックの変換処理を関数化する
           return [
             trackId,
             {

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2,21 +2,16 @@ import { ref, toRaw } from "vue";
 import { createPartialStore } from "./vuex";
 import { createUILockAction } from "./ui";
 import {
-  Tempo,
-  TimeSignature,
-  Note,
   SingingStoreState,
   SingingStoreTypes,
   SingingCommandStoreState,
   SingingCommandStoreTypes,
   SaveResultObject,
-  Singer,
   Phrase,
   transformCommandStore,
   SingingVoice,
   SequencerEditTarget,
   PhraseKey,
-  Track,
   SequenceId,
   SingingVolumeKey,
   SingingVolume,
@@ -98,7 +93,6 @@ import {
 } from "@/sing/utility";
 import { getWorkaroundKeyRangeAdjustment } from "@/sing/workaroundKeyRangeAdjustment";
 import { createLogger } from "@/helpers/log";
-import { noteSchema } from "@/domain/project/schema";
 import { getOrThrow } from "@/helpers/mapHelper";
 import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
 import { ufProjectToVoicevox } from "@/sing/utaformatixProject/toVoicevox";
@@ -128,6 +122,14 @@ import {
   VoiceSynthesisCompleteEvent,
   VolumeGenerationCompleteEvent,
 } from "@/sing/songTrackRendering";
+import {
+  Note,
+  Singer,
+  Tempo,
+  TimeSignature,
+  Track,
+} from "@/domain/project/type";
+import { noteSchema } from "@/domain/project/schema";
 
 const logger = createLogger("store/singing");
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -3484,6 +3484,7 @@ export const singingCommandStore = transformCommandStore(
               throw new Error("Track not found.");
             }
             const rawTrack = toRaw(selectedTrack);
+            // TODO: トラックの変換処理を関数化する
             return {
               name: rawTrack.name,
               singer: rawTrack.singer,
@@ -3531,6 +3532,7 @@ export const singingCommandStore = transformCommandStore(
               throw new Error("Track not found.");
             }
             const rawTrack = toRaw(track);
+            // TODO: トラックの変換処理を関数化する
             return {
               name: rawTrack.name,
               singer: rawTrack.singer,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -63,19 +63,19 @@ import {
   ConfirmDialogOptions,
   WarningDialogOptions,
 } from "@/components/Dialog/Dialog";
-import {
-  LatestProjectType,
-  noteSchema,
-  phonemeTimingEditSchema,
-  singerSchema,
-  tempoSchema,
-  timeSignatureSchema,
-} from "@/domain/project/schema";
 import { HotkeySettingType } from "@/domain/hotkeyAction";
 import {
   MultiFileProjectFormat,
   SingleFileProjectFormat,
 } from "@/sing/utaformatixProject/utils";
+import {
+  Note,
+  Singer,
+  Tempo,
+  TimeSignature,
+  Track,
+} from "@/domain/project/type";
+import { LatestProjectType } from "@/infrastructures/projectFile/type";
 
 /**
  * エディタ用のAudioQuery
@@ -749,34 +749,6 @@ export type AudioPlayerStoreTypes = {
 /*
  * Singing Store Types
  */
-
-// schemaはプロジェクトファイル用
-export type Tempo = z.infer<typeof tempoSchema>;
-
-export type TimeSignature = z.infer<typeof timeSignatureSchema>;
-
-export type Note = z.infer<typeof noteSchema>;
-
-export type Singer = z.infer<typeof singerSchema>;
-
-export type Track = {
-  name: string;
-  singer?: Singer;
-  keyRangeAdjustment: number; // 音域調整量
-  volumeRangeAdjustment: number; // 声量調整量
-  notes: Note[];
-  pitchEditData: number[]; // 値の単位はHzで、データが無いところはVALUE_INDICATING_NO_DATAの値
-  phonemeTimingEditData: Map<NoteId, PhonemeTimingEdit[]>;
-
-  solo: boolean;
-  mute: boolean;
-  gain: number;
-  pan: number;
-};
-
-export type PhonemeTimingEdit = z.infer<typeof phonemeTimingEditSchema>;
-
-export type PhonemeTimingEditData = Map<NoteId, PhonemeTimingEdit[]>;
 
 export type PhraseState =
   | "SINGER_IS_NOT_SET"

--- a/tests/unit/domain/project.spec.ts
+++ b/tests/unit/domain/project.spec.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { beforeEach, describe, expect, test } from "vitest";
-import { migrateProjectFileObject } from "@/domain/project";
+import { migrateProjectFileObject } from "@/infrastructures/projectFile/migration";
 import { EngineId, SpeakerId, StyleId } from "@/type/preload";
 import { resetMockMode } from "@/helpers/random";
 import path from "@/helpers/path";

--- a/tests/unit/domain/sing/applyPhonemeTimingEdit.spec.ts
+++ b/tests/unit/domain/sing/applyPhonemeTimingEdit.spec.ts
@@ -3,8 +3,9 @@ import { uuid4 } from "@/helpers/random";
 import { FramePhoneme } from "@/openapi";
 import { applyPhonemeTimingEditAndAdjust } from "@/sing/domain";
 import { createArray } from "@/sing/utility";
-import { EditorFrameAudioQuery, PhonemeTimingEdit } from "@/store/type";
+import { EditorFrameAudioQuery } from "@/store/type";
 import { NoteId } from "@/type/preload";
+import { PhonemeTimingEdit } from "@/domain/project/type";
 
 const frameRate = 93.75;
 

--- a/tests/unit/domain/sing/shouldPlayTracks.spec.ts
+++ b/tests/unit/domain/sing/shouldPlayTracks.spec.ts
@@ -1,7 +1,7 @@
 import { it, expect, describe } from "vitest";
 import { uuid4 } from "@/helpers/random";
 import { createDefaultTrack, shouldPlayTracks } from "@/sing/domain";
-import { Track } from "@/store/type";
+import { Track } from "@/domain/project/type";
 import { TrackId } from "@/type/preload";
 
 const createTrack = ({ solo, mute }: { solo: boolean; mute: boolean }) => {

--- a/tests/unit/lib/songTrackRenderer/type.ts
+++ b/tests/unit/lib/songTrackRenderer/type.ts
@@ -1,6 +1,6 @@
+import { Note } from "@/domain/project/type";
 import {
   EditorFrameAudioQueryKey,
-  Note,
   PhraseKey,
   SingingPitchKey,
   SingingVoiceKey,

--- a/tests/unit/lib/songTrackRenderer/utility.ts
+++ b/tests/unit/lib/songTrackRenderer/utility.ts
@@ -15,18 +15,12 @@ import {
 } from "@/sing/songTrackRendering";
 import { getOverlappingNoteIds } from "@/sing/storeHelper";
 import { calculateHash, getLast } from "@/sing/utility";
-import {
-  Note,
-  PhraseKey,
-  Singer,
-  SingingVoice,
-  Tempo,
-  Track,
-} from "@/store/type";
+import { PhraseKey, SingingVoice } from "@/store/type";
 import { EngineId, NoteId, StyleId, TrackId } from "@/type/preload";
 import { ExhaustiveError } from "@/type/utility";
 import { getOrThrow } from "@/helpers/mapHelper";
 import { createDefaultTrack } from "@/sing/domain";
+import { Note, Singer, Tempo, Track } from "@/domain/project/type";
 
 /**
  * SongTrackRenderer のテスト用のユーティリティー。


### PR DESCRIPTION
## 内容

現在のmainブランチでは、プロジェクトファイル（永続化）に関わる型と関数が`domain`ディレクトリ内で定義されていますが、関心の分離が守られていない（ドメインレイヤー内に永続化に関する知識が入っている）という問題があります。
プロジェクトファイル関連の型と関数を`domain`ディレクトリの外に出し、それらがドメインに依存するようにして、この問題を解決します。

具体的には、以下を行います。

- **ドメインの型とプロジェクトファイルの型を別ファイルに分離**
  - ドメインの型（`src/store/type.ts`で定義されていた型）は`src/domain/project/type.ts`に
  - プロジェクトファイルのスキーマは`src/infrastructures/projectFile/schema.ts`に
    - スキーマの名前も`projectSchema`から`projectFileSchema`に変更
  - プロジェクトファイルの型は`src/infrastructures/projectFile/type.ts`に
- **プロジェクトファイルのマイグレーションとバリデーションの処理を別ファイルに分離**
  - マイグレーションは`src/infrastructures/projectFile/migration.ts`に
  - バリデーションは`src/infrastructures/projectFile/validation.ts`に
- **ソングのトラックのみプロジェクトファイル用の型を定義**
  - プロジェクトファイル用のトラックの型を`SerializableTrack`として定義
- **トラックの変換処理を関数化するTODOコメントを追加**

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2675#discussion_r2160036766

## その他

typoのマイグレーションを行っているところでtypoのエラーが出ています…
（たぶんファイルを変更したから出たんだと思います）