### PR TITLE
fix: ソングエディタでvvproj以外のファイルからのインポートが動作していないのを修正

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1,4 +1,4 @@
-import { ref, toRaw } from "vue";
+import { ref } from "vue";
 import { createPartialStore } from "./vuex";
 import { createUILockAction } from "./ui";
 import {
@@ -3479,27 +3479,25 @@ export const singingCommandStore = transformCommandStore(
           );
 
           const filteredTracks = trackIndexes.map((trackIndex): Track => {
-            const track = tracks[trackIndex];
-            if (!track) {
+            const importedTrack = tracks[trackIndex];
+            if (!importedTrack) {
               throw new Error("Track not found.");
             }
-            const rawTrack = toRaw(selectedTrack);
-            // TODO: トラックの変換処理を関数化する
             return {
-              name: rawTrack.name,
-              singer: rawTrack.singer,
-              keyRangeAdjustment: rawTrack.keyRangeAdjustment,
-              volumeRangeAdjustment: rawTrack.volumeRangeAdjustment,
-              notes: track.notes.map((note) => ({
+              name: selectedTrack.name,
+              singer: selectedTrack.singer,
+              keyRangeAdjustment: selectedTrack.keyRangeAdjustment,
+              volumeRangeAdjustment: selectedTrack.volumeRangeAdjustment,
+              notes: importedTrack.notes.map((note) => ({
                 ...note,
                 id: NoteId(uuid4()),
               })),
-              pitchEditData: rawTrack.pitchEditData,
-              phonemeTimingEditData: rawTrack.phonemeTimingEditData,
-              solo: rawTrack.solo,
-              mute: rawTrack.mute,
-              gain: rawTrack.gain,
-              pan: rawTrack.pan,
+              pitchEditData: selectedTrack.pitchEditData,
+              phonemeTimingEditData: selectedTrack.phonemeTimingEditData,
+              solo: selectedTrack.solo,
+              mute: selectedTrack.mute,
+              gain: selectedTrack.gain,
+              pan: selectedTrack.pan,
             };
           });
 
@@ -3527,29 +3525,28 @@ export const singingCommandStore = transformCommandStore(
           }
 
           const filteredTracks = trackIndexes.map((trackIndex): Track => {
-            const track = tracks[trackOrder[trackIndex]];
-            if (!track) {
+            const importedTrack = tracks[trackOrder[trackIndex]];
+            if (!importedTrack) {
               throw new Error("Track not found.");
             }
-            const rawTrack = toRaw(track);
             // TODO: トラックの変換処理を関数化する
             return {
-              name: rawTrack.name,
-              singer: rawTrack.singer,
-              keyRangeAdjustment: rawTrack.keyRangeAdjustment,
-              volumeRangeAdjustment: rawTrack.volumeRangeAdjustment,
-              notes: rawTrack.notes.map((note) => ({
+              name: importedTrack.name,
+              singer: importedTrack.singer,
+              keyRangeAdjustment: importedTrack.keyRangeAdjustment,
+              volumeRangeAdjustment: importedTrack.volumeRangeAdjustment,
+              notes: importedTrack.notes.map((note) => ({
                 ...note,
                 id: NoteId(uuid4()),
               })),
-              pitchEditData: rawTrack.pitchEditData,
+              pitchEditData: importedTrack.pitchEditData,
               phonemeTimingEditData: recordToMap(
-                rawTrack.phonemeTimingEditData,
+                importedTrack.phonemeTimingEditData,
               ),
-              solo: rawTrack.solo,
-              mute: rawTrack.mute,
-              gain: rawTrack.gain,
-              pan: rawTrack.pan,
+              solo: importedTrack.solo,
+              mute: importedTrack.mute,
+              gain: importedTrack.gain,
+              pan: importedTrack.pan,
             };
           });
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -3490,7 +3490,7 @@ export const singingCommandStore = transformCommandStore(
               singer: rawTrack.singer,
               keyRangeAdjustment: rawTrack.keyRangeAdjustment,
               volumeRangeAdjustment: rawTrack.volumeRangeAdjustment,
-              notes: rawTrack.notes.map((note) => ({
+              notes: track.notes.map((note) => ({
                 ...note,
                 id: NoteId(uuid4()),
               })),

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -3473,9 +3473,8 @@ export const singingCommandStore = transformCommandStore(
             throw new Error("TPQN does not match. Must be converted.");
           }
 
-          const selectedTrack = getOrThrow(
-            state.tracks,
-            getters.SELECTED_TRACK_ID,
+          const selectedTrack = cloneWithUnwrapProxy(
+            getOrThrow(state.tracks, getters.SELECTED_TRACK_ID),
           );
 
           const filteredTracks = trackIndexes.map((trackIndex): Track => {
@@ -3484,20 +3483,11 @@ export const singingCommandStore = transformCommandStore(
               throw new Error("Track not found.");
             }
             return {
-              name: selectedTrack.name,
-              singer: selectedTrack.singer,
-              keyRangeAdjustment: selectedTrack.keyRangeAdjustment,
-              volumeRangeAdjustment: selectedTrack.volumeRangeAdjustment,
+              ...selectedTrack,
               notes: importedTrack.notes.map((note) => ({
                 ...note,
                 id: NoteId(uuid4()),
               })),
-              pitchEditData: selectedTrack.pitchEditData,
-              phonemeTimingEditData: selectedTrack.phonemeTimingEditData,
-              solo: selectedTrack.solo,
-              mute: selectedTrack.mute,
-              gain: selectedTrack.gain,
-              pan: selectedTrack.pan,
             };
           });
 


### PR DESCRIPTION
## 内容
#2675 でfilteredTracksを生成する際にnoteとしてインポートファイルから生成されたtracksを元にしたtrackではなくrawTrackの方を使うようになっていたので、それ以前の様にtrackを使うように戻しました。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #2692

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
