### PR TITLE
fix: デフォルトエンジンの「フォルダを開く」ボタンが表示されている問題を修正

### DIFF
--- a/src/backend/electron/renderer/menuBarData.ts
+++ b/src/backend/electron/renderer/menuBarData.ts
@@ -43,7 +43,7 @@ export const useElectronMenuBarData = (
             engineIcons.value[engineInfo.uuid],
           disableWhenUiLocked: false,
           subMenu: removeNullableAndBoolean([
-            Boolean(engineInfo.path) && {
+            !engineInfo.isDefault && {
               type: "button",
               label: "フォルダを開く",
               onClick: () => {


### PR DESCRIPTION
## 内容

デフォルトエンジンの「フォルダを開く」ボタンが表示されていました。
デフォルトエンジンのフォルダは開くことができないので表示されないようになっていたはずなので修正します。

## スクリーンショット・動画など

![スクリーンショット 2025-06-28 133012](https://github.com/user-attachments/assets/ca920c2f-9691-44b5-95bb-0a272861cd0a)

## その他

`engineInfo.path`には空文字列が入ることはないと思うのですが念のため空文字列になっても非表示になるようにしておきました。