### PR TITLE
chore(build): PyInstallerv6エンジンに変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ on:
         default: false
 
 env:
-  VOICEVOX_ENGINE_VERSION: 0.24.1
+  VOICEVOX_ENGINE_VERSION: 0.25.0-preview-pyinstaller.0
   VOICEVOX_RESOURCE_VERSION: 0.24.1
   VOICEVOX_EDITOR_VERSION:
     |- # releaseタグ名か、workflow_dispatchでのバージョン名か、999.999.999-developが入る


### PR DESCRIPTION
## 内容

PyInstaller更新により正常に動作するか確認用のPRです。
特にmacOSのDMG版が正常に動作するか確認する必要があります。

## 関連 Issue

ref VOICEVOX/voicevox_engine#1667
https://github.com/VOICEVOX/voicevox_engine/issues/1667#issuecomment-3041158926

## その他

多分変更するのはここだけでいいはず。