### PR TITLE
fix: レンダリング中かどうかのチェックが正しく行われていないのを修正

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2005,7 +2005,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       });
 
       // レンダリング中の場合は、レンダリングの中断を要求して終了する
-      if (state.nowRendering) {
+      if (songTrackRenderer.isRendering) {
         songTrackRenderer.requestRenderingInterruption();
         return;
       }
@@ -2047,7 +2047,9 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         mutations.SET_STOP_RENDERING_REQUESTED({
           stopRenderingRequested: true,
         });
-        songTrackRenderer.requestRenderingInterruption();
+        if (songTrackRenderer.isRendering) {
+          songTrackRenderer.requestRenderingInterruption();
+        }
 
         await createPromiseThatResolvesWhen(() => !state.nowRendering);
 


### PR DESCRIPTION
## 内容

`songTrackRenderer`の`requestRenderingInterruption`メソッドはレンダリング中でないときに呼び出すとエラーをthrowしますが、今のmainブランチでは、レンダリング中かどうかのチェックを`songTrackRenderer.isRendering`ではなく`state.nowRendering`で行っています。
また、`state.nowRendering`がtrueで`songTrackRenderer.isRendering`がfalseになるタイミングがあり、このタイミングで`requestRenderingInterruption`メソッドが呼ばれるとエラーが発生します。

現在のバージョン（0.24.1）ではエラーが発生することはなさそうで、もし発生したとしても致命的な状況にはならなそうですが、意図した挙動ではないので、このPRで修正を行います。

### エラーが発生するタイミング

`songTrackRenderer`の`render`メソッドの終了直前に`isRendering`がfalseになり、再レンダリング要求がある場合は再度`render`メソッドが実行されて`isRendering`がtrueになりますが、`render`メソッドは`await`しているので、`await`以降の処理は別の（新たな）マイクロタスクとして実行されます。

今のmainブランチのコードは、この`render`メソッドの終了と再実行の間に何も処理が挟まらない（`nowRendering`がtrueであれば`isRendering`もtrue）のを前提として実装されていますが、前述のとおり`render`メソッドの再実行は別のマイクロタスクとして実行されるので、この前に他のマイクロタスクが実行されると、そのタスクでは、`nowRendering`がtrueで`isRendering`がfalseになります。ここで`RENDER`アクションが呼び出されて
```ts
if (state.nowRendering) {
  songTrackRenderer.requestRenderingInterruption();
}
```
というコードが実行されると、`isRendering`はfalseなので`requestRenderingInterruption`メソッド内でエラーが発生します。

## 関連 Issue

## その他

グローバルな状態を非同期で複数回変更する処理（`RENDER`アクションのような処理）は、間にマイクロタスクが挟まって意図しないタイミングで状態が読み書きされるということが起こってしまう危険があるので、そういう処理はマクロタスクとして開始するようにしたほうが良いのかもしれません。