### PR TITLE
chore: GHA上で動かすcurlにも`-f`を付ける

### DIFF
--- a/.github/actions/download-engine/action.yml
+++ b/.github/actions/download-engine/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Get version
       shell: bash
       run: |
-        curl -s https://api.github.com/repos/${{ inputs.repo }}/releases \
+        curl -fs https://api.github.com/repos/${{ inputs.repo }}/releases \
             -H 'authorization: Bearer ${{ github.token }}' \
             -H 'content-type: application/json' > $TEMPDIR/releases.json
 
@@ -66,7 +66,7 @@ runs:
         cat $TEMPDIR/target.json | jq -er '[.assets[] | select(.name | contains("'$TARGET'") and endswith(".7z.txt"))][0]' > $TEMPDIR/assets_txt.json
         LIST_URL=$(cat $TEMPDIR/assets_txt.json | jq -er '.browser_download_url')
         echo "7z.txt url: $LIST_URL"
-        echo $LIST_URL | xargs curl -sSL --retry 3 --retry-delay 5 > $TEMPDIR/download_name.txt
+        echo $LIST_URL | xargs curl -fsSL --retry 3 --retry-delay 5 > $TEMPDIR/download_name.txt
         echo "Files to download:"
         cat $TEMPDIR/download_name.txt | sed -e 's|^|- |'
 
@@ -74,7 +74,7 @@ runs:
         for i in $(cat $TEMPDIR/download_name.txt); do
           URL=$(cat $TEMPDIR/target.json | jq -er "[.assets[] | select(.name == \"$i\")][0].browser_download_url")
           echo "Download url: $URL, dest: $TEMPDIR/$i"
-          curl -sSL $URL --retry 3 --retry-delay 5 -o $TEMPDIR/$i &
+          curl -fsSL $URL --retry 3 --retry-delay 5 -o $TEMPDIR/$i &
         done
         for job in `jobs -p`; do
           wait $job

--- a/tools/codesign_setup.bash
+++ b/tools/codesign_setup.bash
@@ -32,7 +32,7 @@ fi
 
 # eSignerCKAのセットアップ
 if [ ! -d "$ESIGNERCKA_INSTALL_DIR" ]; then
-    curl -LO --retry 3 --retry-delay 5 \
+    curl -fLO --retry 3 --retry-delay 5 \
         "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.6/SSL.COM-eSigner-CKA_1.0.6.zip"
     unzip -o SSL.COM-eSigner-CKA_1.0.6.zip
     mv *eSigner*CKA_*.exe eSigner_CKA_Installer.exe


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_engine#1775 および VOICEVOX/voicevox_core#1112 と同じことを行う。

[installer\_linux.sh](https://github.com/VOICEVOX/voicevox/blob/8558f68858f522b5fd63e9556028b0be9c52b549/build/installer_linux.sh)に関しては、`-f`は既に入っているので何もしない。`--retry`が入ってはいないが、 #2217 でもここには`--retry`は導入されなかったので今回もしない。

\[追記\] 仮にinstaller\_linux.shに`--retry`を入れようとなった場合は、"feat: "として別PRを作るのがよいのではと思ってます。

## 関連 Issue

## スクリーンショット・動画など

## その他
