### PR TITLE
refactor: storeにおけるDot記法への移行により使われなくなったリテラル記法インターフェースの削除

### DIFF
--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -179,11 +179,9 @@ export interface StoreOptions<
   strict?: boolean;
   devtools?: boolean;
 }
-
 export interface ActionContext<S, R, SG extends GettersBase> {
   /**
-   * @deprecated
-   * 本メソッドは非推奨です。代わりにactionsを使ってください。
+   * @deprecated 本メソッドは非推奨です。代わりにactionsを使ってください。
    *
    * VOICEVOXでは独自の型定義ラッパーを用いてvuexを利用しており、
    * 型定義ラッパーを用いた呼び出しが推奨されます。
@@ -192,8 +190,7 @@ export interface ActionContext<S, R, SG extends GettersBase> {
    */
   dispatch: DefaultDispatch;
   /**
-   * @deprecated
-   * 本メソッドは非推奨です。代わりにmutationsを使ってください。
+   * @deprecated 本メソッドは非推奨です。代わりにmutationsを使ってください。
    *
    * VOICEVOXでは独自の型定義ラッパーを用いてvuexを利用しており、
    * 型定義ラッパーを用いた呼び出しが推奨されます。


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox/issues/2088

上記issueによってVOICEVOXのstoreにおけるMutation, Actionへの呼び出しが`commit("MUT_NAME")`、`dispatch("ACT_NAME")`から`mutations.MUTNAME()`、`actions.ACT_NAME()`にて呼び出せるようになりました。

これに伴い`commit`や`dispatch`は使うべきではなくなったため、vuexデフォルトの型へ戻します。
また、`@deprecated`を付け、間違えて使わないように誘導を行います。


## 関連 Issue

close #2088 

## スクリーンショット・動画など


## その他
