### PR TITLE
fix: 利用規約のテキスト取得メソッドのバグを修正

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -171,7 +171,7 @@ export const indexStore = createPartialStore<IndexStoreTypes>({
 
   GET_POLICY_TEXT: {
     async action() {
-      return await window.backend.getTextAsset("PrivacyPolicy");
+      return await window.backend.getTextAsset("Policy");
     },
   },
 

--- a/tests/e2e/browser/初回起動時.spec.ts
+++ b/tests/e2e/browser/初回起動時.spec.ts
@@ -11,7 +11,7 @@ test("起動したら利用規約ダイアログと利用規約内容が表示�
   });
 
   await test.step("利用規約の内容が表示されていることを確認", async () => {
-    expect(page.getByText("ダミー利用規約").isVisible()).toBeTruthy();
+    await expect(page.getByText("ダミー利用規約")).toBeVisible();
   });
 });
 

--- a/tests/e2e/browser/初回起動時.spec.ts
+++ b/tests/e2e/browser/初回起動時.spec.ts
@@ -11,7 +11,7 @@ test("起動したら利用規約ダイアログと利用規約内容が表示�
   });
 
   await test.step("利用規約の内容が表示されていることを確認", async () => {
-    await expect(page.getByText("ダミー利用規約")).toBeVisible();
+    expect(page.getByText("ダミー利用規約").isVisible()).toBeTruthy();
   });
 });
 

--- a/tests/e2e/browser/初回起動時.spec.ts
+++ b/tests/e2e/browser/初回起動時.spec.ts
@@ -3,9 +3,15 @@ import { gotoHome } from "../navigators";
 
 test.beforeEach(gotoHome);
 
-test("起動したら「利用規約に関するお知らせ」が表示される", async ({ page }) => {
+test("起動したら利用規約ダイアログと利用規約内容が表示される", async ({
+  page,
+}) => {
   await expect(page.getByText("利用規約に関するお知らせ")).toBeVisible({
     timeout: 90 * 1000,
+  });
+
+  await test.step("利用規約の内容が表示されていることを確認", async () => {
+    await expect(page.getByText("ダミー利用規約")).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## 内容

利用規約が表示されていないバグがあったため修正です。

## その他
