### PR TITLE
feat: ビルドしたAppImageを展開して編集してappimagetoolで再度パッケージする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,13 @@ jobs:
 
           $sed -i 's/"version": "999.999.999"/"version": "${{ env.VOICEVOX_EDITOR_VERSION }}"/' package.json
 
+      # for appimagetool v1.9.0
+      - name: install desktop-file-utils
+        if: startsWith(matrix.artifact_name, 'linux-')
+        run: |
+          sudo apt-get update
+          sudo apt-get install desktop-file-utils
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 

--- a/build/appImageArtifactBuildCompleted.ts
+++ b/build/appImageArtifactBuildCompleted.ts
@@ -45,11 +45,11 @@ async function fixDesktopfile(desktopfilePath: string) {
   const desktopfile = await fs.readFile(desktopfilePath, {
     encoding: "utf-8",
   });
-  const fixdDesktopfile = desktopfile.replace(
+  const fixedDesktopfile = desktopfile.replace(
     /^(Exec=.*)( --no-sandbox(?= |$))(.*)/m,
     "$1$3",
   );
-  await fs.writeFile(desktopfilePath, fixdDesktopfile);
+  await fs.writeFile(desktopfilePath, fixedDesktopfile);
 }
 
 /*

--- a/build/appImageArtifactBuildCompleted.ts
+++ b/build/appImageArtifactBuildCompleted.ts
@@ -34,8 +34,8 @@ async function fixAppRun(appDir: string) {
       "electron-builder等の更新によりAppRunが予期せぬコードに変更されています。",
     );
   }
-  const fixdAppRun = appRun.replace(searchPattern, `$&\n${injectCode}`);
-  await fs.writeFile(appRunPath, fixdAppRun);
+  const fixedAppRun = appRun.replace(searchPattern, `$&\n${injectCode}`);
+  await fs.writeFile(appRunPath, fixedAppRun);
 }
 
 /**

--- a/build/appImageArtifactBuildCompleted.ts
+++ b/build/appImageArtifactBuildCompleted.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ArtifactCreated } from "electron-builder";
+
+const appimagetoolPath = path.join(
+  import.meta.dirname,
+  "..",
+  "vendored",
+  "appimagetool",
+  "appimagetool.AppImage",
+);
+
+const injectCode = `
+if ! unshare -Ur true 2>/dev/null ; then
+  args+=("--no-sandbox")
+  NUMBER_OF_ARGS=$((NUMBER_OF_ARGS + 1))
+fi
+`;
+
+/**
+ * AppRunスクリプトに'--no-sandbox'が必要か判定して自動的に追加するコードを注入する
+ */
+async function fixAppRun(appDir: string) {
+  const appRunPath = path.join(appDir, "AppRun");
+  const appRun = await fs.readFile(appRunPath, {
+    encoding: "utf-8",
+  });
+  const searchPattern = /^args=\("\$@"\)\nNUMBER_OF_ARGS="\$#"$/m;
+  if (!searchPattern.test(appRun) || appRun.search("--no-sandbox") >= 0) {
+    // 想定するコードが存在しない、または同様のコードが実装されている可能性がある
+    throw new Error(
+      "electron-builder等の更新によりAppRunが予期せぬコードに変更されています。",
+    );
+  }
+  const fixdAppRun = appRun.replace(searchPattern, `$&\n${injectCode}`);
+  await fs.writeFile(appRunPath, fixdAppRun);
+}
+
+/**
+ * デフォルトで作成される.desktopファイルのExecキーから'--no-sandbox'を取り除く
+ */
+async function fixDesktopfile(desktopfilePath: string) {
+  const desktopfile = await fs.readFile(desktopfilePath, {
+    encoding: "utf-8",
+  });
+  const fixdDesktopfile = desktopfile.replace(
+    /^(Exec=.*)( --no-sandbox(?= |$))(.*)/m,
+    "$1$3",
+  );
+  await fs.writeFile(desktopfilePath, fixdDesktopfile);
+}
+
+/*
+ * electron-builderが作成したAppImageを修正する
+ * appimagetoolで再パッケージすることでlibfuse2をインストール不要にする
+ */
+export async function appImageArtifactBuildCompleted(
+  artifactCreated: ArtifactCreated,
+) {
+  const artifactPath = artifactCreated.file;
+  const tempDir = await fs.mkdtemp(path.join(tmpdir(), "appimage-build"));
+  try {
+    execFileSync(artifactPath, ["--appimage-extract"], { cwd: tempDir });
+    const appDir = path.join(tempDir, "squashfs-root");
+    await fixAppRun(appDir);
+    const productFilename = artifactCreated.packager.appInfo.productFilename;
+    const desktopfilePath = path.join(appDir, `${productFilename}.desktop`);
+    await fixDesktopfile(desktopfilePath);
+    execFileSync(appimagetoolPath, ["--no-appstream", appDir, artifactPath], {
+      stdio: "inherit",
+    });
+    // NOTE: AutoUpdaterを使う場合'app-builder-bin blockmap ...'を使用してblockmapを生成する
+    // 恐らく以下のコードで動作するようになるかもしれない。
+    // import { appBuilderPath } from "app-builder-bin";
+    // const result = execFileSync(appBuilderPath, [
+    //   "blockmap",
+    //   "--input",
+    //   artifactPath,
+    // ]);
+    // const updateInfo = JSON.parse(result.toString());
+    // artifactCreated.updateInfo = updateInfo;
+  } finally {
+    await fs.rm(tempDir, { recursive: true });
+  }
+}

--- a/build/appImageArtifactBuildCompleted.ts
+++ b/build/appImageArtifactBuildCompleted.ts
@@ -13,6 +13,7 @@ const appimagetoolPath = path.join(
 );
 
 const fixedAppRunCode = `#!/bin/bash
+set -e
 apprun="\${APPDIR:-$(dirname "$0")}/AppRunOriginal"
 if unshare -Ur true 2>/dev/null ; then
   exec "$apprun" "$@"

--- a/build/artifactBuildCompleted.ts
+++ b/build/artifactBuildCompleted.ts
@@ -1,0 +1,12 @@
+import { ArtifactCreated } from "electron-builder";
+import { appImageArtifactBuildCompleted } from "./appImageArtifactBuildCompleted";
+
+export default async function artifactBuildCompleted(
+  artifactCreated: ArtifactCreated,
+) {
+  const platformName = artifactCreated.packager.platform.name;
+  const targetName = artifactCreated.target?.name;
+  if (platformName === "linux" && targetName === "appImage") {
+    await appImageArtifactBuildCompleted(artifactCreated);
+  }
+}

--- a/build/electronBuilderConfig.ts
+++ b/build/electronBuilderConfig.ts
@@ -4,6 +4,7 @@ import { config } from "dotenv";
 import { Configuration as ElectronBuilderConfiguration } from "electron-builder";
 import { z } from "zod";
 import afterAllArtifactBuild from "./afterAllArtifactBuild";
+import artifactBuildCompleted from "./artifactBuildCompleted";
 
 const rootDir = path.join(import.meta.dirname, "..");
 const dotenvPath = path.join(rootDir, ".env.production");
@@ -109,6 +110,7 @@ const builderOptions: ElectronBuilderConfiguration = {
   appId: "jp.hiroshiba.voicevox",
   copyright: "Hiroshiba Kazuyuki",
   afterAllArtifactBuild,
+  artifactBuildCompleted,
   win: {
     icon: "public/icon.png",
     target: [

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -412,8 +412,7 @@ DESKTOP_FILE=$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -1)
 chmod +x "${DESKTOP_FILE}"
 
 ESCAPED_APP_DIR=$(echo "$APP_DIR" | sed 's/\//\\\//g')
-# TODO: --no-sandboxをつけているのはセキュリティが強化されたUbuntu 24.04で動作させるため ref:https://github.com/electron/electron/issues/41066。外せたら外す。
-sed "s/Exec=.*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE} %U --no-sandbox/" "${DESKTOP_FILE}" > _
+sed "s/Exec=[^[:space:]]*/Exec=${ESCAPED_APP_DIR}\/${APPIMAGE}/" "${DESKTOP_FILE}" > _
 mv _ "${DESKTOP_FILE}"
 
 mkdir -p "${DESKTOP_ENTRY_INSTALL_DIR}"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "preinstall": "npx -y only-allow pnpm",
     "postinstall": "pnpm run postinstall:packages && pnpm run postinstall:download-scripts",
     "postinstall:packages": "electron-builder install-app-deps && playwright install chromium",
-    "postinstall:download-scripts": "tsx tools/download7z.ts && tsx tools/downloadTypos.ts",
+    "postinstall:download-scripts": "tsx tools/download7z.ts && tsx tools/downloadTypos.ts && tsx tools/downloadAppimagetool.ts",
     "postuninstall": "electron-builder install-app-deps"
   },
   "dependencies": {

--- a/tools/downloadAppimagetool.ts
+++ b/tools/downloadAppimagetool.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { retryFetch } from "./helper";
+
+const APPIMAGETOOL_VERSION = "1.9.0";
+
+const distDir = path.join(
+  import.meta.dirname,
+  "..",
+  "vendored",
+  "appimagetool",
+);
+const appimagetoolPath = path.join(distDir, "appimagetool.AppImage");
+const versionFilePath = path.join(distDir, "version.txt");
+
+async function isDownloaded() {
+  try {
+    await fs.access(appimagetoolPath);
+    await fs.access(versionFilePath);
+  } catch {
+    return false;
+  }
+  const currentVersion = await fs.readFile(versionFilePath, "utf-8");
+  if (currentVersion !== APPIMAGETOOL_VERSION) {
+    await fs.rm(distDir, { recursive: true });
+    return false;
+  }
+  return true;
+}
+
+function getDownloadURL() {
+  const arch: Record<string, string> = {
+    arm: "armhf",
+    arm64: "aarch64",
+    ia32: "i686",
+    x64: "x86_64",
+  };
+  return `https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-${arch[process.arch]}.AppImage`;
+}
+
+async function main() {
+  if (await isDownloaded()) {
+    console.log("appimagetool already downloaded");
+    return;
+  }
+  await fs.mkdir(distDir, { recursive: true });
+  const url = getDownloadURL();
+  const result = await retryFetch(url);
+  const data = await result.bytes();
+  await fs.writeFile(appimagetoolPath, data, { mode: 0o755 });
+  await fs.writeFile(versionFilePath, APPIMAGETOOL_VERSION);
+}
+
+if (process.platform === "linux") {
+  await main();
+}


### PR DESCRIPTION
## 内容

ビルドしたAppImageを一度展開して編集してappimagetoolで再度パッケージすることで以下の問題を解決・回避します

AppRun(AppImageが起動したときに一番最初に実行されるスクリプト)にuser namespaceが使用可能か確認して自動的に`--no-sandbox`を引数に追加するようにします。
これによりuser namespaceが制限されているUbuntu 24.04では起動できるようにしつつ他の使用可能なディストリビューションではセキュリティを維持することができます。
ref #2071

appimagetoolでパッケージすることで起動するためにlibfuse2のインストールを不要にします。

## 関連 Issue

- resolve #1006
(libfuse2が不要になるため結果的に不要になる)

## その他

動作確認は主にVirtualBox上のUbuntu 24.04上で行っています。

### ビルドの安定性に関する問題

appimagetoolに安定性の問題があります。
appimagetool 1.9.0の動作するために`desktop-file-validate`が必要なので`desktop-file-utils`をインストールする必要があります。
Continuous buildの方は不要ですがmainにコミットがある度に更新されているようなので安定性が確保できません。

また、appimagetoolはデフォルトではビルドの度に自動的に`type2-runtime`を[Continuous build](https://github.com/AppImage/type2-runtime/releases/tag/continuous)からダウンロードしてきます。
これもmainにコミットがある度に更新されるようです。
runtimeについてはこれ以外に使えるビルド済みバイナリは用意されていないようです。

### AutoUpdaterへの影響

ビルド後にファイルを差し替えするためAutoUpdater(特に差分更新の機能)が機能しなくなると思います。
念のため機能するようにできるコードをコメントアウトして書いておきましたが動作チェックはできていません。

---

他にはelectron-builderの更新に気を使う必要があるということでしょうか?
この辺りの更新作業がelectron-builder側で進んでいる様子はありませんが…