### PR TITLE
AppImageを圧縮&分割せず配布する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -446,43 +446,22 @@ jobs:
         env:
           THUMBPRINT_PATH: /tmp/esignercka_thumbprint.txt
 
-      - name: Create Linux AppImage split
-        if: endsWith(matrix.installer_artifact_name, '-appimage')
-        run: |
-          cd dist_electron/
-
-          for appImageFile in *.AppImage; do
-            echo "Splitting ${appImageFile}"
-
-            # compressed to MyArtifact.AppImage.7z.001, MyArtifact.AppImage.7z.002, ...
-            7z -v1g a "${{ matrix.linux_appimage_7z_name }}.7z" "${appImageFile}"
-
-            # Output split archive name<TAB>size<TAB>hash list to myartifact.7z.txt
-            ls "${{ matrix.linux_appimage_7z_name }}.7z".* > archives_name.txt
-            stat --printf="%s\n" "${{ matrix.linux_appimage_7z_name }}.7z".* > archives_size.txt
-            md5sum "${{ matrix.linux_appimage_7z_name }}.7z".* | awk '{print $1}' | tr a-z A-Z > archives_hash.txt
-
-            paste -d '\t' archives_name.txt archives_size.txt archives_hash.txt > archives.txt
-
-            mv archives.txt "${{ matrix.installer_artifact_name }}.7z.txt"
-          done
-
-      - name: Upload Linux AppImage split to Artifacts
+      - name: Upload Linux AppImage to Artifacts
         if: endsWith(matrix.installer_artifact_name, '-appimage') && github.event.inputs.upload_artifact == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.installer_artifact_name }}-release
           path: |-
-            dist_electron/*.7z.*
+            dist_electron/*.AppImage
 
-      - name: Upload Linux AppImage split to Release Assets
+      - name: Upload Linux AppImage to Release Assets
         if: endsWith(matrix.installer_artifact_name, '-appimage') && (github.event.release.tag_name || github.event.inputs.version) != ''
         uses: softprops/action-gh-release@v2
         with:
           prerelease: ${{ github.event.inputs.prerelease }}
           tag_name: ${{ env.VOICEVOX_EDITOR_VERSION }}
           files: |-
-            dist_electron/*.7z.*
+            dist_electron/*.AppImage
           target_commitish: ${{ github.sha }}
 
       - name: Upload macOS dmg to Artifacts


### PR DESCRIPTION
## 内容

AppImageは既にSquashFSで圧縮されているので7zと分割をやめる。チェックサム用のtxtも消せる。
.tar.gzより小さい。