### PR TITLE
build: {ja,en-US}.pakロケール以外の言語パックを削除する

### DIFF
--- a/build/electronBuilderConfig.ts
+++ b/build/electronBuilderConfig.ts
@@ -111,6 +111,7 @@ const builderOptions: ElectronBuilderConfiguration = {
   copyright: "Hiroshiba Kazuyuki",
   afterAllArtifactBuild,
   artifactBuildCompleted,
+  electronLanguages: ["en-US", "ja"],
   win: {
     icon: "public/icon.png",
     target: [


### PR DESCRIPTION
## 内容

[electronLanguages](https://github.com/VOICEVOX/voicevox/pull/2751#issuecomment-3335114827)で不要なロケールを消す。
macOSには何故か聞かない。#2751 を置き換える。

## 関連 Issue

close #2748