### PR TITLE
展開時間とサイズの為にAppImageでzstdを使用

### DIFF
--- a/build/appImageArtifactBuildCompleted.ts
+++ b/build/appImageArtifactBuildCompleted.ts
@@ -48,6 +48,7 @@ async function fixDesktopfile(desktopfilePath: string) {
 /*
  * electron-builderが作成したAppImageを修正する
  * appimagetoolで再パッケージすることでlibfuse2をインストール不要にする
+ * 旧バージョンの為に--comp zstdを明示
  */
 export async function appImageArtifactBuildCompleted(
   artifactCreated: ArtifactCreated,
@@ -61,7 +62,7 @@ export async function appImageArtifactBuildCompleted(
     const productFilename = artifactCreated.packager.appInfo.productFilename;
     const desktopfilePath = path.join(appDir, `${productFilename}.desktop`);
     await fixDesktopfile(desktopfilePath);
-    execFileSync(appimagetoolPath, ["--no-appstream", appDir, artifactPath], {
+    execFileSync(appimagetoolPath, ["--no-appstream", "--comp", "zstd", appDir, artifactPath], {
       stdio: "inherit",
     });
     // NOTE: AutoUpdaterを使う場合'app-builder-bin blockmap ...'を使用してblockmapを生成する


### PR DESCRIPTION
## 内容

0.24.2 GPU版のAppImageがZSTDでなかったのでZSTDにする。
前: 3.1 GB (3114807919 バイト), --appimage-extract:  8.23 secs 
後: 2.9 GB (2894887416 バイト), --appimage-extract:  5.21 secs
なので上位互換。