### PR TITLE
feat: ElectronのNode.jsおよびChromiumの正確なバージョンをターゲットにビルドするようにする

### DIFF
--- a/build/getElectronVersion.mjs
+++ b/build/getElectronVersion.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+
 // Electron内部のNode.jsのバージョンとChromiumのバージョンを取得するスクリプト
 // 必ずElectronを使って実行する必要がある。
 import { app } from "electron";

--- a/build/getElectronVersion.mjs
+++ b/build/getElectronVersion.mjs
@@ -7,11 +7,6 @@ process.on("uncaughtException", () => {
   process.exit(1);
 });
 
-/**
- * @param {string} prefix
- * @param {string} rawVersion
- * @return {string}
- */
 function processVersion(prefix, rawVersion) {
   const version = rawVersion.split(".").slice(0, 3).join(".");
   return `${prefix}${version}`;

--- a/build/getElectronVersion.mjs
+++ b/build/getElectronVersion.mjs
@@ -1,0 +1,25 @@
+// @ts-check
+// Electron内部のNode.jsのバージョンとChromiumのバージョンを取得するスクリプト
+// 必ずElectronを使って実行する必要がある。
+import { app } from "electron";
+process.on("uncaughtException", () => {
+  process.exit(1);
+});
+
+/**
+ * @param {string} prefix
+ * @param {string} rawVersion
+ * @return {string}
+ */
+function processVersion(prefix, rawVersion) {
+  const version = rawVersion.split(".").slice(0, 3).join(".");
+  return `${prefix}${version}`;
+}
+
+process.stdout.write(
+  JSON.stringify({
+    node: processVersion("node", process.versions.node),
+    chrome: processVersion("chrome", process.versions.chrome),
+  }),
+);
+app.quit();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
 /// <reference types="vitest" />
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { rm } from "node:fs/promises";
 import electron from "vite-plugin-electron/simple";
 import tsconfigPaths from "vite-tsconfig-paths";
 import vue from "@vitejs/plugin-vue";
+import electronPath from "electron";
 import checker from "vite-plugin-checker";
 import { BuildOptions, defineConfig, loadEnv, Plugin } from "vite";
 import { quasar } from "@quasar/vite-plugin";
@@ -23,6 +25,19 @@ const isBrowser = process.env.VITE_TARGET === "browser";
 const isProduction = process.env.NODE_ENV === "production";
 
 const ignorePaths = (paths: string[]) => paths.map((path) => `!${path}`);
+
+function getElectronTargetVersion(): {
+  node: string;
+  chrome: string;
+} {
+  // @ts-expect-error: Electronの外でelectronをインポートするとファイルパスが得られる
+  const result = execFileSync(electronPath, [
+    "--no-sandbox",
+    path.join(import.meta.dirname, "build/getElectronVersion.mjs"),
+  ]);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return JSON.parse(result);
+}
 
 export default defineConfig((options) => {
   const mode = z
@@ -58,6 +73,10 @@ export default defineConfig((options) => {
     ? "inline"
     : false;
 
+  const electronTargetVersion = isElectron
+    ? getElectronTargetVersion()
+    : undefined;
+
   // ref: electronの起動をスキップしてデバッグ起動を軽くする
   const skipLaunchElectron =
     mode === "test" || process.env.SKIP_LAUNCH_ELECTRON === "1";
@@ -66,6 +85,7 @@ export default defineConfig((options) => {
     root: path.resolve(import.meta.dirname, "src"),
     envDir: import.meta.dirname,
     build: {
+      target: electronTargetVersion?.chrome,
       outDir: path.resolve(import.meta.dirname, "dist"),
       chunkSizeWarningLimit: 10000,
       sourcemap,
@@ -125,6 +145,7 @@ export default defineConfig((options) => {
                   }),
               ],
               build: {
+                target: electronTargetVersion?.node,
                 outDir: path.resolve(import.meta.dirname, "dist"),
                 sourcemap,
               },
@@ -143,6 +164,7 @@ export default defineConfig((options) => {
                 isProduction && checkSuspiciousImportsPlugin({}),
               ],
               build: {
+                target: electronTargetVersion?.chrome,
                 outDir: path.resolve(import.meta.dirname, "dist"),
                 sourcemap,
               },


### PR DESCRIPTION
## 内容

Viteの`target`をビルドするElectronのバージョンに合わせてピンポイントで指定するようにします。
これにより僅かにビルド後のファイルサイズが減少します。

ブラウザ版はViteのデフォルトのままです。

## その他

[Vite v6のデフォルト](https://v6.vite.dev/config/build-options.html#build-target)は`'modules'`であり具体的には`['es2020', 'edge88', 'firefox78', 'chrome87', 'safari14']`であり若干古いです。