### PR TITLE
fix: `ButtonToggleCell`の選択済みボタンをクリックすると未選択状態になる問題を修正

### DIFF
--- a/src/components/Dialog/SettingDialog/ButtonToggleCell.vue
+++ b/src/components/Dialog/SettingDialog/ButtonToggleCell.vue
@@ -2,7 +2,16 @@
 
 <template>
   <BaseRowCard :title :description :disabled="disable">
-    <BaseToggleGroup v-model="model" type="single" :disabled="disable">
+    <BaseToggleGroup
+      :modelValue="model"
+      type="single"
+      :disabled="disable"
+      @update:modelValue="
+        (val) => {
+          if (typeof val !== 'undefined') model = val;
+        }
+      "
+    >
       <template v-for="option in options" :key="option.label">
         <BaseTooltip
           v-if="option.description != null"


### PR DESCRIPTION
## 内容

設定ダイアログで2種類以上の設定から1つを選ぶボタンで既に選択済みのボタンを押すと何も設定されていない状態になってしまう問題を修正します。

## 関連 Issue

fix #2760
