### PR TITLE
chore: `updateEngineSetting`をインライン化

### DIFF
--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -337,13 +337,6 @@ export class EngineAndVvppController {
     }
   }
 
-  /** エンジンの設定を更新し、保存する */
-  updateEngineSetting(engineId: EngineId, engineSetting: EngineSettingType) {
-    const engineSettings = this.configManager.get("engineSettings");
-    engineSettings[engineId] = engineSetting;
-    this.configManager.set(`engineSettings`, engineSettings);
-  }
-
   // エンジンの準備と起動
   async launchEngines() {
     // AltPortInfosを再生成する。

--- a/src/backend/electron/ipcMainHandle.ts
+++ b/src/backend/electron/ipcMainHandle.ts
@@ -304,7 +304,9 @@ export function getIpcMainHandle(params: {
     },
 
     SET_ENGINE_SETTING: async (_, engineId, engineSetting) => {
-      engineAndVvppController.updateEngineSetting(engineId, engineSetting);
+      const engineSettings = configManager.get("engineSettings");
+      engineSettings[engineId] = engineSetting;
+      configManager.set("engineSettings", engineSettings);
     },
 
     SET_NATIVE_THEME: (_, source) => {


### PR DESCRIPTION
## 内容

メソッドにするほどのものではない不要っぽい処理をインライン化しました。

- `src/backend/electron/ipcMainHandle.ts:306` でエンジン設定更新処理を直接 `configManager` に適用するようインライン化。
- `src/backend/electron/engineAndVvppController.ts:340` から不要になった `updateEngineSetting` メソッドを削除。

## 関連 Issue
- なし

## スクリーンショット・動画など
- UI 変更なし

## その他

