### PR TITLE
chore(build): .AppImage.7zの圧縮レベルを0にする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -454,8 +454,10 @@ jobs:
           for appImageFile in *.AppImage; do
             echo "Splitting ${appImageFile}"
 
-            # compressed to MyArtifact.AppImage.7z.001, MyArtifact.AppImage.7z.002, ...
-            7z -v1g a "${{ matrix.linux_appimage_7z_name }}.7z" "${appImageFile}"
+            # Split to MyArtifact.AppImage.7z.001, MyArtifact.AppImage.7z.002, ...
+            # Use compression level 0 since AppImage is already compressed
+            # .7z is needed for installer_linux.sh yet
+            7z -mx=0 -v1g a "${{ matrix.linux_appimage_7z_name }}.7z" "${appImageFile}"
 
             # Output split archive name<TAB>size<TAB>hash list to myartifact.7z.txt
             ls "${{ matrix.linux_appimage_7z_name }}.7z".* > archives_name.txt


### PR DESCRIPTION
## 内容

AppImageは圧縮済みなので、7zの圧縮レベルを0にして展開を早くします。
7z無しで単に分割する(#2750)とスクリプトの互換性が壊れる為。
残念ながら、この方法ではインストール中にディスク上に大きなファイルが出現するのまでは防げません(`curl`から`7z -si`にパイプできそうですが、できません)。