### PR TITLE
fix: 再生中に無声化ツールチップが誤表示される問題を修正

### DIFF
--- a/src/components/Talk/AudioParameter.vue
+++ b/src/components/Talk/AudioParameter.vue
@@ -19,7 +19,7 @@
     </QBadge>
     <!-- NOTE: QTooltipをQSlider内にしたいがquasarが未対応っぽいので兄弟に -->
     <QTooltip
-      v-if="previewSlider.qSliderProps.disable.value"
+      v-if="disable"
       :delay="500"
       transitionShow="jump-up"
       transitionHide="jump-down"


### PR DESCRIPTION
## 内容
- スライダーの無声化ツールチップ表示条件を `props.disable` に限定し、UIロックのみで表示されないようにしました。

## 関連 Issue
- close #2783

## スクリーンショット・動画など
- なし

## その他
- 長さタブでも同じ `AudioParameter` を利用しているため、副作用として再生中に長さスライダーへ同ツールチップが出続ける挙動も解消されます。
