### PR TITLE
ci: macOS runner の macos-13 をアップデート

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
             app_asar_dir: prepackage/VOICEVOX.app/Contents/Resources
             installer_artifact_name: macos-cpu-x64-dmg
             macos_artifact_name: "VOICEVOX.${version}-x64.${ext}"
-            os: macos-13
+            os: macos-15-intel
           # macOS CPU (arm64)
           - artifact_name: macos-cpu-arm64-prepackage
             artifact_path: dist_electron/mac-arm64


### PR DESCRIPTION
## 内容

macOS x64ビルド用のrunnerを非推奨のmacos-13からmacos-15-intelに更新しました。
macos-13は2025年12月4日に廃止予定です。

## 関連 Issue

N/A

## スクリーンショット・動画など

N/A

## その他

🤖 Generated with [Claude Code](https://claude.com/claude-code)