### PR TITLE
feat: 排他モード解除後に音声出力が再開されるようにする

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1785,7 +1785,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         throw new Error("transport is undefined.");
       }
 
-      // NOTE: interruptedも考慮する
+      // TODO: interruptedも考慮する
       if (audioContext.state === "suspended") {
         // NOTE: resumeできない場合はエラーが発生する（排他モードで専有中など）
         await audioContext.resume();


### PR DESCRIPTION
## 内容

排他モード解除後に音声出力が再開されるように、再生開始時に`audioContext.state`が`suspended`の場合は`resume()`するようにします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2301

## その他