### PR TITLE
feat: ノーツ貼り付け時にクオンタイズを行わないようにする

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2780,7 +2780,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
   },
 
   COMMAND_PASTE_NOTES_FROM_CLIPBOARD: {
-    async action({ mutations, state, getters, actions }) {
+    async action({ mutations, getters, actions }) {
       // クリップボードからテキストを読み込む
       let clipboardText;
       try {
@@ -2804,23 +2804,16 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         });
       }
 
-      // パースしたJSONのノートの位置を現在の再生位置に合わせてクオンタイズして貼り付ける
+      // パースしたJSONのノートの位置を現在の再生位置に合わせて貼り付ける
       const currentPlayheadPosition = getters.PLAYHEAD_POSITION;
       const firstNotePosition = notes[0].position;
-      // TODO: クオンタイズの処理を共通化する
-      const snapType = state.sequencerSnapType;
-      const tpqn = state.tpqn;
-      const snapTicks = getNoteDuration(snapType, tpqn);
       const notesToPaste: Note[] = notes.map((note) => {
         // 新しい位置を現在の再生位置に合わせて計算する
-        const pasteOriginPos =
+        const pastePos =
           Number(note.position) - firstNotePosition + currentPlayheadPosition;
-        // クオンタイズ
-        const quantizedPastePos =
-          Math.round(pasteOriginPos / snapTicks) * snapTicks;
         return {
           id: NoteId(uuid4()),
-          position: quantizedPastePos,
+          position: pastePos,
           duration: Number(note.duration),
           noteNumber: Number(note.noteNumber),
           lyric: String(note.lyric),


### PR DESCRIPTION
## 内容

ノーツ貼り付け時にクオンタイズを行わないようにします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/issues/2799

## スクリーンショット・動画など

![貼り付け時にクオンタイズされないようにした](https://github.com/user-attachments/assets/6e677dce-4cb6-42c4-bf29-b57168d83632)

## その他

- 再生した後など、再生ヘッドがスナップしていないときに貼り付けを行うと、ノーツがグリッドに対して数tickずれますが、
オーバーラップはしないのと、まとめて移動すれば直せるので、クオンタイズは必要ないかなと思っています
- VoiSonaとSynthVは、貼り付け時にクオンタイズされないようになっていました