### PR TITLE
installer_linux.shからcurlをpacmanでいれるガイドを消す

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -76,9 +76,6 @@ CentOS/Fedora:
     sudo dnf install curl
 Or
     sudo yum install curl
-
-Arch Linux:
-    sudo pacman -S curl
 EOS
 fi
 


### PR DESCRIPTION
## 内容

`curl`がインストールされていないArch環境は既に壊れている(pacmanの依存)ので、`curl`を入れる案内は意味がありません。消して少しシンプルにします。