### PR TITLE
chore: installer_linux.shからmacOS向けのヒントを消す

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -116,9 +116,6 @@ Or
 
 Arch Linux:
     sudo pacman -S 7zip
-
-MacOS:
-    brew install p7zip
 EOS
 fi
 echo "[-] 7z command: ${COMMAND_7Z}"
@@ -174,9 +171,6 @@ Or
 
 Arch Linux
     sudo pacman -S libsndfile
-
-MacOS:
-    brew install libsndfile
 EOS
         if [ "${IGNORE_RTCOND}" != "1" ]; then
             exit 1


### PR DESCRIPTION
## 内容

installer_linux.shからmacOS向けのヒントを消す。誤混入と思われます。
(Linuxで`brew`は使えなくはないようですが)