### PR TITLE
fix: installer_linux.sh内のアイコンへのパスを新しいものに追従する

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -346,7 +346,7 @@ BANNER
 VOICEVOX_INSTALLED_FILES=(
     "${DESKTOP_ENTRY_INSTALL_DIR}/voicevox.desktop"
     "${ICON_INSTALL_DIR}/voicevox.png"
-    "${ICON_INSTALL_DIR}/hicolor/0x0/apps/voicevox.png"
+    "${ICON_INSTALL_DIR}/hicolor/256x256/apps/voicevox.png"
     "${MIME_INSTALL_DIR}/packages/voicevox.xml"
 )
 


### PR DESCRIPTION
## 内容

アイコンのファイル名(サイズ)を現在のサイズに直す。

## 関連 Issue

close #2834