### PR TITLE
installer_linux.sh: umask対策でcpをinstallに交換する

### DIFF
--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -412,9 +412,8 @@ mv "${DESKTOP_FILE}" "${DESKTOP_ENTRY_INSTALL_DIR}"
 # Install icon
 echo "[+] Installing icon..."
 
-mkdir -p "${ICON_INSTALL_DIR}"
+install -Dm644 squashfs-root/*.png -t "${ICON_INSTALL_DIR}"
 cp -r squashfs-root/usr/share/icons/* "${ICON_INSTALL_DIR}"
-cp squashfs-root/*.png "${ICON_INSTALL_DIR}"
 
 # Register file association
 echo "[+] Registering file association..."


### PR DESCRIPTION
## 内容

異常な`umask`にちょっとだけ強くするため、`cp`を`install`に交換する。