### PR TITLE
build: デスクトップエントリー(.desktop)を追加する

### DIFF
--- a/build/linux/README.md
+++ b/build/linux/README.md
@@ -9,3 +9,8 @@
 
 ファイルの関連付け用。インストーラーが使用します。
 サードパーティパッケージを作成する場合は`/usr/share/mime/packages/voicevox.xml`に配置する。
+
+## voicevox.desktop
+
+アプリケーションランチャーへの登録用。
+サードパーティパッケージを作成する場合は`/usr/share/applications/voicevox.desktop`に配置し、[icon-mac.png](../icons/icon-mac.png)を`/usr/share/pixmaps/voicevox.png`に配置する。

--- a/build/linux/voicevox.desktop
+++ b/build/linux/voicevox.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=VOICEVOX
+Exec=voicevox
+Terminal=false
+Type=Application
+Icon=voicevox
+StartupWMClass=VOICEVOX
+MimeType=application/x-voicevox;
+Categories=AudioVideo;


### PR DESCRIPTION
## 内容

現状のelectron-builderだと余計な圧縮操作(.debや.AppImage生成)無しでソースからvoicevoxを取得しようとした場合に.desktopを入手できないので、消極的にこれを追加します。

## 関連 Issue

close #2787