### PR TITLE
fix: 文の途中から連続再生した際、次以降の文が途中から再生される問題を修正

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1844,9 +1844,6 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
         player.addEventListener("waitstart", (e) => {
           void actions.START_PROGRESS();
           mutations.SET_ACTIVE_AUDIO_KEY({ audioKey: e.audioKey });
-          if (currentAudioKey !== e.audioKey) {
-            mutations.SET_AUDIO_PLAY_START_POINT({ startPoint: undefined });
-          }
           mutations.SET_AUDIO_NOW_GENERATING({
             audioKey: e.audioKey,
             nowGenerating: true,


### PR DESCRIPTION
## 内容

文の途中から連続再生すると、次以降の文も途中から再生される問題を修正します。

本修正により、次以降の文は常に文頭から再生されます。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #2634 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他