### PR TITLE
fix: ソング画面における立ち絵の横位置ずれを修正

### DIFF
--- a/src/components/Sing/CharacterPortrait.vue
+++ b/src/components/Sing/CharacterPortrait.vue
@@ -49,7 +49,7 @@ $portrait-min-height: 500px;
 }
 
 // 画面右下に固定表示
-// 幅固定、高さ可変、画像のアスペクト比を保持、heightを調整
+// 横位置を基準にして中央揃えで表示（画像のアスペクト比を保持）
 .character-portrait-wrap {
   position: absolute;
   right: 300px;


### PR DESCRIPTION
## 内容

ソング画面における立ち絵の横位置ずれを修正します。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #2503 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

左がPRです。

<img width="1914" height="970" alt="image" src="https://github.com/user-attachments/assets/62a7463a-ecd0-45bb-a7e0-76eb4a2657dd" />
<img width="1894" height="974" alt="image" src="https://github.com/user-attachments/assets/37f420b3-e70b-4b8b-8dcb-a0a34b2983f3" />
<img width="1909" height="958" alt="image" src="https://github.com/user-attachments/assets/37306a5c-2d30-4bbb-8e92-b2ec548b1d59" />


<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
