### PR TITLE
docs: Q&AのmacOS動作環境を13から14に更新

### DIFF
--- a/public/qAndA.md
+++ b/public/qAndA.md
@@ -9,7 +9,7 @@
 Windows／Mac／Linux 搭載の PC に対応しています。
 
 ※Windows：Windows 10・Windows 11  
-※Mac：macOS 13(Ventura)以降  
+※Mac：macOS 14(Sonoma)以降  
 ※Linux：Ubuntu 20.04・Ubuntu 22.04
 
 #### GPU 版


### PR DESCRIPTION
## 内容

よくあるご質問（Q&A）ページの動作環境において、macOSの最小要件をmacOS 13 (Ventura)からmacOS 14 (Sonoma)以降に更新しました。

