### PR TITLE
WaylandでIME入力可能になるように起動スクリプト修正

### DIFF
--- a/build/appImageArtifactBuildCompleted.ts
+++ b/build/appImageArtifactBuildCompleted.ts
@@ -15,10 +15,14 @@ const appimagetoolPath = path.join(
 const fixedAppRunCode = `#!/bin/bash
 set -e
 apprun="\${APPDIR:-$(dirname "$0")}/AppRunOriginal"
+wayland_flags=()
+if [ "\${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "\${WAYLAND_DISPLAY:-}" ]; then
+  wayland_flags+=(--enable-features=UseOzonePlatform --ozone-platform=wayland --enable-wayland-ime)
+fi
 if unshare -Ur true 2>/dev/null ; then
-  exec "$apprun" "$@"
+  exec "$apprun" "\${wayland_flags[@]}" "$@"
 else
-  exec "$apprun" "$@" --no-sandbox
+  exec "$apprun" "\${wayland_flags[@]}" "$@" --no-sandbox
 fi
 `;
 


### PR DESCRIPTION
## 内容

 Linux インストーラーの desktop エントリ生成を改善し、Wayland/X11 を起動時に自動判定して必要な起動フラグを付与するラッパー経由で起動するようにしまし た。
Wayland では IME が有効になる起動フラグが必要ですが、desktop エントリ生成でフラグが落ちていたため、起動時に環境を判定して適切なフラグを付与できるようにするためです

## 関連 Issue

直接は関係ないですが、Linuxでの日本語入力という文脈での関連

- #1494
- #1237

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
