### PR TITLE
ci: build.ymlで容量不足エラーを回避する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,9 +140,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Purge disk space at background
+      - name: Purge disk space
         if: startsWith(matrix.os, 'ubuntu-')
-        run: sudo rm -rf /usr/local/lib/android &
+        run: sudo rm -rf /usr/local/lib/android
 
       # NOTE: The default sed of macOS is BSD sed.
       #       There is a difference in specification between BSD sed and GNU sed,


### PR DESCRIPTION
## 内容

`build.ymlで`容量不足によるビルド失敗を、ubuntu-latest イメージのプレインストールAndroidを消す事で防ぎます。
バックグラウンドで削除してCIの遅延を抑えます(30 sくらい)。

## 関連 Issue

close #2893