### PR TITLE
ci: build.ymlの$sedをgsedへのsymlinkのsedにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,6 @@ jobs:
       ELECTRON_CACHE: .cache/electron
       ELECTRON_BUILDER_CACHE: .cache/electron-builder
       cache-version: v2
-      # GNUコマンド
-      sed: ${{ startsWith(matrix.os, 'macos-') && 'gsed' || 'sed' }}
     strategy:
       fail-fast: false
       matrix:
@@ -147,10 +145,11 @@ jobs:
       # NOTE: The default sed of macOS is BSD sed.
       #       There is a difference in specification between BSD sed and GNU sed,
       #       so you need to install GNU sed.
-      - name: Install GNU sed on macOS
+      - name: Install GNU sed as sed on macOS
         if: startsWith(matrix.os, 'macos-')
         run: |
           brew install gnu-sed
+          sudo cp -svf $(command -v gsed) $(brew --prefix)/bin/sed
 
       # Rename executable file
       # NOTE: If the CPU/DirectML/GPU builds have the same package name,
@@ -161,10 +160,10 @@ jobs:
       #       so different package/product names should be used for CPU/DirectML/GPU builds.
       - name: Replace package name & version
         run: |
-          $sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
-          # $sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
+          sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
+          # sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
 
-          $sed -i 's/"version": "999.999.999"/"version": "${{ env.VOICEVOX_EDITOR_VERSION }}"/' package.json
+          sed -i 's/"version": "999.999.999"/"version": "${{ env.VOICEVOX_EDITOR_VERSION }}"/' package.json
 
       # for appimagetool v1.9.0
       - name: install desktop-file-utils
@@ -225,18 +224,18 @@ jobs:
       - name: Overwrite .env.production for Linux
         if: startsWith(matrix.os, 'ubuntu-')
         run: |
-          $sed -i 's|run.exe|./run|g' .env.production
+          sed -i 's|run.exe|./run|g' .env.production
 
       - name: Overwrite .env.production for macOS
         if: startsWith(matrix.os, 'macos-')
         run: |
-          $sed -i 's|vv-engine/run.exe|../Resources/vv-engine/run|g' .env.production
+          sed -i 's|vv-engine/run.exe|../Resources/vv-engine/run|g' .env.production
 
       - name: Replace .env.production infomations
         run: |
           # GTM ID
           gtm_id=$(jq -er '.gtm_container_id' resource/editor/metas.json)
-          $sed -i 's/VITE_GTM_CONTAINER_ID=.*/VITE_GTM_CONTAINER_ID='"$gtm_id"'/' .env.production
+          sed -i 's/VITE_GTM_CONTAINER_ID=.*/VITE_GTM_CONTAINER_ID='"$gtm_id"'/' .env.production
 
       - name: Generate public/licenses.json
         run: pnpm run license:generate -o public/licenses.json


### PR DESCRIPTION
## 内容

`$sed`を`gsed`へのsymlinkの`sed`にして`$sed -i`忘れを防止します。