### PR TITLE
chore: Mac分岐のdead codeを削除

### DIFF
--- a/src/components/Menu/MenuBar/MinMaxCloseButtons.vue
+++ b/src/components/Menu/MenuBar/MinMaxCloseButtons.vue
@@ -1,47 +1,5 @@
 <template>
   <QBadge
-    v-if="$q.platform.is.mac"
-    transparent
-    color="transparent"
-    textColor="display"
-    class="full-height cursor-not-allowed no-border-radius"
-  >
-    <QBtn
-      dense
-      flat
-      round
-      icon="lens"
-      size="8.5px"
-      color="red"
-      class="title-bar-buttons"
-      aria-label="閉じる"
-      @click="closeWindow()"
-    ></QBtn>
-    <QBtn
-      dense
-      flat
-      round
-      icon="lens"
-      size="8.5px"
-      color="yellow"
-      class="title-bar-buttons"
-      aria-label="最小化"
-      @click="minimizeWindow()"
-    ></QBtn>
-    <QBtn
-      dense
-      flat
-      round
-      icon="lens"
-      size="8.5px"
-      color="green"
-      class="title-bar-buttons"
-      aria-label="最大化"
-      @click="toggleMaximizeWindow()"
-    ></QBtn>
-  </QBadge>
-  <QBadge
-    v-else
     transparent
     color="transparent"
     textColor="display"
@@ -91,10 +49,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { mdiWindowRestore } from "@quasar/extras/mdi-v5";
-import { useQuasar } from "quasar";
 import { useStore } from "@/store";
 
-const $q = useQuasar();
 const store = useStore();
 
 const closeWindow = async () => {


### PR DESCRIPTION
## 内容
Mac専用のタイトルバーボタン分岐を削除します。

## 関連 Issue
- ref: #2902 

## スクリーンショット・動画など
（なし）

## その他
（なし）