### PR TITLE
chore: dotenvにquietオプションを足す

### DIFF
--- a/build/electronBuilderConfig.ts
+++ b/build/electronBuilderConfig.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { readdirSync, existsSync, rmSync } from "node:fs";
-import { config } from "dotenv";
+import dotenv from "dotenv";
 import { Configuration as ElectronBuilderConfiguration } from "electron-builder";
 import { z } from "zod";
 import afterAllArtifactBuild from "./afterAllArtifactBuild";
@@ -9,7 +9,7 @@ import artifactBuildCompleted from "./artifactBuildCompleted";
 
 const rootDir = path.join(import.meta.dirname, "..");
 const dotenvPath = path.join(rootDir, ".env.production");
-config({ path: dotenvPath });
+dotenv.config({ path: dotenvPath, quiet: true });
 
 const VOICEVOX_ENGINE_DIR =
   process.env.VOICEVOX_ENGINE_DIR ?? "../voicevox_engine/dist/run/";

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@
 import type { PlaywrightTestConfig, Project } from "@playwright/test";
 import dotenv from "dotenv";
 
-dotenv.config({ path: ".env.test", override: true });
+dotenv.config({ path: ".env.test", override: true, quiet: true });
 
 let project: Project;
 let webServers: PlaywrightTestConfig["webServer"];

--- a/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
+++ b/tests/e2e/browser/アップデート通知ダイアログ.spec.ts
@@ -8,7 +8,7 @@ import { assertNonNullable } from "@/type/utility";
 
 // アップデート通知が出る環境にする
 test.beforeEach(async ({ page }) => {
-  dotenv.config();
+  dotenv.config({ quiet: true });
 
   // 動作環境より新しいバージョン
   const latestVersion = semver.inc(

--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -94,7 +94,7 @@ async function runEngineTest(params: { isUpdate: boolean }) {
 ].forEach(({ envName, envPath, envId }) => {
   test.describe(`${envName}`, () => {
     test.beforeEach(() => {
-      dotenv.config({ path: envPath, override: true });
+      dotenv.config({ path: envPath, override: true, quiet: true });
     });
 
     test("起動したら「利用規約に関するお知らせ」が表示される", async () => {


### PR DESCRIPTION
## 内容

dotenvにquietを追加します（[quietがないと宣伝されるので...](https://github.com/motdotla/dotenv/issues/876)）

## 関連 Issue

- ref: #2866 （からの分割）

## スクリーンショット・動画など

（なし）

## その他

（なし）