### PR TITLE
ci: [release-0.25] electron e2eテストをスキップ

### DIFF
--- a/tests/e2e/electron/example.spec.ts
+++ b/tests/e2e/electron/example.spec.ts
@@ -93,6 +93,9 @@ async function runEngineTest(params: { isUpdate: boolean }) {
   },
 ].forEach(({ envName, envPath, envId }) => {
   test.describe(`${envName}`, () => {
+    // NOTE: latestDefaultEngineInfos.json のフォーマットが変更され、release-0.25では新パーサーがないためスキップ
+    if (envId === "vvpp-default-engine") test.skip();
+
     test.beforeEach(() => {
       dotenv.config({ path: envPath, override: true });
     });


### PR DESCRIPTION
## 内容

mainブランチのPR #2886 で `latestDefaultEngineInfos.json` のフォーマットが変更され、voicevox_blog側で新フォーマットが配信されるようになった。
release-0.25ブランチには新しいパーサーがないため、electron e2eテストがZodErrorで失敗する。

ということでこのテストをスキップする。

## 関連 Issue

ref #2886
