### PR TITLE
feat: スナップショット更新を workflow_dispatch ベースに変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,18 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - "**"
   workflow_dispatch:
+    inputs:
+      update_snapshots:
+        description: "スナップショットを更新する"
+        required: false
+        type: boolean
+        default: false
 
 env:
   VOICEVOX_ENGINE_REPO: "VOICEVOX/voicevox_nemo_engine" # 軽いのでNemoを使う
@@ -21,22 +29,14 @@ jobs:
     outputs:
       shouldUpdateSnapshots: ${{ steps.check-whether-to-update-snapshots.outputs.shouldUpdateSnapshots }}
     steps:
-      - name: Check if commit message includes [update snapshots]
+      - name: Check whether to update snapshots
         id: check-whether-to-update-snapshots
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const commits = ${{ toJson(github.event.commits) }};
-            if (!commits) {
-              // pull_request などでコミットがない場合はスキップ
-              core.setOutput("shouldUpdateSnapshots", false);
-              process.exit(0);
-            }
-            const shouldUpdateSnapshots = commits.some((commit) =>
-              commit.message.toLowerCase().includes("[update snapshots]")
-            );
-            core.setOutput("shouldUpdateSnapshots", shouldUpdateSnapshots);
-            console.log(`shouldUpdateSnapshots: ${shouldUpdateSnapshots}`);
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "shouldUpdateSnapshots=${{ inputs.update_snapshots }}" >> $GITHUB_OUTPUT
+          else
+            echo "shouldUpdateSnapshots=false" >> $GITHUB_OUTPUT
+          fi
 
   # ビルドのテスト
   build-test:

--- a/README.md
+++ b/README.md
@@ -187,14 +187,17 @@ pnpm run test-ui:storybook-vrt # Playwright の UI を表示
 
 1. フォークしたリポジトリの設定で GitHub Actions を有効にします。
 2. リポジトリの設定の Actions > General > Workflow permissions で Read and write permissions を選択します。
-3. `[update snapshots]` という文字列をコミットメッセージに含めてコミットします。
+3. GitHub の Actions タブから「Test」ワークフローを選択し、「Run workflow」をクリックします。
+4. 更新したいブランチを選択し、「スナップショットを更新する」にチェックを入れて実行します。
+
+   gh コマンドでも実行できます。
 
    ```bash
-   git commit -m "UIを変更 [update snapshots]"
+   gh workflow run test.yml -R (ユーザー名)/voicevox --ref (ブランチ名) -f update_snapshots=true
    ```
 
-4. Github Workflow が完了すると、更新されたスクリーンショットがコミットされます。
-5. プルした後、空コミットをプッシュしてテストを再実行します。
+5. Github Workflow が完了すると、更新されたスクリーンショットがコミットされます。
+6. プルした後、空コミットをプッシュしてテストを再実行します。
 
    ```bash
    git commit --allow-empty -m "（テストを再実行）"


### PR DESCRIPTION
## 内容

スナップショット更新の仕組みをコミットメッセージベースから `workflow_dispatch` ベースに変更。

- `on: push` を `branches: [main]` に制限し、フォークリポジトリで不要なワークフロー実行を防止
- README.md のスナップショット更新手順を更新

## 関連 Issue

close #2906

## スクリーンショット・動画など

n/a

## その他

- VOICEVOX/voicevox_blog#339