### PR TITLE
chroe: electron-devtools-installerを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "dotenv": "17.2.3",
     "electron": "39.0.0",
     "electron-builder": "26.1.0",
-    "electron-devtools-installer": "4.0.0",
     "eslint": "9.39.0",
     "eslint-config-flat-gitignore": "2.1.0",
     "eslint-plugin-file-progress": "3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,9 +212,6 @@ importers:
       electron-builder:
         specifier: 26.1.0
         version: 26.1.0(electron-builder-squirrel-windows@25.1.8)
-      electron-devtools-installer:
-        specifier: 4.0.0
-        version: 4.0.0
       eslint:
         specifier: 9.39.0
         version: 9.39.0(jiti@2.6.1)
@@ -2567,9 +2564,6 @@ packages:
     resolution: {integrity: sha512-dvy9sODWE7uqz7l68copgAtO2EKumdkLqCgooNWl7bSFjrubMmjf2hVS6iwSrcb7hLHL02OULBPNp45aeGAcpA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
-
-  electron-devtools-installer@4.0.0:
-    resolution: {integrity: sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==}
 
   electron-log@5.4.3:
     resolution: {integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==}
@@ -5100,9 +5094,6 @@ packages:
     resolution: {integrity: sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==}
     engines: {node: '>=18.12.0'}
 
-  unzip-crx-3@0.2.0:
-    resolution: {integrity: sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==}
-
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -5440,9 +5431,6 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-
-  yaku@0.16.7:
-    resolution: {integrity: sha512-Syu3IB3rZvKvYk7yTiyl1bo/jiEFaaStrgv1V2TIJTqYPStSMQVO8EQjg/z+DRzLq/4LIIharNT3iH1hylEIRw==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -7971,10 +7959,6 @@ snapshots:
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
-
-  electron-devtools-installer@4.0.0:
-    dependencies:
-      unzip-crx-3: 0.2.0
 
   electron-log@5.4.3: {}
 
@@ -10967,12 +10951,6 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
-  unzip-crx-3@0.2.0:
-    dependencies:
-      jszip: 3.10.1
-      mkdirp: 0.5.6
-      yaku: 0.16.7
-
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -11298,8 +11276,6 @@ snapshots:
   xmlbuilder@15.1.1: {}
 
   y18n@5.0.8: {}
-
-  yaku@0.16.7: {}
 
   yallist@4.0.0: {}
 

--- a/src/backend/electron/main.ts
+++ b/src/backend/electron/main.ts
@@ -1,12 +1,7 @@
-"use strict";
-
 import path from "node:path";
-
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 import { app, dialog, Menu, net, protocol, session, shell } from "electron";
-import installExtension, { VUEJS_DEVTOOLS } from "electron-devtools-installer";
-
 import electronLog from "electron-log/main";
 import dayjs from "dayjs";
 import { initializeEngineInfoManager } from "./manager/engineInfoManager";
@@ -423,13 +418,6 @@ void app.whenReady().then(async () => {
     }
   });
 
-  if (isDevelopment && !isTest) {
-    try {
-      await installExtension(VUEJS_DEVTOOLS);
-    } catch (e) {
-      log.error("Vue Devtools failed to install:", e);
-    }
-  }
   // 多重起動防止
   // TODO: readyを待たずにもっと早く実行すべき
   if (


### PR DESCRIPTION
## 内容

機能していない`electron-devtools-installer`を削除します。

## 関連 Issue

resolve #2578

## その他

気になったので`src/backend/electron/main.ts`の`"use strict";`とインポート部分の不要な改行を消しておきました。
esmでは[内容全体が自動的に厳格モードになる](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Strict_mode#%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB%E3%81%A7%E3%81%AE%E5%8E%B3%E6%A0%BC%E3%83%A2%E3%83%BC%E3%83%89)ので`"use strict";`を消しても何も変わらないはずです。