### PR TITLE
fix(welcome): MacではWindowControlsを隠す

### DIFF
--- a/src/welcome/components/MenuBar.vue
+++ b/src/welcome/components/MenuBar.vue
@@ -10,7 +10,7 @@
       {{ titleText }}
     </div>
     <QSpace />
-    <WindowControls :isMaximized :isFullscreen />
+    <WindowControls v-if="!$q.platform.is.mac" :isMaximized :isFullscreen />
   </QBar>
 </template>
 


### PR DESCRIPTION
## 内容

タイトル通りです。

## 関連 Issue
- closes: #2928

## スクリーンショット・動画など

（なし）

## その他

（なし）