### PR TITLE
feat: utaformatixをdynamic-importしてバンドルを分割する

### DIFF
--- a/src/sing/utaformatixProject/fromVoicevox.ts
+++ b/src/sing/utaformatixProject/fromVoicevox.ts
@@ -1,13 +1,16 @@
 // TODO: エクスポート機能を実装する
 
-import { Project as UfProject, UfData } from "@sevenc-nanashi/utaformatix-ts";
+import type {
+  Project as UfProject,
+  UfData,
+} from "@sevenc-nanashi/utaformatix-ts";
 import { VoicevoxScore } from "./common";
 
 /** Voicevoxの楽譜データをUtaformatixのProjectに変換する */
-export const ufProjectFromVoicevox = (
+export const ufProjectFromVoicevox = async (
   { tracks, tpqn, tempos, timeSignatures }: VoicevoxScore,
   projectName: string,
-): UfProject => {
+): Promise<UfProject> => {
   const convertTicks = (ticks: number) => Math.round((ticks / tpqn) * 480);
   const ufData: UfData = {
     formatVersion: 1,
@@ -34,5 +37,6 @@ export const ufProjectFromVoicevox = (
       })),
     },
   };
+  const { Project: UfProject } = await import("@sevenc-nanashi/utaformatix-ts");
   return new UfProject(ufData);
 };

--- a/src/sing/utaformatixProject/toVoicevox.ts
+++ b/src/sing/utaformatixProject/toVoicevox.ts
@@ -1,4 +1,4 @@
-import { Project as UfProject } from "@sevenc-nanashi/utaformatix-ts";
+import type { Project as UfProject } from "@sevenc-nanashi/utaformatix-ts";
 import { VoicevoxScore } from "./common";
 import { DEFAULT_TPQN, createDefaultTrack } from "@/sing/domain";
 import { NoteId } from "@/type/preload";

--- a/src/sing/utaformatixProject/utils.ts
+++ b/src/sing/utaformatixProject/utils.ts
@@ -1,4 +1,4 @@
-import { Project as UfProject } from "@sevenc-nanashi/utaformatix-ts";
+import type { Project as UfProject } from "@sevenc-nanashi/utaformatix-ts";
 import { ExhaustiveError } from "@/type/utility";
 
 export const singleFileProjectFormats = ["smf", "ufdata"] as const;

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -3287,7 +3287,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           getters.SELECTED_TRACK,
           getters.CHARACTER_INFO,
         );
-        const project = ufProjectFromVoicevox(
+        const project = await ufProjectFromVoicevox(
           {
             tempos: state.tempos,
             timeSignatures: state.timeSignatures,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1,6 +1,6 @@
 import { Patch } from "immer";
 import { z } from "zod";
-import { Project as UfProject } from "@sevenc-nanashi/utaformatix-ts";
+import type { Project as UfProject } from "@sevenc-nanashi/utaformatix-ts";
 import {
   MutationTree,
   MutationsBase,

--- a/tests/unit/lib/utaformatixProject/export.spec.ts
+++ b/tests/unit/lib/utaformatixProject/export.spec.ts
@@ -20,7 +20,7 @@ it("トラックを変換できる", async () => {
     lyric: "ど",
   });
 
-  const project = ufProjectFromVoicevox(
+  const project = await ufProjectFromVoicevox(
     {
       tracks: [track],
       tpqn: 480,


### PR DESCRIPTION
## 内容

`utaformatix`のバンドル後のサイズは約1.3MBあります。
viteは特に何もしていない場合は可能な限り単一のファイルにバンドルしようとします。

バンドルサイズが大きい場合パフォーマンスに悪影響があるためV8の記事では50～100KBを超える場合はバンドルの分割が推奨されています。
また、Viteはデフォルトでバンドルサイズが500KBを超える場合警告が出ます。(VOICEVOXでは抑制していますが)
https://v7.vite.dev/config/build-options#build-chunksizewarninglimit

また、HeepSnapshotによるとCompiledCodeだけで4MB以上のメモリを常時消費しているようです。
<img width="960" height="520" alt="ヒープスナップショット" src="https://github.com/user-attachments/assets/955f740a-ecfc-460e-8596-f97186d49c96" />

Electronではネットワークのコストはほぼ無視できる(?)とはいえ起動して1回使うか使わないか程度のものにしてはコストが大きい気がします。

このPRでは`utaformatix`をプロジェクトのインポートをするときに動的にinportすることでリソースの消費を抑制します。

## その他

この変更によって速度面で体感できる効果はありませんでした。
一応メモリ使用量はHeepSnapshot上からは減少しているようですがタスクマネージャー上からではよく分からない程度という感じです。
試してみて一応効果がありそうなのでPRを出してみたという感じです。