### PR TITLE
fix: 歌詞未入力のノート貼り付け時にundefinedが文字列に変換されるバグを修正

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -3034,19 +3034,30 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       }
 
       // パースしたJSONのノートの位置を現在の再生位置に合わせて貼り付ける
-      const currentPlayheadPosition = getters.PLAYHEAD_POSITION;
+      const currentPlayheadPosition = Math.round(getters.PLAYHEAD_POSITION);
       const firstNotePosition = notes[0].position;
+
+      // positionとdurationが整数かチェック
+      const hasNonIntegerValues = notes.some(
+        (note) =>
+          !Number.isInteger(note.position) || !Number.isInteger(note.duration),
+      );
+      if (hasNonIntegerValues) {
+        throw new Error(
+          "Failed to paste notes: position and duration must be integers.",
+        );
+      }
+
       const notesToPaste: Note[] = notes.map((note) => {
         // 新しい位置を現在の再生位置に合わせて計算する
-        const pastePos = Math.round(
-          Number(note.position) - firstNotePosition + currentPlayheadPosition,
-        );
+        const pastePos =
+          note.position - firstNotePosition + currentPlayheadPosition;
         return {
           id: NoteId(uuid4()),
           position: pastePos,
-          duration: Number(note.duration),
-          noteNumber: Number(note.noteNumber),
-          lyric: String(note.lyric),
+          duration: note.duration,
+          noteNumber: note.noteNumber,
+          lyric: note.lyric,
         };
       });
       const pastedNoteIds = notesToPaste.map((note) => note.id);


### PR DESCRIPTION
## 内容

`COMMAND_PASTE_NOTES_FROM_CLIPBOARD`アクションにおいて、歌詞未入力（`lyric`が`undefined`）のノートを貼り付けた際に、`String(note.lyric)`によって`"undefined"`という文字列に変換されてしまうバグを修正します。

### 変更点

- `String(note.lyric)`を削除し、`undefined`をそのまま保持するように修正

ついでに以下も行います。

- 不要な`Number()`キャストを削除（zodの`noteSchema`でパース済みのため不要）
- `position`と`duration`が整数かどうかのバリデーションを追加
- `currentPlayheadPosition`のみを`Math.round()`でroundするように変更（ノートの`position`は整数であるべきなので、ループ内で毎回roundする必要がない）

## 関連 Issue

close #2938

## その他

`noteSchema`では`lyric`は`z.union([z.string(), z.undefined()])`と定義されており、歌詞未入力のときは`undefined`になる仕様です。
zodの`.parse()`が成功した時点で型が保証されているため、`Number()`や`String()`でのキャストは不要です。