### PR TITLE
feat: リリースビルドでMockをバンドルしないようにする

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,6 +103,8 @@ export default defineConfig((options) => {
           main: path.resolve(import.meta.dirname, "src/index.html"),
           welcome: path.resolve(import.meta.dirname, "src/welcome/index.html"),
         },
+        // 明示的に除外しないとリリースビルドでもモックの画像がバンドルされてしまう
+        external: isElectron ? [/.+\/src\/mock\/engineMock\/assets\/.+/] : [],
       },
     },
     publicDir: path.resolve(import.meta.dirname, "public"),


### PR DESCRIPTION
## 内容

製品版のElectron環境では[モックエンジンは使用しない](https://github.com/VOICEVOX/voicevox/blob/6b516dd52c9b3d77c9c4a5341f7465f2bea6eb4a/src/store/proxy.ts#L81-L84)にも関わらずリリースビルドのバンドルに`./src/mock/*`内のコードやファイル、依存パッケージが含まれていました。

コードとビルド設定を修正することで改善します。

## その他

正直あまりファイルサイズとか小さくなりませんが気になっていたので直してみました。