### PR TITLE
`テキストを読み込む`に割り当てる挙動を文字通りにする

### DIFF
--- a/src/components/Talk/TalkEditor.vue
+++ b/src/components/Talk/TalkEditor.vue
@@ -209,7 +209,7 @@ registerHotkeyWithCleanup({
   name: "テキストを読み込む",
   callback: () => {
     if (!uiLocked.value) {
-      void store.actions.SHOW_CONNECT_AND_EXPORT_TEXT_DIALOG();
+      void store.actions.COMMAND_IMPORT_FROM_FILE({ type: "dialog" });
     }
   },
 });


### PR DESCRIPTION
## 内容
`テキストを読み込む`に割り当てたキーを押すと`テキストを繋げて書き出し`が動いていたので、`テキストを読み込む`から期待される挙動にする。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #2948

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
### before

https://github.com/user-attachments/assets/16db6c18-a744-423d-acbb-9dfdd69ada32

### after

https://github.com/user-attachments/assets/259aeaf5-f5c1-4938-9862-a1049d3e3766


## その他
