### PR TITLE
fix: 未使用のQuasar Pluginsを削除

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { createApp } from "vue";
 import { createGtm } from "@gtm-support/vue-gtm";
-import { Quasar, Dialog, Loading, Notify } from "quasar";
+import { Quasar } from "quasar";
 import iconSet from "quasar/icon-set/material-icons";
 import { store, storeKey } from "./store";
 import { ipcMessageReceiver } from "./plugins/ipcMessageReceiverPlugin";
@@ -34,11 +34,6 @@ createApp(App)
       },
     },
     iconSet,
-    plugins: {
-      Dialog,
-      Loading,
-      Notify,
-    },
   })
   .use(hotkeyPlugin)
   .use(ipcMessageReceiver, { store })

--- a/src/welcome/main.ts
+++ b/src/welcome/main.ts
@@ -1,5 +1,5 @@
 import { createApp } from "vue";
-import { Quasar, Dialog, Loading, Notify } from "quasar";
+import { Quasar } from "quasar";
 import iconSet from "quasar/icon-set/material-icons";
 import App from "./components/App.vue";
 import { markdownItPlugin } from "@/plugins/markdownItPlugin";
@@ -24,11 +24,6 @@ createApp(App)
       },
     },
     iconSet,
-    plugins: {
-      Dialog,
-      Loading,
-      Notify,
-    },
   })
   .use(markdownItPlugin)
   .mount("#app");


### PR DESCRIPTION
## 内容

未使用のQuasar Plugin、[`Dialog`](https://quasar.dev/quasar-plugins/dialog), [`Loading`](https://quasar.dev/quasar-plugins/loading), [`Notify`](https://quasar.dev/quasar-plugins/notify)を削除します。
このプラグインは
```TypeScript
const $q = useQuasar();
$q.dialog({ ... });
```
といった使い方をするためのものです。

コードを検索した限り現在このプラグインは使用していないようです。
(以前は使用していたが使わなくなった際に消し忘れたものだと思います。)