### PR TITLE
docs:Mac向けエンジンのパスの記述を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ pnpm run setup-agents
 Windows でインストール先を変更していない場合は`C:/Users/(ユーザー名)/AppData/Local/Programs/VOICEVOX/vv-engine/run.exe`を指定してください。  
 パスの区切り文字は`\`ではなく`/`なのでご注意ください。
 
-macOS 向けの`VOICEVOX.app`を利用している場合は`/path/to/VOICEVOX.app/Resources/MacOS/vv-engine/run`を指定してください。
+macOS 向けの`VOICEVOX.app`を利用している場合は`/path/to/VOICEVOX.app/Contents/Resources/vv-engine/run`を指定してください。
 
 Linux の場合は、[Releases](https://github.com/VOICEVOX/voicevox/releases/)から入手できる tar.gz 版に含まれる`vv-engine/run`コマンドを指定してください。
 AppImage 版の場合は`$ /path/to/VOICEVOX.AppImage --appimage-mount`でファイルシステムをマウントできます。


### PR DESCRIPTION
## 内容

ReadMe.mdのMac向けエンジンのパスの記述が実態と異なっていたため、build.ymlで出力しているパスに合わせました


## 関連 Issue

## その他
