### PR TITLE
fix: テンポ変更時にループ範囲の秒数が更新されない不具合を修正

### DIFF
--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -126,6 +126,8 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         mutations.DESELECT_ALL_NOTES();
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
+        void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
+        void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
         void actions.RENDER();
       }
     },
@@ -145,6 +147,8 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         mutations.DESELECT_ALL_NOTES();
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
+        void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
+        void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
         void actions.RENDER();
       }
     },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1461,6 +1461,14 @@ export type SingingStoreTypes = {
     action(): void;
   };
 
+  SYNC_LOOP_RANGE_TO_TRANSPORT: {
+    action(): void;
+  };
+
+  SYNC_PLAYHEAD_POSITION_TO_TRANSPORT: {
+    action(): void;
+  };
+
   APPLY_DEVICE_ID_TO_AUDIO_CONTEXT: {
     action(payload: { device: string }): void;
   };


### PR DESCRIPTION
## 内容

ループ再生中にテンポを変更すると、ループが正常に機能しない不具合を修正します。

ループ範囲と再生位置はどちらも「tick（拍子単位）」と「秒」の2種類で管理されています。テンポや TPQN が変わると tick から秒への変換結果が変わりますが、Transport の `loopStartTime` / `loopEndTime` / `time`（いずれも秒単位）がテンポ変更後に再計算されていなかったため、以下の不具合が発生していました：

- テンポ変更時にループ位置がずれる
- テンポ変更操作の Undo/Redo 時に再生ヘッドが意図しない位置に飛ぶ

`SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS` と同様のパターンで、以下の2つのアクションを新設します：

- `SYNC_LOOP_RANGE_TO_TRANSPORT`：state の `loopStartTick` / `loopEndTick` を現在のテンポ・TPQN をもとに秒に変換し、`transport.loopStartTime` / `transport.loopEndTime` に反映する
- `SYNC_PLAYHEAD_POSITION_TO_TRANSPORT`：`playheadPosition`（tick）を現在のテンポ・TPQN をもとに秒に変換し、`transport.time` に反映する

これらのアクションを以下の箇所から呼び出すよう修正します：

- `SET_TPQN`：TPQN 設定（TPQN も tick→秒変換に影響するため）
- `SET_TEMPOS`：テンポ一括設定
- `COMMAND_SET_TEMPO`：テンポの追加・変更
- `COMMAND_REMOVE_TEMPO`：テンポの削除
- `COMMAND_IMPORT_TRACKS`：テンポ情報を含むトラックのインポート
- `UNDO` / `REDO`：テンポ変更操作の Undo/Redo 時にも再同期（今回新たに対応）

また、`COMMAND_IMPORT_TRACKS` アクションに `transport` の初期化チェックを追加します。

## 関連 Issue

close #2964

## その他
