### PR TITLE
feat: フレーズのレンダリングデータをプロジェクトファイルに保存・復元する

### DIFF
--- a/src/infrastructures/projectFile/migration.ts
+++ b/src/infrastructures/projectFile/migration.ts
@@ -301,6 +301,13 @@ export const migrateProjectFileObject = async (
     }
   }
 
+  if (semver.satisfies(projectAppVersion, "<0.26.0", semverSatisfiesOptions)) {
+    // フレーズのレンダリングデータの追加
+    projectData.song.phraseQueries = {};
+    projectData.song.phraseSingingPitches = {};
+    projectData.song.phraseSingingVolumes = {};
+  }
+
   // Validation check
   // トークはvalidateTalkProjectで検証する
   // ソングはSET_SCOREの中の`isValidScore`関数で検証される

--- a/src/infrastructures/projectFile/schema.ts
+++ b/src/infrastructures/projectFile/schema.ts
@@ -29,6 +29,22 @@ export const projectFileTrackSchema = z.object({
   pan: z.number(),
 });
 
+const framePhonemeSchema = z.object({
+  phoneme: z.string(),
+  frameLength: z.number(),
+  noteId: z.string().nullable().optional(),
+});
+
+const editorFrameAudioQuerySchema = z.object({
+  f0: z.array(z.number()),
+  volume: z.array(z.number()),
+  phonemes: z.array(framePhonemeSchema),
+  volumeScale: z.number(),
+  outputSamplingRate: z.number(),
+  outputStereo: z.boolean(),
+  frameRate: z.number(),
+});
+
 // プロジェクトファイルのスキーマ
 export const projectFileSchema = z.object({
   appVersion: z.string(),
@@ -44,5 +60,8 @@ export const projectFileSchema = z.object({
     timeSignatures: z.array(timeSignatureSchema),
     tracks: z.record(trackIdSchema, projectFileTrackSchema),
     trackOrder: z.array(trackIdSchema),
+    phraseQueries: z.record(z.string(), editorFrameAudioQuerySchema),
+    phraseSingingPitches: z.record(z.string(), z.array(z.number())),
+    phraseSingingVolumes: z.record(z.string(), z.array(z.number())),
   }),
 });

--- a/src/sing/songTrackRendering.ts
+++ b/src/sing/songTrackRendering.ts
@@ -978,6 +978,16 @@ export type SongTrackRenderingEvent =
   | PhraseRenderingErrorEvent;
 
 /**
+ * ソングトラックレンダラーが保持するキャッシュ。
+ * クエリ・歌唱ピッチ・歌唱ボリュームのそれぞれのキャッシュを含む。
+ */
+export type SongTrackRendererCache = {
+  queryCache: Map<EditorFrameAudioQueryKey, EditorFrameAudioQuery>;
+  singingPitchCache: Map<SingingPitchKey, SingingPitch>;
+  singingVolumeCache: Map<SingingVolumeKey, SingingVolume>;
+};
+
+/**
  * ソングトラックのレンダリング処理を担当するクラス。
  * フレーズ生成、キャッシュ管理、エンジンAPIとの連携、イベント通知などを行う。
  */
@@ -986,16 +996,11 @@ export class SongTrackRenderer {
   private readonly engineSongApi: EngineSongApi;
   private readonly playheadPositionGetter: () => number;
 
-  private readonly queryCache: Map<
-    EditorFrameAudioQueryKey,
-    EditorFrameAudioQuery
-  > = new Map();
-  private readonly singingPitchCache: Map<SingingPitchKey, SingingPitch> =
+  private queryCache: Map<EditorFrameAudioQueryKey, EditorFrameAudioQuery> =
     new Map();
-  private readonly singingVolumeCache: Map<SingingVolumeKey, SingingVolume> =
-    new Map();
-  private readonly singingVoiceCache: Map<SingingVoiceKey, SingingVoice> =
-    new Map();
+  private singingPitchCache: Map<SingingPitchKey, SingingPitch> = new Map();
+  private singingVolumeCache: Map<SingingVolumeKey, SingingVolume> = new Map();
+  private singingVoiceCache: Map<SingingVoiceKey, SingingVoice> = new Map();
 
   private readonly listeners: Set<(event: SongTrackRenderingEvent) => void> =
     new Set();
@@ -1028,6 +1033,24 @@ export class SongTrackRenderer {
     this.config = args.config;
     this.engineSongApi = args.engineSongApi;
     this.playheadPositionGetter = args.playheadPositionGetter;
+  }
+
+  /**
+   * キャッシュを設定する。
+   * 指定されたキャッシュのみを上書きし、指定されなかったものは変更しない。
+   *
+   * @param cache 設定するキャッシュ。各フィールドは省略可能。
+   */
+  setCache(cache: Partial<SongTrackRendererCache>) {
+    if (cache.queryCache != undefined) {
+      this.queryCache = new Map(cache.queryCache);
+    }
+    if (cache.singingPitchCache != undefined) {
+      this.singingPitchCache = new Map(cache.singingPitchCache);
+    }
+    if (cache.singingVolumeCache != undefined) {
+      this.singingVolumeCache = new Map(cache.singingVolumeCache);
+    }
   }
 
   /**

--- a/src/store/project/index.ts
+++ b/src/store/project/index.ts
@@ -6,11 +6,14 @@ import {
   writeProjectFile,
 } from "./saveProjectHelper";
 import { createUILockAction } from "@/store/ui";
-import type {
-  AllActions,
-  AudioItem,
-  ProjectStoreState,
-  ProjectStoreTypes,
+import {
+  type AllActions,
+  type AudioItem,
+  EditorFrameAudioQueryKey,
+  type ProjectStoreState,
+  type ProjectStoreTypes,
+  SingingPitchKey,
+  SingingVolumeKey,
 } from "@/store/type";
 import { TrackId } from "@/type/preload";
 import path from "@/helpers/path";
@@ -23,6 +26,7 @@ import {
   createDefaultTrack,
   DEFAULT_TPQN,
 } from "@/sing/domain";
+import type { SongTrackRendererCache } from "@/sing/songTrackRendering";
 import type { EditorType } from "@/type/preload";
 import { type IsEqual, UnreachableError } from "@/type/utility";
 import {
@@ -65,7 +69,16 @@ const applySongProjectToStore = async (
   actions: DotNotationDispatch<AllActions>,
   songProject: LatestProjectType["song"],
 ) => {
-  const { tpqn, tempos, timeSignatures, tracks, trackOrder } = songProject;
+  const {
+    tpqn,
+    tempos,
+    timeSignatures,
+    tracks,
+    trackOrder,
+    phraseQueries,
+    phraseSingingPitches,
+    phraseSingingVolumes,
+  } = songProject;
 
   await actions.SET_TPQN({ tpqn });
   await actions.SET_TEMPOS({ tempos });
@@ -81,6 +94,30 @@ const applySongProjectToStore = async (
         return [trackId, track];
       }),
     ),
+  });
+
+  const rendererCache: SongTrackRendererCache = {
+    queryCache: new Map(
+      Object.entries(phraseQueries).map(([k, v]) => [
+        EditorFrameAudioQueryKey(k),
+        v,
+      ]),
+    ),
+    singingPitchCache: new Map(
+      Object.entries(phraseSingingPitches).map(([k, v]) => [
+        SingingPitchKey(k),
+        v,
+      ]),
+    ),
+    singingVolumeCache: new Map(
+      Object.entries(phraseSingingVolumes).map(([k, v]) => [
+        SingingVolumeKey(k),
+        v,
+      ]),
+    ),
+  };
+  void actions.SET_SONG_TRACK_RENDERER_CACHE({
+    cache: rendererCache,
   });
 };
 

--- a/src/store/project/index.ts
+++ b/src/store/project/index.ts
@@ -80,22 +80,6 @@ const applySongProjectToStore = async (
     phraseSingingVolumes,
   } = songProject;
 
-  await actions.SET_TPQN({ tpqn });
-  await actions.SET_TEMPOS({ tempos });
-  await actions.SET_TIME_SIGNATURES({ timeSignatures });
-  await actions.SET_TRACKS({
-    tracks: new Map(
-      trackOrder.map((trackId): [TrackId, Track] => {
-        const projectFileTrack = tracks[trackId];
-        if (projectFileTrack == undefined) {
-          throw new Error("projectFileTrack == undefined");
-        }
-        const track = toEditorTrack(projectFileTrack);
-        return [trackId, track];
-      }),
-    ),
-  });
-
   const rendererCache: SongTrackRendererCache = {
     queryCache: new Map(
       Object.entries(phraseQueries).map(([k, v]) => [
@@ -118,6 +102,22 @@ const applySongProjectToStore = async (
   };
   void actions.SET_SONG_TRACK_RENDERER_CACHE({
     cache: rendererCache,
+  });
+
+  await actions.SET_TPQN({ tpqn });
+  await actions.SET_TEMPOS({ tempos });
+  await actions.SET_TIME_SIGNATURES({ timeSignatures });
+  await actions.SET_TRACKS({
+    tracks: new Map(
+      trackOrder.map((trackId): [TrackId, Track] => {
+        const projectFileTrack = tracks[trackId];
+        if (projectFileTrack == undefined) {
+          throw new Error("projectFileTrack == undefined");
+        }
+        const track = toEditorTrack(projectFileTrack);
+        return [trackId, track];
+      }),
+    ),
   });
 };
 

--- a/src/store/project/saveProjectHelper.ts
+++ b/src/store/project/saveProjectHelper.ts
@@ -5,6 +5,7 @@ import type { LatestProjectType } from "@/infrastructures/projectFile/type";
 import { DisplayableError } from "@/helpers/errorHelper";
 import { ResultError } from "@/type/result";
 import { toProjectFileTrack } from "@/infrastructures/projectFile/conversion";
+import { mapToRecord } from "@/sing/utility";
 
 export async function promptProjectSaveFilePath(
   context: ActionContext,
@@ -35,7 +36,11 @@ export async function writeProjectFile(
     timeSignatures,
     tracks,
     trackOrder,
+    phraseQueries,
+    phraseSingingPitches,
+    phraseSingingVolumes,
   } = context.state;
+
   const projectData: LatestProjectType = {
     appVersion,
     talk: {
@@ -53,6 +58,9 @@ export async function writeProjectFile(
         }),
       ),
       trackOrder,
+      phraseQueries: mapToRecord(phraseQueries),
+      phraseSingingPitches: mapToRecord(phraseSingingPitches),
+      phraseSingingVolumes: mapToRecord(phraseSingingVolumes),
     },
   };
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -124,6 +124,7 @@ import {
   type PitchGenerationCompleteEvent,
   type QueryGenerationCompleteEvent,
   SongTrackRenderer,
+  type SongTrackRendererCache,
   type VoiceSynthesisCompleteEvent,
   type VolumeGenerationCompleteEvent,
 } from "@/sing/songTrackRendering";
@@ -1629,6 +1630,18 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
             throw new ExhaustiveError(event);
         }
       });
+    },
+  },
+
+  SET_SONG_TRACK_RENDERER_CACHE: {
+    async action({ actions }, { cache }: { cache: SongTrackRendererCache }) {
+      if (songTrackRenderer == undefined) {
+        void actions.CREATE_AND_SETUP_SONG_TRACK_RENDERER();
+        if (songTrackRenderer == undefined) {
+          throw new Error("songTrackRenderer is undefined.");
+        }
+      }
+      songTrackRenderer.setCache(cache);
     },
   },
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -77,6 +77,7 @@ import type {
 } from "@/domain/project/type";
 import type { LatestProjectType } from "@/infrastructures/projectFile/type";
 import type { WavFormat } from "@/helpers/fileDataGenerator";
+import type { SongTrackRendererCache } from "@/sing/songTrackRendering";
 
 /**
  * エディタ用のAudioQuery
@@ -1065,6 +1066,10 @@ export type SingingStoreTypes = {
 
   CREATE_AND_SETUP_SONG_TRACK_RENDERER: {
     action(): void;
+  };
+
+  SET_SONG_TRACK_RENDERER_CACHE: {
+    action(payload: { cache: SongTrackRendererCache }): void;
   };
 
   SET_PHRASES: {

--- a/tests/unit/domain/__snapshots__/project.spec.ts.snap
+++ b/tests/unit/domain/__snapshots__/project.spec.ts.snap
@@ -4,6 +4,9 @@ exports[`migrateProjectFileObject > v0.14.11 1`] = `
 {
   "appVersion": "999.999.999",
   "song": {
+    "phraseQueries": {},
+    "phraseSingingPitches": {},
+    "phraseSingingVolumes": {},
     "tempos": [
       {
         "bpm": 120,


### PR DESCRIPTION
## 内容

ソングエディタのフレーズのレンダリングデータ（クエリ・歌唱ピッチ・歌唱ボリューム）をプロジェクトファイルに保存し、プロジェクトを開いた際に復元するようにします。

歌唱ピッチ等はAIによる推論で生成されますが、現状エンジン側にシード値を固定する機能がまだ無いため、推論のたびに結果が変わります。
そのため、プロジェクトを開くたびに再レンダリングが走り、ピッチ等が変わってしまうという問題がありました。

レンダリング済みデータをプロジェクトファイルに保存・復元することで、プロジェクトを開き直してもピッチ等が変わらないようにします。

保存時はフレーズが持つデータを保存し、復元時はそれをキャッシュとしてSongTrackRendererにセットする形で実装しています。

### 変更内容

- プロジェクトファイルのスキーマに `phraseQueries`・`phraseSingingPitches`・`phraseSingingVolumes` フィールドを追加します
- v0.26.0未満のプロジェクトファイルを開く際、上記フィールドを空オブジェクトで初期化するマイグレーションを追加します
- `SongTrackRenderer` に `SongTrackRendererCache` 型と `setCache()` メソッドを追加します
- `SET_SONG_TRACK_RENDERER_CACHE` アクションを追加します
- プロジェクト保存時にフレーズのレンダリングデータを書き出し、読み込み時に `SongTrackRenderer` へ復元する処理を実装します

## その他

とりあえず音声以外（ピッチやボリュームなど）を保存・復元するようにしています。
mainにマージするかどうかはお任せします。