### PR TITLE
feat: SequencerParameterGridを追加

### DIFF
--- a/src/components/Sing/ScoreSequencer.vue
+++ b/src/components/Sing/ScoreSequencer.vue
@@ -218,7 +218,7 @@
     <template #after>
       <SequencerParameterPanel
         v-if="isParameterPanelOpen"
-        :offsetX="scrollX"
+        :viewportInfo
         @update:needsAutoScroll="
           (value) => (parameterPanelNeedsAutoScroll = value)
         "

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -9,13 +9,8 @@ import { ref, watch, computed, onUnmounted, onMounted, inject } from "vue";
 import * as PIXI from "pixi.js";
 import { useStore } from "@/store";
 import { useMounted } from "@/composables/useMounted";
-import {
-  tickToBaseX,
-  type ViewportInfo,
-  type CanvasSize,
-} from "@/sing/viewHelper";
+import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
 import { numMeasuresInjectionKey } from "@/components/Sing/ScoreSequencer.vue";
-import type { TimeSignature } from "@/domain/project/type";
 import {
   getBeatDuration,
   getMeasureDuration,
@@ -87,15 +82,6 @@ let graphic: PIXI.Graphics | undefined;
 let requestId: number | undefined;
 let renderInNextFrame = false;
 
-const getMeasureWidth = (timeSignature: TimeSignature) => {
-  const measureTicks = getMeasureDuration(
-    timeSignature.beats,
-    timeSignature.beatType,
-    tpqn.value,
-  );
-  return tickToBaseX(measureTicks, tpqn.value) * props.viewportInfo.scaleX;
-};
-
 const render = () => {
   if (renderer == undefined) {
     throw new Error("renderer is undefined.");
@@ -110,57 +96,56 @@ const render = () => {
     throw new Error("canvasHeight is undefined.");
   }
 
-  const canvasSize: CanvasSize = {
-    width: canvasWidth,
-    height: canvasHeight,
-  };
-
-  // 可視範囲内の小節線・拍線の位置を計算
+  // 可視範囲内の小節線・拍線のX座標を収集する
+  // ±1pxは、丸め誤差で境界線が切れるのを防ぐためのマージン
+  const viewportLeft = props.viewportInfo.offsetX - 1;
+  const viewportRight = props.viewportInfo.offsetX + canvasWidth + 1;
+  const viewportScaleX = props.viewportInfo.scaleX;
   const measureLineXs: number[] = [];
   const beatLineXs: number[] = [];
-  const viewportLeft = props.viewportInfo.offsetX - 1;
-  const viewportRight = props.viewportInfo.offsetX + canvasSize.width + 1;
 
-  // 各拍子セクションの開始tick位置を事前計算
-  const tsSectionStartTicks = getTimeSignaturePositions(
+  // 各拍子のtick位置を事前計算
+  const tsPositions = getTimeSignaturePositions(
     timeSignatures.value,
     tpqn.value,
   );
 
-  // 各拍子セクションから可視範囲内の線座標を収集
+  // 各拍子区間から可視範囲内の線座標を収集
   for (const [i, tsSection] of timeSignatures.value.entries()) {
     const nextTsSection = timeSignatures.value.at(i + 1);
     const nextMeasureNumber =
       nextTsSection?.measureNumber ?? numMeasures.value + 1;
     const measureCount = nextMeasureNumber - tsSection.measureNumber;
-    const measureWidth = getMeasureWidth(tsSection);
+    const measureTicks = getMeasureDuration(
+      tsSection.beats,
+      tsSection.beatType,
+      tpqn.value,
+    );
+    const measureWidth = tickToBaseX(measureTicks, tpqn.value) * viewportScaleX;
     const beatTicks = getBeatDuration(tsSection.beatType, tpqn.value);
-    const beatWidth =
-      tickToBaseX(beatTicks, tpqn.value) * props.viewportInfo.scaleX;
+    const beatWidth = tickToBaseX(beatTicks, tpqn.value) * viewportScaleX;
     const tsSectionStartX =
-      tickToBaseX(tsSectionStartTicks[i], tpqn.value) *
-      props.viewportInfo.scaleX;
-    const tsSectionWidth = measureWidth * measureCount;
+      tickToBaseX(tsPositions[i], tpqn.value) * viewportScaleX;
+    const tsSectionEndX = tsSectionStartX + measureWidth * measureCount;
 
-    // 拍子セクションが可視範囲と重ならなければスキップ
-    if (
-      tsSectionStartX + tsSectionWidth < viewportLeft ||
-      tsSectionStartX > viewportRight
-    ) {
+    // ビューポートと拍子区間の交差
+    const visibleStartX = Math.max(viewportLeft, tsSectionStartX);
+    const visibleEndX = Math.min(viewportRight, tsSectionEndX);
+
+    // 交差が空ならこの拍子区間は見えないのでスキップ
+    if (visibleStartX >= visibleEndX) {
       continue;
     }
 
-    // 拍子セクション内で可視範囲に入る最初と最後の小節インデックス（0始まり）を計算
-    const firstMeasureIndex = Math.max(
-      0,
-      Math.floor((viewportLeft - tsSectionStartX) / measureWidth),
+    // 交差に含まれる小節インデックスの範囲（0始まり）
+    const startMeasureIndex = Math.floor(
+      (visibleStartX - tsSectionStartX) / measureWidth,
     );
-    const lastMeasureIndexExclusive = Math.min(
-      measureCount,
-      Math.ceil((viewportRight - tsSectionStartX) / measureWidth),
+    const endMeasureIndex = Math.ceil(
+      (visibleEndX - tsSectionStartX) / measureWidth,
     );
 
-    for (let k = firstMeasureIndex; k < lastMeasureIndexExclusive; k++) {
+    for (let k = startMeasureIndex; k < endMeasureIndex; k++) {
       const measureX = tsSectionStartX + k * measureWidth;
       // 拍線
       for (let beat = 1; beat < tsSection.beats; beat++) {
@@ -184,7 +169,7 @@ const render = () => {
   for (const x of measureLineXs) {
     const lineX = Math.round(x - props.viewportInfo.offsetX);
     graphic.moveTo(lineX - 0.5, 0);
-    graphic.lineTo(lineX - 0.5, canvasSize.height);
+    graphic.lineTo(lineX - 0.5, canvasHeight);
   }
 
   // 拍線をまとめて描画
@@ -192,7 +177,7 @@ const render = () => {
   for (const x of beatLineXs) {
     const lineX = Math.round(x - props.viewportInfo.offsetX);
     graphic.moveTo(lineX - 0.5, 0);
-    graphic.lineTo(lineX - 0.5, canvasSize.height);
+    graphic.lineTo(lineX - 0.5, canvasHeight);
   }
 
   renderer.render(stage);

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -22,11 +22,6 @@ import {
   getTimeSignaturePositions,
 } from "@/sing/music";
 
-type GridLineInfo = {
-  x: number;
-  type: "measure" | "beat";
-};
-
 const props = defineProps<{
   viewportInfo: ViewportInfo;
 }>();
@@ -121,7 +116,8 @@ const render = () => {
   };
 
   // 可視範囲内の小節線・拍線の位置を計算
-  const visibleLines: GridLineInfo[] = [];
+  const measureLineXs: number[] = [];
+  const beatLineXs: number[] = [];
   const viewportLeft = props.viewportInfo.offsetX - 1;
   const viewportRight = props.viewportInfo.offsetX + canvasSize.width + 1;
 
@@ -168,13 +164,10 @@ const render = () => {
       const measureX = tsSectionStartX + k * measureWidth;
       // 拍線
       for (let beat = 1; beat < tsSection.beats; beat++) {
-        visibleLines.push({
-          x: measureX + beatWidth * beat,
-          type: "beat",
-        });
+        beatLineXs.push(measureX + beatWidth * beat);
       }
       // 小節線（小節の右端 = 次の小節の左端）。先頭の0位置は出力しない
-      visibleLines.push({ x: measureX + measureWidth, type: "measure" });
+      measureLineXs.push(measureX + measureWidth);
     }
   }
 
@@ -184,11 +177,20 @@ const render = () => {
   }
   graphic.clear();
 
-  // 線をまとめて描画
-  for (const line of visibleLines) {
-    const lineX = Math.round(line.x - props.viewportInfo.offsetX);
-    const currentLineStyle = gridLineStyles[currentTheme.value][line.type];
-    graphic.lineStyle(1, currentLineStyle.color, currentLineStyle.alpha);
+  const style = gridLineStyles[currentTheme.value];
+
+  // 小節線をまとめて描画
+  graphic.lineStyle(1, style.measure.color, style.measure.alpha);
+  for (const x of measureLineXs) {
+    const lineX = Math.round(x - props.viewportInfo.offsetX);
+    graphic.moveTo(lineX - 0.5, 0);
+    graphic.lineTo(lineX - 0.5, canvasSize.height);
+  }
+
+  // 拍線をまとめて描画
+  graphic.lineStyle(1, style.beat.color, style.beat.alpha);
+  for (const x of beatLineXs) {
+    const lineX = Math.round(x - props.viewportInfo.offsetX);
     graphic.moveTo(lineX - 0.5, 0);
     graphic.lineTo(lineX - 0.5, canvasSize.height);
   }

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -16,6 +16,7 @@ import {
   getMeasureDuration,
   getTimeSignaturePositions,
 } from "@/sing/music";
+import { assertNonNullable } from "@/type/utility";
 
 const props = defineProps<{
   viewportInfo: ViewportInfo;
@@ -83,18 +84,10 @@ let requestId: number | undefined;
 let renderInNextFrame = false;
 
 const render = () => {
-  if (renderer == undefined) {
-    throw new Error("renderer is undefined.");
-  }
-  if (stage == undefined) {
-    throw new Error("stage is undefined.");
-  }
-  if (canvasWidth == undefined) {
-    throw new Error("canvasWidth is undefined.");
-  }
-  if (canvasHeight == undefined) {
-    throw new Error("canvasHeight is undefined.");
-  }
+  assertNonNullable(renderer);
+  assertNonNullable(stage);
+  assertNonNullable(canvasWidth);
+  assertNonNullable(canvasHeight);
 
   // 可視範囲内の小節線・拍線のX座標を収集する
   // ±1pxは、丸め誤差で境界線が切れるのを防ぐためのマージン
@@ -203,12 +196,8 @@ watch(
 onMounted(() => {
   const canvasContainerElement = canvasContainer.value;
   const canvasElement = canvas.value;
-  if (!canvasContainerElement) {
-    throw new Error("canvasContainerElement is null.");
-  }
-  if (!canvasElement) {
-    throw new Error("canvasElement is null.");
-  }
+  assertNonNullable(canvasContainerElement);
+  assertNonNullable(canvasElement);
 
   canvasWidth = canvasContainerElement.clientWidth;
   canvasHeight = canvasContainerElement.clientHeight;
@@ -234,9 +223,8 @@ onMounted(() => {
   requestId = window.requestAnimationFrame(callback);
 
   resizeObserver = new ResizeObserver(() => {
-    if (renderer == undefined) {
-      throw new Error("renderer is undefined.");
-    }
+    assertNonNullable(renderer);
+
     const canvasContainerWidth = canvasContainerElement.clientWidth;
     const canvasContainerHeight = canvasContainerElement.clientHeight;
 

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -39,20 +39,12 @@ if (injectedValue == undefined) {
 const { numMeasures } = injectedValue;
 
 // テーマに応じた線のスタイル
-const gridLineStyles: {
-  light: {
-    measureLineColor: number;
-    measureLineAlpha: number;
-    beatLineColor: number;
-    beatLineAlpha: number;
-  };
-  dark: {
-    measureLineColor: number;
-    measureLineAlpha: number;
-    beatLineColor: number;
-    beatLineAlpha: number;
-  };
-} = {
+const gridLineStyles: Record<"light" | "dark", {
+  measureLineColor: number;
+  measureLineAlpha: number;
+  beatLineColor: number;
+  beatLineAlpha: number;
+}> = {
   light: {
     measureLineColor: 0x8a8a8a,
     measureLineAlpha: 0.35,

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -88,7 +88,7 @@ let canvasHeight: number | undefined;
 
 let renderer: PIXI.Renderer | undefined;
 let stage: PIXI.Container | undefined;
-const graphics: PIXI.Graphics[] = [];
+let graphic: PIXI.Graphics | undefined;
 let requestId: number | undefined;
 let renderInNextFrame = false;
 
@@ -178,20 +178,10 @@ const render = () => {
     }
   }
 
-  // Graphicsは単一インスタンスに集約して描画する
-  if (graphics.length === 0) {
-    const newGraphic = new PIXI.Graphics();
-    stage.addChild(newGraphic);
-    graphics.push(newGraphic);
-  } else if (graphics.length > 1) {
-    for (let i = graphics.length - 1; i >= 1; i--) {
-      stage.removeChild(graphics[i]);
-      graphics[i].destroy();
-      graphics.splice(i, 1);
-    }
+  if (graphic == undefined) {
+    graphic = new PIXI.Graphics();
+    stage.addChild(graphic);
   }
-
-  const graphic = graphics[0];
   graphic.clear();
 
   // 線をまとめて描画
@@ -277,7 +267,7 @@ onUnmounted(() => {
   if (requestId != undefined) {
     window.cancelAnimationFrame(requestId);
   }
-  for (const graphic of graphics) {
+  if (graphic != undefined) {
     stage?.removeChild(graphic);
     graphic.destroy();
   }

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -152,36 +152,29 @@ const render = () => {
     return lineScreenX >= -1 && lineScreenX <= canvasSize.width + 1;
   });
 
-  // Graphicsオブジェクトの数を調整
-  const neededGraphicsCount = visibleLines.length;
-  const currentGraphicsCount = graphics.length;
-
-  if (currentGraphicsCount < neededGraphicsCount) {
-    for (let i = 0; i < neededGraphicsCount - currentGraphicsCount; i++) {
-      const newGraphic = new PIXI.Graphics();
-      stage.addChild(newGraphic);
-      graphics.push(newGraphic);
+  // Graphicsは単一インスタンスに集約して描画する
+  if (graphics.length === 0) {
+    const newGraphic = new PIXI.Graphics();
+    stage.addChild(newGraphic);
+    graphics.push(newGraphic);
+  } else if (graphics.length > 1) {
+    for (let i = graphics.length - 1; i >= 1; i--) {
+      stage.removeChild(graphics[i]);
+      graphics[i].destroy();
+      graphics.splice(i, 1);
     }
   }
 
-  // 線を描画
-  for (let i = 0; i < visibleLines.length; i++) {
-    const line = visibleLines[i];
-    const graphic = graphics[i];
+  const graphic = graphics[0];
+  graphic.clear();
 
+  // 線をまとめて描画
+  for (const line of visibleLines) {
     const lineX = Math.round(line.x - props.viewportInfo.offsetX);
     const currentLineStyle = gridLineStyles[currentTheme.value][line.type];
-
-    graphic.renderable = true;
-    graphic.clear();
     graphic.lineStyle(1, currentLineStyle.color, currentLineStyle.alpha);
     graphic.moveTo(lineX - 0.5, 0);
     graphic.lineTo(lineX - 0.5, canvasSize.height);
-  }
-
-  // 残りのGraphicsを非表示にする
-  for (let i = visibleLines.length; i < graphics.length; i++) {
-    graphics[i].renderable = false;
   }
 
   renderer.render(stage);

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -197,7 +197,7 @@ const render = () => {
 };
 
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
-watch([mounted, timeSignatures, numMeasures, currentTheme], ([mounted]) => {
+watch([mounted, tpqn, timeSignatures, numMeasures, currentTheme], ([mounted]) => {
   if (mounted) {
     renderInNextFrame = true;
   }

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -30,7 +30,9 @@ const props = defineProps<{
 const store = useStore();
 const tpqn = computed(() => store.state.tpqn);
 const timeSignatures = computed(() => store.state.timeSignatures);
-const isDark = computed(() => store.state.currentTheme === "Dark");
+const currentTheme = computed(() =>
+  store.state.currentTheme === "Dark" ? "dark" : "light",
+);
 
 const injectedValue = inject(numMeasuresInjectionKey);
 if (injectedValue == undefined) {
@@ -38,24 +40,37 @@ if (injectedValue == undefined) {
 }
 const { numMeasures } = injectedValue;
 
+type LineStyle = {
+  color: number;
+  alpha: number;
+};
+
+type GridLineStyle = {
+  measure: LineStyle;
+  beat: LineStyle;
+};
+
 // テーマに応じた線のスタイル
-const gridLineStyles: Record<"light" | "dark", {
-  measureLineColor: number;
-  measureLineAlpha: number;
-  beatLineColor: number;
-  beatLineAlpha: number;
-}> = {
+const gridLineStyles: Record<"light" | "dark", GridLineStyle> = {
   light: {
-    measureLineColor: 0x8a8a8a,
-    measureLineAlpha: 0.35,
-    beatLineColor: 0xc4c4c4,
-    beatLineAlpha: 0.25,
+    measure: {
+      color: 0x8a8a8a,
+      alpha: 0.35,
+    },
+    beat: {
+      color: 0xc4c4c4,
+      alpha: 0.25,
+    },
   },
   dark: {
-    measureLineColor: 0x6b6b6b,
-    measureLineAlpha: 0.35,
-    beatLineColor: 0x4a4a4a,
-    beatLineAlpha: 0.25,
+    measure: {
+      color: 0x6b6b6b,
+      alpha: 0.35,
+    },
+    beat: {
+      color: 0x4a4a4a,
+      alpha: 0.25,
+    },
   },
 };
 
@@ -100,15 +115,6 @@ const render = () => {
     width: canvasWidth,
     height: canvasHeight,
   };
-
-  // 線の色とスタイルを取得
-  const currentGridLineStyle = isDark.value
-    ? gridLineStyles.dark
-    : gridLineStyles.light;
-  const measureLineColor = currentGridLineStyle.measureLineColor;
-  const measureLineAlpha = currentGridLineStyle.measureLineAlpha;
-  const beatLineColor = currentGridLineStyle.beatLineColor;
-  const beatLineAlpha = currentGridLineStyle.beatLineAlpha;
 
   // 小節線と拍線の位置を計算
   const gridLines: GridLineInfo[] = [];
@@ -164,12 +170,11 @@ const render = () => {
     const graphic = graphics[i];
 
     const lineX = Math.round(line.x - props.viewportInfo.offsetX);
-    const color = line.type === "measure" ? measureLineColor : beatLineColor;
-    const alpha = line.type === "measure" ? measureLineAlpha : beatLineAlpha;
+    const currentLineStyle = gridLineStyles[currentTheme.value][line.type];
 
     graphic.renderable = true;
     graphic.clear();
-    graphic.lineStyle(1, color, alpha);
+    graphic.lineStyle(1, currentLineStyle.color, currentLineStyle.alpha);
     graphic.moveTo(lineX - 0.5, 0);
     graphic.lineTo(lineX - 0.5, canvasSize.height);
   }
@@ -183,7 +188,7 @@ const render = () => {
 };
 
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
-watch([mounted, timeSignatures, numMeasures, isDark], ([mounted]) => {
+watch([mounted, timeSignatures, numMeasures, currentTheme], ([mounted]) => {
   if (mounted) {
     renderInNextFrame = true;
   }

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -1,0 +1,281 @@
+<template>
+  <div ref="canvasContainer" class="canvas-container">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, computed, onUnmounted, onMounted, inject } from "vue";
+import * as PIXI from "pixi.js";
+import { useStore } from "@/store";
+import { useMounted } from "@/composables/useMounted";
+import {
+  tickToBaseX,
+  type ViewportInfo,
+  type CanvasSize,
+} from "@/sing/viewHelper";
+import { numMeasuresInjectionKey } from "@/components/Sing/ScoreSequencer.vue";
+import type { TimeSignature } from "@/domain/project/type";
+import { getBeatDuration, getMeasureDuration } from "@/sing/music";
+
+type GridLineInfo = {
+  x: number;
+  type: "measure" | "beat";
+};
+
+const props = defineProps<{
+  viewportInfo: ViewportInfo;
+}>();
+
+const store = useStore();
+const tpqn = computed(() => store.state.tpqn);
+const timeSignatures = computed(() => store.state.timeSignatures);
+const isDark = computed(() => store.state.currentTheme === "Dark");
+
+const injectedValue = inject(numMeasuresInjectionKey);
+if (injectedValue == undefined) {
+  throw new Error("injectedValue is undefined.");
+}
+const { numMeasures } = injectedValue;
+
+// テーマに応じた線のスタイル
+const gridLineStyles: {
+  light: {
+    measureLineColor: number;
+    measureLineAlpha: number;
+    beatLineColor: number;
+    beatLineAlpha: number;
+  };
+  dark: {
+    measureLineColor: number;
+    measureLineAlpha: number;
+    beatLineColor: number;
+    beatLineAlpha: number;
+  };
+} = {
+  light: {
+    measureLineColor: 0x8a8a8a,
+    measureLineAlpha: 0.35,
+    beatLineColor: 0xc4c4c4,
+    beatLineAlpha: 0.25,
+  },
+  dark: {
+    measureLineColor: 0x6b6b6b,
+    measureLineAlpha: 0.35,
+    beatLineColor: 0x4a4a4a,
+    beatLineAlpha: 0.25,
+  },
+};
+
+const { mounted } = useMounted();
+
+const canvasContainer = ref<HTMLElement | null>(null);
+const canvas = ref<HTMLCanvasElement | null>(null);
+let resizeObserver: ResizeObserver | undefined;
+let canvasWidth: number | undefined;
+let canvasHeight: number | undefined;
+
+let renderer: PIXI.Renderer | undefined;
+let stage: PIXI.Container | undefined;
+const graphics: PIXI.Graphics[] = [];
+let requestId: number | undefined;
+let renderInNextFrame = false;
+
+const getMeasureWidth = (timeSignature: TimeSignature) => {
+  const measureTicks = getMeasureDuration(
+    timeSignature.beats,
+    timeSignature.beatType,
+    tpqn.value,
+  );
+  return tickToBaseX(measureTicks, tpqn.value) * props.viewportInfo.scaleX;
+};
+
+const render = () => {
+  if (renderer == undefined) {
+    throw new Error("renderer is undefined.");
+  }
+  if (stage == undefined) {
+    throw new Error("stage is undefined.");
+  }
+  if (canvasWidth == undefined) {
+    throw new Error("canvasWidth is undefined.");
+  }
+  if (canvasHeight == undefined) {
+    throw new Error("canvasHeight is undefined.");
+  }
+
+  const canvasSize: CanvasSize = {
+    width: canvasWidth,
+    height: canvasHeight,
+  };
+
+  // 線の色とスタイルを取得
+  const currentGridLineStyle = isDark.value
+    ? gridLineStyles.dark
+    : gridLineStyles.light;
+  const measureLineColor = currentGridLineStyle.measureLineColor;
+  const measureLineAlpha = currentGridLineStyle.measureLineAlpha;
+  const beatLineColor = currentGridLineStyle.beatLineColor;
+  const beatLineAlpha = currentGridLineStyle.beatLineAlpha;
+
+  // 小節線と拍線の位置を計算
+  const gridLines: GridLineInfo[] = [];
+  let measureStartX = 0;
+  for (const [i, timeSignature] of timeSignatures.value.entries()) {
+    const nextTimeSignature = timeSignatures.value.at(i + 1);
+    const nextMeasureNumber =
+      nextTimeSignature?.measureNumber ?? numMeasures.value + 1;
+    const width = getMeasureWidth(timeSignature);
+    const beatTicks = getBeatDuration(timeSignature.beatType, tpqn.value);
+    const beatWidth =
+      tickToBaseX(beatTicks, tpqn.value) * props.viewportInfo.scaleX;
+
+    for (
+      let measureNumber = timeSignature.measureNumber;
+      measureNumber < nextMeasureNumber;
+      measureNumber++
+    ) {
+      // 拍線
+      for (let beat = 1; beat < timeSignature.beats; beat++) {
+        gridLines.push({
+          x: measureStartX + beatWidth * beat,
+          type: "beat",
+        });
+      }
+      // 小節線（小節の右端 = 次の小節の左端）。先頭の0位置は出力しない
+      measureStartX += width;
+      gridLines.push({ x: measureStartX, type: "measure" });
+    }
+  }
+
+  // カリング: 画面外の線は除外
+  const visibleLines = gridLines.filter((line) => {
+    const lineScreenX = line.x - props.viewportInfo.offsetX;
+    return lineScreenX >= -1 && lineScreenX <= canvasSize.width + 1;
+  });
+
+  // Graphicsオブジェクトの数を調整
+  const neededGraphicsCount = visibleLines.length;
+  const currentGraphicsCount = graphics.length;
+
+  if (currentGraphicsCount < neededGraphicsCount) {
+    for (let i = 0; i < neededGraphicsCount - currentGraphicsCount; i++) {
+      const newGraphic = new PIXI.Graphics();
+      stage.addChild(newGraphic);
+      graphics.push(newGraphic);
+    }
+  }
+
+  // 線を描画
+  for (let i = 0; i < visibleLines.length; i++) {
+    const line = visibleLines[i];
+    const graphic = graphics[i];
+
+    const lineX = Math.round(line.x - props.viewportInfo.offsetX);
+    const color = line.type === "measure" ? measureLineColor : beatLineColor;
+    const alpha = line.type === "measure" ? measureLineAlpha : beatLineAlpha;
+
+    graphic.renderable = true;
+    graphic.clear();
+    graphic.lineStyle(1, color, alpha);
+    graphic.moveTo(lineX - 0.5, 0);
+    graphic.lineTo(lineX - 0.5, canvasSize.height);
+  }
+
+  // 残りのGraphicsを非表示にする
+  for (let i = visibleLines.length; i < graphics.length; i++) {
+    graphics[i].renderable = false;
+  }
+
+  renderer.render(stage);
+};
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch([mounted, timeSignatures, numMeasures, isDark], ([mounted]) => {
+  if (mounted) {
+    renderInNextFrame = true;
+  }
+});
+
+watch(
+  () => [props.viewportInfo.scaleX, props.viewportInfo.offsetX],
+  () => {
+    renderInNextFrame = true;
+  },
+);
+
+onMounted(() => {
+  const canvasContainerElement = canvasContainer.value;
+  const canvasElement = canvas.value;
+  if (!canvasContainerElement) {
+    throw new Error("canvasContainerElement is null.");
+  }
+  if (!canvasElement) {
+    throw new Error("canvasElement is null.");
+  }
+
+  canvasWidth = canvasContainerElement.clientWidth;
+  canvasHeight = canvasContainerElement.clientHeight;
+
+  renderer = new PIXI.Renderer({
+    view: canvasElement,
+    backgroundAlpha: 0,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+    width: canvasWidth,
+    height: canvasHeight,
+  });
+  stage = new PIXI.Container();
+
+  const callback = () => {
+    if (renderInNextFrame) {
+      render();
+      renderInNextFrame = false;
+    }
+    requestId = window.requestAnimationFrame(callback);
+  };
+  requestId = window.requestAnimationFrame(callback);
+
+  resizeObserver = new ResizeObserver(() => {
+    if (renderer == undefined) {
+      throw new Error("renderer is undefined.");
+    }
+    const canvasContainerWidth = canvasContainerElement.clientWidth;
+    const canvasContainerHeight = canvasContainerElement.clientHeight;
+
+    if (canvasContainerWidth > 0 && canvasContainerHeight > 0) {
+      canvasWidth = canvasContainerWidth;
+      canvasHeight = canvasContainerHeight;
+      renderer.resize(canvasWidth, canvasHeight);
+      renderInNextFrame = true;
+    }
+  });
+  resizeObserver.observe(canvasContainerElement);
+});
+
+onUnmounted(() => {
+  if (requestId != undefined) {
+    window.cancelAnimationFrame(requestId);
+  }
+  for (const graphic of graphics) {
+    stage?.removeChild(graphic);
+    graphic.destroy();
+  }
+  stage?.destroy(true);
+  renderer?.destroy(true);
+  resizeObserver?.disconnect();
+});
+</script>
+
+<style scoped lang="scss">
+@use "@/styles/v2/variables" as vars;
+
+.canvas-container {
+  overflow: hidden;
+  pointer-events: none;
+  position: relative;
+
+  contain: strict; // canvasのサイズが変わるのを無視する
+}
+</style>

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -116,41 +116,57 @@ const render = () => {
     height: canvasHeight,
   };
 
-  // 小節線と拍線の位置を計算
-  const gridLines: GridLineInfo[] = [];
-  let measureStartX = 0;
+  // 可視範囲内の小節線・拍線の位置を計算
+  const visibleLines: GridLineInfo[] = [];
+  const viewportLeft = props.viewportInfo.offsetX - 1;
+  const viewportRight = props.viewportInfo.offsetX + canvasSize.width + 1;
+
+  let sectionStartX = 0;
   for (const [i, timeSignature] of timeSignatures.value.entries()) {
     const nextTimeSignature = timeSignatures.value.at(i + 1);
     const nextMeasureNumber =
       nextTimeSignature?.measureNumber ?? numMeasures.value + 1;
-    const width = getMeasureWidth(timeSignature);
+    const measureCount = nextMeasureNumber - timeSignature.measureNumber;
+    const measureWidth = getMeasureWidth(timeSignature);
     const beatTicks = getBeatDuration(timeSignature.beatType, tpqn.value);
     const beatWidth =
       tickToBaseX(beatTicks, tpqn.value) * props.viewportInfo.scaleX;
+    const sectionWidth = measureWidth * measureCount;
 
-    for (
-      let measureNumber = timeSignature.measureNumber;
-      measureNumber < nextMeasureNumber;
-      measureNumber++
+    // セクションが可視範囲と重ならなければスキップ
+    if (
+      sectionStartX + sectionWidth < viewportLeft ||
+      sectionStartX > viewportRight
     ) {
+      sectionStartX += sectionWidth;
+      continue;
+    }
+
+    // セクション内で可視範囲に入る最初と最後の小節インデックス（0始まり）を計算
+    const firstMeasureIndex = Math.max(
+      0,
+      Math.floor((viewportLeft - sectionStartX) / measureWidth),
+    );
+    const lastMeasureIndexExclusive = Math.min(
+      measureCount,
+      Math.ceil((viewportRight - sectionStartX) / measureWidth),
+    );
+
+    for (let k = firstMeasureIndex; k < lastMeasureIndexExclusive; k++) {
+      const measureX = sectionStartX + k * measureWidth;
       // 拍線
       for (let beat = 1; beat < timeSignature.beats; beat++) {
-        gridLines.push({
-          x: measureStartX + beatWidth * beat,
+        visibleLines.push({
+          x: measureX + beatWidth * beat,
           type: "beat",
         });
       }
       // 小節線（小節の右端 = 次の小節の左端）。先頭の0位置は出力しない
-      measureStartX += width;
-      gridLines.push({ x: measureStartX, type: "measure" });
+      visibleLines.push({ x: measureX + measureWidth, type: "measure" });
     }
-  }
 
-  // カリング: 画面外の線は除外
-  const visibleLines = gridLines.filter((line) => {
-    const lineScreenX = line.x - props.viewportInfo.offsetX;
-    return lineScreenX >= -1 && lineScreenX <= canvasSize.width + 1;
-  });
+    sectionStartX += sectionWidth;
+  }
 
   // Graphicsは単一インスタンスに集約して描画する
   if (graphics.length === 0) {

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -16,7 +16,11 @@ import {
 } from "@/sing/viewHelper";
 import { numMeasuresInjectionKey } from "@/components/Sing/ScoreSequencer.vue";
 import type { TimeSignature } from "@/domain/project/type";
-import { getBeatDuration, getMeasureDuration } from "@/sing/music";
+import {
+  getBeatDuration,
+  getMeasureDuration,
+  getTimeSignaturePositions,
+} from "@/sing/music";
 
 type GridLineInfo = {
   x: number;
@@ -121,41 +125,49 @@ const render = () => {
   const viewportLeft = props.viewportInfo.offsetX - 1;
   const viewportRight = props.viewportInfo.offsetX + canvasSize.width + 1;
 
-  let sectionStartX = 0;
-  for (const [i, timeSignature] of timeSignatures.value.entries()) {
-    const nextTimeSignature = timeSignatures.value.at(i + 1);
+  // 各拍子セクションの開始tick位置を事前計算
+  const tsSectionStartTicks = getTimeSignaturePositions(
+    timeSignatures.value,
+    tpqn.value,
+  );
+
+  // 各拍子セクションから可視範囲内の線座標を収集
+  for (const [i, tsSection] of timeSignatures.value.entries()) {
+    const nextTsSection = timeSignatures.value.at(i + 1);
     const nextMeasureNumber =
-      nextTimeSignature?.measureNumber ?? numMeasures.value + 1;
-    const measureCount = nextMeasureNumber - timeSignature.measureNumber;
-    const measureWidth = getMeasureWidth(timeSignature);
-    const beatTicks = getBeatDuration(timeSignature.beatType, tpqn.value);
+      nextTsSection?.measureNumber ?? numMeasures.value + 1;
+    const measureCount = nextMeasureNumber - tsSection.measureNumber;
+    const measureWidth = getMeasureWidth(tsSection);
+    const beatTicks = getBeatDuration(tsSection.beatType, tpqn.value);
     const beatWidth =
       tickToBaseX(beatTicks, tpqn.value) * props.viewportInfo.scaleX;
-    const sectionWidth = measureWidth * measureCount;
+    const tsSectionStartX =
+      tickToBaseX(tsSectionStartTicks[i], tpqn.value) *
+      props.viewportInfo.scaleX;
+    const tsSectionWidth = measureWidth * measureCount;
 
-    // セクションが可視範囲と重ならなければスキップ
+    // 拍子セクションが可視範囲と重ならなければスキップ
     if (
-      sectionStartX + sectionWidth < viewportLeft ||
-      sectionStartX > viewportRight
+      tsSectionStartX + tsSectionWidth < viewportLeft ||
+      tsSectionStartX > viewportRight
     ) {
-      sectionStartX += sectionWidth;
       continue;
     }
 
-    // セクション内で可視範囲に入る最初と最後の小節インデックス（0始まり）を計算
+    // 拍子セクション内で可視範囲に入る最初と最後の小節インデックス（0始まり）を計算
     const firstMeasureIndex = Math.max(
       0,
-      Math.floor((viewportLeft - sectionStartX) / measureWidth),
+      Math.floor((viewportLeft - tsSectionStartX) / measureWidth),
     );
     const lastMeasureIndexExclusive = Math.min(
       measureCount,
-      Math.ceil((viewportRight - sectionStartX) / measureWidth),
+      Math.ceil((viewportRight - tsSectionStartX) / measureWidth),
     );
 
     for (let k = firstMeasureIndex; k < lastMeasureIndexExclusive; k++) {
-      const measureX = sectionStartX + k * measureWidth;
+      const measureX = tsSectionStartX + k * measureWidth;
       // 拍線
-      for (let beat = 1; beat < timeSignature.beats; beat++) {
+      for (let beat = 1; beat < tsSection.beats; beat++) {
         visibleLines.push({
           x: measureX + beatWidth * beat,
           type: "beat",
@@ -164,8 +176,6 @@ const render = () => {
       // 小節線（小節の右端 = 次の小節の左端）。先頭の0位置は出力しない
       visibleLines.push({ x: measureX + measureWidth, type: "measure" });
     }
-
-    sectionStartX += sectionWidth;
   }
 
   // Graphicsは単一インスタンスに集約して描画する

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -268,7 +268,7 @@ onUnmounted(() => {
     stage?.removeChild(graphic);
     graphic.destroy();
   }
-  stage?.destroy(true);
+  stage?.destroy();
   renderer?.destroy(true);
   resizeObserver?.disconnect();
 });

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -197,11 +197,14 @@ const render = () => {
 };
 
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
-watch([mounted, tpqn, timeSignatures, numMeasures, currentTheme], ([mounted]) => {
-  if (mounted) {
-    renderInNextFrame = true;
-  }
-});
+watch(
+  [mounted, tpqn, timeSignatures, numMeasures, currentTheme],
+  ([mounted]) => {
+    if (mounted) {
+      renderInNextFrame = true;
+    }
+  },
+);
 
 watch(
   () => [props.viewportInfo.scaleX, props.viewportInfo.offsetX],

--- a/src/components/Sing/SequencerParameterPanel.vue
+++ b/src/components/Sing/SequencerParameterPanel.vue
@@ -6,10 +6,13 @@
       <ParameterPanelEditTargetSwitcher :editTarget :changeEditTarget />
     </div>
     <div class="edit-area">
-      <SequencerPhonemeTimingEditor v-if="editTarget === 'PHONEME_TIMING'" />
+      <SequencerPhonemeTimingEditor
+        v-if="editTarget === 'PHONEME_TIMING'"
+        :viewportInfo
+      />
       <SequencerVolumeEditor
         v-if="editTarget === 'VOLUME'"
-        :offsetX="props.offsetX"
+        :offsetX="viewportInfo.offsetX"
         @update:needsAutoScroll="
           (value) => emit('update:needsAutoScroll', value)
         "
@@ -25,10 +28,9 @@ import { useStore } from "@/store";
 import type { ParameterPanelEditTarget } from "@/store/type";
 import ParameterPanelEditTargetSwitcher from "@/components/Sing/ParameterPanelEditTargetSwitcher.vue";
 import SequencerPhonemeTimingEditor from "@/components/Sing/SequencerPhonemeTimingEditor.vue";
+import type { ViewportInfo } from "@/sing/viewHelper";
 
-const props = defineProps<{
-  offsetX: number;
-}>();
+defineProps<{ viewportInfo: ViewportInfo }>();
 
 const emit = defineEmits<{
   "update:needsAutoScroll": [value: boolean];

--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -1,10 +1,49 @@
 <template>
-  <div class="phoneme-timing-editor">音素タイミング編集</div>
+  <div class="phoneme-timing-editor">
+    <div class="axis-area"></div>
+    <div class="parameter-area">
+      <SequencerParameterGrid class="parameter-grid" :viewportInfo />
+    </div>
+  </div>
 </template>
+
+<script setup lang="ts">
+import type { ViewportInfo } from "@/sing/viewHelper";
+import SequencerParameterGrid from "@/components/Sing/SequencerParameterGrid.vue";
+
+defineProps<{
+  viewportInfo: ViewportInfo;
+}>();
+</script>
 
 <style scoped lang="scss">
 .phoneme-timing-editor {
   width: 100%;
   height: 100%;
+  overflow: hidden;
+
+  display: grid;
+  grid-template-columns: 48px 1fr;
+}
+
+.axis-area {
+  grid-column: 1;
+  grid-row: 1;
+  border-right: solid 1px var(--scheme-color-sing-piano-keys-right-border);
+}
+
+.parameter-area {
+  grid-column: 2;
+  grid-row: 1;
+  overflow: hidden;
+  position: relative;
+
+  display: grid;
+  grid-template-rows: 12px 26px 28px 1fr;
+}
+
+.parameter-grid {
+  grid-column: 1;
+  grid-row: 1 / 5;
 }
 </style>

--- a/src/sing/sequencerStateMachine/common.ts
+++ b/src/sing/sequencerStateMachine/common.ts
@@ -5,6 +5,7 @@ import {
   type CursorState,
   PREVIEW_SOUND_DURATION,
   type PreviewMode,
+  type ViewportInfo,
 } from "@/sing/viewHelper";
 import type { Store } from "@/store";
 import type { SequencerEditTarget } from "@/store/type";
@@ -20,12 +21,7 @@ export type PositionOnSequencer = {
   readonly frequency: number;
 };
 
-export type ViewportInfo = {
-  readonly scaleX: number;
-  readonly scaleY: number;
-  readonly offsetX: number;
-  readonly offsetY: number;
-};
+export type { ViewportInfo };
 
 export type Input =
   | {

--- a/src/sing/viewHelper.ts
+++ b/src/sing/viewHelper.ts
@@ -174,3 +174,15 @@ export const cursorStateSchema = z.enum([
   "ERASE",
 ]);
 export type CursorState = z.infer<typeof cursorStateSchema>;
+
+export type ViewportInfo = {
+  readonly scaleX: number;
+  readonly scaleY: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+};
+
+export type CanvasSize = {
+  readonly width: number;
+  readonly height: number;
+};


### PR DESCRIPTION
## 内容

音素タイミングエディターの背景に表示するグリッド（小節線・拍線）を実装します。

### グリッドコンポーネントの追加

- `SequencerParameterGrid.vue` を新規追加します。PIXI.js を用いて小節線と拍線を描画するコンポーネントです。
- 拍子情報（`timeSignatures`）と小節数（`numMeasures`）から線の位置を計算し、画面外の線はカリングして描画対象から除外します。`PIXI.Graphics` は必要な本数だけ生成し、再描画時に使い回します。
- 線の色はライト／ダークの両テーマに対応させています。

### 音素タイミングエディターのレイアウト変更

- これまでプレースホルダーだった `SequencerPhonemeTimingEditor.vue` を、左側の軸エリアと右側のパラメーターエリアからなる 2 カラムのグリッドレイアウトに変更します。
- パラメーターエリアの背面に `SequencerParameterGrid` を配置します。

### ビューポート情報の受け渡し方法の整理

- グリッドの描画には `scaleX` と `offsetX` の両方が必要なため、親コンポーネントから子へ渡していたスクロール位置（`offsetX`）を、`scaleX` / `scaleY` / `offsetX` / `offsetY` をまとめた `ViewportInfo` 型として渡すように変更します。
- 受け渡し経路は `ScoreSequencer` → `SequencerParameterPanel` → `SequencerPhonemeTimingEditor` → `SequencerParameterGrid` です。途中の `SequencerVolumeEditor` には従来どおり `offsetX` のみを渡します。
- `ViewportInfo` 型と、関連して使う `CanvasSize` 型を `src/sing/viewHelper.ts` に追加します。

## 関連 Issue

- VOICEVOX/voicevox#2261

## スクリーンショット・動画など

<img width="553" height="251" alt="image" src="https://github.com/user-attachments/assets/6c334eb5-ed4f-4ada-be3e-02e7e11120a8" />

## その他

将来的に `src/sing/graphics/pitchLine.ts` のようにグリッド描画処理をクラス化し、Vue コンポーネント化をやめる設計も検討しているため、`src/components/Sing/SequencerGrid/` のように Container と Presentation に分け `index.stories.ts` を用意する構成にはせず、とりあえず単一の `.vue` ファイルとして実装しています。
