### PR TITLE
feat: 不要なnon null assertionをESLintで禁止する

### DIFF
--- a/eslint-plugin/index.ts
+++ b/eslint-plugin/index.ts
@@ -1,9 +1,11 @@
 import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 import noStrictNullable from "./no-strict-nullable";
+import noUselessNonNullAssertion from "./no-useless-non-null-assertion";
 import pkg from "./package.json" with { type: "json" };
 
 const rules: FlatConfig.Plugin["rules"] = {
   "no-strict-nullable": noStrictNullable,
+  "no-useless-non-null-assertion": noUselessNonNullAssertion,
 };
 
 const plugin: FlatConfig.Plugin = {
@@ -21,6 +23,18 @@ const voicevoxPlugin = {
         },
         rules: {
           "@voicevox/no-strict-nullable": "error",
+        },
+      },
+    ],
+    allTyped: [
+      {
+        name: "@voicevox/all-typed",
+        plugins: {
+          "@voicevox": plugin,
+        },
+        rules: {
+          "@voicevox/no-strict-nullable": "error",
+          "@voicevox/no-useless-non-null-assertion": "error",
         },
       },
     ],

--- a/eslint-plugin/no-useless-non-null-assertion.md
+++ b/eslint-plugin/no-useless-non-null-assertion.md
@@ -1,0 +1,7 @@
+# non-unnecessary-non-null-assertion
+
+`assertNonNullable`、`ensureNotNullish`を`T | null | undefined`以外の型に対して使用することを禁止します。
+
+NOTE:
+`assertNonNullable`、`ensureNotNullish`が`@/type/utility`からのものかどうかはチェックしていないため、他の場所で定義された同名の関数にも同様のチェックが適用されてしまう。
+もし他の場所で定義された同名の関数が存在してそれを使用している場合は、このルールを無効化するか、ちゃんと`@/type/utility`からのものかどうかをチェックするルールを追加する必要がある。

--- a/eslint-plugin/no-useless-non-null-assertion.ts
+++ b/eslint-plugin/no-useless-non-null-assertion.ts
@@ -1,0 +1,58 @@
+import ts from "typescript";
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "./create-rule";
+
+export default createRule({
+  name: "no-useless-non-null-assertion",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow calling assertNonNullable or ensureNotNullish on values that cannot be null or undefined.",
+    },
+    schema: [],
+    messages: {
+      unnecessary:
+        "この値は型に null / undefined を含まないため、{{ functionName }} を呼び出す必要はありません。",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function includesNullish(type: ts.Type): boolean {
+      const parts = type.isUnion() ? type.types : [type];
+      return parts.some(
+        (t) =>
+          (t.flags & ts.TypeFlags.Null) !== 0 ||
+          (t.flags & ts.TypeFlags.Undefined) !== 0,
+      );
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (
+          node.callee.type !== TSESTree.AST_NODE_TYPES.Identifier ||
+          (node.callee.name !== "assertNonNullable" &&
+            node.callee.name !== "ensureNotNullish")
+        ) {
+          return;
+        }
+
+        const arg = node.arguments[0];
+        if (!arg) return;
+
+        const tsNode = services.esTreeNodeToTSNodeMap.get(arg);
+        const type = checker.getTypeAtLocation(tsNode);
+
+        if (!includesNullish(type)) {
+          context.report({
+            node: arg,
+            messageId: "unnecessary",
+          });
+        }
+      },
+    };
+  },
+});

--- a/eslint-plugin/no-useless-non-null-assertion.ts
+++ b/eslint-plugin/no-useless-non-null-assertion.ts
@@ -50,6 +50,9 @@ export default createRule({
           context.report({
             node: arg,
             messageId: "unnecessary",
+            data: {
+              functionName: node.callee.name,
+            },
           });
         }
       },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -121,7 +121,10 @@ export default defineConfigWithVueTs(
   {
     name: "voicevox/type-checked/typescript",
     files: ["**/*.ts", "**/*.mts"],
-    extends: [...tsConfigs.recommendedTypeChecked],
+    extends: [
+      ...tsConfigs.recommendedTypeChecked,
+      ...pluginConfig(voicevoxPlugin.configs.allTyped),
+    ],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -136,7 +139,10 @@ export default defineConfigWithVueTs(
   {
     name: "voicevox/type-checked/vue",
     files: ["**/*.vue"],
-    extends: [...tsConfigs.recommendedTypeChecked],
+    extends: [
+      ...tsConfigs.recommendedTypeChecked,
+      ...pluginConfig(voicevoxPlugin.configs.allTyped),
+    ],
     languageOptions: {
       parser: vueParser,
       parserOptions: {

--- a/src/backend/electron/engineAndVvppController.ts
+++ b/src/backend/electron/engineAndVvppController.ts
@@ -21,7 +21,6 @@ import { loadEnvEngineInfos } from "@/domain/defaultEngine/envEngineInfo";
 import type { ProgressCallback } from "@/helpers/progressHelper";
 import { createLogger } from "@/helpers/log";
 import { DisplayableError, errorToMessage } from "@/helpers/errorHelper";
-import { assertNonNullable } from "@/type/utility";
 import { isLinux, isMac, isWindows } from "@/helpers/platform";
 
 const log = createLogger("EngineAndVvppController");
@@ -247,10 +246,6 @@ export class EngineAndVvppController {
 
     for (const envEngineInfo of this.getDownloadableEnvEngineInfos()) {
       const latestUrl = envEngineInfo.latestUrl;
-      assertNonNullable(
-        latestUrl,
-        `latestUrl is undefined for ${envEngineInfo.name}`,
-      );
 
       const latestInfo = await fetchLatestDefaultEngineInfo(latestUrl);
       if (latestInfo.formatVersion != 1) {

--- a/tests/e2e/browser/utils.ts
+++ b/tests/e2e/browser/utils.ts
@@ -49,10 +49,8 @@ export async function saveProject(page: Page): Promise<string> {
     await getQuasarMenu(page, "プロジェクトの複製を保存").click();
     await waitForUiUnlock(page);
     const [fileId] = await saveFileDialogHandle.getFileIds();
-    assertNonNullable(fileId);
     const writtenFiles = await writeFileHandle.getWrittenFileBuffers();
     const writtenFile = writtenFiles[fileId];
-    assertNonNullable(writtenFile);
     return writtenFile.toString("utf-8");
   });
 }


### PR DESCRIPTION
## 内容

`@voicevox/no-useless-non-null-assertion`というルールを追加します。動作は名前通りです。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）