### PR TITLE
feat: pixi.js を v8（8.17.1）にアップグレード

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "// TODO: hotkeys-jsのメジャーバージョン更新は動作テストしてから https://github.com/VOICEVOX/voicevox/pull/2953#pullrequestreview-3819334546": "",
   "dependencies": {
     "@gtm-support/vue-gtm": "3.1.0",
-    "@pixi/unsafe-eval": "7.4.3",
     "@quasar/extras": "1.17.0",
     "@sevenc-nanashi/utaformatix-ts": "jsr:0.4.0",
     "@std/path": "jsr:1.1.4",
@@ -75,7 +74,7 @@
     "markdown-it": "14.1.1",
     "move-file": "4.1.0",
     "multistream": "4.1.0",
-    "pixi.js": "7.4.3",
+    "pixi.js": "8.17.1",
     "quasar": "2.18.6",
     "reka-ui": "2.8.0",
     "rfdc": "1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,6 @@ importers:
       '@gtm-support/vue-gtm':
         specifier: 3.1.0
         version: 3.1.0(vue@3.5.27(typescript@5.9.3))
-      '@pixi/unsafe-eval':
-        specifier: 7.4.3
-        version: 7.4.3(@pixi/core@7.4.3)
       '@quasar/extras':
         specifier: 1.17.0
         version: 1.17.0
@@ -70,8 +67,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       pixi.js:
-        specifier: 7.4.3
-        version: 7.4.3
+        specifier: 8.17.1
+        version: 8.17.1
       quasar:
         specifier: 2.18.6
         version: 2.18.6
@@ -955,210 +952,8 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
-  '@pixi/accessibility@7.4.3':
-    resolution: {integrity: sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-      '@pixi/events': 7.4.3
-
-  '@pixi/app@7.4.3':
-    resolution: {integrity: sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-
-  '@pixi/assets@7.4.3':
-    resolution: {integrity: sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/color@7.4.3':
-    resolution: {integrity: sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==}
-
   '@pixi/colord@2.9.6':
     resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
-
-  '@pixi/compressed-textures@7.4.3':
-    resolution: {integrity: sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==}
-    peerDependencies:
-      '@pixi/assets': 7.4.3
-      '@pixi/core': 7.4.3
-
-  '@pixi/constants@7.4.3':
-    resolution: {integrity: sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==}
-
-  '@pixi/core@7.4.3':
-    resolution: {integrity: sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==}
-
-  '@pixi/display@7.4.3':
-    resolution: {integrity: sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/events@7.4.3':
-    resolution: {integrity: sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-
-  '@pixi/extensions@7.4.3':
-    resolution: {integrity: sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==}
-
-  '@pixi/extract@7.4.3':
-    resolution: {integrity: sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-alpha@7.4.3':
-    resolution: {integrity: sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-blur@7.4.3':
-    resolution: {integrity: sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-color-matrix@7.4.3':
-    resolution: {integrity: sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-displacement@7.4.3':
-    resolution: {integrity: sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-fxaa@7.4.3':
-    resolution: {integrity: sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-noise@7.4.3':
-    resolution: {integrity: sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/graphics@7.4.3':
-    resolution: {integrity: sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-      '@pixi/sprite': 7.4.3
-
-  '@pixi/math@7.4.3':
-    resolution: {integrity: sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==}
-
-  '@pixi/mesh-extras@7.4.3':
-    resolution: {integrity: sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/mesh': 7.4.3
-
-  '@pixi/mesh@7.4.3':
-    resolution: {integrity: sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-
-  '@pixi/mixin-cache-as-bitmap@7.4.3':
-    resolution: {integrity: sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-      '@pixi/sprite': 7.4.3
-
-  '@pixi/mixin-get-child-by-name@7.4.3':
-    resolution: {integrity: sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==}
-    peerDependencies:
-      '@pixi/display': 7.4.3
-
-  '@pixi/mixin-get-global-position@7.4.3':
-    resolution: {integrity: sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-
-  '@pixi/particle-container@7.4.3':
-    resolution: {integrity: sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-      '@pixi/sprite': 7.4.3
-
-  '@pixi/prepare@7.4.3':
-    resolution: {integrity: sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-      '@pixi/graphics': 7.4.3
-      '@pixi/text': 7.4.3
-
-  '@pixi/runner@7.4.3':
-    resolution: {integrity: sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==}
-
-  '@pixi/settings@7.4.3':
-    resolution: {integrity: sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==}
-
-  '@pixi/sprite-animated@7.4.3':
-    resolution: {integrity: sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/sprite': 7.4.3
-
-  '@pixi/sprite-tiling@7.4.3':
-    resolution: {integrity: sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-      '@pixi/sprite': 7.4.3
-
-  '@pixi/sprite@7.4.3':
-    resolution: {integrity: sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-
-  '@pixi/spritesheet@7.4.3':
-    resolution: {integrity: sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==}
-    peerDependencies:
-      '@pixi/assets': 7.4.3
-      '@pixi/core': 7.4.3
-
-  '@pixi/text-bitmap@7.4.3':
-    resolution: {integrity: sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==}
-    peerDependencies:
-      '@pixi/assets': 7.4.3
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-      '@pixi/mesh': 7.4.3
-      '@pixi/text': 7.4.3
-
-  '@pixi/text-html@7.4.3':
-    resolution: {integrity: sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3
-      '@pixi/sprite': 7.4.3
-      '@pixi/text': 7.4.3
-
-  '@pixi/text@7.4.3':
-    resolution: {integrity: sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/sprite': 7.4.3
-
-  '@pixi/ticker@7.4.3':
-    resolution: {integrity: sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==}
-
-  '@pixi/unsafe-eval@7.4.3':
-    resolution: {integrity: sha512-iR2iLcMculCSmn3x446ICCL5iokmFuLZDgNo7k1Q5rzNiULELIixfpSJwvlJqrJPY1kda0oqGHgVGRQ2vGfaLg==}
-    peerDependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/utils@7.4.3':
-    resolution: {integrity: sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1489,17 +1284,14 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/css-font-loading-module@0.0.12':
-    resolution: {integrity: sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==}
-
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/earcut@2.1.4':
-    resolution: {integrity: sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==}
+  '@types/earcut@3.0.0':
+    resolution: {integrity: sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==}
 
   '@types/encoding-japanese@2.2.1':
     resolution: {integrity: sha512-6jjepuTusvySxMLP7W6usamlbgf0F4sIDvm7EzYePjLHY7zWUv4yz2PLUnu0vuNVtXOTLu2cRdFcDg40J5Owsw==}
@@ -1840,9 +1632,13 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
+
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -2539,8 +2335,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  earcut@2.2.4:
-    resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2837,8 +2633,8 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -3108,6 +2904,9 @@ packages:
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3548,6 +3347,9 @@ packages:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
     engines: {node: '>=14'}
     hasBin: true
+
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -4151,6 +3953,9 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -4222,8 +4027,8 @@ packages:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
 
-  pixi.js@7.4.3:
-    resolution: {integrity: sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==}
+  pixi.js@8.17.1:
+    resolution: {integrity: sha512-OB4TpZHrP5RYy+7FqmFrAc0IHRhfOoNIfF4sVeinvK3aG1r2pYrSMneJAKi9+WvGKC70Dj7GEpZ2OZGB6o/xdg==}
 
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
@@ -4362,9 +4167,6 @@ packages:
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
-
-  punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -5026,6 +4828,10 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tiny-lru@11.4.7:
+    resolution: {integrity: sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==}
+    engines: {node: '>=12'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5241,10 +5047,6 @@ packages:
 
   uri-templates@0.2.0:
     resolution: {integrity: sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==}
-
-  url@0.11.4:
-    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
-    engines: {node: '>= 0.4'}
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -6314,199 +6116,7 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
-  '@pixi/accessibility@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/events@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/events': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-
-  '@pixi/app@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-
-  '@pixi/assets@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@types/css-font-loading-module': 0.0.12
-
-  '@pixi/color@7.4.3':
-    dependencies:
-      '@pixi/colord': 2.9.6
-
   '@pixi/colord@2.9.6': {}
-
-  '@pixi/compressed-textures@7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/assets': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/core': 7.4.3
-
-  '@pixi/constants@7.4.3': {}
-
-  '@pixi/core@7.4.3':
-    dependencies:
-      '@pixi/color': 7.4.3
-      '@pixi/constants': 7.4.3
-      '@pixi/extensions': 7.4.3
-      '@pixi/math': 7.4.3
-      '@pixi/runner': 7.4.3
-      '@pixi/settings': 7.4.3
-      '@pixi/ticker': 7.4.3
-      '@pixi/utils': 7.4.3
-
-  '@pixi/display@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/events@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-
-  '@pixi/extensions@7.4.3': {}
-
-  '@pixi/extract@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-alpha@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-blur@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-color-matrix@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-displacement@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-fxaa@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/filter-noise@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/graphics@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-
-  '@pixi/math@7.4.3': {}
-
-  '@pixi/mesh-extras@7.4.3(@pixi/core@7.4.3)(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/mesh': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-
-  '@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-
-  '@pixi/mixin-cache-as-bitmap@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-
-  '@pixi/mixin-get-child-by-name@7.4.3(@pixi/display@7.4.3(@pixi/core@7.4.3))':
-    dependencies:
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-
-  '@pixi/mixin-get-global-position@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-
-  '@pixi/particle-container@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-
-  '@pixi/prepare@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/graphics@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/graphics': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-
-  '@pixi/runner@7.4.3': {}
-
-  '@pixi/settings@7.4.3':
-    dependencies:
-      '@pixi/constants': 7.4.3
-      '@types/css-font-loading-module': 0.0.12
-      ismobilejs: 1.1.1
-
-  '@pixi/sprite-animated@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-
-  '@pixi/sprite-tiling@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-
-  '@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-
-  '@pixi/spritesheet@7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/assets': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/core': 7.4.3
-
-  '@pixi/text-bitmap@7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))':
-    dependencies:
-      '@pixi/assets': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/mesh': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-      '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-
-  '@pixi/text-html@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-      '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-
-  '@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
-    dependencies:
-      '@pixi/core': 7.4.3
-      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-
-  '@pixi/ticker@7.4.3':
-    dependencies:
-      '@pixi/extensions': 7.4.3
-      '@pixi/settings': 7.4.3
-      '@pixi/utils': 7.4.3
-
-  '@pixi/unsafe-eval@7.4.3(@pixi/core@7.4.3)':
-    dependencies:
-      '@pixi/core': 7.4.3
-
-  '@pixi/utils@7.4.3':
-    dependencies:
-      '@pixi/color': 7.4.3
-      '@pixi/constants': 7.4.3
-      '@pixi/settings': 7.4.3
-      '@types/earcut': 2.1.4
-      earcut: 2.2.4
-      eventemitter3: 4.0.7
-      url: 0.11.4
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6786,15 +6396,13 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/css-font-loading-module@0.0.12': {}
-
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/earcut@2.1.4': {}
+  '@types/earcut@3.0.0': {}
 
   '@types/encoding-japanese@2.2.1': {}
 
@@ -7254,6 +6862,8 @@ snapshots:
   '@vueuse/shared@14.2.0(vue@3.5.27(typescript@5.9.3))':
     dependencies:
       vue: 3.5.27(typescript@5.9.3)
+
+  '@webgpu/types@0.1.69': {}
 
   '@xmldom/xmldom@0.8.11': {}
 
@@ -7972,7 +7582,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  earcut@2.2.4: {}
+  earcut@3.0.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -8397,7 +8007,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventemitter3@4.0.7: {}
+  eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -8736,6 +8346,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
 
   glob-parent@5.1.2:
     dependencies:
@@ -9193,6 +8807,8 @@ snapshots:
       glob: 10.5.0
       js-cookie: 3.0.5
       nopt: 7.2.1
+
+  js-binary-schema-parser@2.0.3: {}
 
   js-cookie@3.0.5: {}
 
@@ -9949,6 +9565,8 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse-svg-path@0.1.2: {}
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -10006,38 +9624,18 @@ snapshots:
     dependencies:
       pngjs: 7.0.0
 
-  pixi.js@7.4.3:
+  pixi.js@8.17.1:
     dependencies:
-      '@pixi/accessibility': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/events@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/app': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-      '@pixi/assets': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/compressed-textures': 7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)
-      '@pixi/core': 7.4.3
-      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/events': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-      '@pixi/extensions': 7.4.3
-      '@pixi/extract': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/filter-alpha': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/filter-blur': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/filter-color-matrix': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/filter-displacement': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/filter-fxaa': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/filter-noise': 7.4.3(@pixi/core@7.4.3)
-      '@pixi/graphics': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/mesh': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-      '@pixi/mesh-extras': 7.4.3(@pixi/core@7.4.3)(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/mixin-cache-as-bitmap': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/mixin-get-child-by-name': 7.4.3(@pixi/display@7.4.3(@pixi/core@7.4.3))
-      '@pixi/mixin-get-global-position': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-      '@pixi/particle-container': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/prepare': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/graphics@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))
-      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
-      '@pixi/sprite-animated': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/sprite-tiling': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/spritesheet': 7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)
-      '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
-      '@pixi/text-bitmap': 7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))
-      '@pixi/text-html': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))
+      '@pixi/colord': 2.9.6
+      '@types/earcut': 3.0.0
+      '@webgpu/types': 0.1.69
+      '@xmldom/xmldom': 0.8.11
+      earcut: 3.0.2
+      eventemitter3: 5.0.4
+      gifuct-js: 2.1.2
+      ismobilejs: 1.1.1
+      parse-svg-path: 0.1.2
+      tiny-lru: 11.4.7
 
   pkce-challenge@5.0.1: {}
 
@@ -10209,8 +9807,6 @@ snapshots:
       once: 1.4.0
 
   punycode.js@2.3.1: {}
-
-  punycode@1.4.1: {}
 
   punycode@2.3.1: {}
 
@@ -10977,6 +10573,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tiny-lru@11.4.7: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -11172,11 +10770,6 @@ snapshots:
       punycode: 2.3.1
 
   uri-templates@0.2.0: {}
-
-  url@0.11.4:
-    dependencies:
-      punycode: 1.4.1
-      qs: 6.14.1
 
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:

--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -109,6 +109,7 @@ let resizeObserver: ResizeObserver | undefined;
 let canvasWidth: number | undefined;
 let canvasHeight: number | undefined;
 
+// TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmounted, isInitializedなどのフラグを無くす
 let renderer: PIXI.Renderer | undefined;
 let stage: PIXI.Container | undefined;
 let originalPitchLine: PitchLine | undefined;

--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -6,10 +6,9 @@
 
 <script setup lang="ts">
 import { ref, watch, computed, onUnmounted, onMounted } from "vue";
-import "@pixi/unsafe-eval";
+import "pixi.js/unsafe-eval";
 import * as PIXI from "pixi.js";
 import { useStore } from "@/store";
-import { useMounted } from "@/composables/useMounted";
 import { frequencyToNoteNumber, secondToTick } from "@/sing/music";
 import {
   UNVOICED_PHONEMES,
@@ -104,8 +103,6 @@ const isPitchLineVisible = computed(() => {
   return store.getters.SELECTED_TRACK.singer != undefined;
 });
 
-const { mounted } = useMounted();
-
 const canvasContainer = ref<HTMLElement | null>(null);
 const canvas = ref<HTMLCanvasElement | null>(null);
 let resizeObserver: ResizeObserver | undefined;
@@ -118,6 +115,8 @@ let originalPitchLine: PitchLine | undefined;
 let pitchEditLine: PitchLine | undefined;
 let requestId: number | undefined;
 let renderInNextFrame = false;
+let isUnmounted = false;
+const isInitialized = ref(false);
 
 const render = () => {
   if (renderer == undefined) {
@@ -294,13 +293,13 @@ const updatePitchEditLineDataMap = async () => {
 const originalPitchLock = new Mutex({ maxPending: 1 });
 const pitchEditLock = new Mutex({ maxPending: 1 });
 
-// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+// NOTE: isInitializedをwatchしているので、初期化完了後に必ず１回実行される
 watch(
-  [mounted, singingGuidesInSelectedTrack, tempos, tpqn],
-  async ([mounted]) => {
+  [isInitialized, singingGuidesInSelectedTrack, tempos, tpqn],
+  async ([isInitialized]) => {
     try {
       await using _lock = await originalPitchLock.acquire();
-      if (mounted) {
+      if (isInitialized) {
         await updateOriginalPitchLineDataMap();
       }
     } catch (e) {
@@ -309,13 +308,13 @@ watch(
   },
 );
 
-// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+// NOTE: isInitializedをwatchしているので、初期化完了後に必ず１回実行される
 watch(
-  [mounted, pitchEditData, previewPitchEdit, tempos, tpqn],
-  async ([mounted]) => {
+  [isInitialized, pitchEditData, previewPitchEdit, tempos, tpqn],
+  async ([isInitialized]) => {
     try {
       await using _lock = await pitchEditLock.acquire();
-      if (mounted) {
+      if (isInitialized) {
         await updatePitchEditLineDataMap();
       }
     } catch (e) {
@@ -340,7 +339,7 @@ watch(
   },
 );
 
-onMounted(() => {
+onMounted(async () => {
   const canvasContainerElement = canvasContainer.value;
   const canvasElement = canvas.value;
   if (!canvasContainerElement) {
@@ -353,8 +352,8 @@ onMounted(() => {
   canvasWidth = canvasContainerElement.clientWidth;
   canvasHeight = canvasContainerElement.clientHeight;
 
-  renderer = new PIXI.Renderer({
-    view: canvasElement,
+  renderer = await PIXI.autoDetectRenderer({
+    canvas: canvasElement,
     backgroundAlpha: 0,
     antialias: true,
     resolution: window.devicePixelRatio || 1,
@@ -362,6 +361,20 @@ onMounted(() => {
     width: canvasWidth,
     height: canvasHeight,
   });
+  if (isUnmounted) {
+    renderer.destroy({ removeView: true });
+    return;
+  }
+
+  // webGLVersionをチェックする
+  // 2未満の場合、ピッチの表示ができないのでエラーとしてロギングする
+  if (renderer instanceof PIXI.WebGLRenderer) {
+    const webGLVersion = renderer.context.webGLVersion;
+    if (webGLVersion < 2) {
+      error(`webGLVersion is less than 2. webGLVersion: ${webGLVersion}`);
+    }
+  }
+
   stage = new PIXI.Container();
   originalPitchLine = new PitchLine(
     originalPitchLineColor.value,
@@ -374,15 +387,8 @@ onMounted(() => {
     isPitchLineVisible.value,
   );
 
-  stage.addChild(originalPitchLine.displayObject);
-  stage.addChild(pitchEditLine.displayObject);
-
-  // webGLVersionをチェックする
-  // 2未満の場合、ピッチの表示ができないのでエラーとしてロギングする
-  const webGLVersion = renderer.context.webGLVersion;
-  if (webGLVersion < 2) {
-    error(`webGLVersion is less than 2. webGLVersion: ${webGLVersion}`);
-  }
+  stage.addChild(originalPitchLine.container);
+  stage.addChild(pitchEditLine.container);
 
   const callback = () => {
     if (renderInNextFrame) {
@@ -408,16 +414,19 @@ onMounted(() => {
     }
   });
   resizeObserver.observe(canvasContainerElement);
+
+  isInitialized.value = true;
 });
 
 onUnmounted(() => {
+  isUnmounted = true;
   if (requestId != undefined) {
     window.cancelAnimationFrame(requestId);
   }
   originalPitchLine?.destroy();
   pitchEditLine?.destroy();
   stage?.destroy();
-  renderer?.destroy(true);
+  renderer?.destroy({ removeView: true });
   resizeObserver?.disconnect();
 });
 </script>

--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -354,6 +354,8 @@ onMounted(async () => {
   canvasHeight = canvasContainerElement.clientHeight;
 
   renderer = await PIXI.autoDetectRenderer({
+    preference: "webgl",
+    preferWebGLVersion: 2,
     canvas: canvasElement,
     backgroundAlpha: 0,
     antialias: true,

--- a/src/components/Sing/SequencerVolumeEditor.vue
+++ b/src/components/Sing/SequencerVolumeEditor.vue
@@ -166,6 +166,7 @@ const canvas = ref<HTMLCanvasElement | null>(null);
 const viewportWidth = ref<number>();
 const viewportHeight = ref<number>();
 
+  // TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
 let renderer: PIXI.Renderer | undefined;
 let stage: PIXI.Container | undefined;
 let gridGraphics: PIXI.Graphics | undefined;

--- a/src/components/Sing/SequencerVolumeEditor.vue
+++ b/src/components/Sing/SequencerVolumeEditor.vue
@@ -166,7 +166,7 @@ const canvas = ref<HTMLCanvasElement | null>(null);
 const viewportWidth = ref<number>();
 const viewportHeight = ref<number>();
 
-  // TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
+// TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
 let renderer: PIXI.Renderer | undefined;
 let stage: PIXI.Container | undefined;
 let gridGraphics: PIXI.Graphics | undefined;

--- a/src/components/Sing/SequencerVolumeEditor.vue
+++ b/src/components/Sing/SequencerVolumeEditor.vue
@@ -175,6 +175,7 @@ let editedVolumeLine: VolumeLine | undefined;
 let requestId: number | undefined;
 let resizeObserver: ResizeObserver | undefined;
 let renderInNextFrame = false;
+let isUnmounted = false;
 let viewportRectCache:
   | { left: number; top: number; width: number; height: number }
   | undefined;
@@ -273,9 +274,10 @@ const updateGrid = () => {
       if (measureX < -1 || measureX > width + 1) {
         continue;
       }
-      gridGraphics.lineStyle(1, measureColor, 0.35);
-      gridGraphics.moveTo(measureX, 0);
-      gridGraphics.lineTo(measureX, height);
+      gridGraphics
+        .moveTo(measureX, 0)
+        .lineTo(measureX, height)
+        .stroke({ width: 1, color: measureColor, alpha: 0.35 });
 
       if (m === measuresInPattern) {
         continue;
@@ -285,9 +287,10 @@ const updateGrid = () => {
         if (beatX < -1 || beatX > width + 1) {
           continue;
         }
-        gridGraphics.lineStyle(1, beatColor, 0.22);
-        gridGraphics.moveTo(beatX, 0);
-        gridGraphics.lineTo(beatX, height);
+        gridGraphics
+          .moveTo(beatX, 0)
+          .lineTo(beatX, height)
+          .stroke({ width: 1, color: beatColor, alpha: 0.22 });
       }
     }
   }
@@ -327,14 +330,14 @@ const render = () => {
       const clampedStart = Math.max(0, startX);
       const clampedEnd = Math.min(viewInfo.viewportWidth, endX);
       if (clampedEnd > clampedStart) {
-        erasePreviewOverlay.beginFill(0x000000, 0.12);
-        erasePreviewOverlay.drawRect(
-          clampedStart,
-          0,
-          clampedEnd - clampedStart,
-          viewInfo.viewportHeight,
-        );
-        erasePreviewOverlay.endFill();
+        erasePreviewOverlay
+          .rect(
+            clampedStart,
+            0,
+            clampedEnd - clampedStart,
+            viewInfo.viewportHeight,
+          )
+          .fill({ color: 0x000000, alpha: 0.12 });
       }
     }
   }
@@ -643,7 +646,7 @@ watch(
   },
 );
 
-onMounted(() => {
+onMounted(async () => {
   const containerEl = canvasContainer.value;
   const canvasEl = canvas.value;
   if (!containerEl || !canvasEl) {
@@ -666,8 +669,8 @@ onMounted(() => {
   viewportWidth.value = containerEl.clientWidth;
   viewportHeight.value = containerEl.clientHeight;
 
-  renderer = new PIXI.Renderer({
-    view: canvasEl,
+  renderer = await PIXI.autoDetectRenderer({
+    canvas: canvasEl,
     backgroundAlpha: 0,
     antialias: true,
     resolution: window.devicePixelRatio || 1,
@@ -675,6 +678,10 @@ onMounted(() => {
     width: viewportWidth.value,
     height: viewportHeight.value,
   });
+  if (isUnmounted) {
+    renderer.destroy({ removeView: true });
+    return;
+  }
   stage = new PIXI.Container();
   erasePreviewOverlay = new PIXI.Graphics();
   gridGraphics = new PIXI.Graphics();
@@ -694,8 +701,8 @@ onMounted(() => {
 
   stage.addChild(erasePreviewOverlay); // 下地
   stage.addChild(gridGraphics); // グリッドはオーバーレイの上に
-  stage.addChild(originalVolumeLine.displayObject);
-  stage.addChild(editedVolumeLine.displayObject);
+  stage.addChild(originalVolumeLine.container);
+  stage.addChild(editedVolumeLine.container);
 
   const callback = () => {
     if (renderInNextFrame) {
@@ -738,6 +745,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  isUnmounted = true;
   if (requestId != undefined) {
     window.cancelAnimationFrame(requestId);
   }
@@ -745,7 +753,7 @@ onUnmounted(() => {
   editedVolumeLine?.destroy();
   gridGraphics?.destroy();
   stage?.destroy();
-  renderer?.destroy(true);
+  renderer?.destroy({ removeView: true });
   resizeObserver?.disconnect();
   window.removeEventListener("pointermove", onWindowPointerMove);
   window.removeEventListener("pointerup", onWindowPointerUp);

--- a/src/sing/graphics/lineStrip.ts
+++ b/src/sing/graphics/lineStrip.ts
@@ -38,15 +38,15 @@ export class Color {
 export class LineStrip {
   readonly color: Color;
   readonly width: number;
-  private readonly mesh: PIXI.Mesh<PIXI.Shader>;
+  private readonly mesh: PIXI.Mesh<PIXI.Geometry, PIXI.Shader>;
   private readonly shader: PIXI.Shader;
   private readonly geometry: PIXI.Geometry;
   private readonly pointsBuffer: PIXI.Buffer;
 
   private points: Float32Array;
 
-  get displayObject() {
-    return this.mesh as PIXI.DisplayObject;
+  get container(): PIXI.Container {
+    return this.mesh;
   }
 
   get renderable() {
@@ -77,41 +77,56 @@ export class LineStrip {
     }
     this.color = color;
     this.width = width;
-    this.shader = PIXI.Shader.from(
-      lineStripVertexShaderSource,
-      fragmentShaderSource,
-      { color: color.toRgbaArray().map((value) => value / 255) },
-    );
+    this.shader = PIXI.Shader.from({
+      gl: {
+        vertex: lineStripVertexShaderSource,
+        fragment: fragmentShaderSource,
+      },
+      resources: {
+        uniforms: new PIXI.UniformGroup({
+          uLineColor: {
+            value: color.toRgbaArray().map((value) => value / 255),
+            type: "vec4<f32>",
+          },
+        }),
+      },
+    });
     this.points = new Float32Array(numOfPoints * 2);
-    // @ts-expect-error 動くので無視。恐らくpixi.js v7の型定義がTypeScript 5.7以降に対応していないため。
-    this.pointsBuffer = new PIXI.Buffer(this.points, false);
+    this.pointsBuffer = new PIXI.Buffer({
+      data: this.points,
+      usage: PIXI.BufferUsage.VERTEX,
+    });
     const vertices = this.generateLineSegmentVertices(width);
     const sizeOfFloat = 4;
-    this.geometry = new PIXI.Geometry();
-    this.geometry.instanced = true;
-    this.geometry.instanceCount = numOfPoints - 1;
-    this.geometry.addAttribute("pos", vertices.flat(), 3);
-    this.geometry.addAttribute(
-      "pointA",
-      this.pointsBuffer,
-      2,
-      false,
-      PIXI.TYPES.FLOAT,
-      sizeOfFloat * 2,
-      0,
-      true,
-    );
-    this.geometry.addAttribute(
-      "pointB",
-      this.pointsBuffer,
-      2,
-      false,
-      PIXI.TYPES.FLOAT,
-      sizeOfFloat * 2,
-      sizeOfFloat * 2,
-      true,
-    );
-    this.mesh = new PIXI.Mesh(this.geometry, this.shader);
+    this.geometry = new PIXI.Geometry({
+      instanceCount: numOfPoints - 1,
+      attributes: {
+        pos: {
+          buffer: new PIXI.Buffer({
+            data: new Float32Array(vertices.flat()),
+            usage: PIXI.BufferUsage.VERTEX,
+          }),
+          format: "float32x3",
+          stride: 3 * sizeOfFloat,
+          offset: 0,
+        },
+        pointA: {
+          buffer: this.pointsBuffer,
+          format: "float32x2",
+          stride: sizeOfFloat * 2,
+          offset: 0,
+          instance: true,
+        },
+        pointB: {
+          buffer: this.pointsBuffer,
+          format: "float32x2",
+          stride: sizeOfFloat * 2,
+          offset: sizeOfFloat * 2,
+          instance: true,
+        },
+      },
+    });
+    this.mesh = new PIXI.Mesh({ geometry: this.geometry, shader: this.shader });
   }
 
   private generateLineSegmentVertices(width: number) {
@@ -138,8 +153,7 @@ export class LineStrip {
    * 折れ線を更新します。（設定されたポイントを適用します）
    */
   update() {
-    // @ts-expect-error 動くので無視。恐らくpixi.js v7の型定義がTypeScript 5.7以降に対応していないため。
-    this.pointsBuffer.update(this.points);
+    this.pointsBuffer.data = this.points;
     if (this.geometry.instanceCount !== this.numOfPoints - 1) {
       this.geometry.instanceCount = this.numOfPoints - 1;
     }

--- a/src/sing/graphics/pitchLine.ts
+++ b/src/sing/graphics/pitchLine.ts
@@ -35,11 +35,7 @@ export class PitchLine {
   pitchDataMap: Map<PitchDataHash, PitchData>;
 
   private readonly lineStripMap: Map<PitchDataHash, LineStrip>;
-  private readonly container: PIXI.Container;
-
-  get displayObject(): PIXI.DisplayObject {
-    return this.container;
-  }
+  readonly container: PIXI.Container;
 
   constructor(color: Color, width: number, isVisible: boolean) {
     this.color = color;
@@ -69,7 +65,7 @@ export class PitchLine {
         !lineStrip.color.equals(this.color) ||
         lineStrip.width !== this.width
       ) {
-        this.container.removeChild(lineStrip.displayObject);
+        this.container.removeChild(lineStrip.container);
         removedLineStrips.push(lineStrip);
         this.lineStripMap.delete(key);
       }
@@ -93,7 +89,7 @@ export class PitchLine {
         lineStrip = new LineStrip(pitchData.length, this.color, this.width);
       }
 
-      this.container.addChild(lineStrip.displayObject);
+      this.container.addChild(lineStrip.container);
       this.lineStripMap.set(key, lineStrip);
     }
 

--- a/src/sing/graphics/shaders/fragmentShader.glsl
+++ b/src/sing/graphics/shaders/fragmentShader.glsl
@@ -1,10 +1,10 @@
 #version 300 es
 precision mediump float;
 
-uniform vec4 color;
+uniform vec4 uLineColor;
 
 out vec4 outColor;
 
 void main() {
-  outColor = color;
+  outColor = uLineColor;
 }

--- a/src/sing/graphics/shaders/lineStripVertexShader.glsl
+++ b/src/sing/graphics/shaders/lineStripVertexShader.glsl
@@ -6,8 +6,9 @@ in vec3 pos; // 頂点の位置
 in vec2 pointA; // 線分の始点の位置
 in vec2 pointB; // 線分の終点の位置
 
-uniform mat3 translationMatrix;
-uniform mat3 projectionMatrix;
+uniform mat3 uProjectionMatrix;
+uniform mat3 uWorldTransformMatrix;
+uniform mat3 uTransformMatrix;
 
 void main() {
   vec2 basisVecX = normalize(pointB - pointA);
@@ -15,6 +16,6 @@ void main() {
   vec2 rotatedPos = basisVecX * pos.x + basisVecY * pos.y;
   // mix(pointA, pointB, pos.z) は (pos.z == 0) ? pointA : pointB と同じ
   vec2 translatedPos = rotatedPos + mix(pointA, pointB, pos.z);
-  vec3 transformedPos = projectionMatrix * translationMatrix * vec3(translatedPos, 1.0);
+  vec3 transformedPos = uProjectionMatrix * uWorldTransformMatrix * uTransformMatrix * vec3(translatedPos, 1.0);
   gl_Position = vec4(transformedPos.xy, 0.0, 1.0);
 }

--- a/src/sing/graphics/volumeLine.ts
+++ b/src/sing/graphics/volumeLine.ts
@@ -42,13 +42,9 @@ export class VolumeLine {
   areaAlpha: number;
   isVisible: boolean;
 
-  private readonly container: PIXI.Container;
+  readonly container: PIXI.Container;
   private readonly area: PIXI.Graphics;
   private readonly line: PIXI.Graphics;
-
-  get displayObject(): PIXI.DisplayObject {
-    return this.container;
-  }
 
   constructor(options: VolumeLineOptions) {
     this.color = options.color;
@@ -75,12 +71,13 @@ export class VolumeLine {
 
     this.area.clear();
     this.line.clear();
-    this.line.lineStyle({
+
+    const strokeStyle = {
       width: this.width,
       color: colorToHex(this.color),
       alpha,
       alignment: 0.5,
-    });
+    };
 
     for (const segment of segments) {
       if (segment.length < 2) continue;
@@ -109,16 +106,16 @@ export class VolumeLine {
       }));
 
       if (this.showArea) {
-        this.area.beginFill(colorToHex(this.color), this.areaAlpha);
-        this.area.moveTo(screenPoints[0].x, viewInfo.viewportHeight);
-        for (const p of screenPoints) {
-          this.area.lineTo(p.x, p.y);
-        }
-        this.area.lineTo(
-          screenPoints[screenPoints.length - 1].x,
-          viewInfo.viewportHeight,
-        );
-        this.area.endFill();
+        this.area
+          .poly([
+            { x: screenPoints[0].x, y: viewInfo.viewportHeight },
+            ...screenPoints,
+            {
+              x: screenPoints[screenPoints.length - 1].x,
+              y: viewInfo.viewportHeight,
+            },
+          ])
+          .fill({ color: colorToHex(this.color), alpha: this.areaAlpha });
       }
 
       if (this.dashed) {
@@ -167,6 +164,8 @@ export class VolumeLine {
         }
       }
     }
+
+    this.line.stroke(strokeStyle);
   }
 
   destroy() {


### PR DESCRIPTION
## 内容

pixi.js を v7（7.4.3）から v8（8.17.1）にアップグレードし、v8 への対応を行いました。

主に[公式マイグレーションガイド](https://pixijs.com/8.x/guides/migrations/v8)に沿って対応しましたが、以下の点はガイドに記載がなく、pixi.js のソースコードを確認して対応しました。

- `GlMeshAdaptor.execute()` が自動注入する uniform が変わった。
  変換行列 uniform 名が `projectionMatrix` / `translationMatrix` から `uProjectionMatrix` / `uWorldTransformMatrix` / `uTransformMatrix` に変わり、`uColor`（Mesh のティントカラー）が新たに注入されるようになった。
- `buffer.update()` が廃止され、`data` セッターへの代入に置き換わった。
- `Buffer` コンストラクタの引数 `dynamic` が廃止され、`PIXI.BufferUsage` フラグで用途を指定する形に変わった。
- `Geometry` の `instanced` プロパティが廃止され、各属性定義の `instance: true` フラグで指定する形に変わった。
- `Mesh` の型パラメータが `<TShader>` から `<TGeometry, TShader>` に変わった。

### パッケージ

- `pixi.js` を v7.4.3 から v8.17.1（最新版）にアップグレードした。
- `@pixi/unsafe-eval` を削除し、import 元を `pixi.js/unsafe-eval` に変更した。
  - v8 で unsafe-eval が本体に統合され、外部パッケージが不要になったため。

行った操作は `pnpm add pixi.js@8.17.1` と `pnpm remove @pixi/unsafe-eval` のみで、`pnpm audit` などのセキュリティ監査は行っていません。

### Renderer の非同期化（SequencerPitch.vue / SequencerVolumeEditor.vue）

- `new PIXI.Renderer()` を `await PIXI.autoDetectRenderer()` に置き換え、`onMounted` のコールバックを `async` 関数に変更した。
  - v8 で Renderer の同期初期化が廃止され、非同期初期化のみになったため。
- `autoDetectRenderer()` の初期化オプションのキー名を `view` から `canvas` に変更した。
  - v8 でこのキー名が変更されたため。
- `renderer.destroy(true)` を `renderer.destroy({ removeView: true })` に変更した。
  - v8 でも `boolean` 形式は引き続き許容されるが、オプションオブジェクト形式の方が意図が明確で可読性が高いため。
- `webGLVersion` へのアクセスを `instanceof PIXI.WebGLRenderer` でナローイングするようにした。
  - `webGLVersion` は `WebGLRenderer` 固有のプロパティで `WebGPURenderer` には存在せず、型安全にアクセスするには `instanceof` によるナローイングが必要なため。
- `isUnmounted` フラグを追加し、`autoDetectRenderer()` 完了時点でアンマウント済みであれば即 destroy して return するようにした。
  - 非同期化により、初期化完了前にコンポーネントがアンマウントされるケースが発生しうるようになったため。

### 初期化完了前のウォッチャー起動への対応（SequencerPitch.vue）

- `mounted` を watch する代わりに `isInitialized` フラグ（`ref<boolean>`）を watch するよう変更した。`isInitialized.value = true` は `onMounted` の処理の最後にセットする。併せて、不要になった `useMounted` の使用を削除した。
  - v7 では Renderer 初期化が同期だったため、`onMounted` コールバックは `originalPitchLine` / `pitchEditLine` への代入まで到達してから完了していた。`useMounted` は内部で `onMounted` フックを使って `mounted.value` を `true` にするため、`mounted` を監視するウォッチャーが走る時点では必ず `PitchLine` が生成済みだった。
  - v8 で Renderer 初期化が非同期になったことで、`PitchLine` の生成は `onMounted` コールバック完了後にずれ込むようになり、`mounted.value = true` のセット（＝ウォッチャー起動）が `PitchLine` 生成より先に起こるケースが生じた。
  - そこで、ウォッチャーの依存配列に `isInitialized` を加え、`isInitialized.value = true` のセット時にウォッチャーが自動で発火することで初期データを反映する形にした。`isInitialized.value = true` は全初期化完了後にセットするため、ウォッチャー内では `PitchLine` が必ず生成済みであることが保証される。

### DisplayObject の廃止（lineStrip.ts / pitchLine.ts / volumeLine.ts）

- `displayObject` ゲッターを `container` に改名し、戻り値型を `PIXI.DisplayObject` から `PIXI.Container` に変更した。
  - v8 で `DisplayObject` が廃止され、`Container` が全表示オブジェクトの基底クラスになったため。
  - ゲッター名 `displayObject` は `DisplayObject` 型を返すことを示唆する名前であり、型と乖離が生じるため、実態に合った `container` に改名した。
- `pitchLine.ts` / `volumeLine.ts` では上記に加え、`container` ゲッターを廃止し、`readonly container` フィールドを private から public に変更した。
  - これらのゲッターは単純にフィールドを返すだけだったため、publicな `readonly container` フィールドに一本化した。

### カスタムシェーダー関連 API（lineStrip.ts）

- `Shader.from()` の引数をオブジェクト形式に変更した。
  - v8 では頂点・フラグメントシェーダーを `{ gl: { vertex, fragment } }` で渡し、uniform の値は `UniformGroup` にまとめて `resources` に渡す形に変わった。`UniformGroup` 内の各 uniform の型は WGSL 風の文字列（`"vec4<f32>"` 等）で指定する。
- フラグメントシェーダーの uniform 名を `color` から `uLineColor` に変更した。
  - v8 の `GlMeshAdaptor.execute()` がシェーダーにビルトイン uniform `uColor`（Mesh のティントカラー）を自動注入しており、`uColor` という名前では上書きされてしまうため、競合しない `uLineColor` を採用した。
- 頂点シェーダーの変換行列 uniform 名を `projectionMatrix` / `translationMatrix` から `uProjectionMatrix` / `uWorldTransformMatrix` / `uTransformMatrix` に変更した。
  - `GlMeshAdaptor.execute()` がこれらの値をシェーダーに自動注入するが、v8 で名前が変更されており、GLSL 側の `uniform` 宣言名を合わせないと値が注入されないため。
- `Buffer` のコンストラクタをオブジェクト形式に変更し、`usage` フラグを追加した。
  - v8 で `new Buffer(data, dynamic)` のシグネチャが廃止され、オブジェクト形式が必須になったため。
- `buffer.update()` を `buffer.data = value` のセッター代入に変更した。
  - v8 では `data` セッターがデータ更新と GPU への通知を一括で行うようになり、別途 `update()` を呼ぶ必要がなくなったため。
- `Geometry` のコンストラクタをオブジェクト形式に変更した。
  - v8 で `addAttribute()` による属性の逐次追加が廃止され、`attributes` オブジェクトで一括定義する形に変わったため。併せて、属性の型指定も型定数 `PIXI.TYPES.FLOAT` から `"float32x2"` 等の `VertexFormat` 文字列に変わった。
- `Mesh` のコンストラクタをオブジェクト形式に変更した。
- 上記に伴い、v7 の型定義の不整合を回避するために付けていた `@ts-expect-error` コメントを削除した。

### Graphics API の変更（SequencerVolumeEditor.vue / volumeLine.ts）

v8 で Graphics の描画 API が変更されました。v7 では「スタイル設定（`lineStyle` / `beginFill`）→ シェイプ描画（`moveTo` / `lineTo` / `drawRect` 等）→ `endFill` で確定」という順序でしたが、v8 では「シェイプ描画 → `.stroke()` / `.fill()` でスタイル適用」という順序に変わりました。

- `lineStyle` + `moveTo` / `lineTo` を `moveTo` / `lineTo` + `.stroke({ ... })` に置き換えた。
- `beginFill` / `drawRect` / `endFill` を `rect(...).fill({ ... })` に置き換えた。
- `beginFill` / `moveTo` / `lineTo` / `endFill` を `poly([...]).fill({ ... })` に置き換えた。
- `volumeLine.ts` で `stroke()` をセグメントのループ外で 1 回だけ呼ぶよう変更した。
  - ループ内で `stroke()` を呼ぶと、セグメント数に比例して `GraphicsContext` にストロークコマンドが積まれてしまうため。

## 関連 Issue

close #2988

## その他