### PR TITLE
ci: 書き込みが必要な job に permissions: を明示する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ defaults:
 jobs:
   build-and-upload:
     environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment（false時の挙動は2022年7月10日時点で未定義動作）
+    permissions:
+      contents: write
     env:
       ELECTRON_CACHE: .cache/electron
       ELECTRON_BUILDER_CACHE: .cache/electron-builder

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,8 @@ defaults:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: github/issue-labeler@v3.4
       with:

--- a/.github/workflows/release_latest_dev.yml
+++ b/.github/workflows/release_latest_dev.yml
@@ -15,6 +15,8 @@ jobs:
   latest-dev-build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'VOICEVOX'
+    permissions:
+      actions: write
     steps:
       - name: Trigger workflow_dispatch
         uses: actions/github-script@v7


### PR DESCRIPTION
## 内容

`GITHUB_TOKEN` のデフォルト権限を read-only に切り替えるにあたり、書き込みが必要な job に `permissions:` を明示しました。

- `build.yml` の `build-and-upload` job: `softprops/action-gh-release@v2` がリリースアセットをアップロードするため `contents: write` を追加
- `labeler.yml` の `triage` job: `github/issue-labeler@v3.4` が Issue にラベルを付与するため `issues: write` を追加
- `release_latest_dev.yml` の `latest-dev-build` job: `actions/github-script` が `createWorkflowDispatch` を呼び出すため `actions: write` を追加

`test.yml` の `commit-snapshots` job はすでに `contents: write` が明示済みで対応不要です。reusable workflow の呼び出しはありません。

## 関連 Issue

ref VOICEVOX/voicevox_project#93