### PR TITLE
feat: Vuexのpluginsでstore.watchを型安全に書けるようにして、RENDERなどの処理をwatchで呼ぶようにする

### DIFF
--- a/docs/細かい設計方針.md
+++ b/docs/細かい設計方針.md
@@ -6,14 +6,10 @@
 これは、ダイアログの結果によってダイアログ前後の挙動を 1 つの Action に書けるという利便性を取ったためです。  
 ダイアログの種類によっては View に直接作用してダイアログ UI を表示するものもありますが、これも許容することにしています。
 
-## Vuex の state にある Map / 配列を watch するとき
+## Vuex の state にある Map や配列を watch するとき
 
-state にある Map / 配列を `store.watch` や Vue の `watch` で監視する場合、書き方として以下の 2 つがあります。
-
-- mutation で Map / 配列を丸ごと新しい参照に差し替え、watch の getter で Map / 配列の参照そのものを返す
-- mutation で `Map.set` や `Array.push` などにより Map / 配列を in-place 更新し、watch の getter で `[...state.xxx]` のように展開した配列を返す
-
-要素数が多い場合のパフォーマンス上の理由から、本リポジトリでは前者を採用している箇所があります。getter 関数を監視ソースとした watch は getter の戻り値（オブジェクトの場合は参照）が前回と異なるときにのみ発火するため、前者を採用している箇所では、mutation で Map / 配列を更新する際は必ず新しい Map / 配列のインスタンスに差し替えてください（`Map.set` や `Array.push` のような in-place 更新では発火しません）。
+要素数が多くなりうる Map や配列は、パフォーマンスのためにインスタンス自体を watch する前提にしています。
+更新するときは必ず新しいインスタンスに差し替えてください。
 
 ## EngineId、SpeakerId、StyleId
 

--- a/docs/細かい設計方針.md
+++ b/docs/細かい設計方針.md
@@ -6,6 +6,15 @@
 これは、ダイアログの結果によってダイアログ前後の挙動を 1 つの Action に書けるという利便性を取ったためです。  
 ダイアログの種類によっては View に直接作用してダイアログ UI を表示するものもありますが、これも許容することにしています。
 
+## Vuex の state にある Map / 配列を watch するとき
+
+state にある Map / 配列を `store.watch` や Vue の `watch` で監視する場合、書き方として以下の 2 つがあります。
+
+- mutation で Map / 配列を丸ごと新しい参照に差し替え、watch の getter で Map / 配列の参照そのものを返す
+- mutation で `Map.set` や `Array.push` などにより Map / 配列を in-place 更新し、watch の getter で `[...state.xxx]` のように展開した配列を返す
+
+要素数が多い場合のパフォーマンス上の理由から、本リポジトリでは前者を採用している箇所があります。getter 関数を監視ソースとした watch は getter の戻り値（オブジェクトの場合は参照）が前回と異なるときにのみ発火するため、前者を採用している箇所では、mutation で Map / 配列を更新する際は必ず新しい Map / 配列のインスタンスに差し替えてください（`Map.set` や `Array.push` のような in-place 更新では発火しません）。
+
 ## EngineId、SpeakerId、StyleId
 
 EngineId はエンジンが持つ ID で、世界で唯一かつ不変です。

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -110,14 +110,6 @@ watchEffect(() => {
   });
 });
 
-// デフォルト歌詞の設定が変わったら再レンダリング
-watch(
-  () => store.state.defaultLyricMode,
-  () => {
-    void store.actions.RENDER();
-  },
-);
-
 // ソフトウェアを初期化
 const { hotkeyManager } = useHotkeyManager();
 const isEnginesReady = ref(false);

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -128,7 +128,6 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
-        void actions.RENDER();
       }
     },
   },
@@ -149,7 +148,6 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
-        void actions.RENDER();
       }
     },
   },

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -125,7 +125,6 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
       if (editor === "song") {
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         mutations.DESELECT_ALL_NOTES();
-        void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       }
     },
@@ -144,7 +143,6 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
       if (editor === "song") {
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         mutations.DESELECT_ALL_NOTES();
-        void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       }
     },

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -120,12 +120,11 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
         applyPatches(state, command.undoPatches);
       }
     },
-    action({ mutations, actions }, { editor }: { editor: EditorType }) {
+    action({ mutations }, { editor }: { editor: EditorType }) {
       mutations.UNDO({ editor });
       if (editor === "song") {
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         mutations.DESELECT_ALL_NOTES();
-        void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       }
     },
   },
@@ -138,12 +137,11 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
         applyPatches(state, command.redoPatches);
       }
     },
-    action({ mutations, actions }, { editor }: { editor: EditorType }) {
+    action({ mutations }, { editor }: { editor: EditorType }) {
       mutations.REDO({ editor });
       if (editor === "song") {
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         mutations.DESELECT_ALL_NOTES();
-        void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       }
     },
   },

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -125,7 +125,6 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
       if (editor === "song") {
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         mutations.DESELECT_ALL_NOTES();
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       }
@@ -145,7 +144,6 @@ export const commandStore = createPartialStore<CommandStoreTypes>({
       if (editor === "song") {
         // TODO: 存在しないノートのみ選択解除、あるいはSELECTED_NOTE_IDS getterを作る
         mutations.DESELECT_ALL_NOTES();
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -415,7 +415,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
   },
 
   plugins: [...singingStorePlugins],
-  
+
   strict: !isProduction,
 });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -412,6 +412,22 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...singingStore.actions,
     ...singingCommandStore.actions,
   },
+  plugins: [
+    ...(uiStore.plugins ?? []),
+    ...(audioStore.plugins ?? []),
+    ...(audioPlayerStore.plugins ?? []),
+    ...(engineStore.plugins ?? []),
+    ...(commandStore.plugins ?? []),
+    ...(projectStore.plugins ?? []),
+    ...(settingStore.plugins ?? []),
+    ...(audioCommandStore.plugins ?? []),
+    ...(presetStore.plugins ?? []),
+    ...(dictionaryStore.plugins ?? []),
+    ...(indexStore.plugins ?? []),
+    ...(proxyStore.plugins ?? []),
+    ...(singingStore.plugins ?? []),
+    ...(singingCommandStore.plugins ?? []),
+  ],
   strict: !isProduction,
 });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -413,7 +413,9 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...singingStore.actions,
     ...singingCommandStore.actions,
   },
+
   plugins: [...singingStorePlugins],
+  
   strict: !isProduction,
 });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,6 +25,7 @@ import { audioPlayerStoreState, audioPlayerStore } from "./audioPlayer";
 import {
   singingStoreState,
   singingStore,
+  singingStorePlugins,
   singingCommandStoreState,
   singingCommandStore,
 } from "./singing";
@@ -412,22 +413,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...singingStore.actions,
     ...singingCommandStore.actions,
   },
-  plugins: [
-    ...(uiStore.plugins ?? []),
-    ...(audioStore.plugins ?? []),
-    ...(audioPlayerStore.plugins ?? []),
-    ...(engineStore.plugins ?? []),
-    ...(commandStore.plugins ?? []),
-    ...(projectStore.plugins ?? []),
-    ...(settingStore.plugins ?? []),
-    ...(audioCommandStore.plugins ?? []),
-    ...(presetStore.plugins ?? []),
-    ...(dictionaryStore.plugins ?? []),
-    ...(indexStore.plugins ?? []),
-    ...(proxyStore.plugins ?? []),
-    ...(singingStore.plugins ?? []),
-    ...(singingCommandStore.plugins ?? []),
-  ],
+  plugins: [...singingStorePlugins],
   strict: !isProduction,
 });
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -853,8 +853,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         withRelated,
         trackId,
       });
-
-      void actions.RENDER();
     },
   },
 
@@ -863,13 +861,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const track = getOrThrow(state.tracks, trackId);
       track.keyRangeAdjustment = keyRangeAdjustment;
     },
-    async action({ actions, mutations }, { keyRangeAdjustment, trackId }) {
+    async action({ mutations }, { keyRangeAdjustment, trackId }) {
       if (!isValidKeyRangeAdjustment(keyRangeAdjustment)) {
         throw new Error("The keyRangeAdjustment is invalid.");
       }
       mutations.SET_KEY_RANGE_ADJUSTMENT({ keyRangeAdjustment, trackId });
-
-      void actions.RENDER();
     },
   },
 
@@ -878,7 +874,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const track = getOrThrow(state.tracks, trackId);
       track.volumeRangeAdjustment = volumeRangeAdjustment;
     },
-    async action({ actions, mutations }, { volumeRangeAdjustment, trackId }) {
+    async action({ mutations }, { volumeRangeAdjustment, trackId }) {
       if (!isValidVolumeRangeAdjustment(volumeRangeAdjustment)) {
         throw new Error("The volumeRangeAdjustment is invalid.");
       }
@@ -886,8 +882,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         volumeRangeAdjustment,
         trackId,
       });
-
-      void actions.RENDER();
     },
   },
 
@@ -909,7 +903,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
 
       void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
       void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
-      void actions.RENDER();
     },
   },
 
@@ -934,7 +927,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
 
       void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
       void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
-      void actions.RENDER();
     },
   },
 
@@ -1061,13 +1053,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const selectedTrack = getOrThrow(state.tracks, trackId);
       selectedTrack.notes = notes;
     },
-    async action({ mutations, actions }, { notes, trackId }) {
+    async action({ mutations }, { notes, trackId }) {
       if (!isValidNotes(notes)) {
         throw new Error("The notes are invalid.");
       }
       mutations.SET_NOTES({ notes, trackId });
-
-      void actions.RENDER();
     },
   },
 
@@ -1196,7 +1186,10 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         newEdits = [...existingEdits, phonemeTimingEdit];
         newEdits.sort((a, b) => a.phonemeIndexInNote - b.phonemeIndexInNote);
       }
-      targetTrack.phonemeTimingEditData.set(noteId, newEdits);
+      targetTrack.phonemeTimingEditData = new Map([
+        ...targetTrack.phonemeTimingEditData,
+        [noteId, newEdits],
+      ]);
     },
   },
 
@@ -1214,20 +1207,19 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       }
 
       // 各ノートの編集データを更新
+      const tempData = new Map(targetTrack.phonemeTimingEditData);
       for (const [noteId, phonemeIndexes] of targetsByNoteId) {
-        const currentEdits = getOrThrow(
-          targetTrack.phonemeTimingEditData,
-          noteId,
-        );
+        const currentEdits = getOrThrow(tempData, noteId);
         const newEdits = currentEdits.filter(
           (edit) => !phonemeIndexes.includes(edit.phonemeIndexInNote),
         );
         if (newEdits.length === 0) {
-          targetTrack.phonemeTimingEditData.delete(noteId);
+          tempData.delete(noteId);
         } else {
-          targetTrack.phonemeTimingEditData.set(noteId, newEdits);
+          tempData.set(noteId, newEdits);
         }
       }
+      targetTrack.phonemeTimingEditData = tempData;
     },
   },
 
@@ -1248,7 +1240,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       tempData.splice(startFrame, pitchArray.length, ...pitchArray);
       track.pitchEditData = tempData;
     },
-    async action({ actions, mutations }, { pitchArray, startFrame, trackId }) {
+    async action({ mutations }, { pitchArray, startFrame, trackId }) {
       if (startFrame < 0) {
         throw new Error("startFrame must be greater than or equal to 0.");
       }
@@ -1256,8 +1248,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         throw new Error("The pitch edit data is invalid.");
       }
       mutations.SET_PITCH_EDIT_DATA({ pitchArray, startFrame, trackId });
-
-      void actions.RENDER();
     },
   },
 
@@ -1278,7 +1268,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       tempData.splice(startFrame, volumeArray.length, ...volumeArray);
       track.volumeEditData = tempData;
     },
-    async action({ actions, mutations }, { volumeArray, startFrame, trackId }) {
+    async action({ mutations }, { volumeArray, startFrame, trackId }) {
       if (startFrame < 0) {
         throw new Error("startFrame must be greater than or equal to 0.");
       }
@@ -1286,8 +1276,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         throw new Error("The volume edit data is invalid.");
       }
       mutations.SET_VOLUME_EDIT_DATA({ volumeArray, startFrame, trackId });
-
-      void actions.RENDER();
     },
   },
 
@@ -1319,10 +1307,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const track = getOrThrow(state.tracks, trackId);
       track.pitchEditData = [];
     },
-    async action({ actions, mutations }, { trackId }) {
+    async action({ mutations }, { trackId }) {
       mutations.CLEAR_PITCH_EDIT_DATA({ trackId });
-
-      void actions.RENDER();
     },
   },
 
@@ -1332,10 +1318,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const track = getOrThrow(state.tracks, trackId);
       track.volumeEditData = [];
     },
-    async action({ actions, mutations }, { trackId }) {
+    async action({ mutations }, { trackId }) {
       mutations.CLEAR_VOLUME_EDIT_DATA({ trackId });
-
-      void actions.RENDER();
     },
   },
 
@@ -2161,7 +2145,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       mutations.INSERT_TRACK({ trackId, track, prevTrackId });
 
       void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-      void actions.RENDER();
     },
   },
 
@@ -2177,7 +2160,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       mutations.DELETE_TRACK({ trackId });
 
       void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-      void actions.RENDER();
     },
   },
 
@@ -2210,7 +2192,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       mutations.SET_TRACK({ trackId, track });
 
       void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-      void actions.RENDER();
     },
   },
 
@@ -2226,7 +2207,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       mutations.SET_TRACKS({ tracks });
 
       void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-      void actions.RENDER();
     },
   },
 
@@ -3115,7 +3095,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
   },
 
   COMMAND_PASTE_NOTES_FROM_CLIPBOARD: {
-    async action({ mutations, getters, actions }) {
+    async action({ mutations, getters }) {
       // クリップボードからテキストを読み込む
       let clipboardText;
       try {
@@ -3182,13 +3162,12 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         );
       }
 
-      // ノートを追加してレンダリングする
+      // ノートを追加する
       mutations.COMMAND_ADD_NOTES({
         notes: notesToPaste,
         trackId: getters.SELECTED_TRACK_ID,
       });
 
-      void actions.RENDER();
       // 貼り付けたノートを選択する
       mutations.DESELECT_ALL_NOTES();
       mutations.SELECT_NOTES({ noteIds: pastedNoteIds });
@@ -3196,7 +3175,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
   },
 
   COMMAND_QUANTIZE_SELECTED_NOTES: {
-    action({ state, mutations, getters, actions }) {
+    action({ state, mutations, getters }) {
       const selectedTrack = getters.SELECTED_TRACK;
       const selectedNotes = selectedTrack.notes.filter((note: Note) => {
         return getters.SELECTED_NOTE_IDS.has(note.id);
@@ -3214,8 +3193,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         notes: quantizedNotes,
         trackId: getters.SELECTED_TRACK_ID,
       });
-
-      void actions.RENDER();
     },
   },
 
@@ -3314,7 +3291,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       mutations.UNSOLO_ALL_TRACKS();
 
       void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-      void actions.RENDER();
     },
   },
 
@@ -3487,6 +3463,29 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       },
     ),
   },
+  plugins: [
+    (store) => {
+      store.watch(
+        (state) => [
+          state.tpqn,
+          state.tempos,
+          [...state.tracks.values()].map((track) => [
+            track.singer,
+            track.keyRangeAdjustment,
+            track.volumeRangeAdjustment,
+            track.notes,
+            track.phonemeTimingEditData,
+            track.pitchEditData,
+            track.volumeEditData,
+          ]),
+          state.defaultLyricMode,
+        ],
+        () => {
+          void store.actions.RENDER();
+        },
+      );
+    },
+  ],
 });
 
 export const singingCommandStoreState: SingingCommandStoreState = {};
@@ -3504,8 +3503,6 @@ export const singingCommandStore = transformCommandStore(
       async action({ actions, mutations }, { singer, withRelated, trackId }) {
         void actions.SETUP_SINGER({ singer });
         mutations.COMMAND_SET_SINGER({ singer, withRelated, trackId });
-
-        void actions.RENDER();
       },
     },
     COMMAND_SET_KEY_RANGE_ADJUSTMENT: {
@@ -3515,7 +3512,7 @@ export const singingCommandStore = transformCommandStore(
           trackId,
         });
       },
-      async action({ actions, mutations }, { keyRangeAdjustment, trackId }) {
+      async action({ mutations }, { keyRangeAdjustment, trackId }) {
         if (!isValidKeyRangeAdjustment(keyRangeAdjustment)) {
           throw new Error("The keyRangeAdjustment is invalid.");
         }
@@ -3523,8 +3520,6 @@ export const singingCommandStore = transformCommandStore(
           keyRangeAdjustment,
           trackId,
         });
-
-        void actions.RENDER();
       },
     },
     COMMAND_SET_VOLUME_RANGE_ADJUSTMENT: {
@@ -3534,7 +3529,7 @@ export const singingCommandStore = transformCommandStore(
           trackId,
         });
       },
-      async action({ actions, mutations }, { volumeRangeAdjustment, trackId }) {
+      async action({ mutations }, { volumeRangeAdjustment, trackId }) {
         if (!isValidVolumeRangeAdjustment(volumeRangeAdjustment)) {
           throw new Error("The volumeRangeAdjustment is invalid.");
         }
@@ -3542,8 +3537,6 @@ export const singingCommandStore = transformCommandStore(
           volumeRangeAdjustment,
           trackId,
         });
-
-        void actions.RENDER();
       },
     },
     COMMAND_SET_TEMPO: {
@@ -3569,7 +3562,6 @@ export const singingCommandStore = transformCommandStore(
 
         void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
-        void actions.RENDER();
       },
     },
     COMMAND_REMOVE_TEMPO: {
@@ -3597,7 +3589,6 @@ export const singingCommandStore = transformCommandStore(
 
         void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
-        void actions.RENDER();
       },
     },
     COMMAND_SET_TIME_SIGNATURE: {
@@ -3637,7 +3628,7 @@ export const singingCommandStore = transformCommandStore(
       mutation(draft, { notes, trackId }) {
         singingStore.mutations.ADD_NOTES(draft, { notes, trackId });
       },
-      action({ getters, mutations, actions }, { notes, trackId }) {
+      action({ getters, mutations }, { notes, trackId }) {
         const existingNoteIds = getters.ALL_NOTE_IDS;
         const isValidNotes = notes.every((value) => {
           return !existingNoteIds.has(value.id) && isValidNote(value);
@@ -3646,15 +3637,13 @@ export const singingCommandStore = transformCommandStore(
           throw new Error("The notes are invalid.");
         }
         mutations.COMMAND_ADD_NOTES({ notes, trackId });
-
-        void actions.RENDER();
       },
     },
     COMMAND_UPDATE_NOTES: {
       mutation(draft, { notes, trackId }) {
         singingStore.mutations.UPDATE_NOTES(draft, { notes, trackId });
       },
-      action({ getters, mutations, actions }, { notes, trackId }) {
+      action({ getters, mutations }, { notes, trackId }) {
         const existingNoteIds = getters.ALL_NOTE_IDS;
         const isValidNotes = notes.every((value) => {
           return existingNoteIds.has(value.id) && isValidNote(value);
@@ -3663,15 +3652,13 @@ export const singingCommandStore = transformCommandStore(
           throw new Error("The notes are invalid.");
         }
         mutations.COMMAND_UPDATE_NOTES({ notes, trackId });
-
-        void actions.RENDER();
       },
     },
     COMMAND_REMOVE_NOTES: {
       mutation(draft, { noteIds, trackId }) {
         singingStore.mutations.REMOVE_NOTES(draft, { noteIds, trackId });
       },
-      action({ getters, mutations, actions }, { noteIds, trackId }) {
+      action({ getters, mutations }, { noteIds, trackId }) {
         const existingNoteIds = getters.ALL_NOTE_IDS;
         const isValidNoteIds = noteIds.every((value) => {
           return existingNoteIds.has(value);
@@ -3680,18 +3667,14 @@ export const singingCommandStore = transformCommandStore(
           throw new Error("The note ids are invalid.");
         }
         mutations.COMMAND_REMOVE_NOTES({ noteIds, trackId });
-
-        void actions.RENDER();
       },
     },
     COMMAND_REMOVE_SELECTED_NOTES: {
-      action({ mutations, getters, actions }) {
+      action({ mutations, getters }) {
         mutations.COMMAND_REMOVE_NOTES({
           noteIds: [...getters.SELECTED_NOTE_IDS],
           trackId: getters.SELECTED_TRACK_ID,
         });
-
-        void actions.RENDER();
       },
     },
     // 指定されたノートの指定された音素インデックスの音素タイミング編集データをupsertする。
@@ -3704,10 +3687,7 @@ export const singingCommandStore = transformCommandStore(
           trackId,
         });
       },
-      action(
-        { state, mutations, actions },
-        { noteId, phonemeTimingEdit, trackId },
-      ) {
+      action({ state, mutations }, { noteId, phonemeTimingEdit, trackId }) {
         const targetTrack = state.tracks.get(trackId);
         if (targetTrack == undefined) {
           throw new Error("The trackId is invalid.");
@@ -3717,8 +3697,6 @@ export const singingCommandStore = transformCommandStore(
           phonemeTimingEdit,
           trackId,
         });
-
-        void actions.RENDER();
       },
     },
     // 指定された音素タイミング編集データを削除する。
@@ -3729,7 +3707,7 @@ export const singingCommandStore = transformCommandStore(
           trackId,
         });
       },
-      action({ state, mutations, actions }, { targets, trackId }) {
+      action({ state, mutations }, { targets, trackId }) {
         const targetTrack = state.tracks.get(trackId);
         if (targetTrack == undefined) {
           throw new Error("The trackId is invalid.");
@@ -3771,8 +3749,6 @@ export const singingCommandStore = transformCommandStore(
           targets,
           trackId,
         });
-
-        void actions.RENDER();
       },
     },
     COMMAND_SET_PITCH_EDIT_DATA: {
@@ -3783,7 +3759,7 @@ export const singingCommandStore = transformCommandStore(
           trackId,
         });
       },
-      action({ mutations, actions }, { pitchArray, startFrame, trackId }) {
+      action({ mutations }, { pitchArray, startFrame, trackId }) {
         if (startFrame < 0) {
           throw new Error("startFrame must be greater than or equal to 0.");
         }
@@ -3795,8 +3771,6 @@ export const singingCommandStore = transformCommandStore(
           startFrame,
           trackId,
         });
-
-        void actions.RENDER();
       },
     },
     COMMAND_SET_VOLUME_EDIT_DATA: {
@@ -3807,7 +3781,7 @@ export const singingCommandStore = transformCommandStore(
           trackId,
         });
       },
-      action({ mutations, actions }, { volumeArray, startFrame, trackId }) {
+      action({ mutations }, { volumeArray, startFrame, trackId }) {
         if (startFrame < 0) {
           throw new Error("startFrame must be greater than or equal to 0.");
         }
@@ -3819,8 +3793,6 @@ export const singingCommandStore = transformCommandStore(
           startFrame,
           trackId,
         });
-
-        void actions.RENDER();
       },
     },
     COMMAND_ERASE_PITCH_EDIT_DATA: {
@@ -3831,7 +3803,7 @@ export const singingCommandStore = transformCommandStore(
           trackId,
         });
       },
-      action({ mutations, actions }, { startFrame, frameLength, trackId }) {
+      action({ mutations }, { startFrame, frameLength, trackId }) {
         if (startFrame < 0) {
           throw new Error("startFrame must be greater than or equal to 0.");
         }
@@ -3843,8 +3815,6 @@ export const singingCommandStore = transformCommandStore(
           frameLength,
           trackId,
         });
-
-        void actions.RENDER();
       },
     },
     COMMAND_ERASE_VOLUME_EDIT_DATA: {
@@ -3855,7 +3825,7 @@ export const singingCommandStore = transformCommandStore(
           trackId,
         });
       },
-      action({ mutations, actions }, { startFrame, frameLength, trackId }) {
+      action({ mutations }, { startFrame, frameLength, trackId }) {
         if (startFrame < 0) {
           throw new Error("startFrame must be greater than or equal to 0.");
         }
@@ -3867,8 +3837,6 @@ export const singingCommandStore = transformCommandStore(
           frameLength,
           trackId,
         });
-
-        void actions.RENDER();
       },
     },
 
@@ -3897,7 +3865,6 @@ export const singingCommandStore = transformCommandStore(
         });
 
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-        void actions.RENDER();
       },
     },
 
@@ -3909,7 +3876,6 @@ export const singingCommandStore = transformCommandStore(
         mutations.COMMAND_DELETE_TRACK({ trackId });
 
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-        void actions.RENDER();
       },
     },
 
@@ -3953,7 +3919,6 @@ export const singingCommandStore = transformCommandStore(
 
         // SYNC は同期処理なので待機しない
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-        void actions.RENDER();
 
         void actions.SET_SELECTED_TRACK({ trackId: newTrackId });
       },
@@ -4029,7 +3994,6 @@ export const singingCommandStore = transformCommandStore(
         mutations.COMMAND_UNSOLO_ALL_TRACKS();
 
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-        void actions.RENDER();
       },
     },
 
@@ -4093,7 +4057,6 @@ export const singingCommandStore = transformCommandStore(
 
         void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
-        void actions.RENDER();
       },
     },
 
@@ -4133,7 +4096,6 @@ export const singingCommandStore = transformCommandStore(
           });
 
           void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-          void actions.RENDER();
         },
       ),
     },
@@ -4174,7 +4136,6 @@ export const singingCommandStore = transformCommandStore(
           });
 
           void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-          void actions.RENDER();
         },
       ),
     },

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -2135,7 +2135,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       state.tracks.set(trackId, track);
       state.trackOrder.splice(index, 0, trackId);
     },
-    action({ state, mutations, actions }, { trackId, track, prevTrackId }) {
+    action({ state, mutations }, { trackId, track, prevTrackId }) {
       if (state.tracks.has(trackId)) {
         throw new Error(`Track ${trackId} is already registered.`);
       }
@@ -2143,8 +2143,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         throw new Error("The track is invalid.");
       }
       mutations.INSERT_TRACK({ trackId, track, prevTrackId });
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -2153,13 +2151,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       state.tracks.delete(trackId);
       state.trackOrder = state.trackOrder.filter((value) => value !== trackId);
     },
-    async action({ state, mutations, actions }, { trackId }) {
+    async action({ state, mutations }, { trackId }) {
       if (!state.tracks.has(trackId)) {
         throw new Error(`Track ${trackId} does not exist.`);
       }
       mutations.DELETE_TRACK({ trackId });
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -2181,7 +2177,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
     mutation(state, { trackId, track }) {
       state.tracks.set(trackId, track);
     },
-    async action({ state, mutations, actions }, { trackId, track }) {
+    async action({ state, mutations }, { trackId, track }) {
       if (!isValidTrack(track)) {
         throw new Error("The track is invalid.");
       }
@@ -2190,8 +2186,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       }
 
       mutations.SET_TRACK({ trackId, track });
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -2200,13 +2194,11 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       state.tracks = tracks;
       state.trackOrder = Array.from(tracks.keys());
     },
-    async action({ mutations, actions }, { tracks }) {
+    async action({ mutations }, { tracks }) {
       if (![...tracks.values()].every((track) => isValidTrack(track))) {
         throw new Error("The track is invalid.");
       }
       mutations.SET_TRACKS({ tracks });
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -3220,10 +3212,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const track = getOrThrow(state.tracks, trackId);
       track.mute = mute;
     },
-    action({ mutations, actions }, { trackId, mute }) {
+    action({ mutations }, { trackId, mute }) {
       mutations.SET_TRACK_MUTE({ trackId, mute });
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -3232,10 +3222,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const track = getOrThrow(state.tracks, trackId);
       track.solo = solo;
     },
-    action({ mutations, actions }, { trackId, solo }) {
+    action({ mutations }, { trackId, solo }) {
       mutations.SET_TRACK_SOLO({ trackId, solo });
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -3244,10 +3232,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const track = getOrThrow(state.tracks, trackId);
       track.gain = gain;
     },
-    action({ mutations, actions }, { trackId, gain }) {
+    action({ mutations }, { trackId, gain }) {
       mutations.SET_TRACK_GAIN({ trackId, gain });
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -3256,10 +3242,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       const track = getOrThrow(state.tracks, trackId);
       track.pan = pan;
     },
-    action({ mutations, actions }, { trackId, pan }) {
+    action({ mutations }, { trackId, pan }) {
       mutations.SET_TRACK_PAN({ trackId, pan });
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -3287,10 +3271,8 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         track.solo = false;
       }
     },
-    action({ mutations, actions }) {
+    action({ mutations }) {
       mutations.UNSOLO_ALL_TRACKS();
-
-      void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
     },
   },
 
@@ -3482,6 +3464,19 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         ],
         () => {
           void store.actions.RENDER();
+        },
+      );
+
+      store.watch(
+        (state) =>
+          [...state.tracks.values()].map((track) => [
+            track.mute,
+            track.solo,
+            track.gain,
+            track.pan,
+          ]),
+        () => {
+          void store.actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         },
       );
     },
@@ -3863,8 +3858,6 @@ export const singingCommandStore = transformCommandStore(
           track: cloneWithUnwrapProxy(track),
           prevTrackId,
         });
-
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
       },
     },
 
@@ -3872,10 +3865,8 @@ export const singingCommandStore = transformCommandStore(
       mutation(draft, { trackId }) {
         singingStore.mutations.DELETE_TRACK(draft, { trackId });
       },
-      action({ mutations, actions }, { trackId }) {
+      action({ mutations }, { trackId }) {
         mutations.COMMAND_DELETE_TRACK({ trackId });
-
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
       },
     },
 
@@ -3917,9 +3908,6 @@ export const singingCommandStore = transformCommandStore(
           prevTrackId: trackId,
         });
 
-        // SYNC は同期処理なので待機しない
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-
         void actions.SET_SELECTED_TRACK({ trackId: newTrackId });
       },
     },
@@ -3937,10 +3925,8 @@ export const singingCommandStore = transformCommandStore(
       mutation(draft, { trackId, mute }) {
         singingStore.mutations.SET_TRACK_MUTE(draft, { trackId, mute });
       },
-      action({ mutations, actions }, { trackId, mute }) {
+      action({ mutations }, { trackId, mute }) {
         mutations.COMMAND_SET_TRACK_MUTE({ trackId, mute });
-
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
       },
     },
 
@@ -3948,10 +3934,8 @@ export const singingCommandStore = transformCommandStore(
       mutation(draft, { trackId, solo }) {
         singingStore.mutations.SET_TRACK_SOLO(draft, { trackId, solo });
       },
-      action({ mutations, actions }, { trackId, solo }) {
+      action({ mutations }, { trackId, solo }) {
         mutations.COMMAND_SET_TRACK_SOLO({ trackId, solo });
-
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
       },
     },
 
@@ -3959,10 +3943,8 @@ export const singingCommandStore = transformCommandStore(
       mutation(draft, { trackId, gain }) {
         singingStore.mutations.SET_TRACK_GAIN(draft, { trackId, gain });
       },
-      action({ mutations, actions }, { trackId, gain }) {
+      action({ mutations }, { trackId, gain }) {
         mutations.COMMAND_SET_TRACK_GAIN({ trackId, gain });
-
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
       },
     },
 
@@ -3970,10 +3952,8 @@ export const singingCommandStore = transformCommandStore(
       mutation(draft, { trackId, pan }) {
         singingStore.mutations.SET_TRACK_PAN(draft, { trackId, pan });
       },
-      action({ mutations, actions }, { trackId, pan }) {
+      action({ mutations }, { trackId, pan }) {
         mutations.COMMAND_SET_TRACK_PAN({ trackId, pan });
-
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
       },
     },
 
@@ -3990,10 +3970,8 @@ export const singingCommandStore = transformCommandStore(
       mutation(draft) {
         singingStore.mutations.UNSOLO_ALL_TRACKS(draft, undefined);
       },
-      action({ mutations, actions }) {
+      action({ mutations }) {
         mutations.COMMAND_UNSOLO_ALL_TRACKS();
-
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
       },
     },
 
@@ -4054,8 +4032,6 @@ export const singingCommandStore = transformCommandStore(
           timeSignatures,
           tracks: payload,
         });
-
-        void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
       },
     },
@@ -4094,8 +4070,6 @@ export const singingCommandStore = transformCommandStore(
             timeSignatures,
             tracks: filteredTracks,
           });
-
-          void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         },
       ),
     },
@@ -4134,8 +4108,6 @@ export const singingCommandStore = transformCommandStore(
             timeSignatures,
             tracks: filteredTracks,
           });
-
-          void actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         },
       ),
     },

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -901,7 +901,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       }
       mutations.SET_TPQN({ tpqn });
 
-      void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
       void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
     },
   },
@@ -925,7 +924,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       }
       mutations.SET_TEMPOS({ tempos });
 
-      void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
       void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
     },
   },
@@ -3479,6 +3477,13 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
           void store.actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
         },
       );
+
+      store.watch(
+        (state) => [state.tpqn, state.tempos],
+        () => {
+          void store.actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
+        },
+      );
     },
   ],
 });
@@ -3555,7 +3560,6 @@ export const singingCommandStore = transformCommandStore(
         tempo.bpm = round(tempo.bpm, 2);
         mutations.COMMAND_SET_TEMPO({ tempo });
 
-        void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       },
     },
@@ -3582,7 +3586,6 @@ export const singingCommandStore = transformCommandStore(
         }
         mutations.COMMAND_REMOVE_TEMPO({ position });
 
-        void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
         void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       },
     },
@@ -4032,7 +4035,6 @@ export const singingCommandStore = transformCommandStore(
           timeSignatures,
           tracks: payload,
         });
-        void actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
       },
     },
 

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -900,8 +900,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         await actions.SING_STOP_AUDIO();
       }
       mutations.SET_TPQN({ tpqn });
-
-      void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
     },
   },
 
@@ -923,8 +921,6 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         await actions.SING_STOP_AUDIO();
       }
       mutations.SET_TEMPOS({ tempos });
-
-      void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
     },
   },
 
@@ -3482,6 +3478,7 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         (state) => [state.tpqn, state.tempos],
         () => {
           void store.actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
+          void store.actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
         },
       );
     },
@@ -3544,10 +3541,7 @@ export const singingCommandStore = transformCommandStore(
         singingStore.mutations.SET_TEMPO(draft, { tempo });
       },
       // テンポを設定する。既に同じ位置にテンポが存在する場合は置き換える。
-      action(
-        { state, getters, mutations, actions },
-        { tempo }: { tempo: Tempo },
-      ) {
+      action({ state, getters, mutations }, { tempo }: { tempo: Tempo }) {
         if (!transport) {
           throw new Error("transport is undefined.");
         }
@@ -3559,8 +3553,6 @@ export const singingCommandStore = transformCommandStore(
         }
         tempo.bpm = round(tempo.bpm, 2);
         mutations.COMMAND_SET_TEMPO({ tempo });
-
-        void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       },
     },
     COMMAND_REMOVE_TEMPO: {
@@ -3569,7 +3561,7 @@ export const singingCommandStore = transformCommandStore(
       },
       // テンポを削除する。先頭のテンポの場合はデフォルトのテンポに置き換える。
       action(
-        { state, getters, mutations, actions },
+        { state, getters, mutations },
         { position }: { position: number },
       ) {
         const exists = state.tempos.some((value) => {
@@ -3585,8 +3577,6 @@ export const singingCommandStore = transformCommandStore(
           playheadPosition.value = getters.SECOND_TO_TICK(transport.time);
         }
         mutations.COMMAND_REMOVE_TEMPO({ position });
-
-        void actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
       },
     },
     COMMAND_SET_TIME_SIGNATURE: {

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -1,5 +1,5 @@
 import { ref } from "vue";
-import { createPartialStore } from "./vuex";
+import { createPartialStore, type StorePlugins } from "./vuex";
 import { createUILockAction } from "./ui";
 import {
   type SingingStoreState,
@@ -3439,51 +3439,52 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       },
     ),
   },
-  plugins: [
-    (store) => {
-      store.watch(
-        (state) => [
-          state.tpqn,
-          state.tempos,
-          [...state.tracks.values()].map((track) => [
-            track.singer,
-            track.keyRangeAdjustment,
-            track.volumeRangeAdjustment,
-            track.notes,
-            track.phonemeTimingEditData,
-            track.pitchEditData,
-            track.volumeEditData,
-          ]),
-          state.defaultLyricMode,
-        ],
-        () => {
-          void store.actions.RENDER();
-        },
-      );
-
-      store.watch(
-        (state) =>
-          [...state.tracks.values()].map((track) => [
-            track.mute,
-            track.solo,
-            track.gain,
-            track.pan,
-          ]),
-        () => {
-          void store.actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
-        },
-      );
-
-      store.watch(
-        (state) => [state.tpqn, state.tempos],
-        () => {
-          void store.actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
-          void store.actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
-        },
-      );
-    },
-  ],
 });
+
+export const singingStorePlugins: StorePlugins = [
+  (store) => {
+    store.watch(
+      (state) => [
+        state.tpqn,
+        state.tempos,
+        [...state.tracks.values()].map((track) => [
+          track.singer,
+          track.keyRangeAdjustment,
+          track.volumeRangeAdjustment,
+          track.notes,
+          track.phonemeTimingEditData,
+          track.pitchEditData,
+          track.volumeEditData,
+        ]),
+        state.defaultLyricMode,
+      ],
+      () => {
+        void store.actions.RENDER();
+      },
+    );
+
+    store.watch(
+      (state) =>
+        [...state.tracks.values()].map((track) => [
+          track.mute,
+          track.solo,
+          track.gain,
+          track.pan,
+        ]),
+      () => {
+        void store.actions.SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS();
+      },
+    );
+
+    store.watch(
+      (state) => [state.tpqn, state.tempos],
+      () => {
+        void store.actions.SYNC_LOOP_RANGE_TO_TRANSPORT();
+        void store.actions.SYNC_PLAYHEAD_POSITION_TO_TRANSPORT();
+      },
+    );
+  },
+];
 
 export const singingCommandStoreState: SingingCommandStoreState = {};
 

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -5,7 +5,6 @@ import {
   Store as BaseStore,
   useStore as baseUseStore,
   type ModuleTree,
-  type Plugin,
   type StoreOptions as OriginalStoreOptions,
   type GetterTree as OriginalGetterTree,
   type ActionTree as OriginalActionTree,
@@ -36,9 +35,16 @@ export class Store<
   M extends MutationsBase,
 > extends BaseStore<S> {
   constructor(options: StoreOptions<S, G, A, M>) {
-    super(options as OriginalStoreOptions<S>);
+    // Vuexはデフォルトでpluginsをコンストラクタ内（resetStoreState直後）で呼ぶが、
+    // その時点ではVV独自のactionsとmutationsがまだ設定されていない。
+    // そのため、pluginsをoptionsから除いてVuexに渡し、
+    // actions/mutations設定後に手動で呼ぶ形にしている。
+    // なお、Vuexはメンテナンスモードであり今後この動作が変わることはないと考えられる。
+    const { plugins, ...restOptions } = options;
+    super(restOptions as OriginalStoreOptions<S>);
     this.actions = dotNotationDispatchProxy(this.dispatch.bind(this));
     this.mutations = dotNotationCommitProxy(this.commit.bind(this));
+    plugins?.forEach((plugin) => plugin(this));
   }
 
   declare readonly getters: G;
@@ -175,7 +181,7 @@ export interface StoreOptions<
   actions: ActionTree<S, S, A, SG, SA, SM>;
   mutations: MutationTree<S, M>;
   modules?: ModuleTree<S>;
-  plugins?: Plugin<S>[];
+  plugins?: ((store: Store<S, SG, SA, SM>) => void)[];
   strict?: boolean;
   devtools?: boolean;
 }
@@ -419,15 +425,18 @@ type PartialStoreOptions<
   G extends GettersBase,
   A extends ActionsBase,
   M extends MutationsBase,
+  SG extends GettersBase = G,
+  SA extends ActionsBase = A,
+  SM extends MutationsBase = M,
 > = {
   [K in keyof T]: {
     [GAM in keyof T[K]]: GAM extends "getter"
       ? K extends keyof G
-        ? Getter<S, S, G, K, AllGetters>
+        ? Getter<S, S, G, K, SG>
         : never
       : GAM extends "action"
         ? K extends keyof A
-          ? DotNotationAction<S, S, A, K, AllGetters, AllActions, AllMutations>
+          ? DotNotationAction<S, S, A, K, SG, SA, SM>
           : never
         : GAM extends "mutation"
           ? K extends keyof M
@@ -435,6 +444,8 @@ type PartialStoreOptions<
             : never
           : never;
   };
+} & {
+  plugins?: ((store: Store<S, SG, SA, SM>) => void)[];
 };
 
 export const createPartialStore = <
@@ -443,11 +454,21 @@ export const createPartialStore = <
   A extends ActionsBase = StoreType<T, "action">,
   M extends MutationsBase = StoreType<T, "mutation">,
 >(
-  options: PartialStoreOptions<State, T, G, A, M>,
+  options: PartialStoreOptions<
+    State,
+    T,
+    G,
+    A,
+    M,
+    AllGetters,
+    AllActions,
+    AllMutations
+  >,
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
-  const obj = Object.keys(options).reduce(
+  const { plugins, ...storeEntries } = options;
+  const obj = Object.keys(storeEntries).reduce(
     (acc, cur) => {
-      const option = options[cur];
+      const option = storeEntries[cur];
 
       if (option.getter) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -474,5 +495,5 @@ export const createPartialStore = <
     },
   );
 
-  return obj;
+  return { ...obj, plugins };
 };

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -465,10 +465,10 @@ export const createPartialStore = <
     AllMutations
   >,
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
-  const { plugins, ...storeEntries } = options;
-  const obj = Object.keys(storeEntries).reduce(
+  const { plugins, ...restOptions } = options;
+  const obj = Object.keys(restOptions).reduce(
     (acc, cur) => {
-      const option = storeEntries[cur];
+      const option = restOptions[cur];
 
       if (option.getter) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -410,6 +410,10 @@ export type CustomMutationTree<S, M extends MutationsBase> = {
   [K in keyof M]: Mutation<S, M, K>;
 };
 
+export type StorePlugins = ((
+  store: Store<State, AllGetters, AllActions, AllMutations>,
+) => void)[];
+
 type StoreTypesBase = Record<
   string,
   {
@@ -425,18 +429,15 @@ type PartialStoreOptions<
   G extends GettersBase,
   A extends ActionsBase,
   M extends MutationsBase,
-  SG extends GettersBase = G,
-  SA extends ActionsBase = A,
-  SM extends MutationsBase = M,
 > = {
   [K in keyof T]: {
     [GAM in keyof T[K]]: GAM extends "getter"
       ? K extends keyof G
-        ? Getter<S, S, G, K, SG>
+        ? Getter<S, S, G, K, AllGetters>
         : never
       : GAM extends "action"
         ? K extends keyof A
-          ? DotNotationAction<S, S, A, K, SG, SA, SM>
+          ? DotNotationAction<S, S, A, K, AllGetters, AllActions, AllMutations>
           : never
         : GAM extends "mutation"
           ? K extends keyof M
@@ -444,8 +445,6 @@ type PartialStoreOptions<
             : never
           : never;
   };
-} & {
-  plugins?: ((store: Store<S, SG, SA, SM>) => void)[];
 };
 
 export const createPartialStore = <
@@ -454,21 +453,11 @@ export const createPartialStore = <
   A extends ActionsBase = StoreType<T, "action">,
   M extends MutationsBase = StoreType<T, "mutation">,
 >(
-  options: PartialStoreOptions<
-    State,
-    T,
-    G,
-    A,
-    M,
-    AllGetters,
-    AllActions,
-    AllMutations
-  >,
+  options: PartialStoreOptions<State, T, G, A, M>,
 ): StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations> => {
-  const { plugins, ...restOptions } = options;
-  const obj = Object.keys(restOptions).reduce(
+  const obj = Object.keys(options).reduce(
     (acc, cur) => {
-      const option = restOptions[cur];
+      const option = options[cur];
 
       if (option.getter) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -495,5 +484,5 @@ export const createPartialStore = <
     },
   );
 
-  return { ...obj, plugins };
+  return obj;
 };


### PR DESCRIPTION
## 内容

VuexラッパーにおけるStoreOptionsの`plugins`フィールドの型を、VV独自の`Store<S, G, A, M>`を受け取る形に置き換えます。これにより、pluginsの中で`store.watch`を使ったwatchを型安全に書けるようになります。

また、`createPartialStore`にも`plugins`フィールドのサポートを追加し、各ストアモジュールでpluginsを定義できるようにします。`index.ts`では各モジュールのpluginsをマージして`createStore`に渡すようにしています。

さらに、`singingStore`に`plugins`を定義し、`store.watch`でstateを監視して`RENDER` / `SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS` / `SYNC_LOOP_RANGE_TO_TRANSPORT` / `SYNC_PLAYHEAD_POSITION_TO_TRANSPORT`を自動実行するようにします。これにより各actionから直接のaction呼び出しを削除し、副作用の呼び出し元を一元化します。

### `src/store/vuex.ts` の変更

- `StoreOptions`の`plugins`の型を`Plugin<S>[]`から`((store: Store<S, SG, SA, SM>) => void)[]`に変更
  - `SG`/`SA`/`SM`（全体のGetters/Actions/Mutations）を型引数として持たせることで、pluginsからactions・mutationsに型安全にアクセスできるようになる
- `Store`コンストラクタでpluginsをVuexに直接渡さず、actions/mutations設定後に手動で呼ぶように変更
  - VuexはデフォルトでpluginsをStoreのコンストラクタ内でresetStoreState直後（VV独自のactions/mutationsが設定される前）に呼ぶため、その時点で呼ばれるとstoreにactions/mutationsが存在しない
  - Vuexはpluginsを単に呼び出すだけなので、手動で呼んでも等価
- `PartialStoreOptions`に`SG`/`SA`/`SM`型パラメータと`plugins`フィールドを追加
- `createPartialStore`で`plugins`を受け取り、戻り値の`StoreOptions`に含めるように変更

### `src/store/index.ts` の変更

- 各ストアモジュールの`plugins`をスプレッド演算子でマージし、`createStore`のoptionsに渡すように追加

### `src/store/singing.ts` の変更

- `singingStore.plugins`に3つの`store.watch`を追加
  - render対象state（tpqn, tempos, trackの各フィールド, defaultLyricMode）の変化を検知して`RENDER`を実行
  - trackのmute/solo/gain/panの変化を検知して`SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS`を実行
  - tpqn/temposの変化を検知して`SYNC_LOOP_RANGE_TO_TRANSPORT`と`SYNC_PLAYHEAD_POSITION_TO_TRANSPORT`を実行
- 各action内から`void actions.RENDER()` / `void actions.SYNC_XXX()`の直接呼び出しを削除
- `phonemeTimingEditData`の更新を`Map.set()`/`Map.delete()`ではなくMapオブジェクト自体の置き換えに変更
  - `Map.set()`/`Map.delete()`ではMapの参照が変わらず`store.watch`がstateの変化を検知できないため

### `src/store/command.ts` の変更

- `UNDO` / `REDO` actionのsongエディタ処理から`SYNC_TRACKS_AND_TRACK_CHANNEL_STRIPS` / `SYNC_LOOP_RANGE_TO_TRANSPORT` / `SYNC_PLAYHEAD_POSITION_TO_TRANSPORT` / `RENDER`の呼び出しを削除
  - `singingStore.plugins`のwatchが代わりに担うため

### `src/components/App.vue` の変更

- `defaultLyricMode`をwatchして`RENDER`を呼んでいた処理を削除
  - `singingStore.plugins`のwatchが代わりに担うため

## 関連 Issue

close #2970

## その他

`Store`コンストラクタでpluginsを手動で呼ぶ実装は、VuexがStoreのコンストラクタ内でresetStoreState直後にpluginsを単純に呼ぶだけという前提に依存しています。Vuexはメンテナンスモードであり今後この前提が崩れる可能性は極めて低いため、許容できるトレードオフと判断しています。