### PR TITLE
feat: eSignerCKA ダウンロード時に SHA256 チェックサムを検証する

### DIFF
--- a/tools/codesign_setup.bash
+++ b/tools/codesign_setup.bash
@@ -35,9 +35,7 @@ fi
 if [ ! -d "$ESIGNERCKA_INSTALL_DIR" ]; then
     curl -fLO --retry 3 --retry-delay 5 \
         "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.6/SSL.COM-eSigner-CKA_1.0.6.zip"
-
     echo "e4971440e4ebed94328492cf36e18999554c5c657c856f1cb14a6072c8b1c263  SSL.COM-eSigner-CKA_1.0.6.zip" | sha256sum --check
-
     unzip -o SSL.COM-eSigner-CKA_1.0.6.zip
     mv *eSigner*CKA_*.exe eSigner_CKA_Installer.exe
     powershell "

--- a/tools/codesign_setup.bash
+++ b/tools/codesign_setup.bash
@@ -1,7 +1,8 @@
 # !!! コードサイニング証明書を取り扱うので取り扱い注意 !!!
 
-# eSignerCKAを使ってコードサイニング証明書を読み込む
-# electronから利用するためにTHUMBPRINTとsigntoolのパスを出力する
+# eSignerCKAを使ってコードサイニング証明書を読み込む。
+# electronから利用するためにTHUMBPRINTとsigntoolのパスを出力する。
+# バージョンアップ時はチェックサムを sha256sum で確認して更新する。リリースから7日以上経過後が望ましい。
 
 set -eu
 
@@ -34,6 +35,14 @@ fi
 if [ ! -d "$ESIGNERCKA_INSTALL_DIR" ]; then
     curl -fLO --retry 3 --retry-delay 5 \
         "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.6/SSL.COM-eSigner-CKA_1.0.6.zip"
+
+    EXPECTED_SHA256="e4971440e4ebed94328492cf36e18999554c5c657c856f1cb14a6072c8b1c263"
+    DOWNLOADED_SHA256=$(sha256sum SSL.COM-eSigner-CKA_1.0.6.zip | cut -d' ' -f1)
+    if [ "$DOWNLOADED_SHA256" != "$EXPECTED_SHA256" ]; then
+        echo "チェックサムが一致しません: expected=$EXPECTED_SHA256, got=$DOWNLOADED_SHA256"
+        exit 1
+    fi
+
     unzip -o SSL.COM-eSigner-CKA_1.0.6.zip
     mv *eSigner*CKA_*.exe eSigner_CKA_Installer.exe
     powershell "

--- a/tools/codesign_setup.bash
+++ b/tools/codesign_setup.bash
@@ -36,12 +36,7 @@ if [ ! -d "$ESIGNERCKA_INSTALL_DIR" ]; then
     curl -fLO --retry 3 --retry-delay 5 \
         "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.6/SSL.COM-eSigner-CKA_1.0.6.zip"
 
-    EXPECTED_SHA256="e4971440e4ebed94328492cf36e18999554c5c657c856f1cb14a6072c8b1c263"
-    DOWNLOADED_SHA256=$(sha256sum SSL.COM-eSigner-CKA_1.0.6.zip | cut -d' ' -f1)
-    if [ "$DOWNLOADED_SHA256" != "$EXPECTED_SHA256" ]; then
-        echo "チェックサムが一致しません: expected=$EXPECTED_SHA256, got=$DOWNLOADED_SHA256"
-        exit 1
-    fi
+    echo "e4971440e4ebed94328492cf36e18999554c5c657c856f1cb14a6072c8b1c263  SSL.COM-eSigner-CKA_1.0.6.zip" | sha256sum --check
 
     unzip -o SSL.COM-eSigner-CKA_1.0.6.zip
     mv *eSigner*CKA_*.exe eSigner_CKA_Installer.exe


### PR DESCRIPTION
## 内容

`tools/codesign_setup.bash` で eSignerCKA をダウンロードした後に SHA256 チェックサムを検証するようにしました。

## 関連 Issue

close #2998