### PR TITLE
ci: [release-0.25] 書き込みが必要な job に permissions: を明示する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ defaults:
 jobs:
   build-and-upload:
     environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment（false時の挙動は2022年7月10日時点で未定義動作）
+    permissions:
+      contents: write
     env:
       ELECTRON_CACHE: .cache/electron
       ELECTRON_BUILDER_CACHE: .cache/electron-builder

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,8 @@ defaults:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: github/issue-labeler@v3.4
       with:

--- a/.github/workflows/release_latest_dev.yml
+++ b/.github/workflows/release_latest_dev.yml
@@ -15,6 +15,8 @@ jobs:
   latest-dev-build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'VOICEVOX'
+    permissions:
+      actions: write
     steps:
       - name: Trigger workflow_dispatch
         uses: actions/github-script@v7


### PR DESCRIPTION
## 内容

mainブランチのPR #2991 をrelease-0.25に適用します。

`GITHUB_TOKEN` のデフォルト権限を read-only に切り替えた影響で、0.25向けビルドに必要な書き込み権限が不足していたため、書き込みが必要な job に `permissions:` を明示します。

## 関連 Issue

ref VOICEVOX/voicevox_project#93

## スクリーンショット・動画など

なし

## その他

mainブランチのPR #2991 の squash merge commit をチェリーピック。