### PR TITLE
feat: [release-0.25] 7zipをgithubからダウンロードするようにする

### DIFF
--- a/tools/download7z.ts
+++ b/tools/download7z.ts
@@ -8,101 +8,120 @@ import path from "node:path";
 import { retryFetch } from "./helper.js";
 
 const distPath = path.join(import.meta.dirname, "..", "vendored", "7z");
-let url;
-let filesToExtract;
+const versionFilePath = path.join(distPath, "version.txt");
+const sevenZipVersion = "26.00";
+const sevenZipAssetVersion = sevenZipVersion.replace(".", "");
+const sevenZipReleaseBaseUrl =
+  "https://github.com/ip7z/7zip/releases/download/" + sevenZipVersion;
 
-await fs.promises.mkdir(distPath, { recursive: true });
-switch (process.platform) {
-  case "win32": {
-    // 7za.exeは7z形式で圧縮されているので、7zr.exeが必要になる。
-    // Mac/Linuxと違い、インストーラー以外には7z形式でしか配布されていない。
-    // Actionsでインストーラーを動かすことはできないので、単独で配布されている7zr.exeを使い、
-    // 7z形式で圧縮されている7za.exeを展開する。
-    const sevenzrUrl = "https://www.7-zip.org/a/7zr.exe";
+function getPlatformDownloadInfo(): {
+  url: string;
+  filesToExtract: string[];
+  bootstrapUrl?: string;
+} {
+  switch (process.platform) {
+    case "win32": {
+      return {
+        // 7za.exeは7z形式で圧縮されているので、展開用に7zr.exeも取得する。
+        bootstrapUrl: `${sevenZipReleaseBaseUrl}/7zr.exe`,
+        url: `${sevenZipReleaseBaseUrl}/7z${sevenZipAssetVersion}-extra.7z`,
+        // 7za.dll、7zxa.dllはなくても動くので、除外する
+        filesToExtract: ["7za.exe", "License.txt"],
+      };
+    }
+    case "linux": {
+      switch (os.arch()) {
+        case "arm64": {
+          return {
+            url: `${sevenZipReleaseBaseUrl}/7z${sevenZipAssetVersion}-linux-arm64.tar.xz`,
+            filesToExtract: ["7zzs", "License.txt"],
+          };
+        }
+        case "x64": {
+          return {
+            url: `${sevenZipReleaseBaseUrl}/7z${sevenZipAssetVersion}-linux-x64.tar.xz`,
+            filesToExtract: ["7zzs", "License.txt"],
+          };
+        }
+        default: {
+          throw new Error("Unsupported architecture for Linux");
+        }
+      }
+    }
+    case "darwin": {
+      return {
+        url: `${sevenZipReleaseBaseUrl}/7z${sevenZipAssetVersion}-mac.tar.xz`,
+        filesToExtract: ["7zz", "License.txt"],
+      };
+    }
+    default: {
+      throw new Error("Unsupported platform");
+    }
+  }
+}
+
+async function shouldDownload(filesToExtract: string[]) {
+  const versionMatches = await fs.promises
+    .readFile(versionFilePath, "utf-8")
+    .then((version) => version === sevenZipVersion)
+    .catch(() => false);
+
+  if (!versionMatches) {
+    return true;
+  }
+
+  const existingFiles = await fs.promises.readdir(distPath);
+  return filesToExtract.some((file) => !existingFiles.includes(file));
+}
+
+async function downloadBinary(url: string, outputPath: string) {
+  const res = await retryFetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to download binary: ${res.statusText}`);
+  }
+  const buffer = await res.arrayBuffer();
+  await fs.promises.writeFile(outputPath, Buffer.from(buffer));
+}
+
+const { url, filesToExtract, bootstrapUrl } = getPlatformDownloadInfo();
+
+if (await shouldDownload(filesToExtract)) {
+  await fs.promises.rm(distPath, { force: true, recursive: true });
+  await fs.promises.mkdir(distPath, { recursive: true });
+
+  if (bootstrapUrl) {
     const sevenzrPath = path.join(distPath, "7zr.exe");
-    if (!fs.existsSync(sevenzrPath)) {
-      console.log("Downloading 7zr from " + sevenzrUrl);
-      const res = await retryFetch(sevenzrUrl);
-      if (!res.ok) {
-        throw new Error(`Failed to download binary: ${res.statusText}`);
-      }
-      const buffer = await res.arrayBuffer();
-
-      await fs.promises.writeFile(sevenzrPath, Buffer.from(buffer));
-    }
-
-    url = "https://www.7-zip.org/a/7z2201-extra.7z";
-    // 7za.dll、7zxa.dllはなくても動くので、除外する
-    // filesToExtract = ["7za.exe", "7za.dll", "7zxa.dll", "License.txt"];
-    filesToExtract = ["7za.exe", "License.txt"];
-
-    break;
+    console.log("Downloading 7zr from " + bootstrapUrl);
+    await downloadBinary(bootstrapUrl, sevenzrPath);
   }
-  case "linux": {
-    switch (os.arch()) {
-      case "arm64": {
-        url = "https://www.7-zip.org/a/7z2201-linux-arm64.tar.xz";
-        break;
-      }
-      case "x64": {
-        url = "https://www.7-zip.org/a/7z2201-linux-x64.tar.xz";
-        break;
-      }
-      default: {
-        throw new Error("Unsupported architecture for Linux");
-      }
-    }
-    filesToExtract = ["7zzs", "License.txt"];
-    break;
-  }
-  case "darwin": {
-    url = "https://www.7-zip.org/a/7z2107-mac.tar.xz";
-    filesToExtract = ["7zz", "License.txt"];
-    break;
-  }
-  default: {
-    throw new Error("Unsupported platform");
-  }
-}
 
-const existingFiles = await fs.promises.readdir(distPath);
+  console.log("Downloading 7z from " + url);
+  const sevenZipPath = path.join(distPath, path.basename(url));
+  await downloadBinary(url, sevenZipPath);
 
-const notDownloaded = filesToExtract.filter(
-  (file) => !existingFiles.includes(file),
-);
+  console.log("Extracting 7z");
+  const extractor = url.endsWith(".7z")
+    ? spawnSync(
+        path.join(distPath, "7zr.exe"),
+        ["x", "-y", "-o" + distPath, sevenZipPath, ...filesToExtract],
+        {
+          stdio: ["ignore", "inherit", "inherit"],
+        },
+      )
+    : spawnSync(
+        "tar",
+        ["xvf", sevenZipPath, "-v", "-C", distPath, ...filesToExtract],
+        {
+          stdio: ["ignore", "inherit", "inherit"],
+        },
+      );
 
-if (notDownloaded.length === 0) {
+  if (extractor.status !== 0) {
+    console.error("Failed to extract 7z");
+    process.exit(1);
+  }
+
+  await fs.promises.writeFile(versionFilePath, sevenZipVersion);
+} else {
   console.log("7z already downloaded");
-  process.exit(0);
-}
-
-console.log("Downloading 7z from " + url);
-const res = await retryFetch(url);
-if (!res.ok) {
-  throw new Error(`Failed to download binary: ${res.statusText}`);
-}
-const buffer = await res.arrayBuffer();
-const sevenZipPath = path.join(distPath, path.basename(url));
-await fs.promises.writeFile(sevenZipPath, Buffer.from(buffer));
-
-console.log("Extracting 7z");
-const extractor = url.endsWith(".7z")
-  ? spawnSync(
-      path.join(distPath, "7zr.exe"),
-      ["x", "-y", "-o" + distPath, sevenZipPath, ...filesToExtract],
-      {
-        stdio: ["ignore", "inherit", "inherit"],
-      },
-    )
-  : spawnSync(
-      "tar",
-      ["xvf", sevenZipPath, "-v", "-C", distPath, ...filesToExtract],
-      {
-        stdio: ["ignore", "inherit", "inherit"],
-      },
-    );
-
-if (extractor.status !== 0) {
-  console.error("Failed to extract 7z");
-  process.exit(1);
 }


### PR DESCRIPTION
## 内容

mainブランチのPR #2996 をrelease-0.25に適用します。

7-zip.org 側で古い 7-Zip アーカイブが削除され、`pnpm i` の postinstall で `tools/download7z.ts` が失敗するため、7-Zip の GitHub Releases からダウンロードするようにします。

## 関連 Issue

ref #2995

## スクリーンショット・動画など

なし

## その他

mainブランチのPR #2996 の squash merge commit をチェリーピック。