### PR TITLE
test: 音声書き出しE2Eの通知確認を安定化する

### DIFF
--- a/tests/e2e/browser/音声書き出し.spec.ts
+++ b/tests/e2e/browser/音声書き出し.spec.ts
@@ -21,10 +21,12 @@ async function exportSelectedAudioAndSnapshot(page: Page, name: string) {
   });
 
   await test.step("書き出し完了の通知を確認して閉じる", async () => {
-    const notify = page.locator("#q-notify");
-    await expect(notify.getByText("音声を書き出しました")).toBeVisible();
+    const notify = page
+      .getByRole("alert")
+      .filter({ hasText: "音声を書き出しました" });
+    await expect(notify).toBeVisible();
     await notify.getByRole("button", { name: "閉じる" }).click();
-    await expect(notify).not.toBeVisible();
+    await expect(notify).toBeHidden();
   });
 
   await test.step("音声ファイルのバイナリをスナップショット", async () => {


### PR DESCRIPTION
## 内容

音声書き出しE2Eの成功通知確認で、Quasar Notifyのマウント先ではなく通知本体を待つようにしました。
閉じた通知が transition 中に DOM に残っても、次の通知確認で strict mode violation にならないようにしています。