### PR TITLE
chore: WindowsのエンジンへのパスをC:/Usersから%localappdata%に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pnpm run setup-agents
 `.env.production`をコピーして`.env`を作成し、`VITE_DEFAULT_ENGINE_INFOS`内の`executionFilePath`に
 [製品版 VOICEVOX](https://voicevox.hiroshiba.jp/) 内の`vv-engine/run.exe`を指定すれば動きます。
 
-Windows でインストール先を変更していない場合は`C:/Users/(ユーザー名)/AppData/Local/Programs/VOICEVOX/vv-engine/run.exe`を指定してください。  
+Windows でインストール先を変更していない場合は`%LOCALAPPDATA%/Programs/VOICEVOX/vv-engine/run.exe`を指定してください。  
 パスの区切り文字は`\`ではなく`/`なのでご注意ください。
 
 macOS 向けの`VOICEVOX.app`を利用している場合は`/path/to/VOICEVOX.app/Contents/Resources/vv-engine/run`を指定してください。


### PR DESCRIPTION
## 内容

将引擎路径中的硬编码 `C:\Users\用户名` 改为 `%LOCALAPPDATA%` 环境变量

## 相关 Issue

无

## 其他

仅影响 Windows 平台的引擎路径解析