### PR TITLE
refactor: 条件付きexpectを削除し、vitest/no-conditional-expectルールに準拠

### DIFF
--- a/tests/unit/lib/songTrackRenderer/index.spec.ts
+++ b/tests/unit/lib/songTrackRenderer/index.spec.ts
@@ -424,14 +424,10 @@ describe("SongTrackRenderer", () => {
             value.type === "phraseRenderingStarted" &&
             getOrThrow(phraseInfos, value.phraseKey).trackId === trackId,
         );
-        if (track.singer == undefined) {
-          // シンガーが未設定のトラックのフレーズはレンダリングされないはず
-          // eslint-disable-next-line vitest/no-conditional-expect
-          expect(phraseRenderingStartedEventInfos.length).toEqual(0);
-        } else {
-          // シンガーが設定されているトラックのフレーズはレンダリングされるはず
-          // eslint-disable-next-line vitest/no-conditional-expect
-          expect(phraseRenderingStartedEventInfos.length).toEqual(3);
+        // シンガーが未設定のトラックはレンダリングされない（0回）
+        // シンガーが設定されているトラックはレンダリングされる（3回）
+        const expectedCount = track.singer == undefined ? 0 : 3;
+        expect(phraseRenderingStartedEventInfos.length).toEqual(expectedCount);
         }
       }
     },


### PR DESCRIPTION
## 内容

`tests/unit/lib/songTrackRenderer/index.spec.ts` のテスト内にある条件付きの `expect` を削除し、`vitest/no-conditional-expect` ルールに準拠しました。

変更前：

```ts
if (track.singer == undefined) {
  expect(...).toEqual(0);
} else {
  expect(...).toEqual(3);
}
```

変更后：

```ts
const expectedCount = track.singer == undefined ? 0 : 3;
expect(...).toEqual(expectedCount);
```
