### PR TITLE
UNDO/REDOパフォーマンス向上用のハックを削除

### DIFF
--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -57,14 +57,7 @@ export const createCommandMutation =
     editor: EditorType,
   ): Mutation<S, M, K> =>
   (state: S, payload: M[K]): void => {
-    // HACK: コマンド履歴を除外してproduceWithPatchesを高速化
-    // ref: https://github.com/VOICEVOX/voicevox/issues/2143
-    const { undoCommands, redoCommands, ...stateWithoutHistory } = toRaw(state);
-    const command = recordPatches(payloadRecipe)(
-      stateWithoutHistory as S,
-      payload,
-    );
-
+    const command = recordPatches(payloadRecipe)(state, payload);
     applyPatches(state, command.redoPatches);
     state.undoCommands[editor].push(command);
     state.redoCommands[editor].splice(0);
@@ -78,7 +71,7 @@ const recordPatches =
   <S, P>(recipe: PayloadRecipe<S, P>) =>
   (state: S, payload: P): Command => {
     const [, doPatches, undoPatches] = immer.produceWithPatches(
-      state,
+      toRaw(state),
       (draft: S) => recipe(draft, payload),
     );
     return {


### PR DESCRIPTION
This reverts commit ed08b759f6d529f68e7bef28d352038a5f471a4b.

## 内容

- https://github.com/VOICEVOX/voicevox/pull/2885

上記PRで実装された、UNDOREDO監視対象からパッチ情報を除外するHACKを削除します。
#2143 の残タスク

## 関連 Issue

close #2143

## スクリーンショット・動画など

## その他