### PR TITLE
fix: SequencerParameterGridのグリッド線がPixi v8で描画されない問題を修正

### DIFF
--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -159,20 +159,28 @@ const render = () => {
   const style = gridLineStyles[currentTheme.value];
 
   // 小節線をまとめて描画
-  graphic.lineStyle(1, style.measure.color, style.measure.alpha);
   for (const x of measureLineXs) {
     const lineX = Math.round(x - props.viewportInfo.offsetX);
     graphic.moveTo(lineX - 0.5, 0);
     graphic.lineTo(lineX - 0.5, canvasHeight);
   }
+  graphic.stroke({
+    width: 1,
+    color: style.measure.color,
+    alpha: style.measure.alpha,
+  });
 
   // 拍線をまとめて描画
-  graphic.lineStyle(1, style.beat.color, style.beat.alpha);
   for (const x of beatLineXs) {
     const lineX = Math.round(x - props.viewportInfo.offsetX);
     graphic.moveTo(lineX - 0.5, 0);
     graphic.lineTo(lineX - 0.5, canvasHeight);
   }
+  graphic.stroke({
+    width: 1,
+    color: style.beat.color,
+    alpha: style.beat.alpha,
+  });
 
   renderer.render(stage);
 };


### PR DESCRIPTION
## 内容

#3009 で `SequencerParameterGrid.vue` を pixi.js v8 に対応させましたが、Renderer の初期化・破棄まわりのみの対応で、`render()` 内のグリッド線描画が v7 の `Graphics#lineStyle` 方式のまま残っていました。pixi.js v8 では `lineStyle()` は deprecation 警告を出して内部スタイルをセットするだけの互換シムになっており、`.stroke()` を呼ばないと実際には描画されません。そのため v8 環境ではパラメータパネルの小節線・拍線がまったく描画されず、コンソールに deprecation 警告が出続けていました。

本PRでは `render()` 内の描画処理を v8 の「パス構築 → `.stroke()` でスタイル適用」方式へ移行し、グリッド線が正しく描画されるようにします（#2990 の Graphics API 移行方針に準拠）。

### 設計上の補足

- 元コードの「小節線・拍線をグループごとにまとめて描画する」というバッチ設計の意図を維持し、線1本ごとではなくグループごとに `.stroke()` を1回だけ呼ぶ形にしました。
  - #2990 の `volumeLine.ts` と同様に、ループ内で `stroke()` を呼ぶと線数に比例してストロークコマンドが積まれるため、ループ外で1回にまとめています。`SequencerVolumeEditor.vue` の線ごとに `stroke()` する方式とは異なりますが、これは本コンポーネントが元から「グループ単位バッチ」設計だったことを尊重したためです。

## 関連 Issue

- VOICEVOX/voicevox#3009 （本PRが補完する pixi.js v8 対応のコミット）

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
