### PR TITLE
fix: `onlyBuiltDependencies`を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "// --- lifecycle ---": "",
     "preinstall": "npx -y only-allow pnpm",
     "postinstall": "pnpm run postinstall:packages && pnpm run postinstall:download-scripts",
-    "postinstall:packages": "electron-builder install-app-deps && playwright install chromium",
+    "postinstall:packages": "install-electron && electron-builder install-app-deps && playwright install chromium",
     "postinstall:download-scripts": "tsx tools/download7z.ts && tsx tools/downloadTypos.ts && tsx tools/downloadAppimagetool.ts && tsx tools/downloadType2Runtime.ts",
     "postuninstall": "electron-builder install-app-deps"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,5 @@ minimumReleaseAge: 10080
 onlyBuiltDependencies:
   - '@nestjs/core'
   - '@openapitools/openapi-generator-cli'
-  - electron
   - esbuild
-  - msw
   - vue-demi


### PR DESCRIPTION
## 内容

electron v42からelectronバイナリは`postinstall`によってインストール時にダウンロードするのではなく初回実行時に自動的にダウンロードするようになりました。
https://www.electronjs.org/blog/electron-42-0#electron-no-longer-downloads-itself-via-postinstall-script

そのため`onlyBuiltDependencies`に`electron-builder`が不要になったので修正します。

## 関連 Issue

ref #2987

## その他

とりあえず`postinstall:packages`にelectronバイナリを手動でインストールする`install-electron`を追加しておきました。

`msw`が依存パッケージに含まれていなかったためついでに削除しました。