### PR TITLE
test: Playwrightの全体タイムアウトを延ばす

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,7 +53,7 @@ const config: PlaywrightTestConfig = {
   // NOTE: Linux環境ではCIでGPU版をダウンロードしてしまい、かなりの時間がかかってしまうため、タイムアウトを長めに設定する。
   // TODO: CIでCPU版をダウンロードするように修正し、タイムアウトを元に戻す。
   timeout: isElectron ? 5 * 60 * 1000 : 60 * 1000,
-  globalTimeout: 15 * 60 * 1000,
+  globalTimeout: process.env.CI ? 15 * 60 * 1000 : 5 * 60 * 1000,
   globalSetup: isElectron ? "./tests/e2e/electron/setup.ts" : undefined,
   expect: {
     /**

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,7 +53,7 @@ const config: PlaywrightTestConfig = {
   // NOTE: Linux環境ではCIでGPU版をダウンロードしてしまい、かなりの時間がかかってしまうため、タイムアウトを長めに設定する。
   // TODO: CIでCPU版をダウンロードするように修正し、タイムアウトを元に戻す。
   timeout: isElectron ? 5 * 60 * 1000 : 60 * 1000,
-  globalTimeout: 5 * 60 * 1000,
+  globalTimeout: 15 * 60 * 1000,
   globalSetup: isElectron ? "./tests/e2e/electron/setup.ts" : undefined,
   expect: {
     /**


### PR DESCRIPTION
## 内容

Windows の browser e2e が CI 上で 5 分の `globalTimeout` に到達することがあるため、Playwright の全体タイムアウトを 15 分に延ばします。
個別テストの timeout は変更せず、全体の実行時間だけに余裕を持たせています。

`Run pnpm run test:browser-e2e` は成功時でも最大 4 分 57 秒かかっていました。
直近の成功 51 件の中央値は 4 分 22 秒、p90 は 4 分 45 秒でした。

[失敗例](https://github.com/VOICEVOX/voicevox/actions/runs/27127649762/attempts/1)では `37 passed (5.0m)` の直後に `Timed out waiting 300s for the test suite to run` が出ており、5 分の全体タイムアウトに到達しています。

## 関連 Issue

なし

## スクリーンショット・動画など

なし

## その他

- 失敗例: https://github.com/VOICEVOX/voicevox/actions/runs/27127649762/attempts/1
