### PR TITLE
feat: 音素タイミング編集に必要なVueコンポーネントを追加

### DIFF
--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -1,0 +1,329 @@
+<template>
+  <div ref="canvasContainer" class="canvas-container">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, computed, onUnmounted, onMounted, toRaw } from "vue";
+import * as PIXI from "pixi.js";
+import { useStore } from "@/store";
+import { useMounted } from "@/composables/useMounted";
+import {
+  getDoremiFromNoteNumber,
+  tickToBaseX,
+  type ViewportInfo,
+} from "@/sing/viewHelper";
+import { getOrThrow } from "@/helpers/mapHelper";
+import { clamp } from "@/sing/utility";
+
+const props = defineProps<{
+  viewportInfo: ViewportInfo;
+}>();
+
+const store = useStore();
+const tpqn = computed(() => store.state.tpqn);
+const isDark = computed(() => store.state.currentTheme === "Dark");
+const selectedTrack = computed(() => store.getters.SELECTED_TRACK);
+
+type ColorStyle = {
+  noteFill: number;
+  noteBorder: number;
+};
+
+const noteColorStyles: {
+  light: ColorStyle;
+  dark: ColorStyle;
+} = {
+  light: {
+    noteFill: 0xdfe3e0,
+    noteBorder: 0xffffff,
+  },
+  dark: {
+    noteFill: 0x363936,
+    noteBorder: 0x262728,
+  },
+};
+
+const noteColors = computed(() =>
+  isDark.value ? noteColorStyles.dark : noteColorStyles.light,
+);
+
+const noteTextStyles: {
+  light: PIXI.TextStyle;
+  dark: PIXI.TextStyle;
+} = {
+  light: new PIXI.TextStyle({ fill: "#423e3f", fontSize: 14 }),
+  dark: new PIXI.TextStyle({ fill: "#bfbbbc", fontSize: 14 }),
+};
+
+const selectedTrackNotes = computed(() => selectedTrack.value.notes);
+
+const { mounted } = useMounted();
+
+const canvasContainer = ref<HTMLElement | null>(null);
+const canvas = ref<HTMLCanvasElement | null>(null);
+let resizeObserver: ResizeObserver | undefined;
+let canvasWidth: number | undefined;
+let canvasHeight: number | undefined;
+
+// TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
+let isUnmounted = false;
+let renderer: PIXI.Renderer | undefined;
+let stage: PIXI.Container | undefined;
+const graphics: PIXI.Graphics[] = [];
+const texts: PIXI.Text[] = [];
+const textContainersMap = new Map<PIXI.Text, PIXI.Container>();
+const textMasksMap = new Map<PIXI.Text, PIXI.Graphics>();
+let lastIsDark: boolean | undefined;
+let requestId: number | undefined;
+let renderInNextFrame = false;
+
+const render = () => {
+  if (renderer == undefined) {
+    throw new Error("renderer is undefined.");
+  }
+  if (stage == undefined) {
+    throw new Error("stage is undefined.");
+  }
+  if (canvasWidth == undefined) {
+    throw new Error("canvasWidth is undefined.");
+  }
+  if (canvasHeight == undefined) {
+    throw new Error("canvasHeight is undefined.");
+  }
+
+  const notes = selectedTrackNotes.value;
+  const scaleX = store.state.sequencerZoomX;
+  const offsetXValue = props.viewportInfo.offsetX;
+  const colors = noteColors.value;
+  const currentTextStyle = isDark.value
+    ? noteTextStyles.dark
+    : noteTextStyles.light;
+
+  // テーマが変わるとテキストスタイルも変わるため、既存のテキストオブジェクトを全て破棄する
+  if (lastIsDark != undefined && lastIsDark !== isDark.value) {
+    for (const text of texts) {
+      const container = getOrThrow(textContainersMap, text);
+      stage.removeChild(container);
+      container.destroy(true);
+    }
+    texts.length = 0;
+    textContainersMap.clear();
+    textMasksMap.clear();
+  }
+  lastIsDark = isDark.value;
+
+  let graphicsIndex = 0;
+  let textIndex = 0;
+
+  // マスク計算で使うノートの位置情報
+  const notePositions: { screenStartX: number; text: PIXI.Text }[] = [];
+
+  // 各ノートを描画
+  for (const note of notes) {
+    const rawNote = toRaw(note);
+
+    // 位置とサイズを計算
+    const baseStartX = tickToBaseX(rawNote.position, tpqn.value);
+    const baseEndX = tickToBaseX(
+      rawNote.position + rawNote.duration,
+      tpqn.value,
+    );
+    const screenStartX = Math.round(baseStartX * scaleX - offsetXValue);
+    const screenEndX = Math.round(baseEndX * scaleX - offsetXValue);
+    const screenWidth = screenEndX - screenStartX;
+
+    // 画面外のノートは描画しない
+    const noteRight = screenStartX + screenWidth;
+    if (screenWidth < 1 || noteRight < 0 || screenStartX > canvasWidth) {
+      continue;
+    }
+
+    // Graphicsは使い回し、足りない分だけ作成する
+    if (graphicsIndex >= graphics.length) {
+      const newGraphic = new PIXI.Graphics();
+      stage.addChild(newGraphic);
+      graphics.push(newGraphic);
+    }
+    const graphic = graphics[graphicsIndex];
+    graphicsIndex++;
+
+    // ノートの長方形を描画
+    // 選択中のノートも同じ色で描画する
+    graphic.renderable = true;
+    graphic.clear();
+    graphic
+      .roundRect(screenStartX - 0.5, 0.5, screenWidth, canvasHeight - 1, 5)
+      .fill({ color: colors.noteFill, alpha: 1 })
+      .stroke({ width: 1, color: colors.noteBorder, alpha: 1 });
+
+    // ノートの歌詞をテキストで描画
+    const lyric = rawNote.lyric ?? getDoremiFromNoteNumber(rawNote.noteNumber);
+    if (textIndex >= texts.length) {
+      const newText = new PIXI.Text({ text: "", style: currentTextStyle });
+      const container = new PIXI.Container();
+      const mask = new PIXI.Graphics();
+
+      container.mask = mask;
+      container.addChild(newText);
+      container.addChild(mask);
+      stage.addChild(container);
+      texts.push(newText);
+      textContainersMap.set(newText, container);
+      textMasksMap.set(newText, mask);
+    }
+    const text = texts[textIndex];
+    textIndex++;
+
+    text.text = lyric;
+    text.anchor.set(0, 0.5);
+
+    const textContainer = getOrThrow(textContainersMap, text);
+    textContainer.renderable = true;
+    textContainer.x = screenStartX + 3;
+    textContainer.y = canvasHeight / 2;
+
+    notePositions.push({ screenStartX: textContainer.x, text });
+  }
+
+  // 各テキストが次のテキストと重ならないようにマスクをかける
+  for (let i = 0; i < notePositions.length; i++) {
+    const { screenStartX, text } = notePositions[i];
+    const textMask = getOrThrow(textMasksMap, text);
+
+    // デフォルトのマスク幅
+    let maskWidth = 36;
+
+    // 次のテキストがある場合、その位置までに制限
+    if (i + 1 < notePositions.length) {
+      const nextScreenStartX = notePositions[i + 1].screenStartX;
+      maskWidth = clamp(nextScreenStartX - screenStartX, 0, maskWidth);
+    }
+
+    const maskHeight = 36;
+
+    textMask
+      .clear()
+      .rect(0, -maskHeight / 2, maskWidth, maskHeight)
+      .fill({ color: 0xffffff });
+  }
+
+  // 未使用のグラフィックスとテキストを非表示
+  for (let i = graphicsIndex; i < graphics.length; i++) {
+    graphics[i].renderable = false;
+  }
+  for (let i = textIndex; i < texts.length; i++) {
+    const text = texts[i];
+    const textContainer = getOrThrow(textContainersMap, text);
+    textContainer.renderable = false;
+  }
+
+  renderer.render(stage);
+};
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch([mounted, selectedTrackNotes, tpqn], ([mounted]) => {
+  if (mounted) {
+    renderInNextFrame = true;
+  }
+});
+
+watch(isDark, () => {
+  renderInNextFrame = true;
+});
+
+watch(
+  () => [store.state.sequencerZoomX, props.viewportInfo.offsetX],
+  () => {
+    renderInNextFrame = true;
+  },
+);
+
+onMounted(async () => {
+  const canvasContainerElement = canvasContainer.value;
+  const canvasElement = canvas.value;
+  if (canvasContainerElement == undefined) {
+    throw new Error("canvasContainerElement is null.");
+  }
+  if (canvasElement == undefined) {
+    throw new Error("canvasElement is null.");
+  }
+
+  canvasWidth = canvasContainerElement.clientWidth;
+  canvasHeight = canvasContainerElement.clientHeight;
+
+  renderer = await PIXI.autoDetectRenderer({
+    canvas: canvasElement,
+    backgroundAlpha: 0,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+    width: canvasWidth,
+    height: canvasHeight,
+  });
+  if (isUnmounted) {
+    renderer.destroy({ removeView: true });
+    return;
+  }
+  stage = new PIXI.Container();
+
+  const callback = () => {
+    if (renderInNextFrame) {
+      render();
+      renderInNextFrame = false;
+    }
+    requestId = window.requestAnimationFrame(callback);
+  };
+  requestId = window.requestAnimationFrame(callback);
+
+  resizeObserver = new ResizeObserver(() => {
+    if (renderer == undefined) {
+      throw new Error("renderer is undefined.");
+    }
+    const canvasContainerWidth = canvasContainerElement.clientWidth;
+    const canvasContainerHeight = canvasContainerElement.clientHeight;
+
+    if (canvasContainerWidth > 0 && canvasContainerHeight > 0) {
+      canvasWidth = canvasContainerWidth;
+      canvasHeight = canvasContainerHeight;
+      renderer.resize(canvasWidth, canvasHeight);
+      renderInNextFrame = true;
+    }
+  });
+  resizeObserver.observe(canvasContainerElement);
+});
+
+onUnmounted(() => {
+  isUnmounted = true;
+
+  if (requestId != undefined) {
+    window.cancelAnimationFrame(requestId);
+  }
+
+  for (const graphic of graphics) {
+    stage?.removeChild(graphic);
+    graphic.destroy();
+  }
+  for (const text of texts) {
+    const container = getOrThrow(textContainersMap, text);
+    stage?.removeChild(container);
+    container.destroy(true);
+  }
+  textContainersMap.clear();
+  textMasksMap.clear();
+  stage?.destroy(true);
+  renderer?.destroy({ removeView: true });
+  resizeObserver?.disconnect();
+});
+</script>
+
+<style scoped lang="scss">
+.canvas-container {
+  overflow: hidden;
+  pointer-events: none;
+  position: relative;
+
+  contain: strict; // canvasのサイズが変わるのを無視する
+}
+</style>

--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -3,17 +3,53 @@
     <div class="axis-area"></div>
     <div class="parameter-area">
       <SequencerParameterGrid class="parameter-grid" :viewportInfo />
+      <SequencerWaveform class="waveform" :viewportInfo />
+      <SequencerNoteTimings class="note-timings" :viewportInfo />
+      <SequencerPhonemeTimings
+        class="phoneme-timings"
+        :viewportInfo
+        :phonemeTimingInfos
+      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import type { ViewportInfo } from "@/sing/viewHelper";
+import { useStore } from "@/store";
 import SequencerParameterGrid from "@/components/Sing/SequencerParameterGrid.vue";
+import SequencerWaveform from "@/components/Sing/SequencerWaveform.vue";
+import SequencerPhonemeTimings from "@/components/Sing/SequencerPhonemeTimings.vue";
+import SequencerNoteTimings from "@/components/Sing/SequencerNoteTimings.vue";
+import {
+  computePhonemeTimingInfos,
+  getPhraseInfosForTrack,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
+
+const store = useStore();
 
 defineProps<{
   viewportInfo: ViewportInfo;
 }>();
+
+const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
+const phonemeTimingEditData = computed(
+  () => store.getters.SELECTED_TRACK.phonemeTimingEditData,
+);
+const phraseInfos = computed(() =>
+  getPhraseInfosForTrack(
+    store.state.phrases,
+    store.state.phraseQueries,
+    selectedTrackId.value,
+  ),
+);
+const phonemeTimingInfos = computed(() => {
+  return computePhonemeTimingInfos(
+    phraseInfos.value,
+    phonemeTimingEditData.value,
+  );
+});
 </script>
 
 <style scoped lang="scss">
@@ -43,6 +79,21 @@ defineProps<{
 }
 
 .parameter-grid {
+  grid-column: 1;
+  grid-row: 1 / 5;
+}
+
+.waveform {
+  grid-column: 1;
+  grid-row: 4 / 5;
+}
+
+.note-timings {
+  grid-column: 1;
+  grid-row: 2 / 3;
+}
+
+.phoneme-timings {
   grid-column: 1;
   grid-row: 1 / 5;
 }

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -1,0 +1,420 @@
+<template>
+  <div ref="canvasContainer" class="canvas-container">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, computed, onUnmounted, onMounted, toRaw } from "vue";
+import * as PIXI from "pixi.js";
+import { useStore } from "@/store";
+import { useMounted } from "@/composables/useMounted";
+import { secondToTick } from "@/sing/music";
+import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
+import { clamp, getNext } from "@/sing/utility";
+import { getOrThrow } from "@/helpers/mapHelper";
+import { UnreachableError } from "@/type/utility";
+import type { PhonemeTimingInfo } from "@/sing/phonemeTimingEditorStateMachine/common";
+
+type PhonemeDisplayState = "default" | "edited";
+
+type PhonemeDisplayInfo = {
+  readonly phoneme: string;
+  readonly displayState: PhonemeDisplayState;
+  startTime: number;
+};
+
+const props = defineProps<{
+  viewportInfo: ViewportInfo;
+  phonemeTimingInfos: PhonemeTimingInfo[];
+}>();
+
+const store = useStore();
+const tpqn = computed(() => store.state.tpqn);
+const isDark = computed(() => store.state.currentTheme === "Dark");
+const tempos = computed(() => store.state.tempos);
+const phonemeTimingInfos = computed(() => props.phonemeTimingInfos);
+
+type PhonemeTimingLineStyle = { color: number; alpha: number; width: number };
+const phonemeTimingLineStyles: Record<
+  "light" | "dark",
+  Record<PhonemeDisplayState, PhonemeTimingLineStyle>
+> = {
+  light: {
+    default: { color: 0x8bc796, alpha: 1, width: 1 },
+    edited: { color: 0x00a73f, alpha: 1, width: 2 },
+  },
+  dark: {
+    default: { color: 0x547359, alpha: 1, width: 1 },
+    edited: { color: 0x28a652, alpha: 1, width: 2 },
+  },
+};
+
+const phonemeTextStyles: {
+  light: PIXI.TextStyle;
+  dark: PIXI.TextStyle;
+} = {
+  light: new PIXI.TextStyle({ fill: "#252E26", fontSize: 14 }),
+  dark: new PIXI.TextStyle({ fill: "#ccc8c9", fontSize: 14 }),
+};
+
+const { mounted } = useMounted();
+
+const canvasContainer = ref<HTMLElement | null>(null);
+const canvas = ref<HTMLCanvasElement | null>(null);
+
+let resizeObserver: ResizeObserver | undefined;
+let canvasWidth: number | undefined;
+let canvasHeight: number | undefined;
+
+// TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
+let isUnmounted = false;
+let renderer: PIXI.Renderer | undefined;
+let stage: PIXI.Container | undefined;
+
+// 線描画用のGraphicsプール
+const graphics: PIXI.Graphics[] = [];
+// 音素文字をキーとしたTextオブジェクトのプール
+const textsMap = new Map<string, PIXI.Text[]>();
+// Textにマスクを適用するためのContainerのマップ
+const textContainersMap = new Map<PIXI.Text, PIXI.Container>();
+// Textごとのマスク用Graphicsマップ
+const textMasksMap = new Map<PIXI.Text, PIXI.Graphics>();
+
+let lastIsDark: boolean | undefined;
+let requestId: number | undefined;
+let renderInNextFrame = false;
+
+const render = () => {
+  if (renderer == undefined) {
+    throw new Error("renderer is undefined.");
+  }
+  if (stage == undefined) {
+    throw new Error("stage is undefined.");
+  }
+  if (canvasWidth == undefined) {
+    throw new Error("canvasWidth is undefined.");
+  }
+  if (canvasHeight == undefined) {
+    throw new Error("canvasHeight is undefined.");
+  }
+
+  const rawTempos = toRaw(tempos.value);
+  const rawPhonemeTimingInfos = toRaw(phonemeTimingInfos.value);
+  const viewportInfo = props.viewportInfo;
+  const editorFrameRate = store.state.editorFrameRate;
+  const oneFrameSeconds = 1 / editorFrameRate;
+
+  const currentTextStyle = isDark.value
+    ? phonemeTextStyles.dark
+    : phonemeTextStyles.light;
+
+  // テーマが変わるとテキストスタイルも変わるため、既存のテキストオブジェクトを全て破棄する
+  if (lastIsDark != undefined && lastIsDark !== isDark.value) {
+    for (const texts of textsMap.values()) {
+      for (const text of texts) {
+        const container = getOrThrow(textContainersMap, text);
+        stage.removeChild(container);
+        container.destroy(true);
+      }
+    }
+    textsMap.clear();
+    textContainersMap.clear();
+    textMasksMap.clear();
+  }
+  lastIsDark = isDark.value;
+
+  // 描画用の情報を生成
+  const phonemeDisplayInfos: PhonemeDisplayInfo[] = [];
+  for (const phonemeTimingInfo of rawPhonemeTimingInfos) {
+    // 先頭のpauなどnoteIdが無い音素は描画しない
+    if (phonemeTimingInfo.noteId == undefined) {
+      continue;
+    }
+
+    const startTime = phonemeTimingInfo.editedStartTimeSeconds;
+
+    const displayState: PhonemeDisplayState = phonemeTimingInfo.isEdited
+      ? "edited"
+      : "default";
+
+    phonemeDisplayInfos.push({
+      phoneme: phonemeTimingInfo.phoneme,
+      displayState,
+      startTime,
+    });
+  }
+
+  // 音素の順序入れ替わり防止
+  // プレビュー等で音素の位置が変わると前後の音素と順序が入れ替わる可能性があるため、
+  // 表示上は前後の音素との順序を維持するよう制限する
+  for (let i = phonemeDisplayInfos.length - 1; i >= 0; i--) {
+    const phonemeDisplayInfo = phonemeDisplayInfos[i];
+    const nextPhonemeDisplayInfo = getNext(phonemeDisplayInfos, i);
+    if (nextPhonemeDisplayInfo != undefined) {
+      const maxStartTime = nextPhonemeDisplayInfo.startTime - oneFrameSeconds;
+      if (phonemeDisplayInfo.startTime > maxStartTime) {
+        phonemeDisplayInfo.startTime = maxStartTime;
+      }
+    }
+  }
+
+  // 画面外の音素を除外する
+  const cullingMargin = 40;
+  const culledPhonemeDisplayInfos: PhonemeDisplayInfo[] = [];
+  for (const phonemeDisplayInfo of phonemeDisplayInfos) {
+    const phonemeStartTicks = secondToTick(
+      phonemeDisplayInfo.startTime,
+      rawTempos,
+      tpqn.value,
+    );
+    const phonemeStartBaseX = tickToBaseX(phonemeStartTicks, tpqn.value);
+    const phonemeStartX = Math.round(
+      phonemeStartBaseX * viewportInfo.scaleX - viewportInfo.offsetX,
+    );
+    if (
+      phonemeStartX >= -cullingMargin &&
+      phonemeStartX <= canvasWidth + cullingMargin
+    ) {
+      culledPhonemeDisplayInfos.push(phonemeDisplayInfo);
+    }
+  }
+
+  // 線のGraphicsが足りなければ追加
+  while (graphics.length < culledPhonemeDisplayInfos.length) {
+    const newGraphic = new PIXI.Graphics();
+    stage.addChild(newGraphic);
+    graphics.push(newGraphic);
+  }
+
+  // 音素文字ごとに必要なテキスト数をカウント
+  const needTextCountMap = new Map<string, number>();
+  for (const phonemeDisplayInfo of culledPhonemeDisplayInfos) {
+    if (phonemeDisplayInfo.phoneme === "pau") {
+      continue;
+    }
+    const currentCount = needTextCountMap.get(phonemeDisplayInfo.phoneme) ?? 0;
+    needTextCountMap.set(phonemeDisplayInfo.phoneme, currentCount + 1);
+  }
+
+  // テキストオブジェクトが足りなければ追加生成
+  for (const [phonemeStr, needTextCount] of needTextCountMap) {
+    let texts = textsMap.get(phonemeStr);
+    if (texts == undefined) {
+      texts = [];
+      textsMap.set(phonemeStr, texts);
+    }
+
+    const currentTextCount = texts.length;
+    for (let i = 0; i < needTextCount - currentTextCount; i++) {
+      const text = new PIXI.Text({ text: phonemeStr, style: currentTextStyle });
+      const container = new PIXI.Container();
+      const mask = new PIXI.Graphics();
+
+      // 隣の音素にはみ出さないようにマスクを設定する
+      container.mask = mask;
+      container.addChild(text);
+      container.addChild(mask);
+      stage.addChild(container);
+
+      texts.push(text);
+      textContainersMap.set(text, container);
+      textMasksMap.set(text, mask);
+    }
+  }
+
+  // マスク幅の計算で次の音素のX座標が必要になるため、先に全てのX座標を計算しておく
+  const phonemeStartXArray: number[] = [];
+  for (const phonemeDisplayInfo of culledPhonemeDisplayInfos) {
+    const phonemeStartTicks = secondToTick(
+      phonemeDisplayInfo.startTime,
+      rawTempos,
+      tpqn.value,
+    );
+    const phonemeStartBaseX = tickToBaseX(phonemeStartTicks, tpqn.value);
+    const phonemeStartX = Math.round(
+      phonemeStartBaseX * viewportInfo.scaleX - viewportInfo.offsetX,
+    );
+    phonemeStartXArray.push(phonemeStartX);
+  }
+
+  // 未割り当てのTextを管理するため、プールをコピーした一時マップを作る
+  const unassignedTextsMap = new Map<string, PIXI.Text[]>();
+  for (const [phonemeStr, texts] of textsMap) {
+    unassignedTextsMap.set(phonemeStr, [...texts]);
+  }
+
+  // 線とテキストを更新
+  for (let i = 0; i < culledPhonemeDisplayInfos.length; i++) {
+    const phonemeDisplayInfo = culledPhonemeDisplayInfos[i];
+    const phonemeStartX = phonemeStartXArray[i];
+    const nextPhonemeStartX = getNext(phonemeStartXArray, i);
+
+    // 線の更新
+    const graphic = graphics[i];
+    graphic.renderable = true;
+    graphic.clear();
+
+    const themeStyles = isDark.value
+      ? phonemeTimingLineStyles.dark
+      : phonemeTimingLineStyles.light;
+    const lineStyle = themeStyles[phonemeDisplayInfo.displayState];
+
+    const lineX =
+      lineStyle.width % 2 === 1 ? phonemeStartX - 0.5 : phonemeStartX;
+    graphic.moveTo(lineX, 0).lineTo(lineX, canvasHeight).stroke({
+      width: lineStyle.width,
+      color: lineStyle.color,
+      alpha: lineStyle.alpha,
+    });
+
+    // テキストの更新
+    if (phonemeDisplayInfo.phoneme !== "pau") {
+      // プールから取得
+      const text = getOrThrow(
+        unassignedTextsMap,
+        phonemeDisplayInfo.phoneme,
+      ).pop();
+      if (text == undefined) {
+        throw new UnreachableError("text is undefined.");
+      }
+      const textContainer = getOrThrow(textContainersMap, text);
+      const textMask = getOrThrow(textMasksMap, text);
+
+      textContainer.renderable = true;
+      textContainer.x = phonemeStartX + 3; // 線から少し右にずらす
+      textContainer.y = 50;
+
+      // マスク幅の計算
+      let maskWidth = 36;
+      if (nextPhonemeStartX != undefined) {
+        maskWidth = clamp(
+          nextPhonemeStartX - textContainer.x - 1,
+          0,
+          maskWidth,
+        );
+      }
+      const maskHeight = 36;
+
+      // マスクの更新
+      textMask
+        .clear()
+        .rect(0, 0, maskWidth, maskHeight)
+        .fill({ color: 0xffffff });
+    }
+  }
+
+  // 余ったGraphicsを非表示
+  for (let i = culledPhonemeDisplayInfos.length; i < graphics.length; i++) {
+    graphics[i].renderable = false;
+  }
+  // 余ったTextContainerを非表示
+  for (const texts of unassignedTextsMap.values()) {
+    for (const text of texts) {
+      const textContainer = getOrThrow(textContainersMap, text);
+      textContainer.renderable = false;
+    }
+  }
+
+  renderer.render(stage);
+};
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch([mounted, phonemeTimingInfos, tempos, tpqn], ([mounted]) => {
+  if (mounted) {
+    renderInNextFrame = true;
+  }
+});
+
+watch(isDark, () => {
+  renderInNextFrame = true;
+});
+
+watch(
+  () => [props.viewportInfo.scaleX, props.viewportInfo.offsetX],
+  () => {
+    renderInNextFrame = true;
+  },
+);
+
+onMounted(async () => {
+  const canvasContainerElement = canvasContainer.value;
+  const canvasElement = canvas.value;
+  if (canvasContainerElement == undefined) {
+    throw new Error("canvasContainerElement is null.");
+  }
+  if (canvasElement == undefined) {
+    throw new Error("canvasElement is null.");
+  }
+
+  canvasWidth = canvasContainerElement.clientWidth;
+  canvasHeight = canvasContainerElement.clientHeight;
+
+  renderer = await PIXI.autoDetectRenderer({
+    canvas: canvasElement,
+    backgroundAlpha: 0,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+    width: canvasWidth,
+    height: canvasHeight,
+  });
+  if (isUnmounted) {
+    renderer.destroy({ removeView: true });
+    return;
+  }
+  stage = new PIXI.Container();
+
+  const callback = () => {
+    if (renderInNextFrame) {
+      render();
+      renderInNextFrame = false;
+    }
+    requestId = window.requestAnimationFrame(callback);
+  };
+  requestId = window.requestAnimationFrame(callback);
+
+  resizeObserver = new ResizeObserver(() => {
+    if (renderer == undefined) {
+      throw new Error("renderer is undefined.");
+    }
+
+    const newWidth = canvasContainerElement.clientWidth;
+    const newHeight = canvasContainerElement.clientHeight;
+
+    if (newWidth > 0 && newHeight > 0) {
+      canvasWidth = newWidth;
+      canvasHeight = newHeight;
+      renderer.resize(canvasWidth, canvasHeight);
+      renderInNextFrame = true;
+    }
+  });
+  resizeObserver.observe(canvasContainerElement);
+});
+
+onUnmounted(() => {
+  isUnmounted = true;
+
+  if (requestId != undefined) {
+    window.cancelAnimationFrame(requestId);
+  }
+
+  for (const graphic of graphics) {
+    stage?.removeChild(graphic);
+    graphic.destroy();
+  }
+  stage?.destroy(true);
+  renderer?.destroy({ removeView: true });
+  resizeObserver?.disconnect();
+});
+</script>
+
+<style scoped lang="scss">
+.canvas-container {
+  overflow: hidden;
+  pointer-events: none;
+  position: relative;
+
+  contain: strict; // canvasのサイズが変わるのを無視する
+}
+</style>

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -1,0 +1,474 @@
+<template>
+  <div ref="canvasContainer" class="canvas-container">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { z } from "zod";
+import { ref, watch, computed, onUnmounted, onMounted } from "vue";
+import * as PIXI from "pixi.js";
+import { useStore } from "@/store";
+import { useMounted } from "@/composables/useMounted";
+import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
+import { secondToTick, tickToSecond } from "@/sing/music";
+import {
+  generateWaveformPeaks,
+  resamplePeaks,
+  type WaveformPeaks,
+} from "@/sing/waveformPeaks";
+import { Mutex } from "@/helpers/mutex";
+import { createLogger } from "@/helpers/log";
+import { calculateHash } from "@/sing/utility";
+import type { SequenceId } from "@/store/type";
+import type { Tempo } from "@/domain/project/type";
+import { getOrThrow } from "@/helpers/mapHelper";
+import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
+
+const props = defineProps<{
+  viewportInfo: ViewportInfo;
+}>();
+
+const { warn } = createLogger("SequencerWaveform");
+
+const store = useStore();
+const tpqn = computed(() => store.state.tpqn);
+const tempos = computed(() => store.state.tempos);
+const isDark = computed(() => store.state.currentTheme === "Dark");
+const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
+const scaleX = computed(() => store.state.sequencerZoomX);
+
+type AudioEventId = SequenceId;
+
+type AudioEvent = {
+  readonly startTime: number;
+  readonly buffer: AudioBuffer;
+};
+
+// 描画用の波形データ
+type WaveformData = {
+  readonly startX: number;
+  readonly width: number;
+  readonly minValues: Float32Array;
+  readonly maxValues: Float32Array;
+};
+
+const waveformDataKeySchema = z.string().brand<"WaveformDataKey">();
+
+type WaveformDataKey = z.infer<typeof waveformDataKeySchema>;
+
+const computeWaveformDataKey = async (
+  eventId: AudioEventId,
+  event: AudioEvent,
+  scaleXValue: number,
+  temposValue: readonly Tempo[],
+  tpqnValue: number,
+): Promise<WaveformDataKey> => {
+  const hash = await calculateHash({
+    audioEventId: eventId,
+    audioStartTime: event.startTime,
+    scaleX: scaleXValue,
+    tempos: temposValue,
+    tpqn: tpqnValue,
+  });
+  return waveformDataKeySchema.parse(hash);
+};
+
+const phrasesInSelectedTrack = computed(() => {
+  return new Map(
+    [...store.state.phrases.entries()].filter(
+      ([, phrase]) => phrase.trackId === selectedTrackId.value,
+    ),
+  );
+});
+
+const audioEvents = computed<ReadonlyMap<AudioEventId, AudioEvent>>(() => {
+  const events = new Map<AudioEventId, AudioEvent>();
+  for (const [phraseKey, phrase] of phrasesInSelectedTrack.value) {
+    const sequenceId = store.state.phraseSequenceIds.get(phraseKey);
+    if (sequenceId == undefined) {
+      continue;
+    }
+    const buffer = store.getters.GET_SEQUENCE_AUDIO_BUFFER(sequenceId);
+    if (buffer == undefined) {
+      // NoteSequenceなどはAudioBufferを持たないため、スキップする
+      continue;
+    }
+    events.set(sequenceId, { startTime: phrase.startTime, buffer });
+  }
+  return events;
+});
+
+// AudioBufferから算出した波形ピークのMap
+const peaksMap = ref<ReadonlyMap<AudioEventId, WaveformPeaks>>(new Map());
+
+const updatePeaksMap = () => {
+  const audioEventsValue = audioEvents.value;
+
+  const tempMap = new Map(peaksMap.value);
+
+  // 不要なキーを削除
+  for (const eventId of tempMap.keys()) {
+    if (!audioEventsValue.has(eventId)) {
+      tempMap.delete(eventId);
+    }
+  }
+
+  // 新規キーについてpeaksを生成
+  // NOTE: sequenceIdに対応するAudioBufferは不変なので、既存キーの再計算は不要
+  for (const [eventId, event] of audioEventsValue) {
+    if (!tempMap.has(eventId)) {
+      tempMap.set(eventId, generateWaveformPeaks(event.buffer));
+    }
+  }
+
+  peaksMap.value = tempMap;
+};
+
+// 描画用の波形データのMap
+const waveformDataMap = ref<ReadonlyMap<WaveformDataKey, WaveformData>>(
+  new Map(),
+);
+
+// 波形データの更新を直列化するMutex
+const waveformDataMutex = new Mutex({ maxPending: 1 });
+
+const computeWaveformData = (
+  event: AudioEvent,
+  peaks: WaveformPeaks,
+  scaleXValue: number,
+  temposValue: readonly Tempo[],
+  tpqnValue: number,
+): WaveformData => {
+  const durationSeconds = event.buffer.length / event.buffer.sampleRate;
+  const endTime = event.startTime + durationSeconds;
+  const startTicks = secondToTick(event.startTime, temposValue, tpqnValue);
+  const endTicks = secondToTick(endTime, temposValue, tpqnValue);
+
+  const startBaseX = tickToBaseX(startTicks, tpqnValue);
+  const endBaseX = tickToBaseX(endTicks, tpqnValue);
+  const startScreenXAtZeroOffset = startBaseX * scaleXValue;
+  const endScreenXAtZeroOffset = endBaseX * scaleXValue;
+  // 後段のループで0除算が起きないように、1以上に丸める
+  const width = Math.max(
+    1,
+    Math.round(endScreenXAtZeroOffset - startScreenXAtZeroOffset),
+  );
+
+  // 各ピクセル境界に対応するサンプル位置を求める
+  const pixelBoundarySamples: number[] = [];
+  const tickRange = endTicks - startTicks;
+  for (let i = 0; i <= width; i++) {
+    const pixelTick = startTicks + (tickRange * i) / width;
+    const pixelTime = tickToSecond(pixelTick, temposValue, tpqnValue);
+    pixelBoundarySamples.push(
+      (pixelTime - event.startTime) * event.buffer.sampleRate,
+    );
+  }
+
+  const { minValues, maxValues } = resamplePeaks(peaks, pixelBoundarySamples);
+
+  return {
+    startX: startScreenXAtZeroOffset,
+    width,
+    minValues,
+    maxValues,
+  };
+};
+
+const updateWaveformDataMap = async () => {
+  const audioEventsValue = audioEvents.value;
+  const peaksMapValue = peaksMap.value;
+  const scaleXValue = scaleX.value;
+  // NOTE: Tempoが型レベルでイミュータブルになっていないので、cloneしている
+  const temposValue = cloneWithUnwrapProxy(tempos.value);
+  const tpqnValue = tpqn.value;
+
+  const tempMap = new Map(waveformDataMap.value);
+
+  const keyedEvents = new Map<
+    WaveformDataKey,
+    { eventId: AudioEventId; event: AudioEvent }
+  >();
+  for (const [eventId, event] of audioEventsValue) {
+    const key = await computeWaveformDataKey(
+      eventId,
+      event,
+      scaleXValue,
+      temposValue,
+      tpqnValue,
+    );
+    keyedEvents.set(key, { eventId, event });
+  }
+
+  // 不要なキーを削除
+  for (const key of tempMap.keys()) {
+    if (!keyedEvents.has(key)) {
+      tempMap.delete(key);
+    }
+  }
+
+  // 新規キーについて描画用の波形データを計算
+  for (const [key, { eventId, event }] of keyedEvents) {
+    if (!tempMap.has(key)) {
+      const peaks = getOrThrow(peaksMapValue, eventId);
+      const waveformData = computeWaveformData(
+        event,
+        peaks,
+        scaleXValue,
+        temposValue,
+        tpqnValue,
+      );
+      tempMap.set(key, waveformData);
+    }
+  }
+
+  waveformDataMap.value = tempMap;
+};
+
+const { mounted } = useMounted();
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch([mounted, audioEvents], ([mountedValue]) => {
+  if (mountedValue) {
+    updatePeaksMap();
+  }
+});
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch(
+  [mounted, audioEvents, peaksMap, scaleX, tempos, tpqn],
+  async ([mountedValue]) => {
+    if (mountedValue) {
+      try {
+        await using _lock = await waveformDataMutex.acquire();
+        await updateWaveformDataMap();
+      } catch (e) {
+        warn("Failed to update waveform data map.", e);
+      }
+    }
+  },
+);
+
+type WaveformColorStyle = {
+  color: number;
+  alpha: number;
+};
+
+const waveformColorStyles: {
+  light: WaveformColorStyle;
+  dark: WaveformColorStyle;
+} = {
+  light: {
+    color: 0xb0b0b0,
+    alpha: 0.5,
+  },
+  dark: {
+    color: 0x707070,
+    alpha: 0.6,
+  },
+};
+
+const waveformColors = computed(() =>
+  isDark.value ? waveformColorStyles.dark : waveformColorStyles.light,
+);
+
+const canvasContainer = ref<HTMLElement | null>(null);
+const canvas = ref<HTMLCanvasElement | null>(null);
+let resizeObserver: ResizeObserver | undefined;
+let canvasWidth: number | undefined;
+let canvasHeight: number | undefined;
+
+// TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
+let isUnmounted = false;
+let renderer: PIXI.Renderer | undefined;
+let stage: PIXI.Container | undefined;
+const graphics: PIXI.Graphics[] = [];
+let requestId: number | undefined;
+let renderInNextFrame = false;
+
+function drawWaveform(
+  graphic: PIXI.Graphics,
+  waveformData: WaveformData,
+  startScreenX: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  color: number,
+  alpha: number,
+) {
+  const { minValues, maxValues } = waveformData;
+  const centerY = canvasHeight / 2;
+  const amplitudeScale = canvasHeight / 2;
+  const cullingMargin = 2;
+
+  graphic.clear();
+  const points: number[] = [];
+
+  // 最大値をたどって上半分の頂点を作成
+  for (let i = 0; i < waveformData.width; i++) {
+    const x = startScreenX + i;
+    if (x < -cullingMargin || x > canvasWidth + cullingMargin) {
+      continue;
+    }
+    points.push(x, centerY - maxValues[i] * amplitudeScale);
+  }
+
+  // 最小値を逆順にたどって下半分の頂点を作成
+  for (let i = waveformData.width - 1; i >= 0; i--) {
+    const x = startScreenX + i;
+    if (x < -cullingMargin || x > canvasWidth + cullingMargin) {
+      continue;
+    }
+    points.push(x, centerY - minValues[i] * amplitudeScale);
+  }
+
+  // 頂点の数が4個以上なら描画
+  if (points.length / 2 >= 4) {
+    graphic.poly(points).fill({ color, alpha });
+  }
+}
+
+const render = () => {
+  if (renderer == undefined) {
+    throw new Error("renderer is undefined.");
+  }
+  if (stage == undefined) {
+    throw new Error("stage is undefined.");
+  }
+  if (canvasWidth == undefined) {
+    throw new Error("canvasWidth is undefined.");
+  }
+  if (canvasHeight == undefined) {
+    throw new Error("canvasHeight is undefined.");
+  }
+
+  const waveformColorsValue = waveformColors.value;
+  const offsetXValue = props.viewportInfo.offsetX;
+  const waveformDataMapValue = waveformDataMap.value;
+
+  let graphicsIndex = 0;
+  for (const waveformData of waveformDataMapValue.values()) {
+    // Graphicsは使い回し、足りない分だけ作成する
+    if (graphicsIndex >= graphics.length) {
+      const newGraphic = new PIXI.Graphics();
+      stage.addChild(newGraphic);
+      graphics.push(newGraphic);
+    }
+    const graphic = graphics[graphicsIndex];
+    graphicsIndex++;
+
+    const startScreenX = Math.round(waveformData.startX - offsetXValue);
+    const endScreenX = startScreenX + waveformData.width;
+
+    if (endScreenX < 0 || startScreenX > canvasWidth) {
+      graphic.renderable = false;
+    } else {
+      graphic.renderable = true;
+      drawWaveform(
+        graphic,
+        waveformData,
+        startScreenX,
+        canvasWidth,
+        canvasHeight,
+        waveformColorsValue.color,
+        waveformColorsValue.alpha,
+      );
+    }
+  }
+
+  for (let i = graphicsIndex; i < graphics.length; i++) {
+    graphics[i].renderable = false;
+  }
+
+  renderer.render(stage);
+};
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch(
+  [mounted, waveformDataMap, isDark, () => props.viewportInfo.offsetX],
+  ([mountedValue]) => {
+    if (mountedValue) {
+      renderInNextFrame = true;
+    }
+  },
+);
+
+onMounted(async () => {
+  const canvasContainerElement = canvasContainer.value;
+  const canvasElement = canvas.value;
+  if (canvasContainerElement == undefined) {
+    throw new Error("canvasContainerElement is null.");
+  }
+  if (canvasElement == undefined) {
+    throw new Error("canvasElement is null.");
+  }
+
+  canvasWidth = canvasContainerElement.clientWidth;
+  canvasHeight = canvasContainerElement.clientHeight;
+
+  renderer = await PIXI.autoDetectRenderer({
+    canvas: canvasElement,
+    backgroundAlpha: 0,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+    width: canvasWidth,
+    height: canvasHeight,
+  });
+  if (isUnmounted) {
+    renderer.destroy({ removeView: true });
+    return;
+  }
+  stage = new PIXI.Container();
+
+  const callback = () => {
+    if (renderInNextFrame) {
+      render();
+      renderInNextFrame = false;
+    }
+    requestId = window.requestAnimationFrame(callback);
+  };
+  requestId = window.requestAnimationFrame(callback);
+
+  resizeObserver = new ResizeObserver(() => {
+    if (renderer == undefined) {
+      throw new Error("renderer is undefined.");
+    }
+    const canvasContainerWidth = canvasContainerElement.clientWidth;
+    const canvasContainerHeight = canvasContainerElement.clientHeight;
+
+    if (canvasContainerWidth > 0 && canvasContainerHeight > 0) {
+      canvasWidth = canvasContainerWidth;
+      canvasHeight = canvasContainerHeight;
+      renderer.resize(canvasWidth, canvasHeight);
+      renderInNextFrame = true;
+    }
+  });
+  resizeObserver.observe(canvasContainerElement);
+});
+
+onUnmounted(() => {
+  isUnmounted = true;
+
+  if (requestId != undefined) {
+    window.cancelAnimationFrame(requestId);
+  }
+  for (const graphic of graphics) {
+    stage?.removeChild(graphic);
+    graphic.destroy();
+  }
+  stage?.destroy(true);
+  renderer?.destroy({ removeView: true });
+  resizeObserver?.disconnect();
+});
+</script>
+
+<style scoped lang="scss">
+.canvas-container {
+  overflow: hidden;
+  pointer-events: none; // 波形は視覚的表示のみで操作不可
+  position: relative;
+
+  contain: strict; // canvasのサイズが変わるのを無視する
+}
+</style>

--- a/src/helpers/mapHelper.ts
+++ b/src/helpers/mapHelper.ts
@@ -1,7 +1,7 @@
 /** Mapのヘルパー関数 */
 
 /** Mapから値を取得する。指定したキーが存在しない場合は例外を投げる */
-export const getOrThrow = <K, V>(map: Map<K, V>, key: K) => {
+export const getOrThrow = <K, V>(map: ReadonlyMap<K, V>, key: K) => {
   if (!map.has(key)) {
     throw new Error(`Key not found: ${String(key)}`);
   }

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -266,6 +266,31 @@ export function toPhonemes(phonemeTimings: PhonemeTiming[]) {
 }
 
 /**
+ * 各音素のノート内でのインデックスを計算する。
+ * noteIdが変わるとインデックスは0にリセットされる。
+ */
+export function computePhonemeIndicesInNote<
+  T extends { noteId?: string | null },
+>(phonemes: readonly T[]): number[] {
+  const indices: number[] = [];
+  let phonemeIndexInNote = 0;
+
+  for (let i = 0; i < phonemes.length; i++) {
+    const phoneme = phonemes[i];
+    const prevPhoneme = getPrev(phonemes, i);
+
+    if (prevPhoneme == undefined || phoneme.noteId !== prevPhoneme.noteId) {
+      phonemeIndexInNote = 0;
+    } else {
+      phonemeIndexInNote++;
+    }
+    indices.push(phonemeIndexInNote);
+  }
+
+  return indices;
+}
+
+/**
  * 音素タイミング列に音素タイミング編集を適用する。
  */
 export function applyPhonemeTimingEdit(
@@ -273,20 +298,13 @@ export function applyPhonemeTimingEdit(
   phonemeTimingEditData: PhonemeTimingEditData,
   frameRate: number,
 ) {
-  let phonemeIndexInNote = 0;
+  const phonemeIndices = computePhonemeIndicesInNote(phonemeTimings);
+
   for (let i = 0; i < phonemeTimings.length; i++) {
     const phonemeTiming = phonemeTimings[i];
     const prevPhonemeTiming = getPrev(phonemeTimings, i);
     const nextPhonemeTiming = getNext(phonemeTimings, i);
-
-    if (
-      prevPhonemeTiming == undefined ||
-      phonemeTiming.noteId !== prevPhonemeTiming.noteId
-    ) {
-      phonemeIndexInNote = 0;
-    } else {
-      phonemeIndexInNote++;
-    }
+    const phonemeIndexInNote = phonemeIndices[i];
 
     if (phonemeTiming.phoneme === "pau") {
       continue;

--- a/src/sing/music.ts
+++ b/src/sing/music.ts
@@ -98,7 +98,11 @@ const secondToTickForConstantBpm = (
   return seconds * quarterNotesPerSecond * tpqn;
 };
 
-export const tickToSecond = (ticks: number, tempos: Tempo[], tpqn: number) => {
+export const tickToSecond = (
+  ticks: number,
+  tempos: readonly Tempo[],
+  tpqn: number,
+) => {
   let timeOfTempo = 0;
   let tempo = tempos[tempos.length - 1];
   for (let i = 0; i < tempos.length; i++) {
@@ -123,7 +127,7 @@ export const tickToSecond = (ticks: number, tempos: Tempo[], tpqn: number) => {
 
 export const secondToTick = (
   seconds: number,
-  tempos: Tempo[],
+  tempos: readonly Tempo[],
   tpqn: number,
 ) => {
   let timeOfTempo = 0;

--- a/src/sing/phonemeTimingEditorStateMachine/common.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/common.ts
@@ -1,0 +1,186 @@
+import { NoteId, TrackId } from "@/type/preload";
+import type { Note, PhonemeTimingEditData } from "@/domain/project/type";
+import type {
+  EditorFrameAudioQuery,
+  EditorFrameAudioQueryKey,
+  Phrase,
+  PhraseKey,
+} from "@/store/type";
+import { getOrThrow } from "@/helpers/mapHelper";
+import {
+  adjustPhonemeTimings,
+  applyPhonemeTimingEdit,
+  computePhonemeIndicesInNote,
+  toPhonemes,
+  toPhonemeTimings,
+} from "@/sing/domain";
+import { getPrev } from "@/sing/utility";
+
+// 音素タイミングの計算に必要なフレーズ情報
+export type PhraseInfo = Readonly<{
+  startTime: number;
+  query?: EditorFrameAudioQuery;
+  // NOTE: notesは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  notes: Note[];
+  minNonPauseStartFrame: number | undefined;
+  maxNonPauseEndFrame: number | undefined;
+}>;
+
+// 1音素分のタイミング情報
+export type PhonemeTimingInfo = {
+  // NOTE: phraseKeyは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  phraseKey: PhraseKey;
+  phoneme: string;
+  noteId: NoteId | undefined;
+  // NOTE: phonemeIndexInNoteは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  phonemeIndexInNote: number;
+  isEdited: boolean;
+  editedStartTimeSeconds: number;
+  // NOTE: originalStartTimeSecondsは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  originalStartTimeSeconds: number;
+  // NOTE: editedEndTimeSecondsは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  editedEndTimeSeconds: number;
+};
+
+/**
+ * 指定トラックのフレーズ情報を取得する。
+ */
+export function getPhraseInfosForTrack(
+  phrases: Map<PhraseKey, Phrase>,
+  phraseQueries: Map<EditorFrameAudioQueryKey, EditorFrameAudioQuery>,
+  trackId: TrackId,
+): Map<PhraseKey, PhraseInfo> {
+  const phraseInfos = new Map<PhraseKey, PhraseInfo>();
+  for (const [phraseKey, phrase] of phrases) {
+    if (phrase.trackId !== trackId) {
+      continue;
+    }
+    let query = undefined;
+    if (phrase.queryKey != undefined) {
+      query = getOrThrow(phraseQueries, phrase.queryKey);
+    }
+    phraseInfos.set(phraseKey, {
+      startTime: phrase.startTime,
+      query,
+      notes: phrase.notes,
+      minNonPauseStartFrame: phrase.minNonPauseStartFrame,
+      maxNonPauseEndFrame: phrase.maxNonPauseEndFrame,
+    });
+  }
+  return phraseInfos;
+}
+
+/**
+ * 音素タイミングの情報を計算する。
+ */
+export function computePhonemeTimingInfos(
+  phraseInfos: Map<PhraseKey, PhraseInfo>,
+  phonemeTimingEditData: PhonemeTimingEditData,
+): PhonemeTimingInfo[] {
+  // フレーズが時系列順に並んでいることを検証する
+  let prevPhraseStartTime: number | undefined = undefined;
+  for (const phraseInfo of phraseInfos.values()) {
+    if (
+      prevPhraseStartTime != undefined &&
+      phraseInfo.startTime < prevPhraseStartTime
+    ) {
+      throw new Error("phraseInfos must be sorted in chronological order.");
+    }
+    prevPhraseStartTime = phraseInfo.startTime;
+  }
+
+  const phonemeTimingInfos: PhonemeTimingInfo[] = [];
+
+  for (const [phraseKey, phraseInfo] of phraseInfos) {
+    const phraseQuery = phraseInfo.query;
+    if (phraseQuery == undefined) {
+      continue;
+    }
+
+    // 編集を適用した音素列を生成
+    const phonemeTimings = toPhonemeTimings(phraseQuery.phonemes);
+    applyPhonemeTimingEdit(
+      phonemeTimings,
+      phonemeTimingEditData,
+      phraseQuery.frameRate,
+    );
+    adjustPhonemeTimings(
+      phonemeTimings,
+      phraseInfo.minNonPauseStartFrame,
+      phraseInfo.maxNonPauseEndFrame,
+    );
+    const editedPhonemes = toPhonemes(phonemeTimings);
+
+    const phraseStartTime = phraseInfo.startTime;
+    const frameRate = phraseQuery.frameRate;
+
+    const phonemeIndices = computePhonemeIndicesInNote(phraseQuery.phonemes);
+
+    let phonemeStartFrame = 0;
+    let editedPhonemeStartFrame = 0;
+
+    for (let i = 0; i < phraseQuery.phonemes.length; i++) {
+      const phoneme = phraseQuery.phonemes[i];
+      const prevPhoneme = getPrev(phraseQuery.phonemes, i);
+      const editedPhoneme = editedPhonemes[i];
+      const phonemeIndexInNote = phonemeIndices[i];
+
+      const originalStartTimeSeconds =
+        phraseStartTime + phonemeStartFrame / frameRate;
+      const editedStartTimeSeconds =
+        phraseStartTime + editedPhonemeStartFrame / frameRate;
+
+      let noteId: NoteId | undefined;
+      let effectivePhonemeIndexInNote: number;
+
+      if (phoneme.phoneme === "pau") {
+        if (prevPhoneme?.noteId != undefined) {
+          // 末尾のpauは前のノートに含まれるものとして扱い、
+          // 前の音素のnoteIdとphonemeIndexInNote + 1を使う
+          noteId = NoteId(prevPhoneme.noteId);
+          const prevPhonemeIndexInNote = phonemeIndices[i - 1];
+          effectivePhonemeIndexInNote = prevPhonemeIndexInNote + 1;
+        } else {
+          // 先頭のpauなどはノートに属さない
+          noteId = undefined;
+          effectivePhonemeIndexInNote = phonemeIndexInNote;
+        }
+      } else {
+        noteId =
+          phoneme.noteId != undefined ? NoteId(phoneme.noteId) : undefined;
+        effectivePhonemeIndexInNote = phonemeIndexInNote;
+      }
+
+      // 編集が存在するかどうかを判定
+      let isEdited = false;
+      if (noteId != undefined) {
+        const phonemeTimingEdits = phonemeTimingEditData.get(noteId);
+        if (phonemeTimingEdits != undefined) {
+          isEdited = phonemeTimingEdits.some(
+            (edit) => edit.phonemeIndexInNote === effectivePhonemeIndexInNote,
+          );
+        }
+      }
+
+      const editedEndTimeSeconds =
+        phraseStartTime +
+        (editedPhonemeStartFrame + editedPhoneme.frameLength) / frameRate;
+
+      phonemeTimingInfos.push({
+        phraseKey,
+        noteId,
+        phonemeIndexInNote: effectivePhonemeIndexInNote,
+        phoneme: editedPhoneme.phoneme,
+        isEdited,
+        originalStartTimeSeconds,
+        editedStartTimeSeconds,
+        editedEndTimeSeconds,
+      });
+
+      phonemeStartFrame += phoneme.frameLength;
+      editedPhonemeStartFrame += editedPhoneme.frameLength;
+    }
+  }
+
+  return phonemeTimingInfos;
+}

--- a/src/sing/utility.ts
+++ b/src/sing/utility.ts
@@ -93,18 +93,18 @@ export function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
 
-export function getLast<T>(array: T[]) {
+export function getLast<T>(array: readonly T[]) {
   if (array.length === 0) {
     throw new Error("array.length is 0.");
   }
   return array[array.length - 1];
 }
 
-export function getPrev<T>(array: T[], currentIndex: number) {
+export function getPrev<T>(array: readonly T[], currentIndex: number) {
   return currentIndex !== 0 ? array[currentIndex - 1] : undefined;
 }
 
-export function getNext<T>(array: T[], currentIndex: number) {
+export function getNext<T>(array: readonly T[], currentIndex: number) {
   return currentIndex !== array.length - 1
     ? array[currentIndex + 1]
     : undefined;

--- a/src/sing/waveformPeaks.ts
+++ b/src/sing/waveformPeaks.ts
@@ -1,0 +1,200 @@
+/**
+ * 波形のピーク（min/max）データをmipmap形式で保持・参照するための純粋関数群。
+ *
+ * AudioBufferを一度だけ縮約し、複数解像度のピーク配列として保持する。
+ * 描画時には表示解像度に応じたレベルを選択してリサンプルすることで、
+ * ズーム連続変化時のO(audioBuffer.length)再計算を避ける。
+ */
+
+import { getLast } from "@/sing/utility";
+
+type WaveformMipmapLevel = {
+  readonly bucketSize: number;
+  readonly minBuckets: Float32Array;
+  readonly maxBuckets: Float32Array;
+};
+
+/**
+ * 波形ピークのmipmap。
+ * levels[0]が最も細かいレベルで、以降はバケツサイズの昇順に並ぶ。
+ */
+export type WaveformPeaks = readonly WaveformMipmapLevel[];
+
+/**
+ * 波形ピークをリサンプルしたもの。
+ */
+export type ResampledPeaks = {
+  readonly minValues: Float32Array;
+  readonly maxValues: Float32Array;
+};
+
+const BASE_BUCKET_SIZE = 16;
+
+/**
+ * AudioBufferのch0からピークのmipmapを生成する。
+ * 最も細かいレベルのバケツサイズは BASE_BUCKET_SIZE で、
+ * 以降は2倍ずつ大きなバケツサイズのレベルを、バケツ数が1個になるまで積み上げる。
+ */
+export function generateWaveformPeaks(audioBuffer: AudioBuffer): WaveformPeaks {
+  const channel = audioBuffer.getChannelData(0);
+  const numSamples = channel.length;
+
+  // レベル0: サンプルから直接バケツ化
+  const baseNumBuckets = Math.ceil(numSamples / BASE_BUCKET_SIZE);
+  const baseMinBuckets = new Float32Array(baseNumBuckets);
+  const baseMaxBuckets = new Float32Array(baseNumBuckets);
+
+  for (let bucketIndex = 0; bucketIndex < baseNumBuckets; bucketIndex++) {
+    const start = bucketIndex * BASE_BUCKET_SIZE;
+    const end = Math.min(start + BASE_BUCKET_SIZE, numSamples);
+    let min = channel[start];
+    let max = channel[start];
+    for (let i = start + 1; i < end; i++) {
+      const value = channel[i];
+      if (value < min) {
+        min = value;
+      }
+      if (value > max) {
+        max = value;
+      }
+    }
+    baseMinBuckets[bucketIndex] = min;
+    baseMaxBuckets[bucketIndex] = max;
+  }
+
+  const levels: WaveformMipmapLevel[] = [
+    {
+      bucketSize: BASE_BUCKET_SIZE,
+      minBuckets: baseMinBuckets,
+      maxBuckets: baseMaxBuckets,
+    },
+  ];
+
+  // 上位レベル: バケツ数が1個になるまで2バケツずつまとめる
+  while (getLast(levels).minBuckets.length > 1) {
+    const prev = getLast(levels);
+    const prevNumBuckets = prev.minBuckets.length;
+
+    const newBucketSize = prev.bucketSize * 2;
+    const newNumBuckets = Math.ceil(prevNumBuckets / 2);
+    const newMinBuckets = new Float32Array(newNumBuckets);
+    const newMaxBuckets = new Float32Array(newNumBuckets);
+
+    for (let i = 0; i < newNumBuckets; i++) {
+      const a = 2 * i;
+      const b = 2 * i + 1;
+      if (b < prevNumBuckets) {
+        newMinBuckets[i] = Math.min(prev.minBuckets[a], prev.minBuckets[b]);
+        newMaxBuckets[i] = Math.max(prev.maxBuckets[a], prev.maxBuckets[b]);
+      } else {
+        newMinBuckets[i] = prev.minBuckets[a];
+        newMaxBuckets[i] = prev.maxBuckets[a];
+      }
+    }
+
+    levels.push({
+      bucketSize: newBucketSize,
+      minBuckets: newMinBuckets,
+      maxBuckets: newMaxBuckets,
+    });
+  }
+
+  return levels;
+}
+
+/**
+ * 各区間に対応するサンプル範囲を境界配列で指定して、ピークをリサンプルする。
+ * 区間ごとに最適なmipmapレベルを選択するため、サンプル幅が不均等でも適切な解像度になる。
+ *
+ * @param binBoundarySamples 長さ `numBins + 1` の配列。
+ *   `binBoundarySamples[i]` 以上 `binBoundarySamples[i + 1]` 未満が区間 `i` のサンプル範囲。
+ *   各値は音声データ先頭基準のサンプル位置で、単調非減少でなければならない。
+ *   負の値や `numSamples` を超える値も許容され、範囲外は0埋めになる。
+ *   幅0の区間は点として扱い、その位置のサンプルを含むバケツの値になる。
+ *   長さは2以上でなければならない。
+ */
+export function resamplePeaks(
+  peaks: WaveformPeaks,
+  binBoundarySamples: number[],
+): ResampledPeaks {
+  if (peaks.length === 0) {
+    throw new Error("peaks must have at least one level.");
+  }
+  for (const level of peaks) {
+    if (level.minBuckets.length !== level.maxBuckets.length) {
+      throw new Error("minBuckets and maxBuckets must have the same length.");
+    }
+    if (level.minBuckets.length === 0) {
+      throw new Error("every level must have at least one bucket.");
+    }
+  }
+  for (let i = 1; i < peaks.length; i++) {
+    if (peaks[i].bucketSize <= peaks[i - 1].bucketSize) {
+      throw new Error("peaks levels must be in ascending order of bucketSize.");
+    }
+  }
+  if (binBoundarySamples.length < 2) {
+    throw new Error("binBoundarySamples must have at least two elements.");
+  }
+
+  const numBins = binBoundarySamples.length - 1;
+  const minValues = new Float32Array(numBins);
+  const maxValues = new Float32Array(numBins);
+
+  for (let binIndex = 0; binIndex < numBins; binIndex++) {
+    const binStartSample = binBoundarySamples[binIndex];
+    const binEndSample = binBoundarySamples[binIndex + 1];
+    const samplesPerBin = binEndSample - binStartSample;
+    if (samplesPerBin < 0) {
+      throw new Error(
+        "binBoundarySamples must be monotonically non-decreasing.",
+      );
+    }
+    // bucketSize <= samplesPerBin を満たす最大の bucketSize のレベルを選ぶ
+    // どのレベルも条件を満たさないときは、最も細かいレベルを使う
+    let selectedLevel = peaks[0];
+    for (const level of peaks) {
+      if (level.bucketSize > samplesPerBin) {
+        break;
+      }
+      selectedLevel = level;
+    }
+
+    const numBuckets = selectedLevel.minBuckets.length;
+    const bucketSize = selectedLevel.bucketSize;
+    let bucketStart = Math.floor(binStartSample / bucketSize);
+    let bucketEnd = Math.ceil(binEndSample / bucketSize);
+    if (bucketEnd === bucketStart) {
+      bucketEnd = bucketStart + 1;
+    }
+    if (bucketStart < 0) {
+      bucketStart = 0;
+    }
+    if (bucketEnd > numBuckets) {
+      bucketEnd = numBuckets;
+    }
+
+    if (bucketStart >= bucketEnd) {
+      // クランプ前は必ず bucketStart < bucketEnd になっているため、
+      // ここに該当するのは区間が音声データの完全に外側にあるときだけで、0埋めのままにする
+      continue;
+    }
+
+    let min = selectedLevel.minBuckets[bucketStart];
+    let max = selectedLevel.maxBuckets[bucketStart];
+    for (let i = bucketStart + 1; i < bucketEnd; i++) {
+      const bucketMin = selectedLevel.minBuckets[i];
+      const bucketMax = selectedLevel.maxBuckets[i];
+      if (bucketMin < min) {
+        min = bucketMin;
+      }
+      if (bucketMax > max) {
+        max = bucketMax;
+      }
+    }
+    minValues[binIndex] = min;
+    maxValues[binIndex] = max;
+  }
+
+  return { minValues, maxValues };
+}

--- a/tests/unit/lib/waveformPeaks.spec.ts
+++ b/tests/unit/lib/waveformPeaks.spec.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from "vitest";
+import { generateWaveformPeaks, resamplePeaks } from "@/sing/waveformPeaks";
+import { createArray } from "@/sing/utility";
+
+function makeAudioBuffer(samples: number[], sampleRate = 24000): AudioBuffer {
+  const channel = new Float32Array(samples);
+  return {
+    length: channel.length,
+    sampleRate,
+    numberOfChannels: 1,
+    duration: channel.length / sampleRate,
+    getChannelData: (ch: number) => {
+      if (ch !== 0) {
+        throw new Error("only ch0 supported in test");
+      }
+      return channel;
+    },
+  } as unknown as AudioBuffer;
+}
+
+/**
+ * レベル0のバケツ（16サンプル）ごとにmin/maxを指定してサンプル配列を作る。
+ * 各バケツは先頭サンプルがmin、2番目のサンプルがmax、残り14サンプルが0になる。
+ * 0埋め部分がそのバケツのmin/maxに影響しないよう、min <= 0 <= max でなければならない。
+ */
+function makeBucketSamples(
+  bucketMinMaxList: [min: number, max: number][],
+): number[] {
+  const samples: number[] = [];
+  for (const [min, max] of bucketMinMaxList) {
+    if (min > 0 || max < 0) {
+      throw new Error("min <= 0 <= max でなければなりません。");
+    }
+    samples.push(min, max, ...createArray(14, () => 0));
+  }
+  return samples;
+}
+
+function expectFloat32ArrayCloseTo(actual: Float32Array, expected: number[]) {
+  expect(actual.length).toBe(expected.length);
+  for (let i = 0; i < expected.length; i++) {
+    expect(actual[i]).toBeCloseTo(expected[i]);
+  }
+}
+
+describe("generateWaveformPeaks", () => {
+  it("16サンプル以下ならバケツ1個のレベルが1つだけできる", () => {
+    const peaks = generateWaveformPeaks(makeAudioBuffer([0.1, -0.2, 0.3]));
+    expect(peaks.length).toBe(1);
+    expect(peaks[0].bucketSize).toBe(16);
+    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.2]);
+    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.3]);
+  });
+
+  it("レベル0は16サンプルごとのバケツになり、各バケツがその範囲のmin/maxを持つ", () => {
+    // バケツ0（[0, 16)）: min -0.4（i=3）, max 0.6（i=10）
+    // バケツ1（[16, 32)）: min -0.7（i=25）, max 0.8（i=20）
+    const samples = createArray(32, (i) => {
+      if (i === 3) {
+        return -0.4;
+      }
+      if (i === 10) {
+        return 0.6;
+      }
+      if (i === 20) {
+        return 0.8;
+      }
+      if (i === 25) {
+        return -0.7;
+      }
+      return 0;
+    });
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    expect(peaks[0].bucketSize).toBe(16);
+    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.4, -0.7]);
+    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.6, 0.8]);
+  });
+
+  it("サンプル数が16の倍数でないとき、最後のバケツは端数サンプルのみで計算される", () => {
+    // 16サンプルの0埋めバケツ + 端数4サンプル
+    const samples = [...createArray(16, () => 0), 0.1, -0.3, 0.5, 0.2];
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // ceil(20 / 16) = 2バケツで、バケツ1は [16, 20) の4サンプルのみ
+    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [0, -0.3]);
+    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0, 0.5]);
+  });
+
+  it("バケツ数が1になるまで、隣接2バケツをmin/max統合したレベルが積まれる", () => {
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.4, 0.2],
+      [-0.2, 0.8],
+      [-0.3, 0.3],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    expect(peaks.length).toBe(3);
+
+    // レベル0: 入力そのままの4バケツ
+    expect(peaks[0].bucketSize).toBe(16);
+    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.1, -0.4, -0.2, -0.3]);
+    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.1, 0.2, 0.8, 0.3]);
+
+    // レベル1: 隣接2バケツの統合
+    expect(peaks[1].bucketSize).toBe(32);
+    expectFloat32ArrayCloseTo(peaks[1].minBuckets, [-0.4, -0.3]);
+    expectFloat32ArrayCloseTo(peaks[1].maxBuckets, [0.2, 0.8]);
+
+    // レベル2: 全体のmin/max
+    expect(peaks[2].bucketSize).toBe(64);
+    expectFloat32ArrayCloseTo(peaks[2].minBuckets, [-0.4]);
+    expectFloat32ArrayCloseTo(peaks[2].maxBuckets, [0.8]);
+  });
+
+  it("バケツ数が奇数のとき、最後のバケツは単独で上位レベルに引き継がれる", () => {
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.2, 0.2],
+      [-0.5, 0.6],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // レベル1: バケツ0と1の統合 + バケツ2の単独引き継ぎ
+    expectFloat32ArrayCloseTo(peaks[1].minBuckets, [-0.2, -0.5]);
+    expectFloat32ArrayCloseTo(peaks[1].maxBuckets, [0.2, 0.6]);
+  });
+});
+
+describe("resamplePeaks", () => {
+  it("不正なpeaksを渡すとエラーになる", () => {
+    // 空のpeaks
+    expect(() => resamplePeaks([], [0, 16, 32])).toThrow();
+
+    // バケツが0個のレベルを含む
+    const emptyBucketsPeaks = [
+      {
+        bucketSize: 16,
+        minBuckets: new Float32Array(0),
+        maxBuckets: new Float32Array(0),
+      },
+    ];
+    expect(() => resamplePeaks(emptyBucketsPeaks, [0, 16, 32])).toThrow();
+
+    // minBucketsとmaxBucketsの長さが一致しない
+    const mismatchedLengthPeaks = [
+      {
+        bucketSize: 16,
+        minBuckets: new Float32Array(2),
+        maxBuckets: new Float32Array(1),
+      },
+    ];
+    expect(() => resamplePeaks(mismatchedLengthPeaks, [0, 16, 32])).toThrow();
+
+    // レベルがバケツサイズの昇順に並んでいない
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.2, 0.2],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const reversedPeaks = [...peaks].reverse();
+    expect(() => resamplePeaks(reversedPeaks, [0, 16, 32])).toThrow();
+  });
+
+  it("不正なbinBoundarySamplesを渡すとエラーになる", () => {
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.2, 0.2],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 長さが2未満
+    expect(() => resamplePeaks(peaks, [])).toThrow();
+    expect(() => resamplePeaks(peaks, [0])).toThrow();
+
+    // 減少している
+    expect(() => resamplePeaks(peaks, [0, 32, 16])).toThrow();
+  });
+
+  it("幅0の区間は点として扱われ、その位置のサンプルを含むバケツの値になる", () => {
+    const samples = makeBucketSamples([
+      [-0.3, 0.3],
+      [-0.5, 0.5],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間1はバケツ境界ちょうど（位置16）の幅0区間で、サンプル16を含むバケツ1の値になる
+    // 区間3はバケツ1の内部（位置24）の幅0区間で、バケツ1の値になる
+    const result = resamplePeaks(peaks, [0, 16, 16, 24, 24, 32]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.3, -0.5, -0.5, -0.5, -0.5]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.3, 0.5, 0.5, 0.5, 0.5]);
+  });
+
+  it("音声データ範囲外にある幅0の区間はゼロ埋めのままになる", () => {
+    const samples = makeBucketSamples([[-0.3, 0.3]]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間0は先頭より前（位置-8）、区間2は末尾（位置16）の幅0区間で、どちらもゼロ埋めになる
+    const result = resamplePeaks(peaks, [-8, -8, 16, 16]);
+    expectFloat32ArrayCloseTo(result.minValues, [0, -0.3, 0]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0, 0.3, 0]);
+  });
+
+  it("区間のサンプル幅が16未満のときは最も細かいレベル0が使われる", () => {
+    // バケツ0にだけ非ゼロ値、バケツ1は全ゼロ
+    const samples = makeBucketSamples([
+      [-0.4, 0.4],
+      [0, 0],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 8サンプル幅の区間3つにはレベル0（bucketSize 16）が使われるため、
+    // バケツ0に属する区間0と1は -0.4/0.4、バケツ1に属する区間2は 0/0 になる
+    // もし粗いレベル1（bucketSize 32、全体で1バケツ）が使われると区間2にも -0.4/0.4 が現れる
+    const result = resamplePeaks(peaks, [0, 8, 16, 24]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.4, -0.4, 0]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.4, 0.4, 0]);
+  });
+
+  it("区間のサンプル幅より粗いレベルは選ばれない（隣の区間に値が漏れない）", () => {
+    // 64サンプル中、バケツ2（[32, 48)）にだけ非ゼロ値を置く
+    const samples = makeBucketSamples([
+      [0, 0],
+      [0, 0],
+      [0, 0.9],
+      [0, 0],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 32サンプル幅の区間2つには bucketSize 32 のレベルが選ばれるはず
+    // もし粗いレベル（bucketSize 64）が選ばれると、区間0のmaxにも0.9が漏れる
+    const result = resamplePeaks(peaks, [0, 32, 64]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0, 0.9]);
+  });
+
+  it("サンプル幅の異なる区間ごとに適切なレベルが独立して選ばれる", () => {
+    // 128サンプルで、レベル0は8バケツ
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.2, 0.2],
+      [-0.3, 0.3],
+      [-0.4, 0.4],
+      [-0.5, 0.5],
+      [-0.6, 0.6],
+      [-0.7, 0.7],
+      [-0.8, 0.8],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間0と1は32サンプル幅なので bucketSize 32 のレベル、
+    // 区間2は64サンプル幅なので bucketSize 64 のレベルが使われる
+    // どの区間もバケツ境界に揃っているため、結果は各区間の実min/maxと一致する
+    const result = resamplePeaks(peaks, [0, 32, 64, 128]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.2, -0.4, -0.8]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.2, 0.4, 0.8]);
+  });
+
+  it("区間境界がバケツ境界に揃っていない場合、区間と重なるバケツ全体のmin/maxになる", () => {
+    // バケツ0の先頭2サンプル（[0, 2)）にだけ非ゼロ値、バケツ1は全ゼロ
+    const samples = makeBucketSamples([
+      [-0.4, 0.4],
+      [0, 0],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間 [8, 24) のサンプルはすべて0だが、バケツ0と1の両方に重なるため、
+    // バケツ0のmin/max（-0.4/0.4）が結果に含まれる
+    const result = resamplePeaks(peaks, [8, 24]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.4]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.4]);
+  });
+
+  it("音声データの範囲外にはみ出す区間は範囲内のみ反映され、完全に範囲外ならゼロになる", () => {
+    const samples = createArray(64, () => 0.4);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間0 [-32, -16): 完全に範囲外なので 0/0
+    // 区間1 [-16, 16): 負側にはみ出すが範囲内に 0.4 があるので 0.4/0.4
+    // 区間2 [16, 80): 末尾側にはみ出すが範囲内に 0.4 があるので 0.4/0.4
+    // 区間3 [80, 96): 完全に範囲外なので 0/0
+    const result = resamplePeaks(peaks, [-32, -16, 16, 80, 96]);
+    expectFloat32ArrayCloseTo(result.minValues, [0, 0.4, 0.4, 0]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0, 0.4, 0.4, 0]);
+  });
+
+  it("全体を1区間に集約すると全体のmin/maxになる", () => {
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.5, 0.3],
+      [-0.2, 0.6],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    const result = resamplePeaks(peaks, [0, 48]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.5]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.6]);
+  });
+});


### PR DESCRIPTION
## 内容

音素タイミング編集機能の実装の一部として、音素タイミング編集エリア（SequencerPhonemeTimingEditor）に表示系のコンポーネントを追加します。
編集操作（ドラッグによるタイミング変更など）は後続のPRで実装予定です。

追加するコンポーネントは、
- 音素タイミング（エリア全体の高さに縦線と音素名）
- ノート（エリア上部に長方形と歌詞）
- 合成音声の波形（エリア下部）

の3つです。いずれもPixiJSによる描画で、描画まわりの骨組み（描画ループやリサイズ対応など）は既存のシーケンサー系コンポーネントと同じです。

### 音素タイミングの表示（SequencerPhonemeTimings）

各音素の開始位置に縦線を引き、その右横に音素名を表示します。
表示するタイミングは、フレーズのクエリの音素列に編集データを適用して計算します。

表示の仕様は次のとおりです。

- 編集済みの音素は線の色と太さが変わり、未編集の音素と区別できる
- 音素名は隣の音素の位置までマスクされ、重ならないようになっている
- pauは線のみで音素名は表示されない。フレーズ先頭のpauなどノートに属さない音素は線も表示されない
- フレーズ末尾のpauは直前のノートに属する音素として扱っている（ノート末尾のタイミングとして編集できるようにするため）
- 編集のプレビューで音素が前後の音素を追い越す位置に来ても、表示上は音素の順序が維持される

### 波形の表示（SequencerWaveform）

選択トラックの各フレーズの音声波形を表示します。
横方向の位置と幅は時刻をテンポに従ってtickへ変換して求めるため、テンポを変えると波形の表示も伸縮します。

描画自体は1ピクセルごとにサンプルのmin/maxを取って塗る一般的な方式ですが、これを毎回AudioBuffer全体の走査で行うと、ズーム変更のたびに重い再計算が走ります。なので、AudioBufferごとにピークを複数解像度へ縮約したもの（mipmap）を一度だけ作っておき、描画時はピクセル幅に合った解像度を参照するようにしています。

実装面のポイントは次のとおりです。

- ピーク計算は純粋関数として `sing/waveformPeaks.ts` に切り出し、ユニットテストを付けている
- テンポ変化で時間とX座標の対応が非線形になるため、リサンプルはピクセル境界ごとのサンプル位置を配列で渡す形にしている
- ピクセル単位の波形データはズームやテンポが変わったときだけ再計算し、結果はハッシュキーと紐づけて保持
- 再計算は非同期で行うため、Mutexで直列化している（ハッシュキーでの保持とMutexでの直列化はSequencerPitchと同様の方式）

### ノートの表示（SequencerNoteTimings）

音素とノートの対応を把握しやすくするため、選択トラックのノートを長方形と歌詞で表示します（歌詞が無いノートはドレミ表記）。
シーケンサー本体のノート表示と異なり、選択状態などは表示しません。

### その他の変更

ユーティリティ関数の引数のreadonly化や、ノート内音素インデックス計算の関数への切り出しなど、上記の実装で必要になった既存コードの小さな変更を含みます。

## 関連 Issue

- VOICEVOX/voicevox#2261

## スクリーンショット・動画など

## その他

今回追加した表示は、パラメータパネルの切り替えスイッチで音素タイミングを選ぶと確認できます。
