### PR TITLE
ci: Storybook VRTのindex.json取得を待つ

### DIFF
--- a/tests/e2e/storybook/スクリーンショット.spec.ts
+++ b/tests/e2e/storybook/スクリーンショット.spec.ts
@@ -32,6 +32,23 @@ type Theme = "light" | "dark";
 const toSnapshotFileName = (story: Story, theme: Theme) =>
   `${story.id}-${theme}.png`;
 
+// fetchが成功するまで待つ。
+const fetchStorybookIndex = async (): Promise<Response> => {
+  const timeoutAt = Date.now() + 30 * 1000;
+
+  while (true) {
+    try {
+      return await fetch("http://localhost:7357/index.json");
+    } catch (e) {
+      if (Date.now() >= timeoutAt) {
+        throw e;
+      }
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 500));
+    }
+  }
+};
+
 // テスト対象のStory一覧を取得する。
 // play-fnが付いているStoryはUnit Test用Storyとみなしてスクリーンショットを撮らない
 const getStoriesToTest = (index: StorybookIndex) =>
@@ -46,7 +63,7 @@ let index: StorybookIndex;
 
 try {
   index = storybookIndexSchema.parse(
-    await fetch("http://localhost:7357/index.json").then((res) => res.json()),
+    await fetchStorybookIndex().then((res) => res.json()),
   );
 } catch (e) {
   throw new Error(`Storybookのindex.jsonの取得に失敗しました`, {


### PR DESCRIPTION
## 内容

Storybook VRT の `index.json` 取得が一時的に失敗することを考えて、fetch が成功するまでリトライし続けるようにしました。

## 関連 Issue

close #3037
