### PR TITLE
feat: 音素タイミングエディターに音声波形表示を追加

### DIFF
--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -3,6 +3,7 @@
     <div class="axis-area"></div>
     <div class="parameter-area">
       <SequencerParameterGrid class="parameter-grid" :viewportInfo />
+      <SequencerWaveform class="waveform" :viewportInfo />
     </div>
   </div>
 </template>
@@ -10,6 +11,7 @@
 <script setup lang="ts">
 import type { ViewportInfo } from "@/sing/viewHelper";
 import SequencerParameterGrid from "@/components/Sing/SequencerParameterGrid.vue";
+import SequencerWaveform from "@/components/Sing/SequencerWaveform.vue";
 
 defineProps<{
   viewportInfo: ViewportInfo;
@@ -45,5 +47,10 @@ defineProps<{
 .parameter-grid {
   grid-column: 1;
   grid-row: 1 / 5;
+}
+
+.waveform {
+  grid-column: 1;
+  grid-row: 4 / 5;
 }
 </style>

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -1,0 +1,474 @@
+<template>
+  <div ref="canvasContainer" class="canvas-container">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { z } from "zod";
+import { ref, watch, computed, onUnmounted, onMounted } from "vue";
+import * as PIXI from "pixi.js";
+import { useStore } from "@/store";
+import { useMounted } from "@/composables/useMounted";
+import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
+import { secondToTick, tickToSecond } from "@/sing/music";
+import {
+  generateWaveformPeaks,
+  resamplePeaks,
+  type WaveformPeaks,
+} from "@/sing/waveformPeaks";
+import { Mutex } from "@/helpers/mutex";
+import { createLogger } from "@/helpers/log";
+import { calculateHash } from "@/sing/utility";
+import type { SequenceId } from "@/store/type";
+import type { Tempo } from "@/domain/project/type";
+import { getOrThrow } from "@/helpers/mapHelper";
+import { cloneWithUnwrapProxy } from "@/helpers/cloneWithUnwrapProxy";
+
+const props = defineProps<{
+  viewportInfo: ViewportInfo;
+}>();
+
+const { warn } = createLogger("SequencerWaveform");
+
+const store = useStore();
+const tpqn = computed(() => store.state.tpqn);
+const tempos = computed(() => store.state.tempos);
+const isDark = computed(() => store.state.currentTheme === "Dark");
+const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
+const scaleX = computed(() => store.state.sequencerZoomX);
+
+type AudioEventId = SequenceId;
+
+type AudioEvent = {
+  readonly startTime: number;
+  readonly buffer: AudioBuffer;
+};
+
+// 描画用の波形データ
+type WaveformData = {
+  readonly startX: number;
+  readonly width: number;
+  readonly minValues: Float32Array;
+  readonly maxValues: Float32Array;
+};
+
+const waveformDataKeySchema = z.string().brand<"WaveformDataKey">();
+
+type WaveformDataKey = z.infer<typeof waveformDataKeySchema>;
+
+const computeWaveformDataKey = async (
+  eventId: AudioEventId,
+  event: AudioEvent,
+  scaleXValue: number,
+  temposValue: readonly Tempo[],
+  tpqnValue: number,
+): Promise<WaveformDataKey> => {
+  const hash = await calculateHash({
+    audioEventId: eventId,
+    audioStartTime: event.startTime,
+    scaleX: scaleXValue,
+    tempos: temposValue,
+    tpqn: tpqnValue,
+  });
+  return waveformDataKeySchema.parse(hash);
+};
+
+const phrasesInSelectedTrack = computed(() => {
+  return new Map(
+    [...store.state.phrases.entries()].filter(
+      ([, phrase]) => phrase.trackId === selectedTrackId.value,
+    ),
+  );
+});
+
+const audioEvents = computed<ReadonlyMap<AudioEventId, AudioEvent>>(() => {
+  const events = new Map<AudioEventId, AudioEvent>();
+  for (const [phraseKey, phrase] of phrasesInSelectedTrack.value) {
+    const sequenceId = store.state.phraseSequenceIds.get(phraseKey);
+    if (sequenceId == undefined) {
+      continue;
+    }
+    const buffer = store.getters.GET_SEQUENCE_AUDIO_BUFFER(sequenceId);
+    if (buffer == undefined) {
+      // NoteSequenceなどはAudioBufferを持たないため、スキップする
+      continue;
+    }
+    events.set(sequenceId, { startTime: phrase.startTime, buffer });
+  }
+  return events;
+});
+
+// AudioBufferから算出した波形ピークのMap
+const peaksMap = ref<ReadonlyMap<AudioEventId, WaveformPeaks>>(new Map());
+
+const updatePeaksMap = () => {
+  const audioEventsValue = audioEvents.value;
+
+  const tempMap = new Map(peaksMap.value);
+
+  // 不要なキーを削除
+  for (const eventId of tempMap.keys()) {
+    if (!audioEventsValue.has(eventId)) {
+      tempMap.delete(eventId);
+    }
+  }
+
+  // 新規キーについてpeaksを生成
+  // NOTE: sequenceIdに対応するAudioBufferは不変なので、既存キーの再計算は不要
+  for (const [eventId, event] of audioEventsValue) {
+    if (!tempMap.has(eventId)) {
+      tempMap.set(eventId, generateWaveformPeaks(event.buffer));
+    }
+  }
+
+  peaksMap.value = tempMap;
+};
+
+// 描画用の波形データのMap
+const waveformDataMap = ref<ReadonlyMap<WaveformDataKey, WaveformData>>(
+  new Map(),
+);
+
+// 波形データの更新を直列化するMutex
+const waveformDataMutex = new Mutex({ maxPending: 1 });
+
+const computeWaveformData = (
+  event: AudioEvent,
+  peaks: WaveformPeaks,
+  scaleXValue: number,
+  temposValue: readonly Tempo[],
+  tpqnValue: number,
+): WaveformData => {
+  const durationSeconds = event.buffer.length / event.buffer.sampleRate;
+  const endTime = event.startTime + durationSeconds;
+  const startTicks = secondToTick(event.startTime, temposValue, tpqnValue);
+  const endTicks = secondToTick(endTime, temposValue, tpqnValue);
+
+  const startBaseX = tickToBaseX(startTicks, tpqnValue);
+  const endBaseX = tickToBaseX(endTicks, tpqnValue);
+  const startScreenXAtZeroOffset = startBaseX * scaleXValue;
+  const endScreenXAtZeroOffset = endBaseX * scaleXValue;
+  // 後段のループで0除算が起きないように、1以上に丸める
+  const width = Math.max(
+    1,
+    Math.round(endScreenXAtZeroOffset - startScreenXAtZeroOffset),
+  );
+
+  // 各ピクセル境界に対応するサンプル位置を求める
+  const pixelBoundarySamples: number[] = [];
+  const tickRange = endTicks - startTicks;
+  for (let i = 0; i <= width; i++) {
+    const pixelTick = startTicks + (tickRange * i) / width;
+    const pixelTime = tickToSecond(pixelTick, temposValue, tpqnValue);
+    pixelBoundarySamples.push(
+      (pixelTime - event.startTime) * event.buffer.sampleRate,
+    );
+  }
+
+  const { minValues, maxValues } = resamplePeaks(peaks, pixelBoundarySamples);
+
+  return {
+    startX: startScreenXAtZeroOffset,
+    width,
+    minValues,
+    maxValues,
+  };
+};
+
+const updateWaveformDataMap = async () => {
+  const audioEventsValue = audioEvents.value;
+  const peaksMapValue = peaksMap.value;
+  const scaleXValue = scaleX.value;
+  // NOTE: Tempoが型レベルでイミュータブルになっていないので、cloneしている
+  const temposValue = cloneWithUnwrapProxy(tempos.value);
+  const tpqnValue = tpqn.value;
+
+  const tempMap = new Map(waveformDataMap.value);
+
+  const keyedEvents = new Map<
+    WaveformDataKey,
+    { eventId: AudioEventId; event: AudioEvent }
+  >();
+  for (const [eventId, event] of audioEventsValue) {
+    const key = await computeWaveformDataKey(
+      eventId,
+      event,
+      scaleXValue,
+      temposValue,
+      tpqnValue,
+    );
+    keyedEvents.set(key, { eventId, event });
+  }
+
+  // 不要なキーを削除
+  for (const key of tempMap.keys()) {
+    if (!keyedEvents.has(key)) {
+      tempMap.delete(key);
+    }
+  }
+
+  // 新規キーについて描画用の波形データを計算
+  for (const [key, { eventId, event }] of keyedEvents) {
+    if (!tempMap.has(key)) {
+      const peaks = getOrThrow(peaksMapValue, eventId);
+      const waveformData = computeWaveformData(
+        event,
+        peaks,
+        scaleXValue,
+        temposValue,
+        tpqnValue,
+      );
+      tempMap.set(key, waveformData);
+    }
+  }
+
+  waveformDataMap.value = tempMap;
+};
+
+const { mounted } = useMounted();
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch([mounted, audioEvents], ([mountedValue]) => {
+  if (mountedValue) {
+    updatePeaksMap();
+  }
+});
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch(
+  [mounted, audioEvents, peaksMap, scaleX, tempos, tpqn],
+  async ([mountedValue]) => {
+    if (mountedValue) {
+      try {
+        await using _lock = await waveformDataMutex.acquire();
+        await updateWaveformDataMap();
+      } catch (e) {
+        warn("Failed to update waveform data map.", e);
+      }
+    }
+  },
+);
+
+type WaveformColorStyle = {
+  color: number;
+  alpha: number;
+};
+
+const waveformColorStyles: {
+  light: WaveformColorStyle;
+  dark: WaveformColorStyle;
+} = {
+  light: {
+    color: 0xb0b0b0,
+    alpha: 0.5,
+  },
+  dark: {
+    color: 0x707070,
+    alpha: 0.6,
+  },
+};
+
+const waveformColors = computed(() =>
+  isDark.value ? waveformColorStyles.dark : waveformColorStyles.light,
+);
+
+const canvasContainer = ref<HTMLElement | null>(null);
+const canvas = ref<HTMLCanvasElement | null>(null);
+let resizeObserver: ResizeObserver | undefined;
+let canvasWidth: number | undefined;
+let canvasHeight: number | undefined;
+
+// TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
+let isUnmounted = false;
+let renderer: PIXI.Renderer | undefined;
+let stage: PIXI.Container | undefined;
+const graphics: PIXI.Graphics[] = [];
+let requestId: number | undefined;
+let renderInNextFrame = false;
+
+function drawWaveform(
+  graphic: PIXI.Graphics,
+  waveformData: WaveformData,
+  startScreenX: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  color: number,
+  alpha: number,
+) {
+  const { minValues, maxValues } = waveformData;
+  const centerY = canvasHeight / 2;
+  const amplitudeScale = canvasHeight / 2;
+  const cullingMargin = 2;
+
+  graphic.clear();
+  const points: number[] = [];
+
+  // 最大値をたどって上半分の頂点を作成
+  for (let i = 0; i < waveformData.width; i++) {
+    const x = startScreenX + i;
+    if (x < -cullingMargin || x > canvasWidth + cullingMargin) {
+      continue;
+    }
+    points.push(x, centerY - maxValues[i] * amplitudeScale);
+  }
+
+  // 最小値を逆順にたどって下半分の頂点を作成
+  for (let i = waveformData.width - 1; i >= 0; i--) {
+    const x = startScreenX + i;
+    if (x < -cullingMargin || x > canvasWidth + cullingMargin) {
+      continue;
+    }
+    points.push(x, centerY - minValues[i] * amplitudeScale);
+  }
+
+  // 頂点の数が4個以上なら描画
+  if (points.length / 2 >= 4) {
+    graphic.poly(points).fill({ color, alpha });
+  }
+}
+
+const render = () => {
+  if (renderer == undefined) {
+    throw new Error("renderer is undefined.");
+  }
+  if (stage == undefined) {
+    throw new Error("stage is undefined.");
+  }
+  if (canvasWidth == undefined) {
+    throw new Error("canvasWidth is undefined.");
+  }
+  if (canvasHeight == undefined) {
+    throw new Error("canvasHeight is undefined.");
+  }
+
+  const waveformColorsValue = waveformColors.value;
+  const offsetXValue = props.viewportInfo.offsetX;
+  const waveformDataMapValue = waveformDataMap.value;
+
+  let graphicsIndex = 0;
+  for (const waveformData of waveformDataMapValue.values()) {
+    // Graphicsは使い回し、足りない分だけ作成する
+    if (graphicsIndex >= graphics.length) {
+      const newGraphic = new PIXI.Graphics();
+      stage.addChild(newGraphic);
+      graphics.push(newGraphic);
+    }
+    const graphic = graphics[graphicsIndex];
+    graphicsIndex++;
+
+    const startScreenX = Math.round(waveformData.startX - offsetXValue);
+    const endScreenX = startScreenX + waveformData.width;
+
+    if (endScreenX < 0 || startScreenX > canvasWidth) {
+      graphic.renderable = false;
+    } else {
+      graphic.renderable = true;
+      drawWaveform(
+        graphic,
+        waveformData,
+        startScreenX,
+        canvasWidth,
+        canvasHeight,
+        waveformColorsValue.color,
+        waveformColorsValue.alpha,
+      );
+    }
+  }
+
+  for (let i = graphicsIndex; i < graphics.length; i++) {
+    graphics[i].renderable = false;
+  }
+
+  renderer.render(stage);
+};
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch(
+  [mounted, waveformDataMap, isDark, () => props.viewportInfo.offsetX],
+  ([mountedValue]) => {
+    if (mountedValue) {
+      renderInNextFrame = true;
+    }
+  },
+);
+
+onMounted(async () => {
+  const canvasContainerElement = canvasContainer.value;
+  const canvasElement = canvas.value;
+  if (canvasContainerElement == undefined) {
+    throw new Error("canvasContainerElement is null.");
+  }
+  if (canvasElement == undefined) {
+    throw new Error("canvasElement is null.");
+  }
+
+  canvasWidth = canvasContainerElement.clientWidth;
+  canvasHeight = canvasContainerElement.clientHeight;
+
+  renderer = await PIXI.autoDetectRenderer({
+    canvas: canvasElement,
+    backgroundAlpha: 0,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+    width: canvasWidth,
+    height: canvasHeight,
+  });
+  if (isUnmounted) {
+    renderer.destroy({ removeView: true });
+    return;
+  }
+  stage = new PIXI.Container();
+
+  const callback = () => {
+    if (renderInNextFrame) {
+      render();
+      renderInNextFrame = false;
+    }
+    requestId = window.requestAnimationFrame(callback);
+  };
+  requestId = window.requestAnimationFrame(callback);
+
+  resizeObserver = new ResizeObserver(() => {
+    if (renderer == undefined) {
+      throw new Error("renderer is undefined.");
+    }
+    const canvasContainerWidth = canvasContainerElement.clientWidth;
+    const canvasContainerHeight = canvasContainerElement.clientHeight;
+
+    if (canvasContainerWidth > 0 && canvasContainerHeight > 0) {
+      canvasWidth = canvasContainerWidth;
+      canvasHeight = canvasContainerHeight;
+      renderer.resize(canvasWidth, canvasHeight);
+      renderInNextFrame = true;
+    }
+  });
+  resizeObserver.observe(canvasContainerElement);
+});
+
+onUnmounted(() => {
+  isUnmounted = true;
+
+  if (requestId != undefined) {
+    window.cancelAnimationFrame(requestId);
+  }
+  for (const graphic of graphics) {
+    stage?.removeChild(graphic);
+    graphic.destroy();
+  }
+  stage?.destroy(true);
+  renderer?.destroy({ removeView: true });
+  resizeObserver?.disconnect();
+});
+</script>
+
+<style scoped lang="scss">
+.canvas-container {
+  overflow: hidden;
+  pointer-events: none; // 波形は視覚的表示のみで操作不可
+  position: relative;
+
+  contain: strict; // canvasのサイズが変わるのを無視する
+}
+</style>

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -118,7 +118,8 @@ const updatePeaksMap = () => {
   // NOTE: sequenceIdに対応するAudioBufferは不変なので、既存キーの再計算は不要
   for (const [eventId, event] of audioEventsValue) {
     if (!tempMap.has(eventId)) {
-      tempMap.set(eventId, generateWaveformPeaks(event.buffer));
+      // mipmapの最小のバケツサイズは、最大ズーム時にも解像度が足りる 16 を採用
+      tempMap.set(eventId, generateWaveformPeaks(event.buffer, 16));
     }
   }
 

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -13,9 +13,9 @@ import { useMounted } from "@/composables/useMounted";
 import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
 import { secondToTick, tickToSecond } from "@/sing/music";
 import {
-  generateWaveformPeaks,
+  generateWaveformPeaksMipmap,
   resamplePeaks,
-  type WaveformPeaks,
+  type WaveformPeaksMipmap,
 } from "@/sing/waveformPeaks";
 import { Mutex } from "@/helpers/mutex";
 import { createLogger } from "@/helpers/log";
@@ -99,13 +99,15 @@ const audioEvents = computed<ReadonlyMap<AudioEventId, AudioEvent>>(() => {
   return events;
 });
 
-// AudioBufferから算出した波形ピークのMap
-const peaksMap = ref<ReadonlyMap<AudioEventId, WaveformPeaks>>(new Map());
+// AudioBufferから算出した波形ピークmipmapのMap
+const peaksMipmaps = ref<ReadonlyMap<AudioEventId, WaveformPeaksMipmap>>(
+  new Map(),
+);
 
-const updatePeaksMap = () => {
+const updatePeaksMipmaps = () => {
   const audioEventsValue = audioEvents.value;
 
-  const tempMap = new Map(peaksMap.value);
+  const tempMap = new Map(peaksMipmaps.value);
 
   // 不要なキーを削除
   for (const eventId of tempMap.keys()) {
@@ -114,16 +116,16 @@ const updatePeaksMap = () => {
     }
   }
 
-  // 新規キーについてpeaksを生成
+  // 新規キーについてpeaksMipmapを生成
   // NOTE: sequenceIdに対応するAudioBufferは不変なので、既存キーの再計算は不要
   for (const [eventId, event] of audioEventsValue) {
     if (!tempMap.has(eventId)) {
       // mipmapの最小のバケツサイズは、最大ズーム時にも解像度が足りる 16 を採用
-      tempMap.set(eventId, generateWaveformPeaks(event.buffer, 16));
+      tempMap.set(eventId, generateWaveformPeaksMipmap(event.buffer, 16));
     }
   }
 
-  peaksMap.value = tempMap;
+  peaksMipmaps.value = tempMap;
 };
 
 // 描画用の波形データのMap
@@ -136,7 +138,7 @@ const waveformDataMutex = new Mutex({ maxPending: 1 });
 
 const computeWaveformData = (
   event: AudioEvent,
-  peaks: WaveformPeaks,
+  peaksMipmap: WaveformPeaksMipmap,
   scaleXValue: number,
   temposValue: readonly Tempo[],
   tpqnValue: number,
@@ -167,7 +169,10 @@ const computeWaveformData = (
     );
   }
 
-  const { minValues, maxValues } = resamplePeaks(peaks, pixelBoundarySamples);
+  const { minValues, maxValues } = resamplePeaks(
+    peaksMipmap,
+    pixelBoundarySamples,
+  );
 
   return {
     startX: startScreenXAtZeroOffset,
@@ -179,7 +184,7 @@ const computeWaveformData = (
 
 const updateWaveformDataMap = async () => {
   const audioEventsValue = audioEvents.value;
-  const peaksMapValue = peaksMap.value;
+  const peaksMipmapsValue = peaksMipmaps.value;
   const scaleXValue = scaleX.value;
   // NOTE: Tempoが型レベルでイミュータブルになっていないので、cloneしている
   const temposValue = cloneWithUnwrapProxy(tempos.value);
@@ -212,10 +217,10 @@ const updateWaveformDataMap = async () => {
   // 新規キーについて描画用の波形データを計算
   for (const [key, { eventId, event }] of keyedEvents) {
     if (!tempMap.has(key)) {
-      const peaks = getOrThrow(peaksMapValue, eventId);
+      const peaksMipmap = getOrThrow(peaksMipmapsValue, eventId);
       const waveformData = computeWaveformData(
         event,
-        peaks,
+        peaksMipmap,
         scaleXValue,
         temposValue,
         tpqnValue,
@@ -232,13 +237,13 @@ const { mounted } = useMounted();
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
 watch([mounted, audioEvents], ([mountedValue]) => {
   if (mountedValue) {
-    updatePeaksMap();
+    updatePeaksMipmaps();
   }
 });
 
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
 watch(
-  [mounted, audioEvents, peaksMap, scaleX, tempos, tpqn],
+  [mounted, audioEvents, peaksMipmaps, scaleX, tempos, tpqn],
   async ([mountedValue]) => {
     if (mountedValue) {
       try {

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -119,7 +119,7 @@ const updatePeaksMipmaps = () => {
   // 新規キーについてpeaksMipmapを生成
   for (const [eventId, event] of audioEventsValue) {
     if (!tempMap.has(eventId)) {
-      // NOTE: mipmapの最小のバケツサイズは、最大ズーム時にも解像度が足りる 16 を採用
+      // NOTE: mipmapの最小のバケットサイズは、最大ズーム時にも解像度が足りる 16 を採用
       tempMap.set(eventId, generateWaveformPeaksMipmap(event.buffer, 16));
     }
   }

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -117,10 +117,9 @@ const updatePeaksMipmaps = () => {
   }
 
   // 新規キーについてpeaksMipmapを生成
-  // NOTE: sequenceIdに対応するAudioBufferは不変なので、既存キーの再計算は不要
   for (const [eventId, event] of audioEventsValue) {
     if (!tempMap.has(eventId)) {
-      // mipmapの最小のバケツサイズは、最大ズーム時にも解像度が足りる 16 を採用
+      // NOTE: mipmapの最小のバケツサイズは、最大ズーム時にも解像度が足りる 16 を採用
       tempMap.set(eventId, generateWaveformPeaksMipmap(event.buffer, 16));
     }
   }
@@ -132,9 +131,6 @@ const updatePeaksMipmaps = () => {
 const waveformDataMap = ref<ReadonlyMap<WaveformDataKey, WaveformData>>(
   new Map(),
 );
-
-// 波形データの更新を直列化するMutex
-const waveformDataMutex = new Mutex({ maxPending: 1 });
 
 const computeWaveformData = (
   event: AudioEvent,
@@ -240,6 +236,8 @@ watch([mounted, audioEvents], ([mountedValue]) => {
     updatePeaksMipmaps();
   }
 });
+
+const waveformDataMutex = new Mutex({ maxPending: 1 });
 
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
 watch(

--- a/src/helpers/mapHelper.ts
+++ b/src/helpers/mapHelper.ts
@@ -1,7 +1,7 @@
 /** Mapのヘルパー関数 */
 
 /** Mapから値を取得する。指定したキーが存在しない場合は例外を投げる */
-export const getOrThrow = <K, V>(map: Map<K, V>, key: K) => {
+export const getOrThrow = <K, V>(map: ReadonlyMap<K, V>, key: K) => {
   if (!map.has(key)) {
     throw new Error(`Key not found: ${String(key)}`);
   }

--- a/src/sing/music.ts
+++ b/src/sing/music.ts
@@ -98,7 +98,11 @@ const secondToTickForConstantBpm = (
   return seconds * quarterNotesPerSecond * tpqn;
 };
 
-export const tickToSecond = (ticks: number, tempos: Tempo[], tpqn: number) => {
+export const tickToSecond = (
+  ticks: number,
+  tempos: readonly Tempo[],
+  tpqn: number,
+) => {
   let timeOfTempo = 0;
   let tempo = tempos[tempos.length - 1];
   for (let i = 0; i < tempos.length; i++) {
@@ -123,7 +127,7 @@ export const tickToSecond = (ticks: number, tempos: Tempo[], tpqn: number) => {
 
 export const secondToTick = (
   seconds: number,
-  tempos: Tempo[],
+  tempos: readonly Tempo[],
   tpqn: number,
 ) => {
   let timeOfTempo = 0;

--- a/src/sing/utility.ts
+++ b/src/sing/utility.ts
@@ -93,7 +93,7 @@ export function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
 
-export function getLast<T>(array: T[]) {
+export function getLast<T>(array: readonly T[]) {
   if (array.length === 0) {
     throw new Error("array.length is 0.");
   }

--- a/src/sing/waveformPeaks.ts
+++ b/src/sing/waveformPeaks.ts
@@ -1,7 +1,7 @@
 import { getLast } from "@/sing/utility";
 
 /**
- * mipmapのレベル。バケツサイズと、各バケツのmin/max値を保持する。
+ * mipmapのレベル。バケットサイズと、各バケットのmin/max値を保持する。
  */
 type WaveformPeaksMipmapLevel = {
   readonly bucketSize: number;
@@ -11,7 +11,7 @@ type WaveformPeaksMipmapLevel = {
 
 /**
  * 波形ピークのmipmap。
- * 先頭のレベルが最も細かいレベルで、以降はバケツサイズの昇順に並ぶ。
+ * 先頭のレベルが最も細かいレベルで、以降はバケットサイズの昇順に並ぶ。
  */
 export type WaveformPeaksMipmap = readonly WaveformPeaksMipmapLevel[];
 
@@ -27,8 +27,8 @@ export type ResampledPeaks = {
  * AudioBufferのch0からピークのmipmapを生成する。
  *
  * @param audioBuffer ピークを計算する音声データ。ch0のみ使用される。
- * @param minBucketSize 最小のバケツサイズ。1以上の整数でなければならない。
- * @returns 生成されたピークのmipmap。レベルはバケツサイズで昇順にソートされている。
+ * @param minBucketSize 最小のバケットサイズ。1以上の整数でなければならない。
+ * @returns 生成されたピークのmipmap。レベルはバケットサイズで昇順にソートされている。
  */
 export function generateWaveformPeaksMipmap(
   audioBuffer: AudioBuffer,
@@ -41,7 +41,7 @@ export function generateWaveformPeaksMipmap(
   const channel = audioBuffer.getChannelData(0);
   const numSamples = channel.length;
 
-  // レベル0: サンプルから直接バケツ化
+  // レベル0: サンプルから直接バケット化
   const baseNumBuckets = Math.ceil(numSamples / minBucketSize);
   const baseMinBuckets = new Float32Array(baseNumBuckets);
   const baseMaxBuckets = new Float32Array(baseNumBuckets);
@@ -72,7 +72,7 @@ export function generateWaveformPeaksMipmap(
     },
   ];
 
-  // レベル1以降: バケツ数が1個になるまで2バケツずつまとめる
+  // レベル1以降: バケット数が1個になるまで2バケットずつまとめる
   while (getLast(levels).minBuckets.length > 1) {
     const prev = getLast(levels);
     const prevNumBuckets = prev.minBuckets.length;
@@ -109,13 +109,13 @@ export function generateWaveformPeaksMipmap(
  * 区間ごとに最適なmipmapレベルを選択するため、サンプル幅が不均等でも適切な解像度になる。
  *
  * @param peaksMipmap リサンプル元のピークmipmap。
- *   レベルはバケツサイズで昇順にソートされていなければならない。
+ *   レベルはバケットサイズで昇順にソートされていなければならない。
  * @param binBoundarySamples 各区間の境界をサンプル位置で表した配列。
  *   `binBoundarySamples[i]` 以上 `binBoundarySamples[i + 1]` 未満が区間 `i` のサンプル範囲。
  *   配列の長さは 区間の数 + 1 で、2以上でなければならない。
  *   各値は音声データ先頭基準のサンプル位置で、単調非減少でなければならない。
  *   サンプル数を超える値や負の値も許容され、範囲外は0埋めになる。
- *   幅0の区間は点として扱い、その位置のサンプルを含むバケツの値になる。
+ *   幅0の区間は点として扱い、その位置のサンプルを含むバケットの値になる。
  * @returns 各区間のmin/max値。
  */
 export function resamplePeaks(

--- a/src/sing/waveformPeaks.ts
+++ b/src/sing/waveformPeaks.ts
@@ -34,6 +34,9 @@ export function generateWaveformPeaksMipmap(
   audioBuffer: AudioBuffer,
   minBucketSize: number,
 ): WaveformPeaksMipmap {
+  if (audioBuffer.length === 0) {
+    throw new Error("audioBuffer must have at least one sample.");
+  }
   if (!Number.isInteger(minBucketSize) || minBucketSize < 1) {
     throw new Error("minBucketSize must be a positive integer.");
   }

--- a/src/sing/waveformPeaks.ts
+++ b/src/sing/waveformPeaks.ts
@@ -8,6 +8,9 @@
 
 import { getLast } from "@/sing/utility";
 
+/**
+ * mipmapのレベル。バケツサイズと、各バケツのmin/max値を保持する。
+ */
 type WaveformMipmapLevel = {
   readonly bucketSize: number;
   readonly minBuckets: Float32Array;
@@ -16,7 +19,7 @@ type WaveformMipmapLevel = {
 
 /**
  * 波形ピークのmipmap。
- * levels[0]が最も細かいレベルで、以降はバケツサイズの昇順に並ぶ。
+ * 先頭のレベルが最も細かいレベルで、以降はバケツサイズの昇順に並ぶ。
  */
 export type WaveformPeaks = readonly WaveformMipmapLevel[];
 
@@ -28,25 +31,32 @@ export type ResampledPeaks = {
   readonly maxValues: Float32Array;
 };
 
-const BASE_BUCKET_SIZE = 16;
-
 /**
  * AudioBufferのch0からピークのmipmapを生成する。
- * 最も細かいレベルのバケツサイズは BASE_BUCKET_SIZE で、
- * 以降は2倍ずつ大きなバケツサイズのレベルを、バケツ数が1個になるまで積み上げる。
+ *
+ * @param audioBuffer ピークを計算する音声データ。ch0のみ使用される。
+ * @param minBucketSize 最小のバケツサイズ。1以上の整数でなければならない。
+ * @returns 生成されたピークのmipmap。レベルはバケツサイズで昇順にソートされている。
  */
-export function generateWaveformPeaks(audioBuffer: AudioBuffer): WaveformPeaks {
+export function generateWaveformPeaks(
+  audioBuffer: AudioBuffer,
+  minBucketSize: number,
+): WaveformPeaks {
+  if (!Number.isInteger(minBucketSize) || minBucketSize < 1) {
+    throw new Error("minBucketSize must be a positive integer.");
+  }
+
   const channel = audioBuffer.getChannelData(0);
   const numSamples = channel.length;
 
   // レベル0: サンプルから直接バケツ化
-  const baseNumBuckets = Math.ceil(numSamples / BASE_BUCKET_SIZE);
+  const baseNumBuckets = Math.ceil(numSamples / minBucketSize);
   const baseMinBuckets = new Float32Array(baseNumBuckets);
   const baseMaxBuckets = new Float32Array(baseNumBuckets);
 
   for (let bucketIndex = 0; bucketIndex < baseNumBuckets; bucketIndex++) {
-    const start = bucketIndex * BASE_BUCKET_SIZE;
-    const end = Math.min(start + BASE_BUCKET_SIZE, numSamples);
+    const start = bucketIndex * minBucketSize;
+    const end = Math.min(start + minBucketSize, numSamples);
     let min = channel[start];
     let max = channel[start];
     for (let i = start + 1; i < end; i++) {
@@ -64,13 +74,13 @@ export function generateWaveformPeaks(audioBuffer: AudioBuffer): WaveformPeaks {
 
   const levels: WaveformMipmapLevel[] = [
     {
-      bucketSize: BASE_BUCKET_SIZE,
+      bucketSize: minBucketSize,
       minBuckets: baseMinBuckets,
       maxBuckets: baseMaxBuckets,
     },
   ];
 
-  // 上位レベル: バケツ数が1個になるまで2バケツずつまとめる
+  // レベル1以降: バケツ数が1個になるまで2バケツずつまとめる
   while (getLast(levels).minBuckets.length > 1) {
     const prev = getLast(levels);
     const prevNumBuckets = prev.minBuckets.length;
@@ -106,12 +116,15 @@ export function generateWaveformPeaks(audioBuffer: AudioBuffer): WaveformPeaks {
  * 各区間に対応するサンプル範囲を境界配列で指定して、ピークをリサンプルする。
  * 区間ごとに最適なmipmapレベルを選択するため、サンプル幅が不均等でも適切な解像度になる。
  *
- * @param binBoundarySamples 長さ `numBins + 1` の配列。
+ * @param peaks リサンプル元のピークmipmap。
+ *   レベルはバケツサイズで昇順にソートされていなければならない。
+ * @param binBoundarySamples 各区間の境界をサンプル位置で表した配列。
  *   `binBoundarySamples[i]` 以上 `binBoundarySamples[i + 1]` 未満が区間 `i` のサンプル範囲。
+ *   配列の長さは 区間の数 + 1 で、2以上でなければならない。
  *   各値は音声データ先頭基準のサンプル位置で、単調非減少でなければならない。
- *   負の値や `numSamples` を超える値も許容され、範囲外は0埋めになる。
+ *   サンプル数を超える値や負の値も許容され、範囲外は0埋めになる。
  *   幅0の区間は点として扱い、その位置のサンプルを含むバケツの値になる。
- *   長さは2以上でなければならない。
+ * @returns 各区間のmin/max値。
  */
 export function resamplePeaks(
   peaks: WaveformPeaks,

--- a/src/sing/waveformPeaks.ts
+++ b/src/sing/waveformPeaks.ts
@@ -11,7 +11,7 @@ import { getLast } from "@/sing/utility";
 /**
  * mipmapのレベル。バケツサイズと、各バケツのmin/max値を保持する。
  */
-type WaveformMipmapLevel = {
+type WaveformPeaksMipmapLevel = {
   readonly bucketSize: number;
   readonly minBuckets: Float32Array;
   readonly maxBuckets: Float32Array;
@@ -21,7 +21,7 @@ type WaveformMipmapLevel = {
  * 波形ピークのmipmap。
  * 先頭のレベルが最も細かいレベルで、以降はバケツサイズの昇順に並ぶ。
  */
-export type WaveformPeaks = readonly WaveformMipmapLevel[];
+export type WaveformPeaksMipmap = readonly WaveformPeaksMipmapLevel[];
 
 /**
  * 波形ピークをリサンプルしたもの。
@@ -38,10 +38,10 @@ export type ResampledPeaks = {
  * @param minBucketSize 最小のバケツサイズ。1以上の整数でなければならない。
  * @returns 生成されたピークのmipmap。レベルはバケツサイズで昇順にソートされている。
  */
-export function generateWaveformPeaks(
+export function generateWaveformPeaksMipmap(
   audioBuffer: AudioBuffer,
   minBucketSize: number,
-): WaveformPeaks {
+): WaveformPeaksMipmap {
   if (!Number.isInteger(minBucketSize) || minBucketSize < 1) {
     throw new Error("minBucketSize must be a positive integer.");
   }
@@ -72,7 +72,7 @@ export function generateWaveformPeaks(
     baseMaxBuckets[bucketIndex] = max;
   }
 
-  const levels: WaveformMipmapLevel[] = [
+  const levels: WaveformPeaksMipmapLevel[] = [
     {
       bucketSize: minBucketSize,
       minBuckets: baseMinBuckets,
@@ -116,7 +116,7 @@ export function generateWaveformPeaks(
  * 各区間に対応するサンプル範囲を境界配列で指定して、ピークをリサンプルする。
  * 区間ごとに最適なmipmapレベルを選択するため、サンプル幅が不均等でも適切な解像度になる。
  *
- * @param peaks リサンプル元のピークmipmap。
+ * @param peaksMipmap リサンプル元のピークmipmap。
  *   レベルはバケツサイズで昇順にソートされていなければならない。
  * @param binBoundarySamples 各区間の境界をサンプル位置で表した配列。
  *   `binBoundarySamples[i]` 以上 `binBoundarySamples[i + 1]` 未満が区間 `i` のサンプル範囲。
@@ -127,13 +127,13 @@ export function generateWaveformPeaks(
  * @returns 各区間のmin/max値。
  */
 export function resamplePeaks(
-  peaks: WaveformPeaks,
+  peaksMipmap: WaveformPeaksMipmap,
   binBoundarySamples: number[],
 ): ResampledPeaks {
-  if (peaks.length === 0) {
-    throw new Error("peaks must have at least one level.");
+  if (peaksMipmap.length === 0) {
+    throw new Error("peaksMipmap must have at least one level.");
   }
-  for (const level of peaks) {
+  for (const level of peaksMipmap) {
     if (level.minBuckets.length !== level.maxBuckets.length) {
       throw new Error("minBuckets and maxBuckets must have the same length.");
     }
@@ -141,9 +141,11 @@ export function resamplePeaks(
       throw new Error("every level must have at least one bucket.");
     }
   }
-  for (let i = 1; i < peaks.length; i++) {
-    if (peaks[i].bucketSize <= peaks[i - 1].bucketSize) {
-      throw new Error("peaks levels must be in ascending order of bucketSize.");
+  for (let i = 1; i < peaksMipmap.length; i++) {
+    if (peaksMipmap[i].bucketSize <= peaksMipmap[i - 1].bucketSize) {
+      throw new Error(
+        "peaksMipmap levels must be in ascending order of bucketSize.",
+      );
     }
   }
   if (binBoundarySamples.length < 2) {
@@ -165,8 +167,8 @@ export function resamplePeaks(
     }
     // bucketSize <= samplesPerBin を満たす最大の bucketSize のレベルを選ぶ
     // どのレベルも条件を満たさないときは、最も細かいレベルを使う
-    let selectedLevel = peaks[0];
-    for (const level of peaks) {
+    let selectedLevel = peaksMipmap[0];
+    for (const level of peaksMipmap) {
       if (level.bucketSize > samplesPerBin) {
         break;
       }

--- a/src/sing/waveformPeaks.ts
+++ b/src/sing/waveformPeaks.ts
@@ -1,11 +1,3 @@
-/**
- * 波形のピーク（min/max）データをmipmap形式で保持・参照するための純粋関数群。
- *
- * AudioBufferを一度だけ縮約し、複数解像度のピーク配列として保持する。
- * 描画時には表示解像度に応じたレベルを選択してリサンプルすることで、
- * ズーム連続変化時のO(audioBuffer.length)再計算を避ける。
- */
-
 import { getLast } from "@/sing/utility";
 
 /**

--- a/src/sing/waveformPeaks.ts
+++ b/src/sing/waveformPeaks.ts
@@ -1,0 +1,200 @@
+/**
+ * 波形のピーク（min/max）データをmipmap形式で保持・参照するための純粋関数群。
+ *
+ * AudioBufferを一度だけ縮約し、複数解像度のピーク配列として保持する。
+ * 描画時には表示解像度に応じたレベルを選択してリサンプルすることで、
+ * ズーム連続変化時のO(audioBuffer.length)再計算を避ける。
+ */
+
+import { getLast } from "@/sing/utility";
+
+type WaveformMipmapLevel = {
+  readonly bucketSize: number;
+  readonly minBuckets: Float32Array;
+  readonly maxBuckets: Float32Array;
+};
+
+/**
+ * 波形ピークのmipmap。
+ * levels[0]が最も細かいレベルで、以降はバケツサイズの昇順に並ぶ。
+ */
+export type WaveformPeaks = readonly WaveformMipmapLevel[];
+
+/**
+ * 波形ピークをリサンプルしたもの。
+ */
+export type ResampledPeaks = {
+  readonly minValues: Float32Array;
+  readonly maxValues: Float32Array;
+};
+
+const BASE_BUCKET_SIZE = 16;
+
+/**
+ * AudioBufferのch0からピークのmipmapを生成する。
+ * 最も細かいレベルのバケツサイズは BASE_BUCKET_SIZE で、
+ * 以降は2倍ずつ大きなバケツサイズのレベルを、バケツ数が1個になるまで積み上げる。
+ */
+export function generateWaveformPeaks(audioBuffer: AudioBuffer): WaveformPeaks {
+  const channel = audioBuffer.getChannelData(0);
+  const numSamples = channel.length;
+
+  // レベル0: サンプルから直接バケツ化
+  const baseNumBuckets = Math.ceil(numSamples / BASE_BUCKET_SIZE);
+  const baseMinBuckets = new Float32Array(baseNumBuckets);
+  const baseMaxBuckets = new Float32Array(baseNumBuckets);
+
+  for (let bucketIndex = 0; bucketIndex < baseNumBuckets; bucketIndex++) {
+    const start = bucketIndex * BASE_BUCKET_SIZE;
+    const end = Math.min(start + BASE_BUCKET_SIZE, numSamples);
+    let min = channel[start];
+    let max = channel[start];
+    for (let i = start + 1; i < end; i++) {
+      const value = channel[i];
+      if (value < min) {
+        min = value;
+      }
+      if (value > max) {
+        max = value;
+      }
+    }
+    baseMinBuckets[bucketIndex] = min;
+    baseMaxBuckets[bucketIndex] = max;
+  }
+
+  const levels: WaveformMipmapLevel[] = [
+    {
+      bucketSize: BASE_BUCKET_SIZE,
+      minBuckets: baseMinBuckets,
+      maxBuckets: baseMaxBuckets,
+    },
+  ];
+
+  // 上位レベル: バケツ数が1個になるまで2バケツずつまとめる
+  while (getLast(levels).minBuckets.length > 1) {
+    const prev = getLast(levels);
+    const prevNumBuckets = prev.minBuckets.length;
+
+    const newBucketSize = prev.bucketSize * 2;
+    const newNumBuckets = Math.ceil(prevNumBuckets / 2);
+    const newMinBuckets = new Float32Array(newNumBuckets);
+    const newMaxBuckets = new Float32Array(newNumBuckets);
+
+    for (let i = 0; i < newNumBuckets; i++) {
+      const a = 2 * i;
+      const b = 2 * i + 1;
+      if (b < prevNumBuckets) {
+        newMinBuckets[i] = Math.min(prev.minBuckets[a], prev.minBuckets[b]);
+        newMaxBuckets[i] = Math.max(prev.maxBuckets[a], prev.maxBuckets[b]);
+      } else {
+        newMinBuckets[i] = prev.minBuckets[a];
+        newMaxBuckets[i] = prev.maxBuckets[a];
+      }
+    }
+
+    levels.push({
+      bucketSize: newBucketSize,
+      minBuckets: newMinBuckets,
+      maxBuckets: newMaxBuckets,
+    });
+  }
+
+  return levels;
+}
+
+/**
+ * 各区間に対応するサンプル範囲を境界配列で指定して、ピークをリサンプルする。
+ * 区間ごとに最適なmipmapレベルを選択するため、サンプル幅が不均等でも適切な解像度になる。
+ *
+ * @param binBoundarySamples 長さ `numBins + 1` の配列。
+ *   `binBoundarySamples[i]` 以上 `binBoundarySamples[i + 1]` 未満が区間 `i` のサンプル範囲。
+ *   各値は音声データ先頭基準のサンプル位置で、単調非減少でなければならない。
+ *   負の値や `numSamples` を超える値も許容され、範囲外は0埋めになる。
+ *   幅0の区間は点として扱い、その位置のサンプルを含むバケツの値になる。
+ *   長さは2以上でなければならない。
+ */
+export function resamplePeaks(
+  peaks: WaveformPeaks,
+  binBoundarySamples: number[],
+): ResampledPeaks {
+  if (peaks.length === 0) {
+    throw new Error("peaks must have at least one level.");
+  }
+  for (const level of peaks) {
+    if (level.minBuckets.length !== level.maxBuckets.length) {
+      throw new Error("minBuckets and maxBuckets must have the same length.");
+    }
+    if (level.minBuckets.length === 0) {
+      throw new Error("every level must have at least one bucket.");
+    }
+  }
+  for (let i = 1; i < peaks.length; i++) {
+    if (peaks[i].bucketSize <= peaks[i - 1].bucketSize) {
+      throw new Error("peaks levels must be in ascending order of bucketSize.");
+    }
+  }
+  if (binBoundarySamples.length < 2) {
+    throw new Error("binBoundarySamples must have at least two elements.");
+  }
+
+  const numBins = binBoundarySamples.length - 1;
+  const minValues = new Float32Array(numBins);
+  const maxValues = new Float32Array(numBins);
+
+  for (let binIndex = 0; binIndex < numBins; binIndex++) {
+    const binStartSample = binBoundarySamples[binIndex];
+    const binEndSample = binBoundarySamples[binIndex + 1];
+    const samplesPerBin = binEndSample - binStartSample;
+    if (samplesPerBin < 0) {
+      throw new Error(
+        "binBoundarySamples must be monotonically non-decreasing.",
+      );
+    }
+    // bucketSize <= samplesPerBin を満たす最大の bucketSize のレベルを選ぶ
+    // どのレベルも条件を満たさないときは、最も細かいレベルを使う
+    let selectedLevel = peaks[0];
+    for (const level of peaks) {
+      if (level.bucketSize > samplesPerBin) {
+        break;
+      }
+      selectedLevel = level;
+    }
+
+    const numBuckets = selectedLevel.minBuckets.length;
+    const bucketSize = selectedLevel.bucketSize;
+    let bucketStart = Math.floor(binStartSample / bucketSize);
+    let bucketEnd = Math.ceil(binEndSample / bucketSize);
+    if (bucketEnd === bucketStart) {
+      bucketEnd = bucketStart + 1;
+    }
+    if (bucketStart < 0) {
+      bucketStart = 0;
+    }
+    if (bucketEnd > numBuckets) {
+      bucketEnd = numBuckets;
+    }
+
+    if (bucketStart >= bucketEnd) {
+      // クランプ前は必ず bucketStart < bucketEnd になっているため、
+      // ここに該当するのは区間が音声データの完全に外側にあるときだけで、0埋めのままにする
+      continue;
+    }
+
+    let min = selectedLevel.minBuckets[bucketStart];
+    let max = selectedLevel.maxBuckets[bucketStart];
+    for (let i = bucketStart + 1; i < bucketEnd; i++) {
+      const bucketMin = selectedLevel.minBuckets[i];
+      const bucketMax = selectedLevel.maxBuckets[i];
+      if (bucketMin < min) {
+        min = bucketMin;
+      }
+      if (bucketMax > max) {
+        max = bucketMax;
+      }
+    }
+    minValues[binIndex] = min;
+    maxValues[binIndex] = max;
+  }
+
+  return { minValues, maxValues };
+}

--- a/tests/unit/lib/waveformPeaks.spec.ts
+++ b/tests/unit/lib/waveformPeaks.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { generateWaveformPeaks, resamplePeaks } from "@/sing/waveformPeaks";
 import { createArray } from "@/sing/utility";
 
+const MIN_BUCKET_SIZE = 16;
+
 function makeAudioBuffer(samples: number[], sampleRate = 24000): AudioBuffer {
   const channel = new Float32Array(samples);
   return {
@@ -19,19 +21,23 @@ function makeAudioBuffer(samples: number[], sampleRate = 24000): AudioBuffer {
 }
 
 /**
- * レベル0のバケツ（16サンプル）ごとにmin/maxを指定してサンプル配列を作る。
- * 各バケツは先頭サンプルがmin、2番目のサンプルがmax、残り14サンプルが0になる。
+ * 指定したバケツサイズで区切ったときの各バケツのmin/maxからサンプル配列を作る。
+ * 各バケツは、先頭サンプルがmin、2番目のサンプルがmax、残りが0になる。
  * 0埋め部分がそのバケツのmin/maxに影響しないよう、min <= 0 <= max でなければならない。
  */
 function makeBucketSamples(
   bucketMinMaxList: [min: number, max: number][],
+  bucketSize: number,
 ): number[] {
+  if (bucketSize < 2) {
+    throw new Error("bucketSize は2以上でなければなりません。");
+  }
   const samples: number[] = [];
   for (const [min, max] of bucketMinMaxList) {
     if (min > 0 || max < 0) {
       throw new Error("min <= 0 <= max でなければなりません。");
     }
-    samples.push(min, max, ...createArray(14, () => 0));
+    samples.push(min, max, ...createArray(bucketSize - 2, () => 0));
   }
   return samples;
 }
@@ -44,15 +50,34 @@ function expectFloat32ArrayCloseTo(actual: Float32Array, expected: number[]) {
 }
 
 describe("generateWaveformPeaks", () => {
-  it("16サンプル以下ならバケツ1個のレベルが1つだけできる", () => {
-    const peaks = generateWaveformPeaks(makeAudioBuffer([0.1, -0.2, 0.3]));
+  it("不正なminBucketSizeを渡すとエラーになる", () => {
+    const buffer = makeAudioBuffer([0, 0.1, -0.1]);
+
+    // 0以下はエラー
+    expect(() => generateWaveformPeaks(buffer, 0)).toThrow();
+    expect(() => generateWaveformPeaks(buffer, -1)).toThrow();
+
+    // 非整数はエラー
+    expect(() => generateWaveformPeaks(buffer, 1.5)).toThrow();
+    expect(() => generateWaveformPeaks(buffer, NaN)).toThrow();
+    expect(() => generateWaveformPeaks(buffer, Infinity)).toThrow();
+
+    // 1以上の整数なら通る
+    expect(() => generateWaveformPeaks(buffer, 1)).not.toThrow();
+  });
+
+  it("minBucketSize以下のサンプル数ならバケツ1個のレベルが1つだけできる", () => {
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer([0.1, -0.2, 0.3]),
+      MIN_BUCKET_SIZE,
+    );
     expect(peaks.length).toBe(1);
-    expect(peaks[0].bucketSize).toBe(16);
+    expect(peaks[0].bucketSize).toBe(MIN_BUCKET_SIZE);
     expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.2]);
     expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.3]);
   });
 
-  it("レベル0は16サンプルごとのバケツになり、各バケツがその範囲のmin/maxを持つ", () => {
+  it("レベル0はminBucketSizeごとのバケツになり、各バケツがその範囲のmin/maxを持つ", () => {
     // バケツ0（[0, 16)）: min -0.4（i=3）, max 0.6（i=10）
     // バケツ1（[16, 32)）: min -0.7（i=25）, max 0.8（i=20）
     const samples = createArray(32, (i) => {
@@ -70,17 +95,29 @@ describe("generateWaveformPeaks", () => {
       }
       return 0;
     });
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
-    expect(peaks[0].bucketSize).toBe(16);
+    expect(peaks[0].bucketSize).toBe(MIN_BUCKET_SIZE);
     expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.4, -0.7]);
     expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.6, 0.8]);
   });
 
-  it("サンプル数が16の倍数でないとき、最後のバケツは端数サンプルのみで計算される", () => {
-    // 16サンプルの0埋めバケツ + 端数4サンプル
-    const samples = [...createArray(16, () => 0), 0.1, -0.3, 0.5, 0.2];
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+  it("サンプル数がminBucketSizeの倍数でないとき、最後のバケツは端数サンプルのみで計算される", () => {
+    // minBucketSizeサンプルの0埋めバケツ + 端数4サンプル
+    const samples = [
+      ...createArray(MIN_BUCKET_SIZE, () => 0),
+      0.1,
+      -0.3,
+      0.5,
+      0.2,
+    ];
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // ceil(20 / 16) = 2バケツで、バケツ1は [16, 20) の4サンプルのみ
     expectFloat32ArrayCloseTo(peaks[0].minBuckets, [0, -0.3]);
@@ -88,39 +125,51 @@ describe("generateWaveformPeaks", () => {
   });
 
   it("バケツ数が1になるまで、隣接2バケツをmin/max統合したレベルが積まれる", () => {
-    const samples = makeBucketSamples([
-      [-0.1, 0.1],
-      [-0.4, 0.2],
-      [-0.2, 0.8],
-      [-0.3, 0.3],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.1, 0.1],
+        [-0.4, 0.2],
+        [-0.2, 0.8],
+        [-0.3, 0.3],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     expect(peaks.length).toBe(3);
 
     // レベル0: 入力そのままの4バケツ
-    expect(peaks[0].bucketSize).toBe(16);
+    expect(peaks[0].bucketSize).toBe(MIN_BUCKET_SIZE);
     expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.1, -0.4, -0.2, -0.3]);
     expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.1, 0.2, 0.8, 0.3]);
 
     // レベル1: 隣接2バケツの統合
-    expect(peaks[1].bucketSize).toBe(32);
+    expect(peaks[1].bucketSize).toBe(MIN_BUCKET_SIZE * 2);
     expectFloat32ArrayCloseTo(peaks[1].minBuckets, [-0.4, -0.3]);
     expectFloat32ArrayCloseTo(peaks[1].maxBuckets, [0.2, 0.8]);
 
     // レベル2: 全体のmin/max
-    expect(peaks[2].bucketSize).toBe(64);
+    expect(peaks[2].bucketSize).toBe(MIN_BUCKET_SIZE * 4);
     expectFloat32ArrayCloseTo(peaks[2].minBuckets, [-0.4]);
     expectFloat32ArrayCloseTo(peaks[2].maxBuckets, [0.8]);
   });
 
   it("バケツ数が奇数のとき、最後のバケツは単独で上位レベルに引き継がれる", () => {
-    const samples = makeBucketSamples([
-      [-0.1, 0.1],
-      [-0.2, 0.2],
-      [-0.5, 0.6],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.1, 0.1],
+        [-0.2, 0.2],
+        [-0.5, 0.6],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // レベル1: バケツ0と1の統合 + バケツ2の単独引き継ぎ
     expectFloat32ArrayCloseTo(peaks[1].minBuckets, [-0.2, -0.5]);
@@ -154,21 +203,33 @@ describe("resamplePeaks", () => {
     expect(() => resamplePeaks(mismatchedLengthPeaks, [0, 16, 32])).toThrow();
 
     // レベルがバケツサイズの昇順に並んでいない
-    const samples = makeBucketSamples([
-      [-0.1, 0.1],
-      [-0.2, 0.2],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.1, 0.1],
+        [-0.2, 0.2],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
     const reversedPeaks = [...peaks].reverse();
     expect(() => resamplePeaks(reversedPeaks, [0, 16, 32])).toThrow();
   });
 
   it("不正なbinBoundarySamplesを渡すとエラーになる", () => {
-    const samples = makeBucketSamples([
-      [-0.1, 0.1],
-      [-0.2, 0.2],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.1, 0.1],
+        [-0.2, 0.2],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // 長さが2未満
     expect(() => resamplePeaks(peaks, [])).toThrow();
@@ -179,11 +240,17 @@ describe("resamplePeaks", () => {
   });
 
   it("幅0の区間は点として扱われ、その位置のサンプルを含むバケツの値になる", () => {
-    const samples = makeBucketSamples([
-      [-0.3, 0.3],
-      [-0.5, 0.5],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.3, 0.3],
+        [-0.5, 0.5],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // 区間1はバケツ境界ちょうど（位置16）の幅0区間で、サンプル16を含むバケツ1の値になる
     // 区間3はバケツ1の内部（位置24）の幅0区間で、バケツ1の値になる
@@ -193,8 +260,11 @@ describe("resamplePeaks", () => {
   });
 
   it("音声データ範囲外にある幅0の区間はゼロ埋めのままになる", () => {
-    const samples = makeBucketSamples([[-0.3, 0.3]]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples([[-0.3, 0.3]], MIN_BUCKET_SIZE);
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // 区間0は先頭より前（位置-8）、区間2は末尾（位置16）の幅0区間で、どちらもゼロ埋めになる
     const result = resamplePeaks(peaks, [-8, -8, 16, 16]);
@@ -202,13 +272,19 @@ describe("resamplePeaks", () => {
     expectFloat32ArrayCloseTo(result.maxValues, [0, 0.3, 0]);
   });
 
-  it("区間のサンプル幅が16未満のときは最も細かいレベル0が使われる", () => {
+  it("区間のサンプル幅がminBucketSize未満のときは最も細かいレベル0が使われる", () => {
     // バケツ0にだけ非ゼロ値、バケツ1は全ゼロ
-    const samples = makeBucketSamples([
-      [-0.4, 0.4],
-      [0, 0],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.4, 0.4],
+        [0, 0],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // 8サンプル幅の区間3つにはレベル0（bucketSize 16）が使われるため、
     // バケツ0に属する区間0と1は -0.4/0.4、バケツ1に属する区間2は 0/0 になる
@@ -220,13 +296,19 @@ describe("resamplePeaks", () => {
 
   it("区間のサンプル幅より粗いレベルは選ばれない（隣の区間に値が漏れない）", () => {
     // 64サンプル中、バケツ2（[32, 48)）にだけ非ゼロ値を置く
-    const samples = makeBucketSamples([
-      [0, 0],
-      [0, 0],
-      [0, 0.9],
-      [0, 0],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [0, 0],
+        [0, 0],
+        [0, 0.9],
+        [0, 0],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // 32サンプル幅の区間2つには bucketSize 32 のレベルが選ばれるはず
     // もし粗いレベル（bucketSize 64）が選ばれると、区間0のmaxにも0.9が漏れる
@@ -236,17 +318,23 @@ describe("resamplePeaks", () => {
 
   it("サンプル幅の異なる区間ごとに適切なレベルが独立して選ばれる", () => {
     // 128サンプルで、レベル0は8バケツ
-    const samples = makeBucketSamples([
-      [-0.1, 0.1],
-      [-0.2, 0.2],
-      [-0.3, 0.3],
-      [-0.4, 0.4],
-      [-0.5, 0.5],
-      [-0.6, 0.6],
-      [-0.7, 0.7],
-      [-0.8, 0.8],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.1, 0.1],
+        [-0.2, 0.2],
+        [-0.3, 0.3],
+        [-0.4, 0.4],
+        [-0.5, 0.5],
+        [-0.6, 0.6],
+        [-0.7, 0.7],
+        [-0.8, 0.8],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // 区間0と1は32サンプル幅なので bucketSize 32 のレベル、
     // 区間2は64サンプル幅なので bucketSize 64 のレベルが使われる
@@ -258,11 +346,17 @@ describe("resamplePeaks", () => {
 
   it("区間境界がバケツ境界に揃っていない場合、区間と重なるバケツ全体のmin/maxになる", () => {
     // バケツ0の先頭2サンプル（[0, 2)）にだけ非ゼロ値、バケツ1は全ゼロ
-    const samples = makeBucketSamples([
-      [-0.4, 0.4],
-      [0, 0],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.4, 0.4],
+        [0, 0],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // 区間 [8, 24) のサンプルはすべて0だが、バケツ0と1の両方に重なるため、
     // バケツ0のmin/max（-0.4/0.4）が結果に含まれる
@@ -273,7 +367,10 @@ describe("resamplePeaks", () => {
 
   it("音声データの範囲外にはみ出す区間は範囲内のみ反映され、完全に範囲外ならゼロになる", () => {
     const samples = createArray(64, () => 0.4);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     // 区間0 [-32, -16): 完全に範囲外なので 0/0
     // 区間1 [-16, 16): 負側にはみ出すが範囲内に 0.4 があるので 0.4/0.4
@@ -285,12 +382,18 @@ describe("resamplePeaks", () => {
   });
 
   it("全体を1区間に集約すると全体のmin/maxになる", () => {
-    const samples = makeBucketSamples([
-      [-0.1, 0.1],
-      [-0.5, 0.3],
-      [-0.2, 0.6],
-    ]);
-    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const samples = makeBucketSamples(
+      [
+        [-0.1, 0.1],
+        [-0.5, 0.3],
+        [-0.2, 0.6],
+      ],
+      MIN_BUCKET_SIZE,
+    );
+    const peaks = generateWaveformPeaks(
+      makeAudioBuffer(samples),
+      MIN_BUCKET_SIZE,
+    );
 
     const result = resamplePeaks(peaks, [0, 48]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.5]);

--- a/tests/unit/lib/waveformPeaks.spec.ts
+++ b/tests/unit/lib/waveformPeaks.spec.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from "vitest";
+import { generateWaveformPeaks, resamplePeaks } from "@/sing/waveformPeaks";
+import { createArray } from "@/sing/utility";
+
+function makeAudioBuffer(samples: number[], sampleRate = 24000): AudioBuffer {
+  const channel = new Float32Array(samples);
+  return {
+    length: channel.length,
+    sampleRate,
+    numberOfChannels: 1,
+    duration: channel.length / sampleRate,
+    getChannelData: (ch: number) => {
+      if (ch !== 0) {
+        throw new Error("only ch0 supported in test");
+      }
+      return channel;
+    },
+  } as unknown as AudioBuffer;
+}
+
+/**
+ * レベル0のバケツ（16サンプル）ごとにmin/maxを指定してサンプル配列を作る。
+ * 各バケツは先頭サンプルがmin、2番目のサンプルがmax、残り14サンプルが0になる。
+ * 0埋め部分がそのバケツのmin/maxに影響しないよう、min <= 0 <= max でなければならない。
+ */
+function makeBucketSamples(
+  bucketMinMaxList: [min: number, max: number][],
+): number[] {
+  const samples: number[] = [];
+  for (const [min, max] of bucketMinMaxList) {
+    if (min > 0 || max < 0) {
+      throw new Error("min <= 0 <= max でなければなりません。");
+    }
+    samples.push(min, max, ...createArray(14, () => 0));
+  }
+  return samples;
+}
+
+function expectFloat32ArrayCloseTo(actual: Float32Array, expected: number[]) {
+  expect(actual.length).toBe(expected.length);
+  for (let i = 0; i < expected.length; i++) {
+    expect(actual[i]).toBeCloseTo(expected[i]);
+  }
+}
+
+describe("generateWaveformPeaks", () => {
+  it("16サンプル以下ならバケツ1個のレベルが1つだけできる", () => {
+    const peaks = generateWaveformPeaks(makeAudioBuffer([0.1, -0.2, 0.3]));
+    expect(peaks.length).toBe(1);
+    expect(peaks[0].bucketSize).toBe(16);
+    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.2]);
+    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.3]);
+  });
+
+  it("レベル0は16サンプルごとのバケツになり、各バケツがその範囲のmin/maxを持つ", () => {
+    // バケツ0（[0, 16)）: min -0.4（i=3）, max 0.6（i=10）
+    // バケツ1（[16, 32)）: min -0.7（i=25）, max 0.8（i=20）
+    const samples = createArray(32, (i) => {
+      if (i === 3) {
+        return -0.4;
+      }
+      if (i === 10) {
+        return 0.6;
+      }
+      if (i === 20) {
+        return 0.8;
+      }
+      if (i === 25) {
+        return -0.7;
+      }
+      return 0;
+    });
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    expect(peaks[0].bucketSize).toBe(16);
+    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.4, -0.7]);
+    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.6, 0.8]);
+  });
+
+  it("サンプル数が16の倍数でないとき、最後のバケツは端数サンプルのみで計算される", () => {
+    // 16サンプルの0埋めバケツ + 端数4サンプル
+    const samples = [...createArray(16, () => 0), 0.1, -0.3, 0.5, 0.2];
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // ceil(20 / 16) = 2バケツで、バケツ1は [16, 20) の4サンプルのみ
+    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [0, -0.3]);
+    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0, 0.5]);
+  });
+
+  it("バケツ数が1になるまで、隣接2バケツをmin/max統合したレベルが積まれる", () => {
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.4, 0.2],
+      [-0.2, 0.8],
+      [-0.3, 0.3],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    expect(peaks.length).toBe(3);
+
+    // レベル0: 入力そのままの4バケツ
+    expect(peaks[0].bucketSize).toBe(16);
+    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.1, -0.4, -0.2, -0.3]);
+    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.1, 0.2, 0.8, 0.3]);
+
+    // レベル1: 隣接2バケツの統合
+    expect(peaks[1].bucketSize).toBe(32);
+    expectFloat32ArrayCloseTo(peaks[1].minBuckets, [-0.4, -0.3]);
+    expectFloat32ArrayCloseTo(peaks[1].maxBuckets, [0.2, 0.8]);
+
+    // レベル2: 全体のmin/max
+    expect(peaks[2].bucketSize).toBe(64);
+    expectFloat32ArrayCloseTo(peaks[2].minBuckets, [-0.4]);
+    expectFloat32ArrayCloseTo(peaks[2].maxBuckets, [0.8]);
+  });
+
+  it("バケツ数が奇数のとき、最後のバケツは単独で上位レベルに引き継がれる", () => {
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.2, 0.2],
+      [-0.5, 0.6],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // レベル1: バケツ0と1の統合 + バケツ2の単独引き継ぎ
+    expectFloat32ArrayCloseTo(peaks[1].minBuckets, [-0.2, -0.5]);
+    expectFloat32ArrayCloseTo(peaks[1].maxBuckets, [0.2, 0.6]);
+  });
+});
+
+describe("resamplePeaks", () => {
+  it("不正なpeaksを渡すとエラーになる", () => {
+    // 空のpeaks
+    expect(() => resamplePeaks([], [0, 16, 32])).toThrow();
+
+    // バケツが0個のレベルを含む
+    const emptyBucketsPeaks = [
+      {
+        bucketSize: 16,
+        minBuckets: new Float32Array(0),
+        maxBuckets: new Float32Array(0),
+      },
+    ];
+    expect(() => resamplePeaks(emptyBucketsPeaks, [0, 16, 32])).toThrow();
+
+    // minBucketsとmaxBucketsの長さが一致しない
+    const mismatchedLengthPeaks = [
+      {
+        bucketSize: 16,
+        minBuckets: new Float32Array(2),
+        maxBuckets: new Float32Array(1),
+      },
+    ];
+    expect(() => resamplePeaks(mismatchedLengthPeaks, [0, 16, 32])).toThrow();
+
+    // レベルがバケツサイズの昇順に並んでいない
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.2, 0.2],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+    const reversedPeaks = [...peaks].reverse();
+    expect(() => resamplePeaks(reversedPeaks, [0, 16, 32])).toThrow();
+  });
+
+  it("不正なbinBoundarySamplesを渡すとエラーになる", () => {
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.2, 0.2],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 長さが2未満
+    expect(() => resamplePeaks(peaks, [])).toThrow();
+    expect(() => resamplePeaks(peaks, [0])).toThrow();
+
+    // 減少している
+    expect(() => resamplePeaks(peaks, [0, 32, 16])).toThrow();
+  });
+
+  it("幅0の区間は点として扱われ、その位置のサンプルを含むバケツの値になる", () => {
+    const samples = makeBucketSamples([
+      [-0.3, 0.3],
+      [-0.5, 0.5],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間1はバケツ境界ちょうど（位置16）の幅0区間で、サンプル16を含むバケツ1の値になる
+    // 区間3はバケツ1の内部（位置24）の幅0区間で、バケツ1の値になる
+    const result = resamplePeaks(peaks, [0, 16, 16, 24, 24, 32]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.3, -0.5, -0.5, -0.5, -0.5]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.3, 0.5, 0.5, 0.5, 0.5]);
+  });
+
+  it("音声データ範囲外にある幅0の区間はゼロ埋めのままになる", () => {
+    const samples = makeBucketSamples([[-0.3, 0.3]]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間0は先頭より前（位置-8）、区間2は末尾（位置16）の幅0区間で、どちらもゼロ埋めになる
+    const result = resamplePeaks(peaks, [-8, -8, 16, 16]);
+    expectFloat32ArrayCloseTo(result.minValues, [0, -0.3, 0]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0, 0.3, 0]);
+  });
+
+  it("区間のサンプル幅が16未満のときは最も細かいレベル0が使われる", () => {
+    // バケツ0にだけ非ゼロ値、バケツ1は全ゼロ
+    const samples = makeBucketSamples([
+      [-0.4, 0.4],
+      [0, 0],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 8サンプル幅の区間3つにはレベル0（bucketSize 16）が使われるため、
+    // バケツ0に属する区間0と1は -0.4/0.4、バケツ1に属する区間2は 0/0 になる
+    // もし粗いレベル1（bucketSize 32、全体で1バケツ）が使われると区間2にも -0.4/0.4 が現れる
+    const result = resamplePeaks(peaks, [0, 8, 16, 24]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.4, -0.4, 0]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.4, 0.4, 0]);
+  });
+
+  it("区間のサンプル幅より粗いレベルは選ばれない（隣の区間に値が漏れない）", () => {
+    // 64サンプル中、バケツ2（[32, 48)）にだけ非ゼロ値を置く
+    const samples = makeBucketSamples([
+      [0, 0],
+      [0, 0],
+      [0, 0.9],
+      [0, 0],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 32サンプル幅の区間2つには bucketSize 32 のレベルが選ばれるはず
+    // もし粗いレベル（bucketSize 64）が選ばれると、区間0のmaxにも0.9が漏れる
+    const result = resamplePeaks(peaks, [0, 32, 64]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0, 0.9]);
+  });
+
+  it("サンプル幅の異なる区間ごとに適切なレベルが独立して選ばれる", () => {
+    // 128サンプルで、レベル0は8バケツ
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.2, 0.2],
+      [-0.3, 0.3],
+      [-0.4, 0.4],
+      [-0.5, 0.5],
+      [-0.6, 0.6],
+      [-0.7, 0.7],
+      [-0.8, 0.8],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間0と1は32サンプル幅なので bucketSize 32 のレベル、
+    // 区間2は64サンプル幅なので bucketSize 64 のレベルが使われる
+    // どの区間もバケツ境界に揃っているため、結果は各区間の実min/maxと一致する
+    const result = resamplePeaks(peaks, [0, 32, 64, 128]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.2, -0.4, -0.8]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.2, 0.4, 0.8]);
+  });
+
+  it("区間境界がバケツ境界に揃っていない場合、区間と重なるバケツ全体のmin/maxになる", () => {
+    // バケツ0の先頭2サンプル（[0, 2)）にだけ非ゼロ値、バケツ1は全ゼロ
+    const samples = makeBucketSamples([
+      [-0.4, 0.4],
+      [0, 0],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間 [8, 24) のサンプルはすべて0だが、バケツ0と1の両方に重なるため、
+    // バケツ0のmin/max（-0.4/0.4）が結果に含まれる
+    const result = resamplePeaks(peaks, [8, 24]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.4]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.4]);
+  });
+
+  it("音声データの範囲外にはみ出す区間は範囲内のみ反映され、完全に範囲外ならゼロになる", () => {
+    const samples = createArray(64, () => 0.4);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    // 区間0 [-32, -16): 完全に範囲外なので 0/0
+    // 区間1 [-16, 16): 負側にはみ出すが範囲内に 0.4 があるので 0.4/0.4
+    // 区間2 [16, 80): 末尾側にはみ出すが範囲内に 0.4 があるので 0.4/0.4
+    // 区間3 [80, 96): 完全に範囲外なので 0/0
+    const result = resamplePeaks(peaks, [-32, -16, 16, 80, 96]);
+    expectFloat32ArrayCloseTo(result.minValues, [0, 0.4, 0.4, 0]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0, 0.4, 0.4, 0]);
+  });
+
+  it("全体を1区間に集約すると全体のmin/maxになる", () => {
+    const samples = makeBucketSamples([
+      [-0.1, 0.1],
+      [-0.5, 0.3],
+      [-0.2, 0.6],
+    ]);
+    const peaks = generateWaveformPeaks(makeAudioBuffer(samples));
+
+    const result = resamplePeaks(peaks, [0, 48]);
+    expectFloat32ArrayCloseTo(result.minValues, [-0.5]);
+    expectFloat32ArrayCloseTo(result.maxValues, [0.6]);
+  });
+});

--- a/tests/unit/lib/waveformPeaks.spec.ts
+++ b/tests/unit/lib/waveformPeaks.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { generateWaveformPeaks, resamplePeaks } from "@/sing/waveformPeaks";
+import {
+  generateWaveformPeaksMipmap,
+  resamplePeaks,
+} from "@/sing/waveformPeaks";
 import { createArray } from "@/sing/utility";
 
 const MIN_BUCKET_SIZE = 16;
@@ -49,32 +52,32 @@ function expectFloat32ArrayCloseTo(actual: Float32Array, expected: number[]) {
   }
 }
 
-describe("generateWaveformPeaks", () => {
+describe("generateWaveformPeaksMipmap", () => {
   it("不正なminBucketSizeを渡すとエラーになる", () => {
     const buffer = makeAudioBuffer([0, 0.1, -0.1]);
 
     // 0以下はエラー
-    expect(() => generateWaveformPeaks(buffer, 0)).toThrow();
-    expect(() => generateWaveformPeaks(buffer, -1)).toThrow();
+    expect(() => generateWaveformPeaksMipmap(buffer, 0)).toThrow();
+    expect(() => generateWaveformPeaksMipmap(buffer, -1)).toThrow();
 
     // 非整数はエラー
-    expect(() => generateWaveformPeaks(buffer, 1.5)).toThrow();
-    expect(() => generateWaveformPeaks(buffer, NaN)).toThrow();
-    expect(() => generateWaveformPeaks(buffer, Infinity)).toThrow();
+    expect(() => generateWaveformPeaksMipmap(buffer, 1.5)).toThrow();
+    expect(() => generateWaveformPeaksMipmap(buffer, NaN)).toThrow();
+    expect(() => generateWaveformPeaksMipmap(buffer, Infinity)).toThrow();
 
     // 1以上の整数なら通る
-    expect(() => generateWaveformPeaks(buffer, 1)).not.toThrow();
+    expect(() => generateWaveformPeaksMipmap(buffer, 1)).not.toThrow();
   });
 
   it("minBucketSize以下のサンプル数ならバケツ1個のレベルが1つだけできる", () => {
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer([0.1, -0.2, 0.3]),
       MIN_BUCKET_SIZE,
     );
-    expect(peaks.length).toBe(1);
-    expect(peaks[0].bucketSize).toBe(MIN_BUCKET_SIZE);
-    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.2]);
-    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.3]);
+    expect(peaksMipmap.length).toBe(1);
+    expect(peaksMipmap[0].bucketSize).toBe(MIN_BUCKET_SIZE);
+    expectFloat32ArrayCloseTo(peaksMipmap[0].minBuckets, [-0.2]);
+    expectFloat32ArrayCloseTo(peaksMipmap[0].maxBuckets, [0.3]);
   });
 
   it("レベル0はminBucketSizeごとのバケツになり、各バケツがその範囲のmin/maxを持つ", () => {
@@ -95,14 +98,14 @@ describe("generateWaveformPeaks", () => {
       }
       return 0;
     });
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
-    expect(peaks[0].bucketSize).toBe(MIN_BUCKET_SIZE);
-    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.4, -0.7]);
-    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.6, 0.8]);
+    expect(peaksMipmap[0].bucketSize).toBe(MIN_BUCKET_SIZE);
+    expectFloat32ArrayCloseTo(peaksMipmap[0].minBuckets, [-0.4, -0.7]);
+    expectFloat32ArrayCloseTo(peaksMipmap[0].maxBuckets, [0.6, 0.8]);
   });
 
   it("サンプル数がminBucketSizeの倍数でないとき、最後のバケツは端数サンプルのみで計算される", () => {
@@ -114,14 +117,14 @@ describe("generateWaveformPeaks", () => {
       0.5,
       0.2,
     ];
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
     // ceil(20 / 16) = 2バケツで、バケツ1は [16, 20) の4サンプルのみ
-    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [0, -0.3]);
-    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0, 0.5]);
+    expectFloat32ArrayCloseTo(peaksMipmap[0].minBuckets, [0, -0.3]);
+    expectFloat32ArrayCloseTo(peaksMipmap[0].maxBuckets, [0, 0.5]);
   });
 
   it("バケツ数が1になるまで、隣接2バケツをmin/max統合したレベルが積まれる", () => {
@@ -134,27 +137,30 @@ describe("generateWaveformPeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
-    expect(peaks.length).toBe(3);
+    expect(peaksMipmap.length).toBe(3);
 
     // レベル0: 入力そのままの4バケツ
-    expect(peaks[0].bucketSize).toBe(MIN_BUCKET_SIZE);
-    expectFloat32ArrayCloseTo(peaks[0].minBuckets, [-0.1, -0.4, -0.2, -0.3]);
-    expectFloat32ArrayCloseTo(peaks[0].maxBuckets, [0.1, 0.2, 0.8, 0.3]);
+    expect(peaksMipmap[0].bucketSize).toBe(MIN_BUCKET_SIZE);
+    expectFloat32ArrayCloseTo(
+      peaksMipmap[0].minBuckets,
+      [-0.1, -0.4, -0.2, -0.3],
+    );
+    expectFloat32ArrayCloseTo(peaksMipmap[0].maxBuckets, [0.1, 0.2, 0.8, 0.3]);
 
     // レベル1: 隣接2バケツの統合
-    expect(peaks[1].bucketSize).toBe(MIN_BUCKET_SIZE * 2);
-    expectFloat32ArrayCloseTo(peaks[1].minBuckets, [-0.4, -0.3]);
-    expectFloat32ArrayCloseTo(peaks[1].maxBuckets, [0.2, 0.8]);
+    expect(peaksMipmap[1].bucketSize).toBe(MIN_BUCKET_SIZE * 2);
+    expectFloat32ArrayCloseTo(peaksMipmap[1].minBuckets, [-0.4, -0.3]);
+    expectFloat32ArrayCloseTo(peaksMipmap[1].maxBuckets, [0.2, 0.8]);
 
     // レベル2: 全体のmin/max
-    expect(peaks[2].bucketSize).toBe(MIN_BUCKET_SIZE * 4);
-    expectFloat32ArrayCloseTo(peaks[2].minBuckets, [-0.4]);
-    expectFloat32ArrayCloseTo(peaks[2].maxBuckets, [0.8]);
+    expect(peaksMipmap[2].bucketSize).toBe(MIN_BUCKET_SIZE * 4);
+    expectFloat32ArrayCloseTo(peaksMipmap[2].minBuckets, [-0.4]);
+    expectFloat32ArrayCloseTo(peaksMipmap[2].maxBuckets, [0.8]);
   });
 
   it("バケツ数が奇数のとき、最後のバケツは単独で上位レベルに引き継がれる", () => {
@@ -166,41 +172,43 @@ describe("generateWaveformPeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
     // レベル1: バケツ0と1の統合 + バケツ2の単独引き継ぎ
-    expectFloat32ArrayCloseTo(peaks[1].minBuckets, [-0.2, -0.5]);
-    expectFloat32ArrayCloseTo(peaks[1].maxBuckets, [0.2, 0.6]);
+    expectFloat32ArrayCloseTo(peaksMipmap[1].minBuckets, [-0.2, -0.5]);
+    expectFloat32ArrayCloseTo(peaksMipmap[1].maxBuckets, [0.2, 0.6]);
   });
 });
 
 describe("resamplePeaks", () => {
-  it("不正なpeaksを渡すとエラーになる", () => {
-    // 空のpeaks
+  it("不正なpeaksMipmapを渡すとエラーになる", () => {
+    // 空のpeaksMipmap
     expect(() => resamplePeaks([], [0, 16, 32])).toThrow();
 
     // バケツが0個のレベルを含む
-    const emptyBucketsPeaks = [
+    const emptyBucketsPeaksMipmap = [
       {
         bucketSize: 16,
         minBuckets: new Float32Array(0),
         maxBuckets: new Float32Array(0),
       },
     ];
-    expect(() => resamplePeaks(emptyBucketsPeaks, [0, 16, 32])).toThrow();
+    expect(() => resamplePeaks(emptyBucketsPeaksMipmap, [0, 16, 32])).toThrow();
 
     // minBucketsとmaxBucketsの長さが一致しない
-    const mismatchedLengthPeaks = [
+    const mismatchedLengthPeaksMipmap = [
       {
         bucketSize: 16,
         minBuckets: new Float32Array(2),
         maxBuckets: new Float32Array(1),
       },
     ];
-    expect(() => resamplePeaks(mismatchedLengthPeaks, [0, 16, 32])).toThrow();
+    expect(() =>
+      resamplePeaks(mismatchedLengthPeaksMipmap, [0, 16, 32]),
+    ).toThrow();
 
     // レベルがバケツサイズの昇順に並んでいない
     const samples = makeBucketSamples(
@@ -210,12 +218,12 @@ describe("resamplePeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
-    const reversedPeaks = [...peaks].reverse();
-    expect(() => resamplePeaks(reversedPeaks, [0, 16, 32])).toThrow();
+    const reversedPeaksMipmap = [...peaksMipmap].reverse();
+    expect(() => resamplePeaks(reversedPeaksMipmap, [0, 16, 32])).toThrow();
   });
 
   it("不正なbinBoundarySamplesを渡すとエラーになる", () => {
@@ -226,17 +234,17 @@ describe("resamplePeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
     // 長さが2未満
-    expect(() => resamplePeaks(peaks, [])).toThrow();
-    expect(() => resamplePeaks(peaks, [0])).toThrow();
+    expect(() => resamplePeaks(peaksMipmap, [])).toThrow();
+    expect(() => resamplePeaks(peaksMipmap, [0])).toThrow();
 
     // 減少している
-    expect(() => resamplePeaks(peaks, [0, 32, 16])).toThrow();
+    expect(() => resamplePeaks(peaksMipmap, [0, 32, 16])).toThrow();
   });
 
   it("幅0の区間は点として扱われ、その位置のサンプルを含むバケツの値になる", () => {
@@ -247,27 +255,27 @@ describe("resamplePeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
     // 区間1はバケツ境界ちょうど（位置16）の幅0区間で、サンプル16を含むバケツ1の値になる
     // 区間3はバケツ1の内部（位置24）の幅0区間で、バケツ1の値になる
-    const result = resamplePeaks(peaks, [0, 16, 16, 24, 24, 32]);
+    const result = resamplePeaks(peaksMipmap, [0, 16, 16, 24, 24, 32]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.3, -0.5, -0.5, -0.5, -0.5]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.3, 0.5, 0.5, 0.5, 0.5]);
   });
 
   it("音声データ範囲外にある幅0の区間はゼロ埋めのままになる", () => {
     const samples = makeBucketSamples([[-0.3, 0.3]], MIN_BUCKET_SIZE);
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
     // 区間0は先頭より前（位置-8）、区間2は末尾（位置16）の幅0区間で、どちらもゼロ埋めになる
-    const result = resamplePeaks(peaks, [-8, -8, 16, 16]);
+    const result = resamplePeaks(peaksMipmap, [-8, -8, 16, 16]);
     expectFloat32ArrayCloseTo(result.minValues, [0, -0.3, 0]);
     expectFloat32ArrayCloseTo(result.maxValues, [0, 0.3, 0]);
   });
@@ -281,7 +289,7 @@ describe("resamplePeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
@@ -289,7 +297,7 @@ describe("resamplePeaks", () => {
     // 8サンプル幅の区間3つにはレベル0（bucketSize 16）が使われるため、
     // バケツ0に属する区間0と1は -0.4/0.4、バケツ1に属する区間2は 0/0 になる
     // もし粗いレベル1（bucketSize 32、全体で1バケツ）が使われると区間2にも -0.4/0.4 が現れる
-    const result = resamplePeaks(peaks, [0, 8, 16, 24]);
+    const result = resamplePeaks(peaksMipmap, [0, 8, 16, 24]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.4, -0.4, 0]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.4, 0.4, 0]);
   });
@@ -305,14 +313,14 @@ describe("resamplePeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
     // 32サンプル幅の区間2つには bucketSize 32 のレベルが選ばれるはず
     // もし粗いレベル（bucketSize 64）が選ばれると、区間0のmaxにも0.9が漏れる
-    const result = resamplePeaks(peaks, [0, 32, 64]);
+    const result = resamplePeaks(peaksMipmap, [0, 32, 64]);
     expectFloat32ArrayCloseTo(result.maxValues, [0, 0.9]);
   });
 
@@ -331,7 +339,7 @@ describe("resamplePeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
@@ -339,7 +347,7 @@ describe("resamplePeaks", () => {
     // 区間0と1は32サンプル幅なので bucketSize 32 のレベル、
     // 区間2は64サンプル幅なので bucketSize 64 のレベルが使われる
     // どの区間もバケツ境界に揃っているため、結果は各区間の実min/maxと一致する
-    const result = resamplePeaks(peaks, [0, 32, 64, 128]);
+    const result = resamplePeaks(peaksMipmap, [0, 32, 64, 128]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.2, -0.4, -0.8]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.2, 0.4, 0.8]);
   });
@@ -353,21 +361,21 @@ describe("resamplePeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
     // 区間 [8, 24) のサンプルはすべて0だが、バケツ0と1の両方に重なるため、
     // バケツ0のmin/max（-0.4/0.4）が結果に含まれる
-    const result = resamplePeaks(peaks, [8, 24]);
+    const result = resamplePeaks(peaksMipmap, [8, 24]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.4]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.4]);
   });
 
   it("音声データの範囲外にはみ出す区間は範囲内のみ反映され、完全に範囲外ならゼロになる", () => {
     const samples = createArray(64, () => 0.4);
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
@@ -376,7 +384,7 @@ describe("resamplePeaks", () => {
     // 区間1 [-16, 16): 負側にはみ出すが範囲内に 0.4 があるので 0.4/0.4
     // 区間2 [16, 80): 末尾側にはみ出すが範囲内に 0.4 があるので 0.4/0.4
     // 区間3 [80, 96): 完全に範囲外なので 0/0
-    const result = resamplePeaks(peaks, [-32, -16, 16, 80, 96]);
+    const result = resamplePeaks(peaksMipmap, [-32, -16, 16, 80, 96]);
     expectFloat32ArrayCloseTo(result.minValues, [0, 0.4, 0.4, 0]);
     expectFloat32ArrayCloseTo(result.maxValues, [0, 0.4, 0.4, 0]);
   });
@@ -390,12 +398,12 @@ describe("resamplePeaks", () => {
       ],
       MIN_BUCKET_SIZE,
     );
-    const peaks = generateWaveformPeaks(
+    const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer(samples),
       MIN_BUCKET_SIZE,
     );
 
-    const result = resamplePeaks(peaks, [0, 48]);
+    const result = resamplePeaks(peaksMipmap, [0, 48]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.5]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.6]);
   });

--- a/tests/unit/lib/waveformPeaks.spec.ts
+++ b/tests/unit/lib/waveformPeaks.spec.ts
@@ -6,14 +6,15 @@ import {
 import { createArray } from "@/sing/utility";
 
 const MIN_BUCKET_SIZE = 16;
+const SAMPLE_RATE = 24000;
 
-function makeAudioBuffer(samples: number[], sampleRate = 24000): AudioBuffer {
+function makeAudioBuffer(samples: number[]): AudioBuffer {
   const channel = new Float32Array(samples);
   return {
     length: channel.length,
-    sampleRate,
+    sampleRate: SAMPLE_RATE,
     numberOfChannels: 1,
-    duration: channel.length / sampleRate,
+    duration: channel.length / SAMPLE_RATE,
     getChannelData: (ch: number) => {
       if (ch !== 0) {
         throw new Error("only ch0 supported in test");

--- a/tests/unit/lib/waveformPeaks.spec.ts
+++ b/tests/unit/lib/waveformPeaks.spec.ts
@@ -24,9 +24,9 @@ function makeAudioBuffer(samples: number[], sampleRate = 24000): AudioBuffer {
 }
 
 /**
- * 指定したバケツサイズで区切ったときの各バケツのmin/maxからサンプル配列を作る。
- * 各バケツは、先頭サンプルがmin、2番目のサンプルがmax、残りが0になる。
- * 0埋め部分がそのバケツのmin/maxに影響しないよう、min <= 0 <= max でなければならない。
+ * 指定したバケットサイズで区切ったときの各バケットのmin/maxからサンプル配列を作る。
+ * 各バケットは、先頭サンプルがmin、2番目のサンプルがmax、残りが0になる。
+ * 0埋め部分がそのバケットのmin/maxに影響しないよう、min <= 0 <= max でなければならない。
  */
 function makeBucketSamples(
   bucketMinMaxList: [min: number, max: number][],
@@ -69,7 +69,7 @@ describe("generateWaveformPeaksMipmap", () => {
     expect(() => generateWaveformPeaksMipmap(buffer, 1)).not.toThrow();
   });
 
-  it("minBucketSize以下のサンプル数ならバケツ1個のレベルが1つだけできる", () => {
+  it("minBucketSize以下のサンプル数ならバケット1個のレベルが1つだけできる", () => {
     const peaksMipmap = generateWaveformPeaksMipmap(
       makeAudioBuffer([0.1, -0.2, 0.3]),
       MIN_BUCKET_SIZE,
@@ -80,9 +80,9 @@ describe("generateWaveformPeaksMipmap", () => {
     expectFloat32ArrayCloseTo(peaksMipmap[0].maxBuckets, [0.3]);
   });
 
-  it("レベル0はminBucketSizeごとのバケツになり、各バケツがその範囲のmin/maxを持つ", () => {
-    // バケツ0（[0, 16)）: min -0.4（i=3）, max 0.6（i=10）
-    // バケツ1（[16, 32)）: min -0.7（i=25）, max 0.8（i=20）
+  it("レベル0はminBucketSizeごとのバケットになり、各バケットがその範囲のmin/maxを持つ", () => {
+    // バケット0（[0, 16)）: min -0.4（i=3）, max 0.6（i=10）
+    // バケット1（[16, 32)）: min -0.7（i=25）, max 0.8（i=20）
     const samples = createArray(32, (i) => {
       if (i === 3) {
         return -0.4;
@@ -108,8 +108,8 @@ describe("generateWaveformPeaksMipmap", () => {
     expectFloat32ArrayCloseTo(peaksMipmap[0].maxBuckets, [0.6, 0.8]);
   });
 
-  it("サンプル数がminBucketSizeの倍数でないとき、最後のバケツは端数サンプルのみで計算される", () => {
-    // minBucketSizeサンプルの0埋めバケツ + 端数4サンプル
+  it("サンプル数がminBucketSizeの倍数でないとき、最後のバケットは端数サンプルのみで計算される", () => {
+    // minBucketSizeサンプルの0埋めバケット + 端数4サンプル
     const samples = [
       ...createArray(MIN_BUCKET_SIZE, () => 0),
       0.1,
@@ -122,12 +122,12 @@ describe("generateWaveformPeaksMipmap", () => {
       MIN_BUCKET_SIZE,
     );
 
-    // ceil(20 / 16) = 2バケツで、バケツ1は [16, 20) の4サンプルのみ
+    // ceil(20 / 16) = 2バケットで、バケット1は [16, 20) の4サンプルのみ
     expectFloat32ArrayCloseTo(peaksMipmap[0].minBuckets, [0, -0.3]);
     expectFloat32ArrayCloseTo(peaksMipmap[0].maxBuckets, [0, 0.5]);
   });
 
-  it("バケツ数が1になるまで、隣接2バケツをmin/max統合したレベルが積まれる", () => {
+  it("バケット数が1になるまで、隣接2バケットをmin/max統合したレベルが積まれる", () => {
     const samples = makeBucketSamples(
       [
         [-0.1, 0.1],
@@ -144,7 +144,7 @@ describe("generateWaveformPeaksMipmap", () => {
 
     expect(peaksMipmap.length).toBe(3);
 
-    // レベル0: 入力そのままの4バケツ
+    // レベル0: 入力そのままの4バケット
     expect(peaksMipmap[0].bucketSize).toBe(MIN_BUCKET_SIZE);
     expectFloat32ArrayCloseTo(
       peaksMipmap[0].minBuckets,
@@ -152,7 +152,7 @@ describe("generateWaveformPeaksMipmap", () => {
     );
     expectFloat32ArrayCloseTo(peaksMipmap[0].maxBuckets, [0.1, 0.2, 0.8, 0.3]);
 
-    // レベル1: 隣接2バケツの統合
+    // レベル1: 隣接2バケットの統合
     expect(peaksMipmap[1].bucketSize).toBe(MIN_BUCKET_SIZE * 2);
     expectFloat32ArrayCloseTo(peaksMipmap[1].minBuckets, [-0.4, -0.3]);
     expectFloat32ArrayCloseTo(peaksMipmap[1].maxBuckets, [0.2, 0.8]);
@@ -163,7 +163,7 @@ describe("generateWaveformPeaksMipmap", () => {
     expectFloat32ArrayCloseTo(peaksMipmap[2].maxBuckets, [0.8]);
   });
 
-  it("バケツ数が奇数のとき、最後のバケツは単独で上位レベルに引き継がれる", () => {
+  it("バケット数が奇数のとき、最後のバケットは単独で上位レベルに引き継がれる", () => {
     const samples = makeBucketSamples(
       [
         [-0.1, 0.1],
@@ -177,7 +177,7 @@ describe("generateWaveformPeaksMipmap", () => {
       MIN_BUCKET_SIZE,
     );
 
-    // レベル1: バケツ0と1の統合 + バケツ2の単独引き継ぎ
+    // レベル1: バケット0と1の統合 + バケット2の単独引き継ぎ
     expectFloat32ArrayCloseTo(peaksMipmap[1].minBuckets, [-0.2, -0.5]);
     expectFloat32ArrayCloseTo(peaksMipmap[1].maxBuckets, [0.2, 0.6]);
   });
@@ -188,7 +188,7 @@ describe("resamplePeaks", () => {
     // 空のpeaksMipmap
     expect(() => resamplePeaks([], [0, 16, 32])).toThrow();
 
-    // バケツが0個のレベルを含む
+    // バケットが0個のレベルを含む
     const emptyBucketsPeaksMipmap = [
       {
         bucketSize: 16,
@@ -210,7 +210,7 @@ describe("resamplePeaks", () => {
       resamplePeaks(mismatchedLengthPeaksMipmap, [0, 16, 32]),
     ).toThrow();
 
-    // レベルがバケツサイズの昇順に並んでいない
+    // レベルがバケットサイズの昇順に並んでいない
     const samples = makeBucketSamples(
       [
         [-0.1, 0.1],
@@ -247,7 +247,7 @@ describe("resamplePeaks", () => {
     expect(() => resamplePeaks(peaksMipmap, [0, 32, 16])).toThrow();
   });
 
-  it("幅0の区間は点として扱われ、その位置のサンプルを含むバケツの値になる", () => {
+  it("幅0の区間は点として扱われ、その位置のサンプルを含むバケットの値になる", () => {
     const samples = makeBucketSamples(
       [
         [-0.3, 0.3],
@@ -260,8 +260,8 @@ describe("resamplePeaks", () => {
       MIN_BUCKET_SIZE,
     );
 
-    // 区間1はバケツ境界ちょうど（位置16）の幅0区間で、サンプル16を含むバケツ1の値になる
-    // 区間3はバケツ1の内部（位置24）の幅0区間で、バケツ1の値になる
+    // 区間1はバケット境界ちょうど（位置16）の幅0区間で、サンプル16を含むバケット1の値になる
+    // 区間3はバケット1の内部（位置24）の幅0区間で、バケット1の値になる
     const result = resamplePeaks(peaksMipmap, [0, 16, 16, 24, 24, 32]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.3, -0.5, -0.5, -0.5, -0.5]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.3, 0.5, 0.5, 0.5, 0.5]);
@@ -281,7 +281,7 @@ describe("resamplePeaks", () => {
   });
 
   it("区間のサンプル幅がminBucketSize未満のときは最も細かいレベル0が使われる", () => {
-    // バケツ0にだけ非ゼロ値、バケツ1は全ゼロ
+    // バケット0にだけ非ゼロ値、バケット1は全ゼロ
     const samples = makeBucketSamples(
       [
         [-0.4, 0.4],
@@ -295,15 +295,15 @@ describe("resamplePeaks", () => {
     );
 
     // 8サンプル幅の区間3つにはレベル0（bucketSize 16）が使われるため、
-    // バケツ0に属する区間0と1は -0.4/0.4、バケツ1に属する区間2は 0/0 になる
-    // もし粗いレベル1（bucketSize 32、全体で1バケツ）が使われると区間2にも -0.4/0.4 が現れる
+    // バケット0に属する区間0と1は -0.4/0.4、バケット1に属する区間2は 0/0 になる
+    // もし粗いレベル1（bucketSize 32、全体で1バケット）が使われると区間2にも -0.4/0.4 が現れる
     const result = resamplePeaks(peaksMipmap, [0, 8, 16, 24]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.4, -0.4, 0]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.4, 0.4, 0]);
   });
 
   it("区間のサンプル幅より粗いレベルは選ばれない（隣の区間に値が漏れない）", () => {
-    // 64サンプル中、バケツ2（[32, 48)）にだけ非ゼロ値を置く
+    // 64サンプル中、バケット2（[32, 48)）にだけ非ゼロ値を置く
     const samples = makeBucketSamples(
       [
         [0, 0],
@@ -325,7 +325,7 @@ describe("resamplePeaks", () => {
   });
 
   it("サンプル幅の異なる区間ごとに適切なレベルが独立して選ばれる", () => {
-    // 128サンプルで、レベル0は8バケツ
+    // 128サンプルで、レベル0は8バケット
     const samples = makeBucketSamples(
       [
         [-0.1, 0.1],
@@ -346,14 +346,14 @@ describe("resamplePeaks", () => {
 
     // 区間0と1は32サンプル幅なので bucketSize 32 のレベル、
     // 区間2は64サンプル幅なので bucketSize 64 のレベルが使われる
-    // どの区間もバケツ境界に揃っているため、結果は各区間の実min/maxと一致する
+    // どの区間もバケット境界に揃っているため、結果は各区間の実min/maxと一致する
     const result = resamplePeaks(peaksMipmap, [0, 32, 64, 128]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.2, -0.4, -0.8]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.2, 0.4, 0.8]);
   });
 
-  it("区間境界がバケツ境界に揃っていない場合、区間と重なるバケツ全体のmin/maxになる", () => {
-    // バケツ0の先頭2サンプル（[0, 2)）にだけ非ゼロ値、バケツ1は全ゼロ
+  it("区間境界がバケット境界に揃っていない場合、区間と重なるバケット全体のmin/maxになる", () => {
+    // バケット0の先頭2サンプル（[0, 2)）にだけ非ゼロ値、バケット1は全ゼロ
     const samples = makeBucketSamples(
       [
         [-0.4, 0.4],
@@ -366,8 +366,8 @@ describe("resamplePeaks", () => {
       MIN_BUCKET_SIZE,
     );
 
-    // 区間 [8, 24) のサンプルはすべて0だが、バケツ0と1の両方に重なるため、
-    // バケツ0のmin/max（-0.4/0.4）が結果に含まれる
+    // 区間 [8, 24) のサンプルはすべて0だが、バケット0と1の両方に重なるため、
+    // バケット0のmin/max（-0.4/0.4）が結果に含まれる
     const result = resamplePeaks(peaksMipmap, [8, 24]);
     expectFloat32ArrayCloseTo(result.minValues, [-0.4]);
     expectFloat32ArrayCloseTo(result.maxValues, [0.4]);


### PR DESCRIPTION
## 内容

音素タイミング編集機能の実装の一部として、音素タイミング編集エリア（SequencerPhonemeTimingEditor）に音声波形を表示するコンポーネントを追加します。
ノートや音素タイミング自体の表示、編集操作（ドラッグによるタイミング変更など）は後続のPRで実装予定です。

PixiJSによる描画で、描画まわりの骨組み（描画ループやリサイズ対応など）は既存のシーケンサー系コンポーネントと同じです。

### 波形の表示（SequencerWaveform.vue）

選択トラックの各フレーズの音声波形を表示します。
横方向の位置と幅は時刻をテンポに従ってtickへ変換して求めるため、テンポを変えると波形の表示も伸縮します。

描画自体は1ピクセルごとにサンプルのmin/maxを取って塗る一般的な方式ですが、これを毎回AudioBuffer全体の走査で行うと、ズーム変更のたびに重い再計算が走ります。なので、AudioBufferごとにピークを複数解像度へ縮約したもの（mipmap）を一度だけ作っておき、描画時はピクセル幅に合った解像度を参照するようにしています。

実装面のポイントは次のとおりです。

- ピーク計算は純粋関数として `sing/waveformPeaks.ts` に切り出し、ユニットテストを追加
- テンポ変化で時間とX座標の対応が非線形になるため、リサンプルはピクセル境界ごとのサンプル位置を配列で渡す形にしている
- ピクセル単位の波形データはズームやテンポが変わったときだけ再計算し、結果はハッシュキーと紐づけて保持
- 再計算は非同期で行うため、Mutexで直列化している（ハッシュキーでの保持とMutexでの直列化はSequencerPitchと同様の方式）

### その他の変更

波形表示の実装で必要になった既存ユーティリティ関数（`getOrThrow` / `tickToSecond` / `secondToTick` / `getLast`）の引数のreadonly化を含みます。

## 関連 Issue

- VOICEVOX/voicevox#2261

## スクリーンショット・動画など

## その他

今回追加した表示は、パラメータパネルの切り替えスイッチで音素タイミングを選ぶと確認できます（現時点ではこのエリアには波形のみが表示され、ノートと音素タイミングの表示は後続PRで追加されます）。
