### PR TITLE
fix: COMMAND_IMPORT_TRACKSのactionにTPQN・テンポ・拍子のバリデーションを追加

### DIFF
--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -3994,6 +3994,15 @@ export const singingCommandStore = transformCommandStore(
         { state, mutations, getters, actions },
         { tpqn, tempos, timeSignatures, tracks },
       ) {
+        if (!isValidTpqn(tpqn)) {
+          throw new Error("The tpqn is invalid.");
+        }
+        if (!isValidTempos(tempos)) {
+          throw new Error("The tempos are invalid.");
+        }
+        if (!isValidTimeSignatures(timeSignatures)) {
+          throw new Error("The time signatures are invalid.");
+        }
         if (transport == undefined) {
           throw new Error("transport is undefined.");
         }


### PR DESCRIPTION
## 内容

`COMMAND_IMPORT_TRACKS` の action に `isValidTpqn` / `isValidTempos` / `isValidTimeSignatures` の3つのバリデーションを追加します。

このコマンドの mutation は `SET_TPQN` / `SET_TEMPOS` / `SET_TIME_SIGNATURES` の mutation を直接呼んで複数の更新を1つのコマンドとして束ねていますが、各 mutation に対応する action 側で行われていたバリデーションは束ねるときに引き継がれず、結果として TPQN・テンポ・拍子の検証がすり抜けていました。今回の変更では、束ねる側である `COMMAND_IMPORT_TRACKS` の action でも同じバリデーションを行うことで、他のコマンドと同様の検証方針に揃えます。

## 関連 Issue

ref #2891

## その他
