### PR TITLE
feat: 音素タイミングエディターにノート表示を追加

### DIFF
--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -87,7 +87,7 @@ const render = () => {
   assertNonNullable(noteTextStyles);
 
   const notes = selectedTrackNotes.value;
-  const scaleX = store.state.sequencerZoomX;
+  const scaleX = props.viewportInfo.scaleX;
   const offsetXValue = props.viewportInfo.offsetX;
   const colors = noteColors.value;
   const currentTextStyle = isDark.value
@@ -225,7 +225,7 @@ watch(
     tpqn,
     defaultLyricMode,
     isDark,
-    () => store.state.sequencerZoomX,
+    () => props.viewportInfo.scaleX,
     () => props.viewportInfo.offsetX,
   ],
   ([mounted]) => {

--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -162,6 +162,7 @@ const render = () => {
       getDefaultLyric(rawNote.noteNumber, defaultLyricMode.value);
     if (textIndex >= texts.length) {
       const newText = new PIXI.Text({ text: "", style: currentTextStyle });
+      newText.anchor.set(0, 0.5);
       const container = new PIXI.Container();
       const mask = new PIXI.Graphics();
 
@@ -177,7 +178,6 @@ const render = () => {
     textIndex++;
 
     text.text = lyric;
-    text.anchor.set(0, 0.5);
 
     const textContainer = getOrThrow(textContainersMap, text);
     textContainer.renderable = true;

--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -48,13 +48,14 @@ const noteColors = computed(() =>
   isDark.value ? noteColorStyles.dark : noteColorStyles.light,
 );
 
-const noteTextStyles: {
-  light: PIXI.TextStyle;
-  dark: PIXI.TextStyle;
+const noteTextStyleSpecs: {
+  light: { fill: string };
+  dark: { fill: string };
 } = {
-  light: new PIXI.TextStyle({ fill: "#423e3f", fontSize: 14 }),
-  dark: new PIXI.TextStyle({ fill: "#bfbbbc", fontSize: 14 }),
+  light: { fill: "#423e3f" },
+  dark: { fill: "#bfbbbc" },
 };
+let noteTextStyles: { light: PIXI.TextStyle; dark: PIXI.TextStyle } | undefined;
 
 const selectedTrackNotes = computed(() => selectedTrack.value.notes);
 
@@ -83,6 +84,7 @@ const render = () => {
   assertNonNullable(stage);
   assertNonNullable(canvasWidth);
   assertNonNullable(canvasHeight);
+  assertNonNullable(noteTextStyles);
 
   const notes = selectedTrackNotes.value;
   const scaleX = store.state.sequencerZoomX;
@@ -241,6 +243,23 @@ onMounted(async () => {
 
   canvasWidth = canvasContainerElement.clientWidth;
   canvasHeight = canvasContainerElement.clientHeight;
+
+  // アプリのフォントをPIXIのテキストスタイルに反映する
+  // NOTE: フォントの変更に対応していないが、基本的にフォントが変更されることは少ないので、
+  // 複雑性を下げるためにも対応しない
+  const fontFamily = window.getComputedStyle(canvasContainerElement).fontFamily;
+  noteTextStyles = {
+    light: new PIXI.TextStyle({
+      ...noteTextStyleSpecs.light,
+      fontFamily,
+      fontSize: 14,
+    }),
+    dark: new PIXI.TextStyle({
+      ...noteTextStyleSpecs.dark,
+      fontFamily,
+      fontSize: 14,
+    }),
+  };
 
   renderer = await PIXI.autoDetectRenderer({
     canvas: canvasElement,

--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -294,7 +294,10 @@ onMounted(async () => {
       canvasWidth = canvasContainerWidth;
       canvasHeight = canvasContainerHeight;
       renderer.resize(canvasWidth, canvasHeight);
-      renderInNextFrame = true;
+      // 次フレームに描画を持ち越すとリサイズ直後の空canvasが一瞬表示されて点滅するため、
+      // ペイント前のResizeObserverコールバック内で同期的に描画する
+      renderInNextFrame = false;
+      render();
     }
   });
   resizeObserver.observe(canvasContainerElement);

--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -115,8 +115,8 @@ const render = () => {
   let graphicsIndex = 0;
   let textIndex = 0;
 
-  // マスク計算で使うノートの位置情報
-  const notePositions: { screenStartX: number; text: PIXI.Text }[] = [];
+  // マスク計算で使うテキストの位置情報
+  const textPositions: { textX: number; text: PIXI.Text }[] = [];
 
   // 各ノートを描画
   for (const note of notes) {
@@ -184,21 +184,21 @@ const render = () => {
     textContainer.x = screenStartX + 3;
     textContainer.y = canvasHeight / 2;
 
-    notePositions.push({ screenStartX: textContainer.x, text });
+    textPositions.push({ textX: textContainer.x, text });
   }
 
   // 各テキストが次のテキストと重ならないようにマスクをかける
-  for (let i = 0; i < notePositions.length; i++) {
-    const { screenStartX, text } = notePositions[i];
+  for (let i = 0; i < textPositions.length; i++) {
+    const { textX, text } = textPositions[i];
     const textMask = getOrThrow(textMasksMap, text);
 
     // デフォルトのマスク幅
     let maskWidth = 36;
 
     // 次のテキストがある場合、その位置までに制限
-    if (i + 1 < notePositions.length) {
-      const nextScreenStartX = notePositions[i + 1].screenStartX;
-      maskWidth = clamp(nextScreenStartX - screenStartX, 0, maskWidth);
+    if (i + 1 < textPositions.length) {
+      const nextTextX = textPositions[i + 1].textX;
+      maskWidth = clamp(nextTextX - textX, 0, maskWidth);
     }
 
     const maskHeight = 36;

--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -13,6 +13,7 @@ import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
 import { getDefaultLyric } from "@/sing/domain";
 import { getOrThrow } from "@/helpers/mapHelper";
 import { clamp } from "@/sing/utility";
+import { assertNonNullable } from "@/type/utility";
 
 const props = defineProps<{
   viewportInfo: ViewportInfo;
@@ -78,18 +79,10 @@ let requestId: number | undefined;
 let renderInNextFrame = false;
 
 const render = () => {
-  if (renderer == undefined) {
-    throw new Error("renderer is undefined.");
-  }
-  if (stage == undefined) {
-    throw new Error("stage is undefined.");
-  }
-  if (canvasWidth == undefined) {
-    throw new Error("canvasWidth is undefined.");
-  }
-  if (canvasHeight == undefined) {
-    throw new Error("canvasHeight is undefined.");
-  }
+  assertNonNullable(renderer);
+  assertNonNullable(stage);
+  assertNonNullable(canvasWidth);
+  assertNonNullable(canvasHeight);
 
   const notes = selectedTrackNotes.value;
   const scaleX = store.state.sequencerZoomX;
@@ -243,12 +236,8 @@ watch(
 onMounted(async () => {
   const canvasContainerElement = canvasContainer.value;
   const canvasElement = canvas.value;
-  if (canvasContainerElement == undefined) {
-    throw new Error("canvasContainerElement is null.");
-  }
-  if (canvasElement == undefined) {
-    throw new Error("canvasElement is null.");
-  }
+  assertNonNullable(canvasContainerElement);
+  assertNonNullable(canvasElement);
 
   canvasWidth = canvasContainerElement.clientWidth;
   canvasHeight = canvasContainerElement.clientHeight;
@@ -278,9 +267,7 @@ onMounted(async () => {
   requestId = window.requestAnimationFrame(callback);
 
   resizeObserver = new ResizeObserver(() => {
-    if (renderer == undefined) {
-      throw new Error("renderer is undefined.");
-    }
+    assertNonNullable(renderer);
     const canvasContainerWidth = canvasContainerElement.clientWidth;
     const canvasContainerHeight = canvasContainerElement.clientHeight;
 

--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -1,0 +1,329 @@
+<template>
+  <div ref="canvasContainer" class="canvas-container">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, computed, onUnmounted, onMounted, toRaw } from "vue";
+import * as PIXI from "pixi.js";
+import { useStore } from "@/store";
+import { useMounted } from "@/composables/useMounted";
+import {
+  getDoremiFromNoteNumber,
+  tickToBaseX,
+  type ViewportInfo,
+} from "@/sing/viewHelper";
+import { getOrThrow } from "@/helpers/mapHelper";
+import { clamp } from "@/sing/utility";
+
+const props = defineProps<{
+  viewportInfo: ViewportInfo;
+}>();
+
+const store = useStore();
+const tpqn = computed(() => store.state.tpqn);
+const isDark = computed(() => store.state.currentTheme === "Dark");
+const selectedTrack = computed(() => store.getters.SELECTED_TRACK);
+
+type ColorStyle = {
+  noteFill: number;
+  noteBorder: number;
+};
+
+const noteColorStyles: {
+  light: ColorStyle;
+  dark: ColorStyle;
+} = {
+  light: {
+    noteFill: 0xdfe3e0,
+    noteBorder: 0xffffff,
+  },
+  dark: {
+    noteFill: 0x363936,
+    noteBorder: 0x262728,
+  },
+};
+
+const noteColors = computed(() =>
+  isDark.value ? noteColorStyles.dark : noteColorStyles.light,
+);
+
+const noteTextStyles: {
+  light: PIXI.TextStyle;
+  dark: PIXI.TextStyle;
+} = {
+  light: new PIXI.TextStyle({ fill: "#423e3f", fontSize: 14 }),
+  dark: new PIXI.TextStyle({ fill: "#bfbbbc", fontSize: 14 }),
+};
+
+const selectedTrackNotes = computed(() => selectedTrack.value.notes);
+
+const { mounted } = useMounted();
+
+const canvasContainer = ref<HTMLElement | null>(null);
+const canvas = ref<HTMLCanvasElement | null>(null);
+let resizeObserver: ResizeObserver | undefined;
+let canvasWidth: number | undefined;
+let canvasHeight: number | undefined;
+
+// TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
+let isUnmounted = false;
+let renderer: PIXI.Renderer | undefined;
+let stage: PIXI.Container | undefined;
+const graphics: PIXI.Graphics[] = [];
+const texts: PIXI.Text[] = [];
+const textContainersMap = new Map<PIXI.Text, PIXI.Container>();
+const textMasksMap = new Map<PIXI.Text, PIXI.Graphics>();
+let lastIsDark: boolean | undefined;
+let requestId: number | undefined;
+let renderInNextFrame = false;
+
+const render = () => {
+  if (renderer == undefined) {
+    throw new Error("renderer is undefined.");
+  }
+  if (stage == undefined) {
+    throw new Error("stage is undefined.");
+  }
+  if (canvasWidth == undefined) {
+    throw new Error("canvasWidth is undefined.");
+  }
+  if (canvasHeight == undefined) {
+    throw new Error("canvasHeight is undefined.");
+  }
+
+  const notes = selectedTrackNotes.value;
+  const scaleX = store.state.sequencerZoomX;
+  const offsetXValue = props.viewportInfo.offsetX;
+  const colors = noteColors.value;
+  const currentTextStyle = isDark.value
+    ? noteTextStyles.dark
+    : noteTextStyles.light;
+
+  // テーマが変わるとテキストスタイルも変わるため、既存のテキストオブジェクトを全て破棄する
+  if (lastIsDark != undefined && lastIsDark !== isDark.value) {
+    for (const text of texts) {
+      const container = getOrThrow(textContainersMap, text);
+      stage.removeChild(container);
+      container.destroy(true);
+    }
+    texts.length = 0;
+    textContainersMap.clear();
+    textMasksMap.clear();
+  }
+  lastIsDark = isDark.value;
+
+  let graphicsIndex = 0;
+  let textIndex = 0;
+
+  // マスク計算で使うノートの位置情報
+  const notePositions: { screenStartX: number; text: PIXI.Text }[] = [];
+
+  // 各ノートを描画
+  for (const note of notes) {
+    const rawNote = toRaw(note);
+
+    // 位置とサイズを計算
+    const baseStartX = tickToBaseX(rawNote.position, tpqn.value);
+    const baseEndX = tickToBaseX(
+      rawNote.position + rawNote.duration,
+      tpqn.value,
+    );
+    const screenStartX = Math.round(baseStartX * scaleX - offsetXValue);
+    const screenEndX = Math.round(baseEndX * scaleX - offsetXValue);
+    const screenWidth = screenEndX - screenStartX;
+
+    // 画面外のノートは描画しない
+    const noteRight = screenStartX + screenWidth;
+    if (screenWidth < 1 || noteRight < 0 || screenStartX > canvasWidth) {
+      continue;
+    }
+
+    // Graphicsは使い回し、足りない分だけ作成する
+    if (graphicsIndex >= graphics.length) {
+      const newGraphic = new PIXI.Graphics();
+      stage.addChild(newGraphic);
+      graphics.push(newGraphic);
+    }
+    const graphic = graphics[graphicsIndex];
+    graphicsIndex++;
+
+    // ノートの長方形を描画
+    // 選択中のノートも同じ色で描画する
+    graphic.renderable = true;
+    graphic.clear();
+    graphic
+      .roundRect(screenStartX - 0.5, 0.5, screenWidth, canvasHeight - 1, 5)
+      .fill({ color: colors.noteFill, alpha: 1 })
+      .stroke({ width: 1, color: colors.noteBorder, alpha: 1 });
+
+    // ノートの歌詞をテキストで描画
+    const lyric = rawNote.lyric ?? getDoremiFromNoteNumber(rawNote.noteNumber);
+    if (textIndex >= texts.length) {
+      const newText = new PIXI.Text({ text: "", style: currentTextStyle });
+      const container = new PIXI.Container();
+      const mask = new PIXI.Graphics();
+
+      container.mask = mask;
+      container.addChild(newText);
+      container.addChild(mask);
+      stage.addChild(container);
+      texts.push(newText);
+      textContainersMap.set(newText, container);
+      textMasksMap.set(newText, mask);
+    }
+    const text = texts[textIndex];
+    textIndex++;
+
+    text.text = lyric;
+    text.anchor.set(0, 0.5);
+
+    const textContainer = getOrThrow(textContainersMap, text);
+    textContainer.renderable = true;
+    textContainer.x = screenStartX + 3;
+    textContainer.y = canvasHeight / 2;
+
+    notePositions.push({ screenStartX: textContainer.x, text });
+  }
+
+  // 各テキストが次のテキストと重ならないようにマスクをかける
+  for (let i = 0; i < notePositions.length; i++) {
+    const { screenStartX, text } = notePositions[i];
+    const textMask = getOrThrow(textMasksMap, text);
+
+    // デフォルトのマスク幅
+    let maskWidth = 36;
+
+    // 次のテキストがある場合、その位置までに制限
+    if (i + 1 < notePositions.length) {
+      const nextScreenStartX = notePositions[i + 1].screenStartX;
+      maskWidth = clamp(nextScreenStartX - screenStartX, 0, maskWidth);
+    }
+
+    const maskHeight = 36;
+
+    textMask
+      .clear()
+      .rect(0, -maskHeight / 2, maskWidth, maskHeight)
+      .fill({ color: 0xffffff });
+  }
+
+  // 未使用のグラフィックスとテキストを非表示
+  for (let i = graphicsIndex; i < graphics.length; i++) {
+    graphics[i].renderable = false;
+  }
+  for (let i = textIndex; i < texts.length; i++) {
+    const text = texts[i];
+    const textContainer = getOrThrow(textContainersMap, text);
+    textContainer.renderable = false;
+  }
+
+  renderer.render(stage);
+};
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch([mounted, selectedTrackNotes, tpqn], ([mounted]) => {
+  if (mounted) {
+    renderInNextFrame = true;
+  }
+});
+
+watch(isDark, () => {
+  renderInNextFrame = true;
+});
+
+watch(
+  () => [store.state.sequencerZoomX, props.viewportInfo.offsetX],
+  () => {
+    renderInNextFrame = true;
+  },
+);
+
+onMounted(async () => {
+  const canvasContainerElement = canvasContainer.value;
+  const canvasElement = canvas.value;
+  if (canvasContainerElement == undefined) {
+    throw new Error("canvasContainerElement is null.");
+  }
+  if (canvasElement == undefined) {
+    throw new Error("canvasElement is null.");
+  }
+
+  canvasWidth = canvasContainerElement.clientWidth;
+  canvasHeight = canvasContainerElement.clientHeight;
+
+  renderer = await PIXI.autoDetectRenderer({
+    canvas: canvasElement,
+    backgroundAlpha: 0,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+    width: canvasWidth,
+    height: canvasHeight,
+  });
+  if (isUnmounted) {
+    renderer.destroy({ removeView: true });
+    return;
+  }
+  stage = new PIXI.Container();
+
+  const callback = () => {
+    if (renderInNextFrame) {
+      render();
+      renderInNextFrame = false;
+    }
+    requestId = window.requestAnimationFrame(callback);
+  };
+  requestId = window.requestAnimationFrame(callback);
+
+  resizeObserver = new ResizeObserver(() => {
+    if (renderer == undefined) {
+      throw new Error("renderer is undefined.");
+    }
+    const canvasContainerWidth = canvasContainerElement.clientWidth;
+    const canvasContainerHeight = canvasContainerElement.clientHeight;
+
+    if (canvasContainerWidth > 0 && canvasContainerHeight > 0) {
+      canvasWidth = canvasContainerWidth;
+      canvasHeight = canvasContainerHeight;
+      renderer.resize(canvasWidth, canvasHeight);
+      renderInNextFrame = true;
+    }
+  });
+  resizeObserver.observe(canvasContainerElement);
+});
+
+onUnmounted(() => {
+  isUnmounted = true;
+
+  if (requestId != undefined) {
+    window.cancelAnimationFrame(requestId);
+  }
+
+  for (const graphic of graphics) {
+    stage?.removeChild(graphic);
+    graphic.destroy();
+  }
+  for (const text of texts) {
+    const container = getOrThrow(textContainersMap, text);
+    stage?.removeChild(container);
+    container.destroy(true);
+  }
+  textContainersMap.clear();
+  textMasksMap.clear();
+  stage?.destroy(true);
+  renderer?.destroy({ removeView: true });
+  resizeObserver?.disconnect();
+});
+</script>
+
+<style scoped lang="scss">
+.canvas-container {
+  overflow: hidden;
+  pointer-events: none;
+  position: relative;
+
+  contain: strict; // canvasのサイズが変わるのを無視する
+}
+</style>

--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -9,11 +9,8 @@ import { ref, watch, computed, onUnmounted, onMounted, toRaw } from "vue";
 import * as PIXI from "pixi.js";
 import { useStore } from "@/store";
 import { useMounted } from "@/composables/useMounted";
-import {
-  getDoremiFromNoteNumber,
-  tickToBaseX,
-  type ViewportInfo,
-} from "@/sing/viewHelper";
+import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
+import { getDefaultLyric } from "@/sing/domain";
 import { getOrThrow } from "@/helpers/mapHelper";
 import { clamp } from "@/sing/utility";
 
@@ -24,6 +21,7 @@ const props = defineProps<{
 const store = useStore();
 const tpqn = computed(() => store.state.tpqn);
 const isDark = computed(() => store.state.currentTheme === "Dark");
+const defaultLyricMode = computed(() => store.state.defaultLyricMode);
 const selectedTrack = computed(() => store.getters.SELECTED_TRACK);
 
 type ColorStyle = {
@@ -159,7 +157,9 @@ const render = () => {
       .stroke({ width: 1, color: colors.noteBorder, alpha: 1 });
 
     // ノートの歌詞をテキストで描画
-    const lyric = rawNote.lyric ?? getDoremiFromNoteNumber(rawNote.noteNumber);
+    const lyric =
+      rawNote.lyric ??
+      getDefaultLyric(rawNote.noteNumber, defaultLyricMode.value);
     if (textIndex >= texts.length) {
       const newText = new PIXI.Text({ text: "", style: currentTextStyle });
       const container = new PIXI.Container();
@@ -223,11 +223,14 @@ const render = () => {
 };
 
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
-watch([mounted, selectedTrackNotes, tpqn], ([mounted]) => {
-  if (mounted) {
-    renderInNextFrame = true;
-  }
-});
+watch(
+  [mounted, selectedTrackNotes, tpqn, defaultLyricMode],
+  ([mounted]) => {
+    if (mounted) {
+      renderInNextFrame = true;
+    }
+  },
+);
 
 watch(isDark, () => {
   renderInNextFrame = true;

--- a/src/components/Sing/SequencerNoteTimings.vue
+++ b/src/components/Sing/SequencerNoteTimings.vue
@@ -224,22 +224,19 @@ const render = () => {
 
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
 watch(
-  [mounted, selectedTrackNotes, tpqn, defaultLyricMode],
+  [
+    mounted,
+    selectedTrackNotes,
+    tpqn,
+    defaultLyricMode,
+    isDark,
+    () => store.state.sequencerZoomX,
+    () => props.viewportInfo.offsetX,
+  ],
   ([mounted]) => {
     if (mounted) {
       renderInNextFrame = true;
     }
-  },
-);
-
-watch(isDark, () => {
-  renderInNextFrame = true;
-});
-
-watch(
-  () => [store.state.sequencerZoomX, props.viewportInfo.offsetX],
-  () => {
-    renderInNextFrame = true;
   },
 );
 

--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -4,6 +4,7 @@
     <div class="parameter-area">
       <SequencerParameterGrid class="parameter-grid" :viewportInfo />
       <SequencerWaveform class="waveform" :viewportInfo />
+      <SequencerNoteTimings class="note-timings" :viewportInfo />
     </div>
   </div>
 </template>
@@ -12,6 +13,7 @@
 import type { ViewportInfo } from "@/sing/viewHelper";
 import SequencerParameterGrid from "@/components/Sing/SequencerParameterGrid.vue";
 import SequencerWaveform from "@/components/Sing/SequencerWaveform.vue";
+import SequencerNoteTimings from "@/components/Sing/SequencerNoteTimings.vue";
 
 defineProps<{
   viewportInfo: ViewportInfo;
@@ -52,5 +54,10 @@ defineProps<{
 .waveform {
   grid-column: 1;
   grid-row: 4 / 5;
+}
+
+.note-timings {
+  grid-column: 1;
+  grid-row: 2 / 3;
 }
 </style>

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -36,7 +36,7 @@ const tpqn = computed(() => store.state.tpqn);
 const tempos = computed(() => store.state.tempos);
 const isDark = computed(() => store.state.currentTheme === "Dark");
 const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
-const scaleX = computed(() => store.state.sequencerZoomX);
+const scaleX = computed(() => props.viewportInfo.scaleX);
 
 type AudioEventId = SequenceId;
 


### PR DESCRIPTION
## 内容

音素タイミング編集機能の実装の一部として、音素タイミング編集エリア（SequencerPhonemeTimingEditor）にノートを表示するコンポーネントを追加します。
音素タイミング自体の表示や、編集操作（ドラッグによるタイミング変更など）は後続のPRで実装予定です。

PixiJSによる描画で、描画まわりの骨組み（描画ループやリサイズ対応など）は既存のシーケンサー系コンポーネントと同じです。

### ノートの表示（SequencerNoteTimings.vue）

選択トラックのノートを、ピアノロール側と同じく矩形と歌詞テキストで描画します。音素タイミング編集エリアでは編集対象がノートではなく音素タイミングなので、表示専用とし、選択中・非選択中のスタイルの区別は持たせていません。

実装面のポイントは次のとおりです。

- 歌詞テキストは隣接ノートと重ならないよう、次のノートの開始Xまでをマスク幅としている
- 画面外のノートはスキップし、PIXI.Graphics / PIXI.Text オブジェクトはプールして使い回している

## 関連 Issue

- VOICEVOX/voicevox#2261

## スクリーンショット・動画など

<img width="781" height="427" alt="image" src="https://github.com/user-attachments/assets/bda04018-8261-4642-8104-a4f7bdf3a966" />

## その他

今回追加した表示は、パラメータパネルの切り替えスイッチで音素タイミングを選ぶと確認できます（現時点ではこのエリアに波形とノートが表示され、音素タイミングの表示は後続PRで追加されます）。
