### PR TITLE
fix: シーケンサキャンバスのリサイズ時の点滅を修正する

### DIFF
--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -245,8 +245,7 @@ onMounted(async () => {
       canvasWidth = canvasContainerWidth;
       canvasHeight = canvasContainerHeight;
       renderer.resize(canvasWidth, canvasHeight);
-      // 次フレームに描画を持ち越すとリサイズ直後の空canvasが一瞬表示されて点滅するため、
-      // ペイント前のResizeObserverコールバック内で同期的に描画する
+      // NOTE: 次フレームで再描画するとちらついてしまうため、同期的に再描画する
       renderInNextFrame = false;
       render();
     }

--- a/src/components/Sing/SequencerParameterGrid.vue
+++ b/src/components/Sing/SequencerParameterGrid.vue
@@ -245,7 +245,10 @@ onMounted(async () => {
       canvasWidth = canvasContainerWidth;
       canvasHeight = canvasContainerHeight;
       renderer.resize(canvasWidth, canvasHeight);
-      renderInNextFrame = true;
+      // 次フレームに描画を持ち越すとリサイズ直後の空canvasが一瞬表示されて点滅するため、
+      // ペイント前のResizeObserverコールバック内で同期的に描画する
+      renderInNextFrame = false;
+      render();
     }
   });
   resizeObserver.observe(canvasContainerElement);

--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -413,8 +413,7 @@ onMounted(async () => {
       canvasWidth = canvasContainerWidth;
       canvasHeight = canvasContainerHeight;
       renderer.resize(canvasWidth, canvasHeight);
-      // 次フレームに描画を持ち越すとリサイズ直後の空canvasが一瞬表示されて点滅するため、
-      // ペイント前のResizeObserverコールバック内で同期的に描画する
+      // NOTE: 次フレームで再描画するとちらついてしまうため、同期的に再描画する
       renderInNextFrame = false;
       render();
     }

--- a/src/components/Sing/SequencerPitch.vue
+++ b/src/components/Sing/SequencerPitch.vue
@@ -413,7 +413,10 @@ onMounted(async () => {
       canvasWidth = canvasContainerWidth;
       canvasHeight = canvasContainerHeight;
       renderer.resize(canvasWidth, canvasHeight);
-      renderInNextFrame = true;
+      // 次フレームに描画を持ち越すとリサイズ直後の空canvasが一瞬表示されて点滅するため、
+      // ペイント前のResizeObserverコールバック内で同期的に描画する
+      renderInNextFrame = false;
+      render();
     }
   });
   resizeObserver.observe(canvasContainerElement);

--- a/src/components/Sing/SequencerVolumeEditor.vue
+++ b/src/components/Sing/SequencerVolumeEditor.vue
@@ -733,8 +733,9 @@ onMounted(async () => {
       viewportWidth.value = width;
       viewportHeight.value = height;
       renderer.resize(width, height);
-      render();
+      // NOTE: 次フレームで再描画するとちらついてしまうため、同期的に再描画する
       renderInNextFrame = false;
+      render();
     }
   });
   resizeObserver.observe(containerEl);

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -445,7 +445,10 @@ onMounted(async () => {
       canvasWidth = canvasContainerWidth;
       canvasHeight = canvasContainerHeight;
       renderer.resize(canvasWidth, canvasHeight);
-      renderInNextFrame = true;
+      // 次フレームに描画を持ち越すとリサイズ直後の空canvasが一瞬表示されて点滅するため、
+      // ペイント前のResizeObserverコールバック内で同期的に描画する
+      renderInNextFrame = false;
+      render();
     }
   });
   resizeObserver.observe(canvasContainerElement);

--- a/src/components/Sing/SequencerWaveform.vue
+++ b/src/components/Sing/SequencerWaveform.vue
@@ -445,8 +445,7 @@ onMounted(async () => {
       canvasWidth = canvasContainerWidth;
       canvasHeight = canvasContainerHeight;
       renderer.resize(canvasWidth, canvasHeight);
-      // 次フレームに描画を持ち越すとリサイズ直後の空canvasが一瞬表示されて点滅するため、
-      // ペイント前のResizeObserverコールバック内で同期的に描画する
+      // NOTE: 次フレームで再描画するとちらついてしまうため、同期的に再描画する
       renderInNextFrame = false;
       render();
     }


### PR DESCRIPTION
## 内容

シーケンサの波形表示とパラメータ欄で、パラメータ欄の縦幅を変えたときに表示が一瞬空になって点滅していた問題を修正します。

`SequencerWaveform.vue`、`SequencerParameterGrid.vue`、`SequencerPitch.vue` の `ResizeObserver` コールバック内で、リサイズ後の再描画を次フレームに持ち越さずにその場で同期的に呼ぶように変更しました。

`<canvas>` は `width` と `height` を変えるとピクセルバッファがクリアされる仕様のため、`requestAnimationFrame` で次フレームに描画を委ねていると、リサイズ直後に空の canvas が表示されるフレームが挟まって点滅して見えていました。
`ResizeObserver` のコールバックはレイアウト後・ペイント前に呼ばれるため、その中で同期描画すれば空フレームを挟まずに済みます。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/3050#pullrequestreview-4536651842

## その他
