### PR TITLE
feat: 音素タイミングエディターに音素タイミング表示を追加

### DIFF
--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -9,6 +9,7 @@
         class="phoneme-timings"
         :viewportInfo
         :phonemeTimingInfos
+        :phonemeTextY
       />
     </div>
   </div>
@@ -50,6 +51,18 @@ const phonemeTimingInfos = computed(() => {
     phonemeTimingEditData.value,
   );
 });
+
+// parameter-areaの各行の高さ
+const TOP_ROW_HEIGHT = 12;
+const NOTES_ROW_HEIGHT = 26;
+const PHONEME_TEXTS_ROW_HEIGHT = 28;
+
+// 音素文字行内での音素文字の上端オフセット
+const PHONEME_TEXT_TOP_OFFSET_IN_ROW = 12;
+
+// SequencerPhonemeTimingsの音素文字のY座標
+const phonemeTextY =
+  TOP_ROW_HEIGHT + NOTES_ROW_HEIGHT + PHONEME_TEXT_TOP_OFFSET_IN_ROW;
 </script>
 
 <style scoped lang="scss">
@@ -75,7 +88,11 @@ const phonemeTimingInfos = computed(() => {
   position: relative;
 
   display: grid;
-  grid-template-rows: 12px 26px 28px 1fr;
+  grid-template-rows:
+    v-bind("`${TOP_ROW_HEIGHT}px`")
+    v-bind("`${NOTES_ROW_HEIGHT}px`")
+    v-bind("`${PHONEME_TEXTS_ROW_HEIGHT}px`")
+    1fr;
 }
 
 .parameter-grid {

--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -5,19 +5,51 @@
       <SequencerParameterGrid class="parameter-grid" :viewportInfo />
       <SequencerWaveform class="waveform" :viewportInfo />
       <SequencerNoteTimings class="note-timings" :viewportInfo />
+      <SequencerPhonemeTimings
+        class="phoneme-timings"
+        :viewportInfo
+        :phonemeTimingInfos
+      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import type { ViewportInfo } from "@/sing/viewHelper";
+import { useStore } from "@/store";
 import SequencerParameterGrid from "@/components/Sing/SequencerParameterGrid.vue";
 import SequencerWaveform from "@/components/Sing/SequencerWaveform.vue";
+import SequencerPhonemeTimings from "@/components/Sing/SequencerPhonemeTimings.vue";
 import SequencerNoteTimings from "@/components/Sing/SequencerNoteTimings.vue";
+import {
+  computePhonemeTimingInfos,
+  getPhraseInfosForTrack,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
+
+const store = useStore();
 
 defineProps<{
   viewportInfo: ViewportInfo;
 }>();
+
+const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
+const phonemeTimingEditData = computed(
+  () => store.getters.SELECTED_TRACK.phonemeTimingEditData,
+);
+const phraseInfos = computed(() =>
+  getPhraseInfosForTrack(
+    store.state.phrases,
+    store.state.phraseQueries,
+    selectedTrackId.value,
+  ),
+);
+const phonemeTimingInfos = computed(() => {
+  return computePhonemeTimingInfos(
+    phraseInfos.value,
+    phonemeTimingEditData.value,
+  );
+});
 </script>
 
 <style scoped lang="scss">
@@ -59,5 +91,10 @@ defineProps<{
 .note-timings {
   grid-column: 1;
   grid-row: 2 / 3;
+}
+
+.phoneme-timings {
+  grid-column: 1;
+  grid-row: 1 / 5;
 }
 </style>

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -1,0 +1,420 @@
+<template>
+  <div ref="canvasContainer" class="canvas-container">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, computed, onUnmounted, onMounted, toRaw } from "vue";
+import * as PIXI from "pixi.js";
+import { useStore } from "@/store";
+import { useMounted } from "@/composables/useMounted";
+import { secondToTick } from "@/sing/music";
+import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
+import { clamp, getNext } from "@/sing/utility";
+import { getOrThrow } from "@/helpers/mapHelper";
+import { UnreachableError } from "@/type/utility";
+import type { PhonemeTimingInfo } from "@/sing/phonemeTimingEditorStateMachine/common";
+
+type PhonemeDisplayState = "default" | "edited";
+
+type PhonemeDisplayInfo = {
+  readonly phoneme: string;
+  readonly displayState: PhonemeDisplayState;
+  startTime: number;
+};
+
+const props = defineProps<{
+  viewportInfo: ViewportInfo;
+  phonemeTimingInfos: PhonemeTimingInfo[];
+}>();
+
+const store = useStore();
+const tpqn = computed(() => store.state.tpqn);
+const isDark = computed(() => store.state.currentTheme === "Dark");
+const tempos = computed(() => store.state.tempos);
+const phonemeTimingInfos = computed(() => props.phonemeTimingInfos);
+
+type PhonemeTimingLineStyle = { color: number; alpha: number; width: number };
+const phonemeTimingLineStyles: Record<
+  "light" | "dark",
+  Record<PhonemeDisplayState, PhonemeTimingLineStyle>
+> = {
+  light: {
+    default: { color: 0x8bc796, alpha: 1, width: 1 },
+    edited: { color: 0x00a73f, alpha: 1, width: 2 },
+  },
+  dark: {
+    default: { color: 0x547359, alpha: 1, width: 1 },
+    edited: { color: 0x28a652, alpha: 1, width: 2 },
+  },
+};
+
+const phonemeTextStyles: {
+  light: PIXI.TextStyle;
+  dark: PIXI.TextStyle;
+} = {
+  light: new PIXI.TextStyle({ fill: "#252E26", fontSize: 14 }),
+  dark: new PIXI.TextStyle({ fill: "#ccc8c9", fontSize: 14 }),
+};
+
+const { mounted } = useMounted();
+
+const canvasContainer = ref<HTMLElement | null>(null);
+const canvas = ref<HTMLCanvasElement | null>(null);
+
+let resizeObserver: ResizeObserver | undefined;
+let canvasWidth: number | undefined;
+let canvasHeight: number | undefined;
+
+// TODO: pixi.js関連の変数をまとめてモジュール化し、isUnmountedなどのフラグを無くす
+let isUnmounted = false;
+let renderer: PIXI.Renderer | undefined;
+let stage: PIXI.Container | undefined;
+
+// 線描画用のGraphicsプール
+const graphics: PIXI.Graphics[] = [];
+// 音素文字をキーとしたTextオブジェクトのプール
+const textsMap = new Map<string, PIXI.Text[]>();
+// Textにマスクを適用するためのContainerのマップ
+const textContainersMap = new Map<PIXI.Text, PIXI.Container>();
+// Textごとのマスク用Graphicsマップ
+const textMasksMap = new Map<PIXI.Text, PIXI.Graphics>();
+
+let lastIsDark: boolean | undefined;
+let requestId: number | undefined;
+let renderInNextFrame = false;
+
+const render = () => {
+  if (renderer == undefined) {
+    throw new Error("renderer is undefined.");
+  }
+  if (stage == undefined) {
+    throw new Error("stage is undefined.");
+  }
+  if (canvasWidth == undefined) {
+    throw new Error("canvasWidth is undefined.");
+  }
+  if (canvasHeight == undefined) {
+    throw new Error("canvasHeight is undefined.");
+  }
+
+  const rawTempos = toRaw(tempos.value);
+  const rawPhonemeTimingInfos = toRaw(phonemeTimingInfos.value);
+  const viewportInfo = props.viewportInfo;
+  const editorFrameRate = store.state.editorFrameRate;
+  const oneFrameSeconds = 1 / editorFrameRate;
+
+  const currentTextStyle = isDark.value
+    ? phonemeTextStyles.dark
+    : phonemeTextStyles.light;
+
+  // テーマが変わるとテキストスタイルも変わるため、既存のテキストオブジェクトを全て破棄する
+  if (lastIsDark != undefined && lastIsDark !== isDark.value) {
+    for (const texts of textsMap.values()) {
+      for (const text of texts) {
+        const container = getOrThrow(textContainersMap, text);
+        stage.removeChild(container);
+        container.destroy(true);
+      }
+    }
+    textsMap.clear();
+    textContainersMap.clear();
+    textMasksMap.clear();
+  }
+  lastIsDark = isDark.value;
+
+  // 描画用の情報を生成
+  const phonemeDisplayInfos: PhonemeDisplayInfo[] = [];
+  for (const phonemeTimingInfo of rawPhonemeTimingInfos) {
+    // 先頭のpauなどnoteIdが無い音素は描画しない
+    if (phonemeTimingInfo.noteId == undefined) {
+      continue;
+    }
+
+    const startTime = phonemeTimingInfo.editedStartTimeSeconds;
+
+    const displayState: PhonemeDisplayState = phonemeTimingInfo.isEdited
+      ? "edited"
+      : "default";
+
+    phonemeDisplayInfos.push({
+      phoneme: phonemeTimingInfo.phoneme,
+      displayState,
+      startTime,
+    });
+  }
+
+  // 音素の順序入れ替わり防止
+  // プレビュー等で音素の位置が変わると前後の音素と順序が入れ替わる可能性があるため、
+  // 表示上は前後の音素との順序を維持するよう制限する
+  for (let i = phonemeDisplayInfos.length - 1; i >= 0; i--) {
+    const phonemeDisplayInfo = phonemeDisplayInfos[i];
+    const nextPhonemeDisplayInfo = getNext(phonemeDisplayInfos, i);
+    if (nextPhonemeDisplayInfo != undefined) {
+      const maxStartTime = nextPhonemeDisplayInfo.startTime - oneFrameSeconds;
+      if (phonemeDisplayInfo.startTime > maxStartTime) {
+        phonemeDisplayInfo.startTime = maxStartTime;
+      }
+    }
+  }
+
+  // 画面外の音素を除外する
+  const cullingMargin = 40;
+  const culledPhonemeDisplayInfos: PhonemeDisplayInfo[] = [];
+  for (const phonemeDisplayInfo of phonemeDisplayInfos) {
+    const phonemeStartTicks = secondToTick(
+      phonemeDisplayInfo.startTime,
+      rawTempos,
+      tpqn.value,
+    );
+    const phonemeStartBaseX = tickToBaseX(phonemeStartTicks, tpqn.value);
+    const phonemeStartX = Math.round(
+      phonemeStartBaseX * viewportInfo.scaleX - viewportInfo.offsetX,
+    );
+    if (
+      phonemeStartX >= -cullingMargin &&
+      phonemeStartX <= canvasWidth + cullingMargin
+    ) {
+      culledPhonemeDisplayInfos.push(phonemeDisplayInfo);
+    }
+  }
+
+  // 線のGraphicsが足りなければ追加
+  while (graphics.length < culledPhonemeDisplayInfos.length) {
+    const newGraphic = new PIXI.Graphics();
+    stage.addChild(newGraphic);
+    graphics.push(newGraphic);
+  }
+
+  // 音素文字ごとに必要なテキスト数をカウント
+  const needTextCountMap = new Map<string, number>();
+  for (const phonemeDisplayInfo of culledPhonemeDisplayInfos) {
+    if (phonemeDisplayInfo.phoneme === "pau") {
+      continue;
+    }
+    const currentCount = needTextCountMap.get(phonemeDisplayInfo.phoneme) ?? 0;
+    needTextCountMap.set(phonemeDisplayInfo.phoneme, currentCount + 1);
+  }
+
+  // テキストオブジェクトが足りなければ追加生成
+  for (const [phonemeStr, needTextCount] of needTextCountMap) {
+    let texts = textsMap.get(phonemeStr);
+    if (texts == undefined) {
+      texts = [];
+      textsMap.set(phonemeStr, texts);
+    }
+
+    const currentTextCount = texts.length;
+    for (let i = 0; i < needTextCount - currentTextCount; i++) {
+      const text = new PIXI.Text({ text: phonemeStr, style: currentTextStyle });
+      const container = new PIXI.Container();
+      const mask = new PIXI.Graphics();
+
+      // 隣の音素にはみ出さないようにマスクを設定する
+      container.mask = mask;
+      container.addChild(text);
+      container.addChild(mask);
+      stage.addChild(container);
+
+      texts.push(text);
+      textContainersMap.set(text, container);
+      textMasksMap.set(text, mask);
+    }
+  }
+
+  // マスク幅の計算で次の音素のX座標が必要になるため、先に全てのX座標を計算しておく
+  const phonemeStartXArray: number[] = [];
+  for (const phonemeDisplayInfo of culledPhonemeDisplayInfos) {
+    const phonemeStartTicks = secondToTick(
+      phonemeDisplayInfo.startTime,
+      rawTempos,
+      tpqn.value,
+    );
+    const phonemeStartBaseX = tickToBaseX(phonemeStartTicks, tpqn.value);
+    const phonemeStartX = Math.round(
+      phonemeStartBaseX * viewportInfo.scaleX - viewportInfo.offsetX,
+    );
+    phonemeStartXArray.push(phonemeStartX);
+  }
+
+  // 未割り当てのTextを管理するため、プールをコピーした一時マップを作る
+  const unassignedTextsMap = new Map<string, PIXI.Text[]>();
+  for (const [phonemeStr, texts] of textsMap) {
+    unassignedTextsMap.set(phonemeStr, [...texts]);
+  }
+
+  // 線とテキストを更新
+  for (let i = 0; i < culledPhonemeDisplayInfos.length; i++) {
+    const phonemeDisplayInfo = culledPhonemeDisplayInfos[i];
+    const phonemeStartX = phonemeStartXArray[i];
+    const nextPhonemeStartX = getNext(phonemeStartXArray, i);
+
+    // 線の更新
+    const graphic = graphics[i];
+    graphic.renderable = true;
+    graphic.clear();
+
+    const themeStyles = isDark.value
+      ? phonemeTimingLineStyles.dark
+      : phonemeTimingLineStyles.light;
+    const lineStyle = themeStyles[phonemeDisplayInfo.displayState];
+
+    const lineX =
+      lineStyle.width % 2 === 1 ? phonemeStartX - 0.5 : phonemeStartX;
+    graphic.moveTo(lineX, 0).lineTo(lineX, canvasHeight).stroke({
+      width: lineStyle.width,
+      color: lineStyle.color,
+      alpha: lineStyle.alpha,
+    });
+
+    // テキストの更新
+    if (phonemeDisplayInfo.phoneme !== "pau") {
+      // プールから取得
+      const text = getOrThrow(
+        unassignedTextsMap,
+        phonemeDisplayInfo.phoneme,
+      ).pop();
+      if (text == undefined) {
+        throw new UnreachableError("text is undefined.");
+      }
+      const textContainer = getOrThrow(textContainersMap, text);
+      const textMask = getOrThrow(textMasksMap, text);
+
+      textContainer.renderable = true;
+      textContainer.x = phonemeStartX + 3; // 線から少し右にずらす
+      textContainer.y = 50;
+
+      // マスク幅の計算
+      let maskWidth = 36;
+      if (nextPhonemeStartX != undefined) {
+        maskWidth = clamp(
+          nextPhonemeStartX - textContainer.x - 1,
+          0,
+          maskWidth,
+        );
+      }
+      const maskHeight = 36;
+
+      // マスクの更新
+      textMask
+        .clear()
+        .rect(0, 0, maskWidth, maskHeight)
+        .fill({ color: 0xffffff });
+    }
+  }
+
+  // 余ったGraphicsを非表示
+  for (let i = culledPhonemeDisplayInfos.length; i < graphics.length; i++) {
+    graphics[i].renderable = false;
+  }
+  // 余ったTextContainerを非表示
+  for (const texts of unassignedTextsMap.values()) {
+    for (const text of texts) {
+      const textContainer = getOrThrow(textContainersMap, text);
+      textContainer.renderable = false;
+    }
+  }
+
+  renderer.render(stage);
+};
+
+// NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
+watch([mounted, phonemeTimingInfos, tempos, tpqn], ([mounted]) => {
+  if (mounted) {
+    renderInNextFrame = true;
+  }
+});
+
+watch(isDark, () => {
+  renderInNextFrame = true;
+});
+
+watch(
+  () => [props.viewportInfo.scaleX, props.viewportInfo.offsetX],
+  () => {
+    renderInNextFrame = true;
+  },
+);
+
+onMounted(async () => {
+  const canvasContainerElement = canvasContainer.value;
+  const canvasElement = canvas.value;
+  if (canvasContainerElement == undefined) {
+    throw new Error("canvasContainerElement is null.");
+  }
+  if (canvasElement == undefined) {
+    throw new Error("canvasElement is null.");
+  }
+
+  canvasWidth = canvasContainerElement.clientWidth;
+  canvasHeight = canvasContainerElement.clientHeight;
+
+  renderer = await PIXI.autoDetectRenderer({
+    canvas: canvasElement,
+    backgroundAlpha: 0,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+    width: canvasWidth,
+    height: canvasHeight,
+  });
+  if (isUnmounted) {
+    renderer.destroy({ removeView: true });
+    return;
+  }
+  stage = new PIXI.Container();
+
+  const callback = () => {
+    if (renderInNextFrame) {
+      render();
+      renderInNextFrame = false;
+    }
+    requestId = window.requestAnimationFrame(callback);
+  };
+  requestId = window.requestAnimationFrame(callback);
+
+  resizeObserver = new ResizeObserver(() => {
+    if (renderer == undefined) {
+      throw new Error("renderer is undefined.");
+    }
+
+    const newWidth = canvasContainerElement.clientWidth;
+    const newHeight = canvasContainerElement.clientHeight;
+
+    if (newWidth > 0 && newHeight > 0) {
+      canvasWidth = newWidth;
+      canvasHeight = newHeight;
+      renderer.resize(canvasWidth, canvasHeight);
+      renderInNextFrame = true;
+    }
+  });
+  resizeObserver.observe(canvasContainerElement);
+});
+
+onUnmounted(() => {
+  isUnmounted = true;
+
+  if (requestId != undefined) {
+    window.cancelAnimationFrame(requestId);
+  }
+
+  for (const graphic of graphics) {
+    stage?.removeChild(graphic);
+    graphic.destroy();
+  }
+  stage?.destroy(true);
+  renderer?.destroy({ removeView: true });
+  resizeObserver?.disconnect();
+});
+</script>
+
+<style scoped lang="scss">
+.canvas-container {
+  overflow: hidden;
+  pointer-events: none;
+  position: relative;
+
+  contain: strict; // canvasのサイズが変わるのを無視する
+}
+</style>

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -50,13 +50,16 @@ const phonemeTimingLineStyles: Record<
   },
 };
 
-const phonemeTextStyles: {
-  light: PIXI.TextStyle;
-  dark: PIXI.TextStyle;
+const phonemeTextStyleSpecs: {
+  light: { fill: string };
+  dark: { fill: string };
 } = {
-  light: new PIXI.TextStyle({ fill: "#252E26", fontSize: 14 }),
-  dark: new PIXI.TextStyle({ fill: "#ccc8c9", fontSize: 14 }),
+  light: { fill: "#252E26" },
+  dark: { fill: "#ccc8c9" },
 };
+let phonemeTextStyles:
+  | { light: PIXI.TextStyle; dark: PIXI.TextStyle }
+  | undefined;
 
 const { mounted } = useMounted();
 
@@ -90,6 +93,7 @@ const render = () => {
   assertNonNullable(stage);
   assertNonNullable(canvasWidth);
   assertNonNullable(canvasHeight);
+  assertNonNullable(phonemeTextStyles);
 
   const rawTempos = toRaw(tempos.value);
   const rawPhonemeTimingInfos = toRaw(phonemeTimingInfos.value);
@@ -337,6 +341,23 @@ onMounted(async () => {
 
   canvasWidth = canvasContainerElement.clientWidth;
   canvasHeight = canvasContainerElement.clientHeight;
+
+  // アプリのフォントをPIXIのテキストスタイルに反映する
+  // NOTE: フォントの変更に対応していないが、基本的にフォントが変更されることは少ないので、
+  // 複雑性を下げるためにも対応しない
+  const fontFamily = window.getComputedStyle(canvasContainerElement).fontFamily;
+  phonemeTextStyles = {
+    light: new PIXI.TextStyle({
+      ...phonemeTextStyleSpecs.light,
+      fontFamily,
+      fontSize: 14,
+    }),
+    dark: new PIXI.TextStyle({
+      ...phonemeTextStyleSpecs.dark,
+      fontFamily,
+      fontSize: 14,
+    }),
+  };
 
   renderer = await PIXI.autoDetectRenderer({
     canvas: canvasElement,

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -27,6 +27,7 @@ type PhonemeDisplayInfo = {
 const props = defineProps<{
   viewportInfo: ViewportInfo;
   phonemeTimingInfos: PhonemeTimingInfo[];
+  phonemeTextY: number;
 }>();
 
 const store = useStore();
@@ -280,7 +281,7 @@ const render = () => {
 
       textContainer.renderable = true;
       textContainer.x = phonemeStartX + 3; // 線から少し右にずらす
-      textContainer.y = 50;
+      textContainer.y = props.phonemeTextY;
 
       // マスク幅の計算
       let maskWidth = 36;

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -413,6 +413,16 @@ onUnmounted(() => {
     stage?.removeChild(graphic);
     graphic.destroy();
   }
+  for (const texts of textsMap.values()) {
+    for (const text of texts) {
+      const container = getOrThrow(textContainersMap, text);
+      stage?.removeChild(container);
+      container.destroy(true);
+    }
+  }
+  textsMap.clear();
+  textContainersMap.clear();
+  textMasksMap.clear();
   stage?.destroy(true);
   renderer?.destroy({ removeView: true });
   resizeObserver?.disconnect();

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -393,7 +393,10 @@ onMounted(async () => {
       canvasWidth = newWidth;
       canvasHeight = newHeight;
       renderer.resize(canvasWidth, canvasHeight);
-      renderInNextFrame = true;
+      // 次フレームに描画を持ち越すとリサイズ直後の空canvasが一瞬表示されて点滅するため、
+      // ペイント前のResizeObserverコールバック内で同期的に描画する
+      renderInNextFrame = false;
+      render();
     }
   });
   resizeObserver.observe(canvasContainerElement);

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -13,7 +13,7 @@ import { secondToTick } from "@/sing/music";
 import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
 import { clamp, getNext } from "@/sing/utility";
 import { getOrThrow } from "@/helpers/mapHelper";
-import { UnreachableError } from "@/type/utility";
+import { UnreachableError, assertNonNullable } from "@/type/utility";
 import type { PhonemeTimingInfo } from "@/sing/phonemeTimingEditorStateMachine/common";
 
 type PhonemeDisplayState = "default" | "edited";
@@ -86,18 +86,10 @@ let requestId: number | undefined;
 let renderInNextFrame = false;
 
 const render = () => {
-  if (renderer == undefined) {
-    throw new Error("renderer is undefined.");
-  }
-  if (stage == undefined) {
-    throw new Error("stage is undefined.");
-  }
-  if (canvasWidth == undefined) {
-    throw new Error("canvasWidth is undefined.");
-  }
-  if (canvasHeight == undefined) {
-    throw new Error("canvasHeight is undefined.");
-  }
+  assertNonNullable(renderer);
+  assertNonNullable(stage);
+  assertNonNullable(canvasWidth);
+  assertNonNullable(canvasHeight);
 
   const rawTempos = toRaw(tempos.value);
   const rawPhonemeTimingInfos = toRaw(phonemeTimingInfos.value);
@@ -340,12 +332,8 @@ watch(
 onMounted(async () => {
   const canvasContainerElement = canvasContainer.value;
   const canvasElement = canvas.value;
-  if (canvasContainerElement == undefined) {
-    throw new Error("canvasContainerElement is null.");
-  }
-  if (canvasElement == undefined) {
-    throw new Error("canvasElement is null.");
-  }
+  assertNonNullable(canvasContainerElement);
+  assertNonNullable(canvasElement);
 
   canvasWidth = canvasContainerElement.clientWidth;
   canvasHeight = canvasContainerElement.clientHeight;
@@ -375,9 +363,7 @@ onMounted(async () => {
   requestId = window.requestAnimationFrame(callback);
 
   resizeObserver = new ResizeObserver(() => {
-    if (renderer == undefined) {
-      throw new Error("renderer is undefined.");
-    }
+    assertNonNullable(renderer);
 
     const newWidth = canvasContainerElement.clientWidth;
     const newHeight = canvasContainerElement.clientHeight;

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -34,6 +34,7 @@ const tpqn = computed(() => store.state.tpqn);
 const isDark = computed(() => store.state.currentTheme === "Dark");
 const tempos = computed(() => store.state.tempos);
 const phonemeTimingInfos = computed(() => props.phonemeTimingInfos);
+const editorFrameRate = computed(() => store.state.editorFrameRate);
 
 type PhonemeTimingLineStyle = { color: number; alpha: number; width: number };
 const phonemeTimingLineStyles: Record<
@@ -98,8 +99,8 @@ const render = () => {
   const rawTempos = toRaw(tempos.value);
   const rawPhonemeTimingInfos = toRaw(phonemeTimingInfos.value);
   const viewportInfo = props.viewportInfo;
-  const editorFrameRate = store.state.editorFrameRate;
-  const oneFrameSeconds = 1 / editorFrameRate;
+  const editorFrameRateValue = editorFrameRate.value;
+  const oneFrameSeconds = 1 / editorFrameRateValue;
 
   const currentTextStyle = isDark.value
     ? phonemeTextStyles.dark
@@ -322,6 +323,7 @@ watch(
     phonemeTimingInfos,
     tempos,
     tpqn,
+    editorFrameRate,
     isDark,
     () => props.viewportInfo.scaleX,
     () => props.viewportInfo.offsetX,

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -320,20 +320,20 @@ const render = () => {
 };
 
 // NOTE: mountedをwatchしているので、onMountedの直後に必ず１回実行される
-watch([mounted, phonemeTimingInfos, tempos, tpqn], ([mounted]) => {
-  if (mounted) {
-    renderInNextFrame = true;
-  }
-});
-
-watch(isDark, () => {
-  renderInNextFrame = true;
-});
-
 watch(
-  () => [props.viewportInfo.scaleX, props.viewportInfo.offsetX],
-  () => {
-    renderInNextFrame = true;
+  [
+    mounted,
+    phonemeTimingInfos,
+    tempos,
+    tpqn,
+    isDark,
+    () => props.viewportInfo.scaleX,
+    () => props.viewportInfo.offsetX,
+  ],
+  ([mounted]) => {
+    if (mounted) {
+      renderInNextFrame = true;
+    }
   },
 );
 

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -266,6 +266,31 @@ export function toPhonemes(phonemeTimings: PhonemeTiming[]) {
 }
 
 /**
+ * 各音素のノート内でのインデックスを計算する。
+ * noteIdが変わるとインデックスは0にリセットされる。
+ */
+export function computePhonemeIndicesInNote<
+  T extends { noteId?: string | null },
+>(phonemes: readonly T[]): number[] {
+  const indices: number[] = [];
+  let phonemeIndexInNote = 0;
+
+  for (let i = 0; i < phonemes.length; i++) {
+    const phoneme = phonemes[i];
+    const prevPhoneme = getPrev(phonemes, i);
+
+    if (prevPhoneme == undefined || phoneme.noteId !== prevPhoneme.noteId) {
+      phonemeIndexInNote = 0;
+    } else {
+      phonemeIndexInNote++;
+    }
+    indices.push(phonemeIndexInNote);
+  }
+
+  return indices;
+}
+
+/**
  * 音素タイミング列に音素タイミング編集を適用する。
  */
 export function applyPhonemeTimingEdit(
@@ -273,20 +298,13 @@ export function applyPhonemeTimingEdit(
   phonemeTimingEditData: PhonemeTimingEditData,
   frameRate: number,
 ) {
-  let phonemeIndexInNote = 0;
+  const phonemeIndices = computePhonemeIndicesInNote(phonemeTimings);
+
   for (let i = 0; i < phonemeTimings.length; i++) {
     const phonemeTiming = phonemeTimings[i];
     const prevPhonemeTiming = getPrev(phonemeTimings, i);
     const nextPhonemeTiming = getNext(phonemeTimings, i);
-
-    if (
-      prevPhonemeTiming == undefined ||
-      phonemeTiming.noteId !== prevPhonemeTiming.noteId
-    ) {
-      phonemeIndexInNote = 0;
-    } else {
-      phonemeIndexInNote++;
-    }
+    const phonemeIndexInNote = phonemeIndices[i];
 
     if (phonemeTiming.phoneme === "pau") {
       continue;

--- a/src/sing/phonemeTimingEditorStateMachine/common.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/common.ts
@@ -1,0 +1,186 @@
+import { NoteId, TrackId } from "@/type/preload";
+import type { Note, PhonemeTimingEditData } from "@/domain/project/type";
+import type {
+  EditorFrameAudioQuery,
+  EditorFrameAudioQueryKey,
+  Phrase,
+  PhraseKey,
+} from "@/store/type";
+import { getOrThrow } from "@/helpers/mapHelper";
+import {
+  adjustPhonemeTimings,
+  applyPhonemeTimingEdit,
+  computePhonemeIndicesInNote,
+  toPhonemes,
+  toPhonemeTimings,
+} from "@/sing/domain";
+import { getPrev } from "@/sing/utility";
+
+// 音素タイミングの計算に必要なフレーズ情報
+export type PhraseInfo = Readonly<{
+  startTime: number;
+  query?: EditorFrameAudioQuery;
+  // NOTE: notesは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  notes: Note[];
+  minNonPauseStartFrame: number | undefined;
+  maxNonPauseEndFrame: number | undefined;
+}>;
+
+// 1音素分のタイミング情報
+export type PhonemeTimingInfo = {
+  // NOTE: phraseKeyは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  phraseKey: PhraseKey;
+  phoneme: string;
+  noteId: NoteId | undefined;
+  // NOTE: phonemeIndexInNoteは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  phonemeIndexInNote: number;
+  isEdited: boolean;
+  editedStartTimeSeconds: number;
+  // NOTE: originalStartTimeSecondsは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  originalStartTimeSeconds: number;
+  // NOTE: editedEndTimeSecondsは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
+  editedEndTimeSeconds: number;
+};
+
+/**
+ * 指定トラックのフレーズ情報を取得する。
+ */
+export function getPhraseInfosForTrack(
+  phrases: Map<PhraseKey, Phrase>,
+  phraseQueries: Map<EditorFrameAudioQueryKey, EditorFrameAudioQuery>,
+  trackId: TrackId,
+): Map<PhraseKey, PhraseInfo> {
+  const phraseInfos = new Map<PhraseKey, PhraseInfo>();
+  for (const [phraseKey, phrase] of phrases) {
+    if (phrase.trackId !== trackId) {
+      continue;
+    }
+    let query = undefined;
+    if (phrase.queryKey != undefined) {
+      query = getOrThrow(phraseQueries, phrase.queryKey);
+    }
+    phraseInfos.set(phraseKey, {
+      startTime: phrase.startTime,
+      query,
+      notes: phrase.notes,
+      minNonPauseStartFrame: phrase.minNonPauseStartFrame,
+      maxNonPauseEndFrame: phrase.maxNonPauseEndFrame,
+    });
+  }
+  return phraseInfos;
+}
+
+/**
+ * 音素タイミングの情報を計算する。
+ */
+export function computePhonemeTimingInfos(
+  phraseInfos: Map<PhraseKey, PhraseInfo>,
+  phonemeTimingEditData: PhonemeTimingEditData,
+): PhonemeTimingInfo[] {
+  // フレーズが時系列順に並んでいることを検証する
+  let prevPhraseStartTime: number | undefined = undefined;
+  for (const phraseInfo of phraseInfos.values()) {
+    if (
+      prevPhraseStartTime != undefined &&
+      phraseInfo.startTime < prevPhraseStartTime
+    ) {
+      throw new Error("phraseInfos must be sorted in chronological order.");
+    }
+    prevPhraseStartTime = phraseInfo.startTime;
+  }
+
+  const phonemeTimingInfos: PhonemeTimingInfo[] = [];
+
+  for (const [phraseKey, phraseInfo] of phraseInfos) {
+    const phraseQuery = phraseInfo.query;
+    if (phraseQuery == undefined) {
+      continue;
+    }
+
+    // 編集を適用した音素列を生成
+    const phonemeTimings = toPhonemeTimings(phraseQuery.phonemes);
+    applyPhonemeTimingEdit(
+      phonemeTimings,
+      phonemeTimingEditData,
+      phraseQuery.frameRate,
+    );
+    adjustPhonemeTimings(
+      phonemeTimings,
+      phraseInfo.minNonPauseStartFrame,
+      phraseInfo.maxNonPauseEndFrame,
+    );
+    const editedPhonemes = toPhonemes(phonemeTimings);
+
+    const phraseStartTime = phraseInfo.startTime;
+    const frameRate = phraseQuery.frameRate;
+
+    const phonemeIndices = computePhonemeIndicesInNote(phraseQuery.phonemes);
+
+    let phonemeStartFrame = 0;
+    let editedPhonemeStartFrame = 0;
+
+    for (let i = 0; i < phraseQuery.phonemes.length; i++) {
+      const phoneme = phraseQuery.phonemes[i];
+      const prevPhoneme = getPrev(phraseQuery.phonemes, i);
+      const editedPhoneme = editedPhonemes[i];
+      const phonemeIndexInNote = phonemeIndices[i];
+
+      const originalStartTimeSeconds =
+        phraseStartTime + phonemeStartFrame / frameRate;
+      const editedStartTimeSeconds =
+        phraseStartTime + editedPhonemeStartFrame / frameRate;
+
+      let noteId: NoteId | undefined;
+      let effectivePhonemeIndexInNote: number;
+
+      if (phoneme.phoneme === "pau") {
+        if (prevPhoneme?.noteId != undefined) {
+          // 末尾のpauは前のノートに含まれるものとして扱い、
+          // 前の音素のnoteIdとphonemeIndexInNote + 1を使う
+          noteId = NoteId(prevPhoneme.noteId);
+          const prevPhonemeIndexInNote = phonemeIndices[i - 1];
+          effectivePhonemeIndexInNote = prevPhonemeIndexInNote + 1;
+        } else {
+          // 先頭のpauなどはノートに属さない
+          noteId = undefined;
+          effectivePhonemeIndexInNote = phonemeIndexInNote;
+        }
+      } else {
+        noteId =
+          phoneme.noteId != undefined ? NoteId(phoneme.noteId) : undefined;
+        effectivePhonemeIndexInNote = phonemeIndexInNote;
+      }
+
+      // 編集が存在するかどうかを判定
+      let isEdited = false;
+      if (noteId != undefined) {
+        const phonemeTimingEdits = phonemeTimingEditData.get(noteId);
+        if (phonemeTimingEdits != undefined) {
+          isEdited = phonemeTimingEdits.some(
+            (edit) => edit.phonemeIndexInNote === effectivePhonemeIndexInNote,
+          );
+        }
+      }
+
+      const editedEndTimeSeconds =
+        phraseStartTime +
+        (editedPhonemeStartFrame + editedPhoneme.frameLength) / frameRate;
+
+      phonemeTimingInfos.push({
+        phraseKey,
+        noteId,
+        phonemeIndexInNote: effectivePhonemeIndexInNote,
+        phoneme: editedPhoneme.phoneme,
+        isEdited,
+        originalStartTimeSeconds,
+        editedStartTimeSeconds,
+        editedEndTimeSeconds,
+      });
+
+      phonemeStartFrame += phoneme.frameLength;
+      editedPhonemeStartFrame += editedPhoneme.frameLength;
+    }
+  }
+
+  return phonemeTimingInfos;
+}

--- a/src/sing/phonemeTimingEditorStateMachine/common.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/common.ts
@@ -170,7 +170,7 @@ export function computePhonemeTimingInfos(
         phraseKey,
         noteId,
         phonemeIndexInNote: effectivePhonemeIndexInNote,
-        phoneme: editedPhoneme.phoneme,
+        phoneme: phoneme.phoneme,
         isEdited,
         originalStartTimeSeconds,
         editedStartTimeSeconds,

--- a/src/sing/utility.ts
+++ b/src/sing/utility.ts
@@ -100,11 +100,11 @@ export function getLast<T>(array: readonly T[]) {
   return array[array.length - 1];
 }
 
-export function getPrev<T>(array: T[], currentIndex: number) {
+export function getPrev<T>(array: readonly T[], currentIndex: number) {
   return currentIndex !== 0 ? array[currentIndex - 1] : undefined;
 }
 
-export function getNext<T>(array: T[], currentIndex: number) {
+export function getNext<T>(array: readonly T[], currentIndex: number) {
   return currentIndex !== array.length - 1
     ? array[currentIndex + 1]
     : undefined;


### PR DESCRIPTION
## 内容

音素タイミング編集機能の実装の一部として、音素タイミング編集エリア（SequencerPhonemeTimingEditor）に音素タイミングを表示するコンポーネントを追加します。
編集操作（ドラッグによるタイミング変更など）は後続のPRで実装予定です。

PixiJSによる描画で、描画まわりの骨組み（描画ループやリサイズ対応など）は既存のシーケンサー系コンポーネントと同じです。

### 音素タイミングの表示（SequencerPhonemeTimings.vue）

各音素の開始位置に縦線、その右側に音素文字を描画します。編集済みかどうかで色と線幅を変えます。ノートに属さない先頭の pau は表示しません。

実装面のポイントは次のとおりです。

- 音素文字は隣接音素と重ならないよう、次の音素の開始Xまでをマスク幅にしている
- プレビュー等で前後の音素と表示順が入れ替わると違和感が出るため、表示上のX座標を制限して順序を維持する
- 画面外の音素はスキップし、PIXI.Graphics / PIXI.Text オブジェクトはプールして使い回している

### 音素タイミング情報の計算（phonemeTimingEditorStateMachine/common.ts）

選択トラックのフレーズ情報の収集（`getPhraseInfosForTrack`）と、表示用の音素タイミング情報の計算（`computePhonemeTimingInfos`）を行います。

- 末尾の pau は前のノートに属する音素として扱う（編集データの紐付けでもこの扱いに揃える）
- 一部の型フィールドは現時点では使用しない先行定義（コード内のコメントに明記）
- ディレクトリ名 `phonemeTimingEditorStateMachine` は後続PRで本格的な編集ステートマシンに発展させる予定のため

### その他の変更

- `domain.ts`：音素のノート内インデックスを計算するロジックを `computePhonemeIndicesInNote` として切り出し（既存の `applyPhonemeTimingEdit` と新規 `common.ts` の両方で使うため）
- `utility.ts`：`getPrev` / `getNext` の引数を readonly 化

## 関連 Issue

- VOICEVOX/voicevox#2261

## スクリーンショット・動画など

## その他

今回追加した表示は、パラメータパネルの切り替えスイッチで音素タイミングを選ぶと確認できます（現時点でこのエリアに表示されるのは波形・ノート・音素タイミングまでで、編集操作は後続PRで追加されます）。
