### PR TITLE
feat: 音素タイミングエディターに編集機能を追加

### DIFF
--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -93,6 +93,10 @@ const cursorStyle = computed(() => {
   switch (cursorState.value) {
     case "EW_RESIZE":
       return "ew-resize";
+    case "ERASE":
+      // NOTE: 消しゴム用のカーソル・画像がないため、一旦defaultにしている
+      // TODO: 消しゴム用のカーソル・画像を用意して差し替える
+      return "default";
     default:
       return "default";
   }

--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -1,39 +1,66 @@
 <template>
   <div class="phoneme-timing-editor">
     <div class="axis-area"></div>
-    <div class="parameter-area">
+    <div
+      ref="parameterArea"
+      class="parameter-area"
+      @pointerdown="onPointerDown"
+    >
       <SequencerParameterGrid class="parameter-grid" :viewportInfo />
       <SequencerWaveform class="waveform" :viewportInfo />
       <SequencerNoteTimings class="note-timings" :viewportInfo />
       <SequencerPhonemeTimings
         class="phoneme-timings"
         :viewportInfo
+        :previewPhonemeTiming
         :phonemeTimingInfos
         :phonemeTextY
+      />
+      <SequencerPhonemeTimingToolPalette
+        :sequencerPhonemeTimingTool
+        @update:sequencerPhonemeTimingTool="setSequencerPhonemeTimingTool"
       />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import type { ViewportInfo } from "@/sing/viewHelper";
 import { useStore } from "@/store";
+import { usePhonemeTimingEditorStateMachine } from "@/composables/usePhonemeTimingEditorStateMachine";
+import {
+  onMountedOrActivated,
+  onUnmountedOrDeactivated,
+} from "@/composables/onMountOrActivate";
 import SequencerParameterGrid from "@/components/Sing/SequencerParameterGrid.vue";
 import SequencerWaveform from "@/components/Sing/SequencerWaveform.vue";
 import SequencerPhonemeTimings from "@/components/Sing/SequencerPhonemeTimings.vue";
 import SequencerNoteTimings from "@/components/Sing/SequencerNoteTimings.vue";
+import SequencerPhonemeTimingToolPalette from "@/components/Sing/SequencerPhonemeTimingToolPalette.vue";
+import { assertNonNullable } from "@/type/utility";
 import {
   computePhonemeTimingInfos,
   getPhraseInfosForTrack,
 } from "@/sing/phonemeTimingEditorStateMachine/common";
+import type { PhonemeTimingEditTool } from "@/store/type";
 
 const store = useStore();
+const sequencerPhonemeTimingTool = computed(
+  () => store.state.sequencerPhonemeTimingTool,
+);
 
-defineProps<{
+const setSequencerPhonemeTimingTool = (tool: PhonemeTimingEditTool) => {
+  void store.actions.SET_SEQUENCER_PHONEME_TIMING_TOOL({
+    sequencerPhonemeTimingTool: tool,
+  });
+};
+
+const props = defineProps<{
   viewportInfo: ViewportInfo;
 }>();
 
+const viewportInfo = computed(() => props.viewportInfo);
 const selectedTrackId = computed(() => store.getters.SELECTED_TRACK_ID);
 const phonemeTimingEditData = computed(
   () => store.getters.SELECTED_TRACK.phonemeTimingEditData,
@@ -50,6 +77,72 @@ const phonemeTimingInfos = computed(() => {
     phraseInfos.value,
     phonemeTimingEditData.value,
   );
+});
+
+const { stateMachineProcess, cursorState, previewPhonemeTiming } =
+  usePhonemeTimingEditorStateMachine(
+    store,
+    viewportInfo,
+    phonemeTimingInfos,
+    phraseInfos,
+  );
+
+const parameterArea = ref<HTMLElement | null>(null);
+
+const cursorStyle = computed(() => {
+  switch (cursorState.value) {
+    case "EW_RESIZE":
+      return "ew-resize";
+    default:
+      return "default";
+  }
+});
+
+const getXInBorderBox = (clientX: number, element: HTMLElement) => {
+  return clientX - element.getBoundingClientRect().left;
+};
+
+const getLocalPositionX = (event: PointerEvent): number => {
+  const parameterAreaElement = parameterArea.value;
+  assertNonNullable(parameterAreaElement);
+  return getXInBorderBox(event.clientX, parameterAreaElement);
+};
+
+const onPointerDown = (event: PointerEvent) => {
+  stateMachineProcess({
+    type: "pointerEvent",
+    targetArea: "PhonemeTimingArea",
+    pointerEvent: event,
+    positionX: getLocalPositionX(event),
+  });
+};
+
+const onWindowPointerMove = (event: PointerEvent) => {
+  stateMachineProcess({
+    type: "pointerEvent",
+    targetArea: "Window",
+    pointerEvent: event,
+    positionX: getLocalPositionX(event),
+  });
+};
+
+const onWindowPointerUp = (event: PointerEvent) => {
+  stateMachineProcess({
+    type: "pointerEvent",
+    targetArea: "Window",
+    pointerEvent: event,
+    positionX: getLocalPositionX(event),
+  });
+};
+
+onMountedOrActivated(() => {
+  window.addEventListener("pointermove", onWindowPointerMove);
+  window.addEventListener("pointerup", onWindowPointerUp);
+});
+
+onUnmountedOrDeactivated(() => {
+  window.removeEventListener("pointermove", onWindowPointerMove);
+  window.removeEventListener("pointerup", onWindowPointerUp);
 });
 
 // parameter-areaの各行の高さ
@@ -93,6 +186,7 @@ const phonemeTextY =
     v-bind("`${NOTES_ROW_HEIGHT}px`")
     v-bind("`${PHONEME_TEXTS_ROW_HEIGHT}px`")
     1fr;
+  cursor: v-bind(cursorStyle);
 }
 
 .parameter-grid {

--- a/src/components/Sing/SequencerPhonemeTimingEditor.vue
+++ b/src/components/Sing/SequencerPhonemeTimingEditor.vue
@@ -5,6 +5,7 @@
       ref="parameterArea"
       class="parameter-area"
       @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
     >
       <SequencerParameterGrid class="parameter-grid" :viewportInfo />
       <SequencerWaveform class="waveform" :viewportInfo />
@@ -121,6 +122,15 @@ const onPointerDown = (event: PointerEvent) => {
   });
 };
 
+const onPointerMove = (event: PointerEvent) => {
+  stateMachineProcess({
+    type: "pointerEvent",
+    targetArea: "PhonemeTimingArea",
+    pointerEvent: event,
+    positionX: getLocalPositionX(event),
+  });
+};
+
 const onWindowPointerMove = (event: PointerEvent) => {
   stateMachineProcess({
     type: "pointerEvent",
@@ -139,14 +149,25 @@ const onWindowPointerUp = (event: PointerEvent) => {
   });
 };
 
+const onWindowPointerCancel = (event: PointerEvent) => {
+  stateMachineProcess({
+    type: "pointerEvent",
+    targetArea: "Window",
+    pointerEvent: event,
+    positionX: getLocalPositionX(event),
+  });
+};
+
 onMountedOrActivated(() => {
   window.addEventListener("pointermove", onWindowPointerMove);
   window.addEventListener("pointerup", onWindowPointerUp);
+  window.addEventListener("pointercancel", onWindowPointerCancel);
 });
 
 onUnmountedOrDeactivated(() => {
   window.removeEventListener("pointermove", onWindowPointerMove);
   window.removeEventListener("pointerup", onWindowPointerUp);
+  window.removeEventListener("pointercancel", onWindowPointerCancel);
 });
 
 // parameter-areaの各行の高さ

--- a/src/components/Sing/SequencerPhonemeTimingToolPalette.vue
+++ b/src/components/Sing/SequencerPhonemeTimingToolPalette.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="tool-palette">
+    <QBtn
+      flat
+      round
+      :color="sequencerPhonemeTimingTool === 'MOVE' ? 'primary' : ''"
+      @click="$emit('update:sequencerPhonemeTimingTool', 'MOVE')"
+    >
+      <i class="material-symbols-outlined">swap_horiz</i>
+      <QTooltip
+        anchor="center right"
+        self="center left"
+        :offset="[8, 0]"
+        :delay="500"
+        transitionShow=""
+        transitionHide=""
+      >
+        移動
+      </QTooltip>
+    </QBtn>
+    <QBtn
+      flat
+      round
+      :color="sequencerPhonemeTimingTool === 'ERASE' ? 'primary' : ''"
+      @click="$emit('update:sequencerPhonemeTimingTool', 'ERASE')"
+    >
+      <i class="material-symbols-outlined">ink_eraser</i>
+      <QTooltip
+        anchor="center right"
+        self="center left"
+        :offset="[8, 0]"
+        :delay="500"
+        transitionShow=""
+        transitionHide=""
+      >
+        削除
+      </QTooltip>
+    </QBtn>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { PhonemeTimingEditTool } from "@/store/type";
+
+defineProps<{
+  sequencerPhonemeTimingTool: PhonemeTimingEditTool;
+}>();
+defineEmits<{
+  (
+    event: "update:sequencerPhonemeTimingTool",
+    value: PhonemeTimingEditTool,
+  ): void;
+}>();
+</script>
+
+<style scoped lang="scss">
+.tool-palette {
+  display: flex;
+  flex-direction: column;
+  background: var(--scheme-color-surface);
+  outline: 1px solid var(--scheme-color-outline-variant);
+  position: absolute;
+  top: 12px;
+  left: 16px;
+  z-index: var(--z-index-sing-tool-palette);
+  padding: 2px;
+  border-radius: 24px;
+  gap: 0;
+  box-shadow:
+    0px 8px 16px -4px rgba(0, 0, 0, 0.1),
+    0px 4px 8px -4px rgba(0, 0, 0, 0.06);
+
+  .material-symbols-outlined {
+    font-size: 20px;
+    max-width: 20px;
+  }
+
+  .q-btn {
+    min-height: 40px;
+    min-width: 40px;
+    padding: 8px;
+
+    &.text-primary {
+      background-color: var(--scheme-color-secondary-container);
+      .material-symbols-outlined {
+        color: var(--scheme-color-on-primary-container);
+      }
+    }
+  }
+}
+</style>

--- a/src/components/Sing/SequencerPhonemeTimingToolPalette.vue
+++ b/src/components/Sing/SequencerPhonemeTimingToolPalette.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tool-palette">
+  <div class="tool-palette" @pointerdown.stop>
     <QBtn
       flat
       round

--- a/src/components/Sing/SequencerPhonemeTimings.vue
+++ b/src/components/Sing/SequencerPhonemeTimings.vue
@@ -14,9 +14,12 @@ import { tickToBaseX, type ViewportInfo } from "@/sing/viewHelper";
 import { clamp, getNext } from "@/sing/utility";
 import { getOrThrow } from "@/helpers/mapHelper";
 import { UnreachableError, assertNonNullable } from "@/type/utility";
-import type { PhonemeTimingInfo } from "@/sing/phonemeTimingEditorStateMachine/common";
+import type {
+  PhonemeTimingPreview,
+  PhonemeTimingInfo,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
 
-type PhonemeDisplayState = "default" | "edited";
+type PhonemeDisplayState = "default" | "edited" | "movePreview";
 
 type PhonemeDisplayInfo = {
   readonly phoneme: string;
@@ -26,6 +29,7 @@ type PhonemeDisplayInfo = {
 
 const props = defineProps<{
   viewportInfo: ViewportInfo;
+  previewPhonemeTiming?: PhonemeTimingPreview;
   phonemeTimingInfos: PhonemeTimingInfo[];
   phonemeTextY: number;
 }>();
@@ -34,6 +38,7 @@ const store = useStore();
 const tpqn = computed(() => store.state.tpqn);
 const isDark = computed(() => store.state.currentTheme === "Dark");
 const tempos = computed(() => store.state.tempos);
+const previewPhonemeTiming = computed(() => props.previewPhonemeTiming);
 const phonemeTimingInfos = computed(() => props.phonemeTimingInfos);
 const editorFrameRate = computed(() => store.state.editorFrameRate);
 
@@ -45,10 +50,12 @@ const phonemeTimingLineStyles: Record<
   light: {
     default: { color: 0x8bc796, alpha: 1, width: 1 },
     edited: { color: 0x00a73f, alpha: 1, width: 2 },
+    movePreview: { color: 0x3d7eff, alpha: 1, width: 2 },
   },
   dark: {
     default: { color: 0x547359, alpha: 1, width: 1 },
     edited: { color: 0x28a652, alpha: 1, width: 2 },
+    movePreview: { color: 0x699ff0, alpha: 1, width: 2 },
   },
 };
 
@@ -99,6 +106,7 @@ const render = () => {
 
   const rawTempos = toRaw(tempos.value);
   const rawPhonemeTimingInfos = toRaw(phonemeTimingInfos.value);
+  const preview = previewPhonemeTiming.value;
   const viewportInfo = props.viewportInfo;
   const editorFrameRateValue = editorFrameRate.value;
   const oneFrameSeconds = 1 / editorFrameRateValue;
@@ -130,11 +138,35 @@ const render = () => {
       continue;
     }
 
-    const startTime = phonemeTimingInfo.editedStartTimeSeconds;
+    const isMovePreview =
+      preview?.type === "move" &&
+      preview.noteId === phonemeTimingInfo.noteId &&
+      preview.phonemeIndexInNote === phonemeTimingInfo.phonemeIndexInNote;
+    const isErasePreview =
+      preview?.type === "erase" &&
+      preview.targets.some(
+        (target) =>
+          target.noteId === phonemeTimingInfo.noteId &&
+          target.phonemeIndexInNote === phonemeTimingInfo.phonemeIndexInNote,
+      );
 
-    const displayState: PhonemeDisplayState = phonemeTimingInfo.isEdited
-      ? "edited"
-      : "default";
+    // 削除プレビュー中は元の位置、移動プレビュー中は元の位置にオフセットを加えた位置、それ以外は編集後の位置を使う
+    let startTime: number;
+    if (isErasePreview) {
+      startTime = phonemeTimingInfo.originalStartTimeSeconds;
+    } else if (isMovePreview) {
+      startTime =
+        phonemeTimingInfo.originalStartTimeSeconds + preview.offsetSeconds;
+    } else {
+      startTime = phonemeTimingInfo.editedStartTimeSeconds;
+    }
+
+    let displayState: PhonemeDisplayState = "default";
+    if (isMovePreview) {
+      displayState = "movePreview";
+    } else if (phonemeTimingInfo.isEdited && !isErasePreview) {
+      displayState = "edited";
+    }
 
     phonemeDisplayInfos.push({
       phoneme: phonemeTimingInfo.phoneme,
@@ -322,6 +354,7 @@ watch(
   [
     mounted,
     phonemeTimingInfos,
+    previewPhonemeTiming,
     tempos,
     tpqn,
     editorFrameRate,

--- a/src/composables/usePhonemeTimingEditorStateMachine.ts
+++ b/src/composables/usePhonemeTimingEditorStateMachine.ts
@@ -1,0 +1,72 @@
+import { computed, type ComputedRef, ref, watch } from "vue";
+import type { CursorState, ViewportInfo } from "@/sing/viewHelper";
+import type {
+  PhonemeTimingPreview,
+  PhonemeTimingEditorPartialStore,
+  PhonemeTimingEditorPreviewMode,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorComputedRefs,
+  PhonemeTimingEditorIdleStateId,
+  PhonemeTimingInfo,
+  PhraseInfo,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
+import type { PhraseKey } from "@/store/type";
+import type { TrackId } from "@/type/preload";
+import type { PhonemeTimingEditData, Tempo } from "@/domain/project/type";
+import { createPhonemeTimingEditorStateMachine } from "@/sing/phonemeTimingEditorStateMachine";
+
+export const usePhonemeTimingEditorStateMachine = (
+  store: PhonemeTimingEditorPartialStore,
+  viewportInfo: ComputedRef<ViewportInfo>,
+  phonemeTimingInfos: ComputedRef<PhonemeTimingInfo[]>,
+  phraseInfos: ComputedRef<Map<PhraseKey, PhraseInfo>>,
+) => {
+  const refs = {
+    previewPhonemeTiming: ref<PhonemeTimingPreview | undefined>(undefined),
+    previewMode: ref<PhonemeTimingEditorPreviewMode>("IDLE"),
+    cursorState: ref<CursorState>("UNSET"),
+  };
+
+  const computedRefs: PhonemeTimingEditorComputedRefs = {
+    selectedTrackId: computed<TrackId>(() => store.getters.SELECTED_TRACK_ID),
+    tempos: computed<Tempo[]>(() => store.state.tempos),
+    tpqn: computed<number>(() => store.state.tpqn),
+    viewportInfo,
+    phonemeTimingEditData: computed<PhonemeTimingEditData>(
+      () => store.getters.SELECTED_TRACK.phonemeTimingEditData,
+    ),
+    editorFrameRate: computed<number>(() => store.state.editorFrameRate),
+    phonemeTimingInfos,
+    phraseInfos,
+  };
+
+  const idleStateId = computed<PhonemeTimingEditorIdleStateId>(() =>
+    store.state.sequencerPhonemeTimingTool === "ERASE"
+      ? "erasePhonemeTimingToolIdle"
+      : "movePhonemeTimingToolIdle",
+  );
+
+  const stateMachine = createPhonemeTimingEditorStateMachine(
+    {
+      ...refs,
+      ...computedRefs,
+      store,
+    },
+    idleStateId.value,
+  );
+
+  watch(idleStateId, (value) => {
+    if (stateMachine.currentStateId !== value) {
+      stateMachine.transitionTo(value, undefined);
+    }
+  });
+
+  return {
+    stateMachineProcess: (input: PhonemeTimingEditorInput) => {
+      stateMachine.process(input);
+    },
+    previewPhonemeTiming: computed(() => refs.previewPhonemeTiming.value),
+    previewMode: computed(() => refs.previewMode.value),
+    cursorState: computed(() => refs.cursorState.value),
+  };
+};

--- a/src/sing/domain.ts
+++ b/src/sing/domain.ts
@@ -378,10 +378,6 @@ export function adjustPhonemeTimings(
       ) {
         phonemeTiming.startFrame = maxNonPauseEndFrame;
       }
-      // フレーム長が1以上になるように終了フレームを調整する
-      if (phonemeTiming.endFrame <= phonemeTiming.startFrame) {
-        phonemeTiming.endFrame = phonemeTiming.startFrame + 1;
-      }
     }
 
     // 音素（pauを含む）のフレーム長が1以上になるように開始フレームを調整する

--- a/src/sing/phonemeTimingEditorStateMachine/common.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/common.ts
@@ -1,5 +1,9 @@
+import type { ComputedRef, Ref } from "vue";
+import type { Store } from "@/store";
+import type { StateDefinitions } from "@/sing/stateMachine";
+import type { CursorState, ViewportInfo } from "@/sing/viewHelper";
 import { NoteId, TrackId } from "@/type/preload";
-import type { Note, PhonemeTimingEditData } from "@/domain/project/type";
+import type { Note, PhonemeTimingEditData, Tempo } from "@/domain/project/type";
 import type {
   EditorFrameAudioQuery,
   EditorFrameAudioQueryKey,
@@ -16,6 +20,22 @@ import {
 } from "@/sing/domain";
 import { getPrev } from "@/sing/utility";
 
+// 音素タイミング編集のプレビューデータ
+export type PhonemeTimingPreview =
+  | {
+      type: "move";
+      noteId: NoteId;
+      phonemeIndexInNote: number;
+      offsetSeconds: number;
+    }
+  | {
+      type: "erase";
+      targets: {
+        noteId: NoteId;
+        phonemeIndexInNote: number;
+      }[];
+    };
+
 // 音素タイミングの計算に必要なフレーズ情報
 export type PhraseInfo = Readonly<{
   startTime: number;
@@ -28,19 +48,111 @@ export type PhraseInfo = Readonly<{
 
 // 1音素分のタイミング情報
 export type PhonemeTimingInfo = {
-  // NOTE: phraseKeyは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
   phraseKey: PhraseKey;
   phoneme: string;
   noteId: NoteId | undefined;
-  // NOTE: phonemeIndexInNoteは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
   phonemeIndexInNote: number;
   isEdited: boolean;
   editedStartTimeSeconds: number;
-  // NOTE: originalStartTimeSecondsは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
   originalStartTimeSeconds: number;
-  // NOTE: editedEndTimeSecondsは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
   editedEndTimeSeconds: number;
 };
+
+export type PhonemeTimingEditorInput =
+  | {
+      readonly type: "pointerEvent";
+      readonly targetArea: "PhonemeTimingArea";
+      readonly pointerEvent: PointerEvent;
+      readonly positionX: number;
+    }
+  | {
+      readonly type: "pointerEvent";
+      readonly targetArea: "Window";
+      readonly pointerEvent: PointerEvent;
+      readonly positionX: number;
+    };
+
+export type PhonemeTimingEditorPreviewMode =
+  | "IDLE"
+  | "MOVE_PHONEME_TIMING"
+  | "ERASE_PHONEME_TIMING";
+
+export type PhonemeTimingEditorRefs = {
+  readonly previewPhonemeTiming: Ref<PhonemeTimingPreview | undefined>;
+  readonly previewMode: Ref<PhonemeTimingEditorPreviewMode>;
+  readonly cursorState: Ref<CursorState>;
+};
+
+export type PhonemeTimingEditorComputedRefs = {
+  readonly selectedTrackId: ComputedRef<TrackId>;
+  readonly tempos: ComputedRef<Tempo[]>;
+  readonly tpqn: ComputedRef<number>;
+  readonly viewportInfo: ComputedRef<ViewportInfo>;
+  readonly phonemeTimingEditData: ComputedRef<PhonemeTimingEditData>;
+  readonly editorFrameRate: ComputedRef<number>;
+  readonly phonemeTimingInfos: ComputedRef<PhonemeTimingInfo[]>;
+  readonly phraseInfos: ComputedRef<Map<PhraseKey, PhraseInfo>>;
+};
+
+export type PhonemeTimingEditorPartialStore = {
+  readonly state: Pick<
+    Store["state"],
+    | "tpqn"
+    | "tempos"
+    | "phrases"
+    | "phraseQueries"
+    | "editorFrameRate"
+    | "sequencerPhonemeTimingTool"
+  >;
+  readonly getters: Pick<
+    Store["getters"],
+    "SELECTED_TRACK_ID" | "SELECTED_TRACK"
+  >;
+  readonly actions: Pick<
+    Store["actions"],
+    "COMMAND_UPSERT_PHONEME_TIMING_EDIT" | "COMMAND_ERASE_PHONEME_TIMING_EDITS"
+  >;
+};
+
+export type PhonemeTimingEditorContext = PhonemeTimingEditorRefs &
+  PhonemeTimingEditorComputedRefs & {
+    readonly store: PhonemeTimingEditorPartialStore;
+  };
+
+export type PhonemeTimingEditorIdleStateId =
+  | "movePhonemeTimingToolIdle"
+  | "erasePhonemeTimingToolIdle";
+
+export type PhonemeTimingEditorStateDefinitions = StateDefinitions<
+  [
+    {
+      id: "movePhonemeTimingToolIdle";
+      factoryArgs: undefined;
+    },
+    {
+      id: "movePhonemeTiming";
+      factoryArgs: {
+        targetTrackId: TrackId;
+        noteId: NoteId;
+        phonemeIndexInNote: number;
+        startPositionX: number;
+        returnStateId: PhonemeTimingEditorIdleStateId;
+      };
+    },
+    {
+      id: "erasePhonemeTimingToolIdle";
+      factoryArgs: undefined;
+    },
+    {
+      id: "erasePhonemeTiming";
+      factoryArgs: {
+        targetTrackId: TrackId;
+        startPositionX: number;
+        returnStateId: PhonemeTimingEditorIdleStateId;
+      };
+    },
+  ]
+>;
 
 /**
  * 指定トラックのフレーズ情報を取得する。

--- a/src/sing/phonemeTimingEditorStateMachine/common.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/common.ts
@@ -3,7 +3,7 @@ import type { Store } from "@/store";
 import type { StateDefinitions } from "@/sing/stateMachine";
 import type { CursorState, ViewportInfo } from "@/sing/viewHelper";
 import { NoteId, TrackId } from "@/type/preload";
-import type { Note, PhonemeTimingEditData, Tempo } from "@/domain/project/type";
+import type { PhonemeTimingEditData, Tempo } from "@/domain/project/type";
 import type {
   EditorFrameAudioQuery,
   EditorFrameAudioQueryKey,
@@ -40,8 +40,6 @@ export type PhonemeTimingPreview =
 export type PhraseInfo = Readonly<{
   startTime: number;
   query?: EditorFrameAudioQuery;
-  // NOTE: notesは現時点では未使用。今後の編集機能の実装で使う予定の先行定義
-  notes: Note[];
   minNonPauseStartFrame: number | undefined;
   maxNonPauseEndFrame: number | undefined;
 }>;
@@ -174,7 +172,6 @@ export function getPhraseInfosForTrack(
     phraseInfos.set(phraseKey, {
       startTime: phrase.startTime,
       query,
-      notes: phrase.notes,
       minNonPauseStartFrame: phrase.minNonPauseStartFrame,
       maxNonPauseEndFrame: phrase.maxNonPauseEndFrame,
     });

--- a/src/sing/phonemeTimingEditorStateMachine/index.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/index.ts
@@ -1,0 +1,31 @@
+import type {
+  PhonemeTimingEditorStateDefinitions,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorContext,
+  PhonemeTimingEditorIdleStateId,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
+import { MovePhonemeTimingToolIdleState } from "@/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingToolIdleState";
+import { MovePhonemeTimingState } from "@/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState";
+import { ErasePhonemeTimingToolIdleState } from "@/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingToolIdleState";
+import { ErasePhonemeTimingState } from "@/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingState";
+import { StateMachine } from "@/sing/stateMachine";
+
+export const createPhonemeTimingEditorStateMachine = (
+  context: PhonemeTimingEditorContext,
+  initialState: PhonemeTimingEditorIdleStateId,
+) => {
+  return new StateMachine<
+    PhonemeTimingEditorStateDefinitions,
+    PhonemeTimingEditorInput,
+    PhonemeTimingEditorContext
+  >(
+    {
+      movePhonemeTimingToolIdle: () => new MovePhonemeTimingToolIdleState(),
+      movePhonemeTiming: (args) => new MovePhonemeTimingState(args),
+      erasePhonemeTimingToolIdle: () => new ErasePhonemeTimingToolIdleState(),
+      erasePhonemeTiming: (args) => new ErasePhonemeTimingState(args),
+    },
+    context,
+    initialState,
+  );
+};

--- a/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingState.ts
@@ -1,0 +1,212 @@
+import type { SetNextState, State } from "@/sing/stateMachine";
+import type {
+  PhonemeTimingEditorContext,
+  PhonemeTimingEditorIdleStateId,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorStateDefinitions,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
+import { NoteId, TrackId } from "@/type/preload";
+import { getButton, tickToBaseX } from "@/sing/viewHelper";
+import { secondToTick } from "@/sing/music";
+
+export class ErasePhonemeTimingState implements State<
+  PhonemeTimingEditorStateDefinitions,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorContext
+> {
+  readonly id = "erasePhonemeTiming";
+
+  private readonly targetTrackId: TrackId;
+  private readonly returnStateId: PhonemeTimingEditorIdleStateId;
+
+  private prevPositionX: number;
+  private currentPositionX: number;
+  private targets: {
+    noteId: NoteId;
+    phonemeIndexInNote: number;
+  }[];
+  private shouldApplyPreview: boolean;
+
+  private animationContext:
+    | {
+        previewRequestId: number;
+        executePreviewProcess: boolean;
+      }
+    | undefined;
+
+  constructor(args: {
+    targetTrackId: TrackId;
+    startPositionX: number;
+    returnStateId: PhonemeTimingEditorIdleStateId;
+  }) {
+    this.targetTrackId = args.targetTrackId;
+    this.returnStateId = args.returnStateId;
+
+    this.prevPositionX = args.startPositionX;
+    this.currentPositionX = args.startPositionX;
+    this.targets = [];
+    this.shouldApplyPreview = false;
+  }
+
+  onEnter(context: PhonemeTimingEditorContext) {
+    context.previewPhonemeTiming.value = {
+      type: "erase",
+      targets: [],
+    };
+    context.previewMode.value = "ERASE_PHONEME_TIMING";
+    context.cursorState.value = "CROSSHAIR";
+
+    // 初期位置での当たり判定
+    this.updateEraseTargets(context);
+
+    const previewIfNeeded = () => {
+      if (this.animationContext == undefined) {
+        throw new Error("animationContext is undefined.");
+      }
+      if (this.animationContext.executePreviewProcess) {
+        this.updateEraseTargets(context);
+        this.animationContext.executePreviewProcess = false;
+      }
+      this.animationContext.previewRequestId =
+        requestAnimationFrame(previewIfNeeded);
+    };
+    const previewRequestId = requestAnimationFrame(previewIfNeeded);
+
+    this.animationContext = {
+      executePreviewProcess: false,
+      previewRequestId,
+    };
+  }
+
+  process({
+    input,
+    setNextState,
+  }: {
+    input: PhonemeTimingEditorInput;
+    context: PhonemeTimingEditorContext;
+    setNextState: SetNextState<PhonemeTimingEditorStateDefinitions>;
+  }) {
+    if (this.animationContext == undefined) {
+      throw new Error("animationContext is undefined.");
+    }
+
+    if (input.type === "pointerEvent") {
+      const mouseButton = getButton(input.pointerEvent);
+
+      if (
+        input.targetArea === "Window" ||
+        input.targetArea === "PhonemeTimingArea"
+      ) {
+        if (input.pointerEvent.type === "pointermove") {
+          this.currentPositionX = input.positionX;
+          this.animationContext.executePreviewProcess = true;
+        } else if (
+          input.pointerEvent.type === "pointerup" &&
+          mouseButton === "LEFT_BUTTON"
+        ) {
+          this.shouldApplyPreview = this.targets.length > 0;
+          setNextState(this.returnStateId, undefined);
+        }
+      }
+    }
+  }
+
+  onExit(context: PhonemeTimingEditorContext) {
+    if (this.animationContext == undefined) {
+      throw new Error("animationContext is undefined.");
+    }
+
+    cancelAnimationFrame(this.animationContext.previewRequestId);
+
+    if (this.shouldApplyPreview) {
+      this.applyPreview(context);
+    }
+
+    context.previewPhonemeTiming.value = undefined;
+    context.cursorState.value = "UNSET";
+    context.previewMode.value = "IDLE";
+  }
+
+  private updateEraseTargets(context: PhonemeTimingEditorContext) {
+    const phonemeTimingInfos = context.phonemeTimingInfos.value;
+    const phonemeTimingEditData = context.phonemeTimingEditData.value;
+    const viewportInfo = context.viewportInfo.value;
+    const tempos = context.tempos.value;
+    const tpqn = context.tpqn.value;
+
+    // 高速移動対応: 前回と現在の位置の間の範囲で当たり判定
+    const threshold = 4;
+    const minX =
+      Math.min(this.prevPositionX, this.currentPositionX) - threshold;
+    const maxX =
+      Math.max(this.prevPositionX, this.currentPositionX) + threshold;
+
+    for (const phonemeTimingInfo of phonemeTimingInfos) {
+      if (phonemeTimingInfo.noteId == undefined) {
+        continue;
+      }
+
+      // 編集済みかどうか確認
+      const phonemeTimingEdits = phonemeTimingEditData.get(
+        phonemeTimingInfo.noteId,
+      );
+      const hasExistingEdit =
+        phonemeTimingEdits?.some(
+          (edit) =>
+            edit.phonemeIndexInNote === phonemeTimingInfo.phonemeIndexInNote,
+        ) ?? false;
+
+      if (!hasExistingEdit) {
+        continue;
+      }
+
+      // 音素タイミング線のX座標を計算
+      const phonemeStartTicks = secondToTick(
+        phonemeTimingInfo.editedStartTimeSeconds,
+        tempos,
+        tpqn,
+      );
+      const phonemeStartBaseX = tickToBaseX(phonemeStartTicks, tpqn);
+      const phonemeX = Math.round(
+        phonemeStartBaseX * viewportInfo.scaleX - viewportInfo.offsetX,
+      );
+
+      // カーソルの軌跡範囲内かどうか判定
+      if (phonemeX >= minX && phonemeX <= maxX) {
+        // まだ削除対象リストにない場合、追加
+        const alreadyInTargets = this.targets.some(
+          (t) =>
+            t.noteId === phonemeTimingInfo.noteId &&
+            t.phonemeIndexInNote === phonemeTimingInfo.phonemeIndexInNote,
+        );
+
+        if (!alreadyInTargets) {
+          this.targets.push({
+            noteId: phonemeTimingInfo.noteId,
+            phonemeIndexInNote: phonemeTimingInfo.phonemeIndexInNote,
+          });
+        }
+      }
+    }
+
+    // プレビューを更新
+    context.previewPhonemeTiming.value = {
+      type: "erase",
+      targets: [...this.targets],
+    };
+
+    // 次回のために現在位置を保存
+    this.prevPositionX = this.currentPositionX;
+  }
+
+  private applyPreview(context: PhonemeTimingEditorContext) {
+    if (this.targets.length === 0) {
+      return;
+    }
+
+    void context.store.actions.COMMAND_ERASE_PHONEME_TIMING_EDITS({
+      targets: this.targets,
+      trackId: this.targetTrackId,
+    });
+  }
+}

--- a/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingState.ts
@@ -54,7 +54,7 @@ export class ErasePhonemeTimingState implements State<
       targets: [],
     };
     context.previewMode.value = "ERASE_PHONEME_TIMING";
-    context.cursorState.value = "CROSSHAIR";
+    context.cursorState.value = "ERASE";
 
     // 初期位置での当たり判定
     this.updateEraseTargets(context);

--- a/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingState.ts
@@ -106,6 +106,8 @@ export class ErasePhonemeTimingState implements State<
         ) {
           this.shouldApplyPreview = this.targets.length > 0;
           setNextState(this.returnStateId, undefined);
+        } else if (input.pointerEvent.type === "pointercancel") {
+          setNextState(this.returnStateId, undefined);
         }
       }
     }

--- a/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingToolIdleState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingToolIdleState.ts
@@ -1,0 +1,117 @@
+import type { SetNextState, State } from "@/sing/stateMachine";
+import type {
+  PhonemeTimingEditorContext,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorStateDefinitions,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
+import { getButton, tickToBaseX } from "@/sing/viewHelper";
+import { secondToTick } from "@/sing/music";
+
+export class ErasePhonemeTimingToolIdleState implements State<
+  PhonemeTimingEditorStateDefinitions,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorContext
+> {
+  readonly id = "erasePhonemeTimingToolIdle";
+
+  onEnter(context: PhonemeTimingEditorContext) {
+    context.cursorState.value = "UNSET";
+  }
+
+  process({
+    input,
+    context,
+    setNextState,
+  }: {
+    input: PhonemeTimingEditorInput;
+    context: PhonemeTimingEditorContext;
+    setNextState: SetNextState<PhonemeTimingEditorStateDefinitions>;
+  }) {
+    const viewportInfo = context.viewportInfo.value;
+    const phonemeTimingInfos = context.phonemeTimingInfos.value;
+    const phonemeTimingEditData = context.phonemeTimingEditData.value;
+
+    if (input.type === "pointerEvent") {
+      const mouseButton = getButton(input.pointerEvent);
+      const selectedTrackId = context.selectedTrackId.value;
+
+      const isPointerMove = input.pointerEvent.type === "pointermove";
+      const isPointerDown =
+        input.pointerEvent.type === "pointerdown" &&
+        mouseButton === "LEFT_BUTTON" &&
+        input.targetArea === "PhonemeTimingArea";
+
+      if (!isPointerMove && !isPointerDown) {
+        return;
+      }
+
+      // 編集済み音素タイミングのヒットテスト
+      const threshold = 4;
+      let isHitEditedPhonemeTiming = false;
+      for (const phonemeTimingInfo of phonemeTimingInfos) {
+        if (phonemeTimingInfo.noteId == undefined) {
+          continue;
+        }
+
+        // 編集済みかどうか確認
+        const phonemeTimingEdits = phonemeTimingEditData.get(
+          phonemeTimingInfo.noteId,
+        );
+        const hasExistingEdit =
+          phonemeTimingEdits?.some(
+            (edit) =>
+              edit.phonemeIndexInNote === phonemeTimingInfo.phonemeIndexInNote,
+          ) ?? false;
+
+        if (!hasExistingEdit) {
+          continue;
+        }
+
+        const phonemeStartTicks = secondToTick(
+          phonemeTimingInfo.editedStartTimeSeconds,
+          context.tempos.value,
+          context.tpqn.value,
+        );
+        const phonemeStartBaseX = tickToBaseX(
+          phonemeStartTicks,
+          context.tpqn.value,
+        );
+        const phonemeStartX = Math.round(
+          phonemeStartBaseX * viewportInfo.scaleX - viewportInfo.offsetX,
+        );
+
+        const distance = Math.abs(phonemeStartX - input.positionX);
+        if (distance <= threshold) {
+          isHitEditedPhonemeTiming = true;
+          break;
+        }
+      }
+
+      if (isHitEditedPhonemeTiming) {
+        if (isPointerMove) {
+          context.cursorState.value = "CROSSHAIR";
+        } else {
+          setNextState("erasePhonemeTiming", {
+            targetTrackId: selectedTrackId,
+            startPositionX: input.positionX,
+            returnStateId: this.id,
+          });
+        }
+      } else if (isPointerMove) {
+        context.cursorState.value = "UNSET";
+      } else if (isPointerDown) {
+        // 編集済み音素がない場所でクリックした場合でも削除状態に遷移
+        // （ドラッグで他の編集済み音素を削除できるようにするため）
+        setNextState("erasePhonemeTiming", {
+          targetTrackId: selectedTrackId,
+          startPositionX: input.positionX,
+          returnStateId: this.id,
+        });
+      }
+    }
+  }
+
+  onExit(context: PhonemeTimingEditorContext) {
+    context.cursorState.value = "UNSET";
+  }
+}

--- a/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingToolIdleState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingToolIdleState.ts
@@ -89,7 +89,7 @@ export class ErasePhonemeTimingToolIdleState implements State<
 
       if (isHitEditedPhonemeTiming) {
         if (isPointerMove) {
-          context.cursorState.value = "CROSSHAIR";
+          context.cursorState.value = "ERASE";
         } else {
           setNextState("erasePhonemeTiming", {
             targetTrackId: selectedTrackId,

--- a/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingToolIdleState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/erasePhonemeTimingToolIdleState.ts
@@ -35,7 +35,9 @@ export class ErasePhonemeTimingToolIdleState implements State<
       const mouseButton = getButton(input.pointerEvent);
       const selectedTrackId = context.selectedTrackId.value;
 
-      const isPointerMove = input.pointerEvent.type === "pointermove";
+      const isPointerMove =
+        input.pointerEvent.type === "pointermove" &&
+        input.targetArea === "PhonemeTimingArea";
       const isPointerDown =
         input.pointerEvent.type === "pointerdown" &&
         mouseButton === "LEFT_BUTTON" &&

--- a/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
@@ -1,0 +1,262 @@
+import type { SetNextState, State } from "@/sing/stateMachine";
+import type {
+  PhonemeTimingEditorContext,
+  PhonemeTimingEditorIdleStateId,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorStateDefinitions,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
+import { NoteId, TrackId } from "@/type/preload";
+import { baseXToTick, getButton } from "@/sing/viewHelper";
+import { tickToSecond } from "@/sing/music";
+import { clamp, getPrev } from "@/sing/utility";
+import { getOrThrow } from "@/helpers/mapHelper";
+import { assertNonNullable } from "@/type/utility";
+
+export class MovePhonemeTimingState implements State<
+  PhonemeTimingEditorStateDefinitions,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorContext
+> {
+  readonly id = "movePhonemeTiming";
+
+  private readonly targetTrackId: TrackId;
+  private readonly noteId: NoteId;
+  private readonly phonemeIndexInNote: number;
+  private readonly startPositionX: number;
+  private readonly returnStateId: PhonemeTimingEditorIdleStateId;
+
+  private currentPositionX: number;
+  private shouldApplyPreview: boolean;
+
+  private animationContext:
+    | {
+        previewRequestId: number;
+        executePreviewProcess: boolean;
+      }
+    | undefined;
+
+  constructor(args: {
+    targetTrackId: TrackId;
+    noteId: NoteId;
+    phonemeIndexInNote: number;
+    startPositionX: number;
+    returnStateId: PhonemeTimingEditorIdleStateId;
+  }) {
+    this.targetTrackId = args.targetTrackId;
+    this.noteId = args.noteId;
+    this.phonemeIndexInNote = args.phonemeIndexInNote;
+    this.startPositionX = args.startPositionX;
+    this.returnStateId = args.returnStateId;
+
+    this.currentPositionX = args.startPositionX;
+    this.shouldApplyPreview = false;
+  }
+
+  onEnter(context: PhonemeTimingEditorContext) {
+    const targetInfo = context.phonemeTimingInfos.value.find(
+      (info) =>
+        info.noteId === this.noteId &&
+        info.phonemeIndexInNote === this.phonemeIndexInNote,
+    );
+
+    if (targetInfo != undefined) {
+      const initialOffsetSeconds =
+        targetInfo.editedStartTimeSeconds - targetInfo.originalStartTimeSeconds;
+
+      context.previewPhonemeTiming.value = {
+        type: "move",
+        noteId: this.noteId,
+        phonemeIndexInNote: this.phonemeIndexInNote,
+        offsetSeconds: initialOffsetSeconds,
+      };
+    }
+
+    context.previewMode.value = "MOVE_PHONEME_TIMING";
+    context.cursorState.value = "EW_RESIZE";
+
+    const previewIfNeeded = () => {
+      if (this.animationContext == undefined) {
+        throw new Error("animationContext is undefined.");
+      }
+      if (this.animationContext.executePreviewProcess) {
+        this.updatePreview(context);
+        this.animationContext.executePreviewProcess = false;
+      }
+      this.animationContext.previewRequestId =
+        requestAnimationFrame(previewIfNeeded);
+    };
+    const previewRequestId = requestAnimationFrame(previewIfNeeded);
+
+    this.animationContext = {
+      executePreviewProcess: false,
+      previewRequestId,
+    };
+  }
+
+  process({
+    input,
+    setNextState,
+  }: {
+    input: PhonemeTimingEditorInput;
+    context: PhonemeTimingEditorContext;
+    setNextState: SetNextState<PhonemeTimingEditorStateDefinitions>;
+  }) {
+    if (this.animationContext == undefined) {
+      throw new Error("animationContext is undefined.");
+    }
+
+    if (input.type === "pointerEvent") {
+      const mouseButton = getButton(input.pointerEvent);
+
+      if (
+        input.targetArea === "Window" ||
+        input.targetArea === "PhonemeTimingArea"
+      ) {
+        if (input.pointerEvent.type === "pointermove") {
+          this.currentPositionX = input.positionX;
+          this.animationContext.executePreviewProcess = true;
+        } else if (
+          input.pointerEvent.type === "pointerup" &&
+          mouseButton === "LEFT_BUTTON"
+        ) {
+          const pixelDelta = Math.abs(
+            this.currentPositionX - this.startPositionX,
+          );
+          this.shouldApplyPreview = pixelDelta >= 1;
+          setNextState(this.returnStateId, undefined);
+        }
+      }
+    }
+  }
+
+  onExit(context: PhonemeTimingEditorContext) {
+    if (this.animationContext == undefined) {
+      throw new Error("animationContext is undefined.");
+    }
+
+    cancelAnimationFrame(this.animationContext.previewRequestId);
+
+    const targetInfo = context.phonemeTimingInfos.value.find(
+      (info) =>
+        info.noteId === this.noteId &&
+        info.phonemeIndexInNote === this.phonemeIndexInNote,
+    );
+    if (targetInfo != undefined && this.shouldApplyPreview) {
+      this.applyPreview(context);
+    }
+
+    context.previewPhonemeTiming.value = undefined;
+    context.cursorState.value = "UNSET";
+    context.previewMode.value = "IDLE";
+  }
+
+  private updatePreview(context: PhonemeTimingEditorContext) {
+    const phraseInfos = context.phraseInfos.value;
+    const phonemeTimingInfos = context.phonemeTimingInfos.value;
+    const viewportInfo = context.viewportInfo.value;
+    const tempos = context.tempos.value;
+    const tpqn = context.tpqn.value;
+
+    const targetIndex = phonemeTimingInfos.findIndex(
+      (info) =>
+        info.noteId === this.noteId &&
+        info.phonemeIndexInNote === this.phonemeIndexInNote,
+    );
+    if (targetIndex === -1) {
+      return;
+    }
+
+    const targetInfo = phonemeTimingInfos[targetIndex];
+    const prevInfo = getPrev(phonemeTimingInfos, targetIndex);
+    if (prevInfo == undefined) {
+      throw new Error("Previous phoneme timing info does not exist.");
+    }
+
+    const phraseInfo = getOrThrow(phraseInfos, targetInfo.phraseKey);
+    assertNonNullable(phraseInfo.query);
+    const frameRate = phraseInfo.query.frameRate;
+
+    let minNonPauseStartTime: number | undefined = undefined;
+    if (phraseInfo.minNonPauseStartFrame != undefined) {
+      minNonPauseStartTime =
+        phraseInfo.startTime + phraseInfo.minNonPauseStartFrame / frameRate;
+    }
+
+    let maxNonPauseEndTime: number | undefined = undefined;
+    if (phraseInfo.maxNonPauseEndFrame != undefined) {
+      maxNonPauseEndTime =
+        phraseInfo.startTime + phraseInfo.maxNonPauseEndFrame / frameRate;
+    }
+
+    let minTimeSeconds = prevInfo.editedStartTimeSeconds;
+    if (
+      minNonPauseStartTime != undefined &&
+      minTimeSeconds < minNonPauseStartTime
+    ) {
+      minTimeSeconds = minNonPauseStartTime;
+    }
+
+    let maxTimeSeconds = targetInfo.editedEndTimeSeconds;
+    if (
+      maxNonPauseEndTime != undefined &&
+      maxTimeSeconds > maxNonPauseEndTime
+    ) {
+      maxTimeSeconds = maxNonPauseEndTime;
+    }
+
+    // ピクセル座標からbaseXを計算し、tickを経由して秒に変換
+    // これによりテンポ変更を正しく考慮できる
+    const startBaseX =
+      (this.startPositionX + viewportInfo.offsetX) / viewportInfo.scaleX;
+    const currentBaseX =
+      (this.currentPositionX + viewportInfo.offsetX) / viewportInfo.scaleX;
+
+    const startTicks = baseXToTick(startBaseX, tpqn);
+    const currentTicks = baseXToTick(currentBaseX, tpqn);
+
+    const startSeconds = tickToSecond(startTicks, tempos, tpqn);
+    const currentSeconds = tickToSecond(currentTicks, tempos, tpqn);
+
+    const timeDeltaSeconds = currentSeconds - startSeconds;
+
+    const originalStartTimeSeconds = targetInfo.originalStartTimeSeconds;
+    const editedStartTimeSeconds = targetInfo.editedStartTimeSeconds;
+
+    // 新しいoffsetSecondsを計算
+    // initialStartTimeSeconds + timeDelta が minTimeSeconds と maxTimeSeconds の間になるようにclamp
+    const newStartTime = clamp(
+      editedStartTimeSeconds + timeDeltaSeconds,
+      minTimeSeconds,
+      maxTimeSeconds,
+    );
+
+    const newOffsetSeconds = newStartTime - originalStartTimeSeconds;
+
+    context.previewPhonemeTiming.value = {
+      type: "move",
+      noteId: this.noteId,
+      phonemeIndexInNote: this.phonemeIndexInNote,
+      offsetSeconds: newOffsetSeconds,
+    };
+  }
+
+  private applyPreview(context: PhonemeTimingEditorContext) {
+    const preview = context.previewPhonemeTiming.value;
+    if (preview == undefined || preview.type !== "move") {
+      throw new Error("previewPhonemeTiming is undefined or not move type.");
+    }
+
+    const { offsetSeconds } = preview;
+
+    const phonemeTimingEdit = {
+      phonemeIndexInNote: this.phonemeIndexInNote,
+      offsetSeconds,
+    };
+
+    void context.store.actions.COMMAND_UPSERT_PHONEME_TIMING_EDIT({
+      noteId: this.noteId,
+      phonemeTimingEdit,
+      trackId: this.targetTrackId,
+    });
+  }
+}

--- a/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
@@ -222,8 +222,7 @@ export class MovePhonemeTimingState implements State<
     const originalStartTimeSeconds = targetInfo.originalStartTimeSeconds;
     const editedStartTimeSeconds = targetInfo.editedStartTimeSeconds;
 
-    // 新しいoffsetSecondsを計算
-    // initialStartTimeSeconds + timeDelta が minTimeSeconds と maxTimeSeconds の間になるようにclamp
+    // 前後の音素タイミングとフレーズ範囲端を越えないようclampする
     const newStartTime = clamp(
       editedStartTimeSeconds + timeDeltaSeconds,
       minTimeSeconds,

--- a/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
@@ -126,6 +126,8 @@ export class MovePhonemeTimingState implements State<
           );
           this.shouldApplyPreview = pixelDelta >= 1;
           setNextState(this.returnStateId, undefined);
+        } else if (input.pointerEvent.type === "pointercancel") {
+          setNextState(this.returnStateId, undefined);
         }
       }
     }

--- a/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
@@ -4,6 +4,8 @@ import type {
   PhonemeTimingEditorIdleStateId,
   PhonemeTimingEditorInput,
   PhonemeTimingEditorStateDefinitions,
+  PhonemeTimingInfo,
+  PhraseInfo,
 } from "@/sing/phonemeTimingEditorStateMachine/common";
 import { NoteId, TrackId } from "@/type/preload";
 import { baseXToTick, getButton } from "@/sing/viewHelper";
@@ -176,42 +178,6 @@ export class MovePhonemeTimingState implements State<
     assertNonNullable(phraseInfo.query);
     const frameRate = phraseInfo.query.frameRate;
 
-    let minNonPauseStartTime: number | undefined = undefined;
-    if (phraseInfo.minNonPauseStartFrame != undefined) {
-      minNonPauseStartTime =
-        phraseInfo.startTime + phraseInfo.minNonPauseStartFrame / frameRate;
-    }
-
-    let maxNonPauseEndTime: number | undefined = undefined;
-    if (phraseInfo.maxNonPauseEndFrame != undefined) {
-      maxNonPauseEndTime =
-        phraseInfo.startTime + phraseInfo.maxNonPauseEndFrame / frameRate;
-    }
-
-    // 前後の音素が最低1フレーム分残るようにクランプ範囲を調整する
-    const oneFrameSeconds = 1 / frameRate;
-
-    let minTimeSeconds = prevInfo.editedStartTimeSeconds + oneFrameSeconds;
-    if (
-      minNonPauseStartTime != undefined &&
-      minTimeSeconds < minNonPauseStartTime
-    ) {
-      minTimeSeconds = minNonPauseStartTime;
-    }
-
-    let maxTimeSeconds = targetInfo.editedEndTimeSeconds - oneFrameSeconds;
-    if (
-      maxNonPauseEndTime != undefined &&
-      maxTimeSeconds > maxNonPauseEndTime
-    ) {
-      maxTimeSeconds = maxNonPauseEndTime;
-    }
-
-    // 上記の切り上げ・切り下げで範囲が反転し得るので、その場合は一点に潰す
-    if (minTimeSeconds > maxTimeSeconds) {
-      minTimeSeconds = maxTimeSeconds;
-    }
-
     // ピクセル座標からbaseXを計算し、tickを経由して秒に変換
     // これによりテンポ変更を正しく考慮できる
     const startBaseX =
@@ -230,11 +196,12 @@ export class MovePhonemeTimingState implements State<
     const originalStartTimeSeconds = targetInfo.originalStartTimeSeconds;
     const editedStartTimeSeconds = targetInfo.editedStartTimeSeconds;
 
-    // 前後の音素タイミングとフレーズ範囲端を越えないようclampする
-    const newStartTime = clamp(
+    const newStartTime = this.clampMovingPhonemeStartTime(
       editedStartTimeSeconds + timeDeltaSeconds,
-      minTimeSeconds,
-      maxTimeSeconds,
+      phraseInfo,
+      prevInfo,
+      targetInfo,
+      frameRate,
     );
 
     const newOffsetSeconds = newStartTime - originalStartTimeSeconds;
@@ -265,5 +232,61 @@ export class MovePhonemeTimingState implements State<
       phonemeTimingEdit,
       trackId: this.targetTrackId,
     });
+  }
+
+  /**
+   * 移動対象の音素の開始時刻を、音素タイミングに課される次の制約に基づいてクランプする。
+   * - 前後の音素が最低1フレーム分残ること
+   * - 非pause区間の開始フレームが所定の最小値以上、終了フレームが所定の最大値以下
+   *
+   * @param candidateTimeSeconds - クランプしたい開始時刻の候補
+   * @param phraseInfo - 対象音素が属するフレーズの情報
+   * @param prevInfo - 対象音素の直前の音素のタイミング情報
+   * @param targetInfo - 対象音素のタイミング情報
+   * @param frameRate - フレームレート
+   */
+  private clampMovingPhonemeStartTime(
+    candidateTimeSeconds: number,
+    phraseInfo: PhraseInfo,
+    prevInfo: PhonemeTimingInfo,
+    targetInfo: PhonemeTimingInfo,
+    frameRate: number,
+  ): number {
+    let minNonPauseStartTime: number | undefined = undefined;
+    if (phraseInfo.minNonPauseStartFrame != undefined) {
+      minNonPauseStartTime =
+        phraseInfo.startTime + phraseInfo.minNonPauseStartFrame / frameRate;
+    }
+
+    let maxNonPauseEndTime: number | undefined = undefined;
+    if (phraseInfo.maxNonPauseEndFrame != undefined) {
+      maxNonPauseEndTime =
+        phraseInfo.startTime + phraseInfo.maxNonPauseEndFrame / frameRate;
+    }
+
+    const oneFrameSeconds = 1 / frameRate;
+
+    let minTimeSeconds = prevInfo.editedStartTimeSeconds + oneFrameSeconds;
+    if (
+      minNonPauseStartTime != undefined &&
+      minTimeSeconds < minNonPauseStartTime
+    ) {
+      minTimeSeconds = minNonPauseStartTime;
+    }
+
+    let maxTimeSeconds = targetInfo.editedEndTimeSeconds - oneFrameSeconds;
+    if (
+      maxNonPauseEndTime != undefined &&
+      maxTimeSeconds > maxNonPauseEndTime
+    ) {
+      maxTimeSeconds = maxNonPauseEndTime;
+    }
+
+    // 上記の切り上げ・切り下げで範囲が反転し得るので、その場合は一点に潰す
+    if (minTimeSeconds > maxTimeSeconds) {
+      minTimeSeconds = maxTimeSeconds;
+    }
+
+    return clamp(candidateTimeSeconds, minTimeSeconds, maxTimeSeconds);
   }
 }

--- a/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingState.ts
@@ -188,7 +188,10 @@ export class MovePhonemeTimingState implements State<
         phraseInfo.startTime + phraseInfo.maxNonPauseEndFrame / frameRate;
     }
 
-    let minTimeSeconds = prevInfo.editedStartTimeSeconds;
+    // 前後の音素が最低1フレーム分残るようにクランプ範囲を調整する
+    const oneFrameSeconds = 1 / frameRate;
+
+    let minTimeSeconds = prevInfo.editedStartTimeSeconds + oneFrameSeconds;
     if (
       minNonPauseStartTime != undefined &&
       minTimeSeconds < minNonPauseStartTime
@@ -196,12 +199,17 @@ export class MovePhonemeTimingState implements State<
       minTimeSeconds = minNonPauseStartTime;
     }
 
-    let maxTimeSeconds = targetInfo.editedEndTimeSeconds;
+    let maxTimeSeconds = targetInfo.editedEndTimeSeconds - oneFrameSeconds;
     if (
       maxNonPauseEndTime != undefined &&
       maxTimeSeconds > maxNonPauseEndTime
     ) {
       maxTimeSeconds = maxNonPauseEndTime;
+    }
+
+    // 上記の切り上げ・切り下げで範囲が反転し得るので、その場合は一点に潰す
+    if (minTimeSeconds > maxTimeSeconds) {
+      minTimeSeconds = maxTimeSeconds;
     }
 
     // ピクセル座標からbaseXを計算し、tickを経由して秒に変換

--- a/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingToolIdleState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingToolIdleState.ts
@@ -1,0 +1,97 @@
+import type { SetNextState, State } from "@/sing/stateMachine";
+import type {
+  PhonemeTimingEditorContext,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorStateDefinitions,
+  PhonemeTimingInfo,
+} from "@/sing/phonemeTimingEditorStateMachine/common";
+import { getButton, tickToBaseX } from "@/sing/viewHelper";
+import { secondToTick } from "@/sing/music";
+
+export class MovePhonemeTimingToolIdleState implements State<
+  PhonemeTimingEditorStateDefinitions,
+  PhonemeTimingEditorInput,
+  PhonemeTimingEditorContext
+> {
+  readonly id = "movePhonemeTimingToolIdle";
+
+  onEnter(context: PhonemeTimingEditorContext) {
+    context.cursorState.value = "UNSET";
+  }
+
+  process({
+    input,
+    context,
+    setNextState,
+  }: {
+    input: PhonemeTimingEditorInput;
+    context: PhonemeTimingEditorContext;
+    setNextState: SetNextState<PhonemeTimingEditorStateDefinitions>;
+  }) {
+    const viewportInfo = context.viewportInfo.value;
+    const phonemeTimingInfos = context.phonemeTimingInfos.value;
+
+    if (input.type === "pointerEvent") {
+      const mouseButton = getButton(input.pointerEvent);
+      const selectedTrackId = context.selectedTrackId.value;
+
+      const isPointerMove = input.pointerEvent.type === "pointermove";
+      const isPointerDown =
+        input.pointerEvent.type === "pointerdown" &&
+        mouseButton === "LEFT_BUTTON" &&
+        input.targetArea === "PhonemeTimingArea";
+
+      if (!isPointerMove && !isPointerDown) {
+        return;
+      }
+
+      // ヒットテスト
+      const threshold = 4;
+      let nearest: PhonemeTimingInfo | undefined;
+      let minDistance: number | undefined = undefined;
+      for (const phonemeTimingInfo of phonemeTimingInfos) {
+        const phonemeStartTicks = secondToTick(
+          phonemeTimingInfo.editedStartTimeSeconds,
+          context.tempos.value,
+          context.tpqn.value,
+        );
+        const phonemeStartBaseX = tickToBaseX(
+          phonemeStartTicks,
+          context.tpqn.value,
+        );
+        const phonemeStartX = Math.round(
+          phonemeStartBaseX * viewportInfo.scaleX - viewportInfo.offsetX,
+        );
+
+        const distance = Math.abs(phonemeStartX - input.positionX);
+        if (
+          distance <= threshold &&
+          (minDistance == undefined || distance < minDistance)
+        ) {
+          minDistance = distance;
+          nearest = phonemeTimingInfo;
+        }
+      }
+
+      if (nearest != undefined && nearest.noteId != undefined) {
+        if (isPointerMove) {
+          context.cursorState.value = "EW_RESIZE";
+        } else {
+          setNextState("movePhonemeTiming", {
+            targetTrackId: selectedTrackId,
+            noteId: nearest.noteId,
+            phonemeIndexInNote: nearest.phonemeIndexInNote,
+            startPositionX: input.positionX,
+            returnStateId: this.id,
+          });
+        }
+      } else if (isPointerMove) {
+        context.cursorState.value = "UNSET";
+      }
+    }
+  }
+
+  onExit(context: PhonemeTimingEditorContext) {
+    context.cursorState.value = "UNSET";
+  }
+}

--- a/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingToolIdleState.ts
+++ b/src/sing/phonemeTimingEditorStateMachine/states/movePhonemeTimingToolIdleState.ts
@@ -35,7 +35,9 @@ export class MovePhonemeTimingToolIdleState implements State<
       const mouseButton = getButton(input.pointerEvent);
       const selectedTrackId = context.selectedTrackId.value;
 
-      const isPointerMove = input.pointerEvent.type === "pointermove";
+      const isPointerMove =
+        input.pointerEvent.type === "pointermove" &&
+        input.targetArea === "PhonemeTimingArea";
       const isPointerDown =
         input.pointerEvent.type === "pointerdown" &&
         mouseButton === "LEFT_BUTTON" &&

--- a/src/store/singing.ts
+++ b/src/store/singing.ts
@@ -756,6 +756,7 @@ export const singingStoreState: SingingStoreState = {
   sequencerNoteTool: "EDIT_FIRST",
   sequencerPitchTool: "DRAW",
   sequencerVolumeTool: "DRAW",
+  sequencerPhonemeTimingTool: "MOVE",
   parameterPanelEditTarget: "VOLUME",
   sequencerVolumeVisible: false,
   _selectedNoteIds: new Set(),
@@ -1071,6 +1072,20 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
         notesMap.set(note.id, note);
       }
       const selectedTrack = getOrThrow(state.tracks, trackId);
+
+      const phonemeTimingEditData = selectedTrack.phonemeTimingEditData;
+      for (const existingNote of selectedTrack.notes) {
+        const noteId = existingNote.id;
+        const newNote = notesMap.get(noteId);
+        if (
+          newNote != undefined &&
+          existingNote.lyric !== newNote.lyric &&
+          phonemeTimingEditData.has(noteId)
+        ) {
+          phonemeTimingEditData.delete(noteId);
+        }
+      }
+
       selectedTrack.notes = selectedTrack.notes
         .map((value) => notesMap.get(value.id) ?? value)
         .sort((a, b) => a.position - b.position);
@@ -1093,6 +1108,13 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
       selectedTrack.notes = selectedTrack.notes.filter((value) => {
         return !noteIdsSet.has(value.id);
       });
+
+      const phonemeTimingEditData = selectedTrack.phonemeTimingEditData;
+      for (const noteId of noteIds) {
+        if (phonemeTimingEditData.has(noteId)) {
+          phonemeTimingEditData.delete(noteId);
+        }
+      }
     },
   },
 
@@ -1930,6 +1952,17 @@ export const singingStore = createPartialStore<SingingStoreTypes>({
     },
     async action({ mutations }, { sequencerVolumeTool }) {
       mutations.SET_SEQUENCER_VOLUME_TOOL({ sequencerVolumeTool });
+    },
+  },
+
+  SET_SEQUENCER_PHONEME_TIMING_TOOL: {
+    mutation(state, { sequencerPhonemeTimingTool }) {
+      state.sequencerPhonemeTimingTool = sequencerPhonemeTimingTool;
+    },
+    async action({ mutations }, { sequencerPhonemeTimingTool }) {
+      mutations.SET_SEQUENCER_PHONEME_TIMING_TOOL({
+        sequencerPhonemeTimingTool,
+      });
     },
   },
 

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -849,6 +849,8 @@ export type NoteEditTool = "SELECT_FIRST" | "EDIT_FIRST";
 export type PitchEditTool = "DRAW" | "ERASE";
 // ボリューム編集ツール（VolumeEditor 専用）
 export type VolumeEditTool = "DRAW" | "ERASE";
+// 音素タイミング編集ツール
+export type PhonemeTimingEditTool = "MOVE" | "ERASE";
 // パラメータパネル内の編集対象
 // NOTE: 音素タイミング編集などを追加する際に拡張
 export type ParameterPanelEditTarget = "PHONEME_TIMING" | "VOLUME";
@@ -899,6 +901,7 @@ export type SingingStoreState = {
   sequencerNoteTool: NoteEditTool;
   sequencerPitchTool: PitchEditTool;
   sequencerVolumeTool: VolumeEditTool;
+  sequencerPhonemeTimingTool: PhonemeTimingEditTool;
   parameterPanelEditTarget: ParameterPanelEditTarget;
   sequencerVolumeVisible: boolean;
   _selectedNoteIds: Set<NoteId>;
@@ -1218,6 +1221,13 @@ export type SingingStoreTypes = {
   SET_SEQUENCER_VOLUME_TOOL: {
     mutation: { sequencerVolumeTool: VolumeEditTool };
     action(payload: { sequencerVolumeTool: VolumeEditTool }): void;
+  };
+
+  SET_SEQUENCER_PHONEME_TIMING_TOOL: {
+    mutation: { sequencerPhonemeTimingTool: PhonemeTimingEditTool };
+    action(payload: {
+      sequencerPhonemeTimingTool: PhonemeTimingEditTool;
+    }): void;
   };
 
   SET_PARAMETER_PANEL_EDIT_TARGET: {


### PR DESCRIPTION
## 内容

ソング画面の音素タイミングエディターに、音素タイミングを編集する機能を追加します。あわせて、編集機能の追加時に見つかった音素タイミング調整処理の不具合も修正しています。

エディター内にツールパレットを追加し、「移動」と「削除」のツールを切り替えて編集できるようにしました。移動ツールでは音素タイミング線をドラッグして時間を変更でき、削除ツールでは編集済みのタイミングをカーソルでなぞって編集前の状態に戻せます。編集中の状態管理は、音素タイミング編集用のステートマシンで行います。

### ノートの変更にともなう編集データの削除

ノートの歌詞を変更したときは、対象ノートの音素タイミング編集データを削除するようにしました。Issueでの議論をふまえ、歌詞編集前後で変わっていない音素についても編集を保持しない方針です。
ノートを削除したときは、対応する音素タイミング編集データも削除します。

### 音素タイミング調整処理の修正

`adjustPhonemeTimings` から、音素のフレーム長が1以上になるよう終了フレームを引き伸ばす処理を削除しました。編集した音素タイミングを適用したときに、この調整によって全体のフレーム長が増え、f0のフレーム数と一致しなくなる場合があったためです。

## 関連 Issue

- VOICEVOX/voicevox#2261

## スクリーンショット・動画など

<img width="881" height="549" alt="音素タイミング編集機能を追加" src="https://github.com/user-attachments/assets/33006679-a101-4864-b342-98bcc1e7ecc1" />

## その他
