### PR TITLE
docs: フォントについてのMarkown注釈を正しい形式に修正

### DIFF
--- a/docs/フォントについて.md
+++ b/docs/フォントについて.md
@@ -11,7 +11,7 @@ VOICEVOX では改変したRounded M+ 1pを使用しています。
 
 1. [自家製 Rounded M+ とは](http://jikasei.me/font/rounded-mplus/about.html)から
 Rounded M+をダウンロードします。
-2. [ttfautohint](https://freetype.org/ttfautohint/)をインストールします。[^longnote]:[ttfautohint-py](https://pypi.org/project/ttfautohint-py/)を使用しました。
+2. [ttfautohint](https://freetype.org/ttfautohint/)をインストールします。[^longnote]
 3. [woff2](https://github.com/google/woff2)をビルドします。
 4. `rounded-mplus-20150529.7z`から`rounded-mplus-1p-（ウェイト）.ttf`を全て`src/fonts`に解凍します。
 5. ttfautohintを使用して、Rounded M+のヒント情報を削除します。名前は`Unhinted Rounded M+ 1p`とします。
@@ -27,3 +27,5 @@ foreach ($f in gci("./*.ttf")){
   woff2_compress.exe "unhinted-$($f.name)"
 }
 ```
+
+[^longnote]: [ttfautohint-py](https://pypi.org/project/ttfautohint-py/)を使用しました。


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
VOICEVOX内で使用するフォントの作成方法を解説するファイル内で、注釈が正しく表示されていなかったので修正しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

変更前
<img width="1033" height="632" alt="screenshot-20260628-105808" src="https://github.com/user-attachments/assets/324a8f7b-b109-45ba-9f4e-a70e376e593d" />

変更後
<img width="1031" height="690" alt="screenshot-20260628-105554" src="https://github.com/user-attachments/assets/cb832d4d-9e9f-4ecc-bebf-a9d10778ebb6" />


## その他
