### PR TITLE
chore: no-unused-varsをerrorにする

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -172,7 +172,7 @@ export default defineConfigWithVueTs(
     name: "voicevox/defaults/rules",
     rules: {
       "@typescript-eslint/no-unused-vars": [
-        process.env.NODE_ENV !== "production" ? "warn" : "error", // 開発時のみwarn
+        "error",
         {
           ignoreRestSiblings: true,
           ignoreUsingDeclarations: true,


### PR DESCRIPTION
## 内容

[PR #3017 のレビューコメント](https://github.com/VOICEVOX/voicevox/pull/3017#discussion_r3486198219) で、CIのlintでも `@typescript-eslint/no-unused-vars` がwarningのまま通っていたので、常にerrorにしてみました。

ちなみに、以前は`vite-plugin-checker`によってアプリの起動中にもlintエラーが画面に表示されていて、デバッグしづらかったからこれがwarnになってたんだと思います。
[この提案](https://github.com/VOICEVOX/voicevox/issues/2515)で消えたので、errorに戻して良いかなーと。

## 関連 Issue

ref #2515

## スクリーンショット・動画など

なし

## その他

なし
