### PR TITLE
chore: typosで隠しファイルを検査する

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -18,7 +18,9 @@ commitish = "commitish" # softprops/action-gh-releaseのオプションの１つ
 GAM = "GAM" # VuexのGetter・Action・Mutationの略
 
 [files]
+ignore-hidden = false
 extend-exclude = [
+    ".git",
     "pnpm-lock.yaml",
     "*.svg",
     "public/res/macos-big-sur-software-update-rosetta-alert.jpg", # macos-big-surは正しい固有名詞


### PR DESCRIPTION
## 内容

typosの検査対象に隠しファイルと隠しディレクトリを追加します。
typosは`.github`等の隠しパスを標準で除外するため、隠しパスの検査を有効にしました。

## 関連 Issue

ref https://github.com/VOICEVOX/voicevox/pull/3067#discussion_r3558456262
