### PR TITLE
feat: エンジンが一つだけでもエンジンのライセンス情報などを出すようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,9 +276,6 @@ jobs:
       - name: Generate public/licenses.json
         run: |
           pnpm run license:generate -o public/licenses.json
-          if [ -d voicevox_engine ]; then
-            pnpm run license:merge -o public/licenses.json -i public/licenses.json -i voicevox_engine/licenses.json
-          fi
 
       - name: Overwrite .env.production for installer
         run: |

--- a/src/components/Dialog/HelpDialog/HelpDialog.vue
+++ b/src/components/Dialog/HelpDialog/HelpDialog.vue
@@ -287,9 +287,8 @@ const openLogDirectory = () => window.backend.openLogDirectory();
 }
 
 .help-dialog .q-layout-container :deep(.absolute-full) {
-  right: 0 !important;
-
-  .scroll {
+ right: 0 !important;
+ .scroll {
     left: unset !important;
     right: unset !important;
     width: unset !important;

--- a/src/components/Dialog/HelpDialog/HelpDialog.vue
+++ b/src/components/Dialog/HelpDialog/HelpDialog.vue
@@ -1,6 +1,11 @@
 <template>
-  <QDialog v-model="dialogOpened" maximized transitionShow="jump-up" transitionHide="jump-down"
-    class="help-dialog transparent-backdrop">
+  <QDialog
+    v-model="dialogOpened"
+    maximized
+    transitionShow="jump-up"
+    transitionHide="jump-down"
+    class="help-dialog transparent-backdrop"
+  >
     <QLayout container view="hHh Lpr lff">
       <QPageContainer>
         <QHeader class="q-pa-sm">
@@ -10,19 +15,35 @@
               {{ selectedPage.parent ? selectedPage.parent + " / " : ""
               }}{{ selectedPage.name }}
             </QToolbarTitle>
-            <QBtn v-if="selectedPage.shouldShowOpenLogDirectoryButton" unelevated color="toolbar-button"
-              textColor="toolbar-button-display" class="text-no-wrap text-bold q-mr-sm" @click="openLogDirectory">
+            <QBtn
+              v-if="selectedPage.shouldShowOpenLogDirectoryButton"
+              unelevated
+              color="toolbar-button"
+              textColor="toolbar-button-display"
+              class="text-no-wrap text-bold q-mr-sm"
+              @click="openLogDirectory"
+            >
               ログフォルダを開く
             </QBtn>
             <!-- close button -->
-            <QBtn round flat icon="close" color="display" aria-label="ヘルプを閉じる" @click="dialogOpened = false" />
+            <QBtn
+              round
+              flat
+              icon="close"
+              color="display"
+              aria-label="ヘルプを閉じる"
+              @click="dialogOpened = false"
+            />
           </QToolbar>
         </QHeader>
         <BaseNavigationView>
           <template #sidebar>
             <template v-for="(page, pageIndex) of pagedata" :key="pageIndex">
-              <BaseListItem v-if="page.type === 'item'" :selected="selectedPageIndex === pageIndex"
-                @click="selectedPageIndex = pageIndex">
+              <BaseListItem
+                v-if="page.type === 'item'"
+                :selected="selectedPageIndex === pageIndex"
+                @click="selectedPageIndex = pageIndex"
+              >
                 {{ page.name }}
               </BaseListItem>
               <div v-else-if="page.type === 'separator'" class="list-label">
@@ -31,8 +52,17 @@
             </template>
           </template>
           <QTabPanels v-model="selectedPageIndex">
-            <QTabPanel v-for="(page, pageIndex) of pagedata" :key="pageIndex" :name="pageIndex" class="q-pa-none">
-              <Component :is="page.component" v-if="page.type === 'item'" v-bind="page.props" />
+            <QTabPanel
+              v-for="(page, pageIndex) of pagedata"
+              :key="pageIndex"
+              :name="pageIndex"
+              class="q-pa-none"
+            >
+              <Component
+                :is="page.component"
+                v-if="page.type === 'item'"
+                v-bind="page.props"
+              />
             </QTabPanel>
           </QTabPanels>
         </BaseNavigationView>
@@ -159,13 +189,13 @@ const pagedata = computed(() => {
         updateInfos: updateInfos.value,
         ...(newUpdateResult.value.status == "updateAvailable"
           ? {
-            isUpdateAvailable: true,
-            latestVersion: newUpdateResult.value.latestVersion,
-          }
+              isUpdateAvailable: true,
+              latestVersion: newUpdateResult.value.latestVersion,
+            }
           : {
-            isUpdateAvailable: false,
-            latestVersion: "",
-          }),
+              isUpdateAvailable: false,
+              latestVersion: "",
+            }),
       },
     },
     {

--- a/src/components/Dialog/HelpDialog/HelpDialog.vue
+++ b/src/components/Dialog/HelpDialog/HelpDialog.vue
@@ -287,8 +287,8 @@ const openLogDirectory = () => window.backend.openLogDirectory();
 }
 
 .help-dialog .q-layout-container :deep(.absolute-full) {
- right: 0 !important;
- .scroll {
+  right: 0 !important;
+  .scroll {
     left: unset !important;
     right: unset !important;
     width: unset !important;

--- a/src/components/Dialog/HelpDialog/HelpDialog.vue
+++ b/src/components/Dialog/HelpDialog/HelpDialog.vue
@@ -1,11 +1,6 @@
 <template>
-  <QDialog
-    v-model="dialogOpened"
-    maximized
-    transitionShow="jump-up"
-    transitionHide="jump-down"
-    class="help-dialog transparent-backdrop"
-  >
+  <QDialog v-model="dialogOpened" maximized transitionShow="jump-up" transitionHide="jump-down"
+    class="help-dialog transparent-backdrop">
     <QLayout container view="hHh Lpr lff">
       <QPageContainer>
         <QHeader class="q-pa-sm">
@@ -15,35 +10,19 @@
               {{ selectedPage.parent ? selectedPage.parent + " / " : ""
               }}{{ selectedPage.name }}
             </QToolbarTitle>
-            <QBtn
-              v-if="selectedPage.shouldShowOpenLogDirectoryButton"
-              unelevated
-              color="toolbar-button"
-              textColor="toolbar-button-display"
-              class="text-no-wrap text-bold q-mr-sm"
-              @click="openLogDirectory"
-            >
+            <QBtn v-if="selectedPage.shouldShowOpenLogDirectoryButton" unelevated color="toolbar-button"
+              textColor="toolbar-button-display" class="text-no-wrap text-bold q-mr-sm" @click="openLogDirectory">
               ログフォルダを開く
             </QBtn>
             <!-- close button -->
-            <QBtn
-              round
-              flat
-              icon="close"
-              color="display"
-              aria-label="ヘルプを閉じる"
-              @click="dialogOpened = false"
-            />
+            <QBtn round flat icon="close" color="display" aria-label="ヘルプを閉じる" @click="dialogOpened = false" />
           </QToolbar>
         </QHeader>
         <BaseNavigationView>
           <template #sidebar>
             <template v-for="(page, pageIndex) of pagedata" :key="pageIndex">
-              <BaseListItem
-                v-if="page.type === 'item'"
-                :selected="selectedPageIndex === pageIndex"
-                @click="selectedPageIndex = pageIndex"
-              >
+              <BaseListItem v-if="page.type === 'item'" :selected="selectedPageIndex === pageIndex"
+                @click="selectedPageIndex = pageIndex">
                 {{ page.name }}
               </BaseListItem>
               <div v-else-if="page.type === 'separator'" class="list-label">
@@ -52,17 +31,8 @@
             </template>
           </template>
           <QTabPanels v-model="selectedPageIndex">
-            <QTabPanel
-              v-for="(page, pageIndex) of pagedata"
-              :key="pageIndex"
-              :name="pageIndex"
-              class="q-pa-none"
-            >
-              <Component
-                :is="page.component"
-                v-if="page.type === 'item'"
-                v-bind="page.props"
-              />
+            <QTabPanel v-for="(page, pageIndex) of pagedata" :key="pageIndex" :name="pageIndex" class="q-pa-none">
+              <Component :is="page.component" v-if="page.type === 'item'" v-bind="page.props" />
             </QTabPanel>
           </QTabPanels>
         </BaseNavigationView>
@@ -189,13 +159,13 @@ const pagedata = computed(() => {
         updateInfos: updateInfos.value,
         ...(newUpdateResult.value.status == "updateAvailable"
           ? {
-              isUpdateAvailable: true,
-              latestVersion: newUpdateResult.value.latestVersion,
-            }
+            isUpdateAvailable: true,
+            latestVersion: newUpdateResult.value.latestVersion,
+          }
           : {
-              isUpdateAvailable: false,
-              latestVersion: "",
-            }),
+            isUpdateAvailable: false,
+            latestVersion: "",
+          }),
       },
     },
     {
@@ -216,52 +186,49 @@ const pagedata = computed(() => {
       shouldShowOpenLogDirectoryButton: true,
     },
   ];
-  // エンジンが一つだけの場合は従来の表示のみ
-  if (store.state.engineIds.length > 1) {
-    for (const id of store.getters.GET_SORTED_ENGINE_INFOS.map((m) => m.uuid)) {
-      const manifest = store.state.engineManifests[id];
-      if (!manifest) {
-        warn(`manifest not found: ${id}`);
-        continue;
-      }
-
-      data.push(
-        {
-          type: "separator",
-          name: manifest.name,
-        },
-        {
-          type: "item",
-          name: "利用規約",
-          parent: manifest.name,
-          component: MarkdownView,
-          props: {
-            markdown: manifest.termsOfService,
-          },
-        },
-        {
-          type: "item",
-          name: "ライセンス情報",
-          parent: manifest.name,
-          component: OssLicense,
-          props: {
-            licenses: manifest.dependencyLicenses,
-          },
-        },
-        {
-          type: "item",
-          name: "アップデート情報",
-          parent: manifest.name,
-          component: UpdateInfo,
-          props: {
-            updateInfos: manifest.updateInfos,
-            // TODO: エンジン側で最新バージョンチェックAPIが出来たら実装する。
-            //       https://github.com/VOICEVOX/voicevox_engine/issues/476
-            isUpdateAvailable: false,
-          },
-        },
-      );
+  for (const id of store.getters.GET_SORTED_ENGINE_INFOS.map((m) => m.uuid)) {
+    const manifest = store.state.engineManifests[id];
+    if (!manifest) {
+      warn(`manifest not found: ${id}`);
+      continue;
     }
+
+    data.push(
+      {
+        type: "separator",
+        name: manifest.name,
+      },
+      {
+        type: "item",
+        name: "利用規約",
+        parent: manifest.name,
+        component: MarkdownView,
+        props: {
+          markdown: manifest.termsOfService,
+        },
+      },
+      {
+        type: "item",
+        name: "ライセンス情報",
+        parent: manifest.name,
+        component: OssLicense,
+        props: {
+          licenses: manifest.dependencyLicenses,
+        },
+      },
+      {
+        type: "item",
+        name: "アップデート情報",
+        parent: manifest.name,
+        component: UpdateInfo,
+        props: {
+          updateInfos: manifest.updateInfos,
+          // TODO: エンジン側で最新バージョンチェックAPIが出来たら実装する。
+          //       https://github.com/VOICEVOX/voicevox_engine/issues/476
+          isUpdateAvailable: false,
+        },
+      },
+    );
   }
   return data;
 });
@@ -291,6 +258,7 @@ const openLogDirectory = () => window.backend.openLogDirectory();
 
 .help-dialog .q-layout-container :deep(.absolute-full) {
   right: 0 !important;
+
   .scroll {
     left: unset !important;
     right: unset !important;

--- a/tests/e2e/browser/ヘルプ.spec.ts
+++ b/tests/e2e/browser/ヘルプ.spec.ts
@@ -31,11 +31,11 @@ test("「ヘルプ」メニューから各項目をクリックすると、そ�
   await expect(page.getByText("ヘルプ / 開発コミュニティ")).toBeVisible();
 
   // ライセンス情報
-  await page.getByText("ライセンス情報", { exact: true }).click();
+  await page.getByText("ライセンス情報").first().click();
   await expect(page.getByText("ヘルプ / ライセンス情報")).toBeVisible();
 
   // アップデート情報
-  await page.getByText("アップデート情報", { exact: true }).click();
+  await page.getByText("アップデート情報").first().click();
   await expect(page.getByText("ヘルプ / アップデート情報")).toBeVisible();
 
   // よくあるご質問

--- a/tests/e2e/browser/ヘルプ.spec.ts
+++ b/tests/e2e/browser/ヘルプ.spec.ts
@@ -31,11 +31,11 @@ test("「ヘルプ」メニューから各項目をクリックすると、そ�
   await expect(page.getByText("ヘルプ / 開発コミュニティ")).toBeVisible();
 
   // ライセンス情報
-  await page.getByText("ライセンス情報").first().click();
+  await page.getByText("ライセンス情報", { exact: true }).first().click();
   await expect(page.getByText("ヘルプ / ライセンス情報")).toBeVisible();
 
   // アップデート情報
-  await page.getByText("アップデート情報").first().click();
+  await page.getByText("アップデート情報", { exact: true }).first().click();
   await expect(page.getByText("ヘルプ / アップデート情報")).toBeVisible();
 
   // よくあるご質問


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox/pull/3067#discussion_r3585930464 より。
エンジンが一つだけでも複数エンジン時のようにエンジンごとのライセンス情報をHelpDialog.vueに出すようにします。その関係でビルド時のlicenses.jsonのマージをなくします。

## 関連 Issue

- ref: https://github.com/VOICEVOX/voicevox/pull/3067#discussion_r3585930464

## スクリーンショット・動画など

（無し）

## その他
（無し）