### PR TITLE
fix: Windowsで pnpm run generate-openapi が失敗する問題を修正する

### DIFF
--- a/tools/generateOpenapi.ts
+++ b/tools/generateOpenapi.ts
@@ -49,6 +49,8 @@ async function updateOpenapiJson(engineBase: string) {
  * NOTE: OpenAPI Generator は入力のOpenAPIのパスをURIとして解釈するため、
  * Windowsの区切り文字`\`を含むパスをそのまま渡すと不正な文字として扱われて失敗する。
  * 参考: https://github.com/swagger-api/swagger-parser/issues/2136
+ *
+ * TODO: OpenAPI Generator 側で修正されたらこの関数を削除する。
  */
 function toUriSafePath(targetPath: string) {
   return targetPath.replaceAll(path.sep, "/");

--- a/tools/generateOpenapi.ts
+++ b/tools/generateOpenapi.ts
@@ -43,6 +43,17 @@ async function updateOpenapiJson(engineBase: string) {
   console.log("OpenAPI JSON updated successfully.");
 }
 
+/**
+ * URIとして解釈されても壊れないよう、パスの区切り文字を`/`に統一する。
+ *
+ * NOTE: OpenAPI Generator は入力のOpenAPIのパスをURIとして解釈するため、
+ * Windowsの区切り文字`\`を含むパスをそのまま渡すと不正な文字として扱われて失敗する。
+ * 参考: https://github.com/swagger-api/swagger-parser/issues/2136
+ */
+function toUriSafePath(targetPath: string) {
+  return targetPath.replaceAll(path.sep, "/");
+}
+
 async function runOpenapiGenerator() {
   console.log("Generating OpenAPI client...");
   execSync(
@@ -52,7 +63,7 @@ async function runOpenapiGenerator() {
       "openapi-generator-cli",
       "generate",
       "-i",
-      openapiJsonPath,
+      toUriSafePath(openapiJsonPath),
       "-o",
       openapiDir,
       "-g",


### PR DESCRIPTION
## 内容

Windows環境で `pnpm run generate-openapi` が失敗するため、OpenAPI Generator に渡す入力OpenAPIのパスの区切り文字を `/` に統一します。OpenAPI Generator 側で修正されれば不要になる暫定的な対処です。

### 原因

Windows環境では次のエラーで失敗します。

```
java.net.URISyntaxException: Illegal character in opaque part at index 2: D:\path\to\voicevox\openapi.json
```

OpenAPI 3.1 のスキーマでは swagger-parser が入力のパスをURIとして解釈するため、区切り文字に `\` を含むWindowsの絶対パスが不正な文字として扱われます。エンジンが返すOpenAPIは 3.1 なのでこれに該当します。POSIX環境では発生しないため、CI上では顕在化しません。

- <https://github.com/swagger-api/swagger-parser/issues/2136>
- <https://github.com/OpenAPITools/openapi-generator/issues/18161>

### 対処

入力（`-i`）に渡すパスの区切り文字のみを `/` に統一します。

これは OpenAPI Generator 側で修正されれば不要になる暫定的な対処なので、該当箇所に TODO コメントを入れています。なお、執筆時点で最新の 7.24.0 でも同じエラーが再現するため、バージョン更新では解決できません。

### 採用しなかった案

- `file://` 形式のURIに変換する … インラインスキーマの命名が変わって生成物に差が出るという報告があるため
- 出力先（`-o`）も変換する … `-o` はURIとして解釈されず、変換しなくても動作するため

## その他

このブランチの `openapi.json` からWindowsで生成し直し、コミット済みの生成物と差分がゼロになる（他環境での生成結果を完全に再現できる）ことを確認しています。

（このプルリクエストは Claude Opus 5 によって作成されました）
