### PR TITLE
台本のテキスト欄メニューから直接辞書登録を出来るようにする

### DIFF
--- a/src/components/Dialog/DictionaryManageDialog/DictionaryRegistrationDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog/DictionaryRegistrationDialog.vue
@@ -6,6 +6,7 @@
           flat
           label="キャンセル"
           color="display"
+          :disable="uiLocked"
           @click="dialogOpened = false"
         />
       </QCardActions>
@@ -26,7 +27,7 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
-import { lockUiWhile } from "./common";
+import { lockUiWhile, uiLocked } from "./common";
 import WordEditor from "./WordEditor.vue";
 import { useStore } from "@/store";
 import { UnreachableError } from "@/type/utility";

--- a/src/components/Dialog/DictionaryManageDialog/DictionaryRegistrationDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog/DictionaryRegistrationDialog.vue
@@ -1,0 +1,75 @@
+<template>
+  <QDialog v-model="dialogOpened" persistent>
+    <QCard class="dialog-card">
+      <QCardActions class="justify-end q-pa-sm">
+        <QBtn
+          flat
+          label="キャンセル"
+          color="display"
+          @click="dialogOpened = false"
+        />
+      </QCardActions>
+      <WordEditor
+        v-if="dialogOpened"
+        ref="wordEditor"
+        :key="initialSurface"
+        isNew
+        :initialSurface
+        initialYomi=""
+        :initialWordPriority="5"
+        :initialAccentType="0"
+        @saveNewWord="saveNewWord"
+      />
+    </QCard>
+  </QDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { lockUiWhile } from "./common";
+import WordEditor from "./WordEditor.vue";
+import { useStore } from "@/store";
+import { UnreachableError } from "@/type/utility";
+
+const dialogOpened = defineModel<boolean>("dialogOpened", { default: false });
+defineProps<{
+  initialSurface: string;
+}>();
+
+const store = useStore();
+const wordEditor = ref<InstanceType<typeof WordEditor>>();
+
+const saveNewWord = async () => {
+  if (!wordEditor.value)
+    throw new UnreachableError("wordEditor is not defined");
+
+  const { editState } = wordEditor.value;
+  if (editState.type !== "valid") return;
+
+  try {
+    await lockUiWhile(
+      store.actions.ADD_WORD({
+        surface: editState.surface,
+        pronunciation: editState.yomi,
+        accentType: editState.accentType,
+        priority: editState.wordPriority,
+      }),
+    );
+    dialogOpened.value = false;
+  } catch (e) {
+    void store.actions.SHOW_ALERT_DIALOG({
+      title: "単語の登録に失敗しました",
+      message: "エンジンの再起動をお試しください。",
+    });
+    window.backend.logError(e);
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.dialog-card {
+  width: 720px;
+  max-width: 95vw;
+  max-height: 90vh;
+}
+</style>

--- a/src/components/Talk/AudioCell.vue
+++ b/src/components/Talk/AudioCell.vue
@@ -112,6 +112,10 @@
         @beforeHide="endContextMenuOperation()"
       />
     </QInput>
+    <DictionaryRegistrationDialog
+      v-model:dialogOpened="isDictionaryRegistrationDialogOpen"
+      :initialSurface="selectedSurfaceForDictionary"
+    />
   </div>
 </template>
 
@@ -119,6 +123,7 @@
 import { computed, watch, ref, nextTick } from "vue";
 import { QInput } from "quasar";
 import CharacterButton from "@/components/CharacterButton.vue";
+import DictionaryRegistrationDialog from "@/components/Dialog/DictionaryManageDialog/DictionaryRegistrationDialog.vue";
 import type { MenuItemButton, MenuItemSeparator } from "@/components/Menu/type";
 import ContextMenu from "@/components/Menu/ContextMenu/Container.vue";
 import { useStore } from "@/store";
@@ -544,6 +549,8 @@ const enableDeleteButton = computed(() => {
 
 // テキスト編集エリアの右クリック
 const contextMenu = ref<InstanceType<typeof ContextMenu>>();
+const selectedSurfaceForDictionary = ref("");
+const isDictionaryRegistrationDialogOpen = ref(false);
 
 // FIXME: 可能なら`isRangeSelected`と`contextMenuHeader`をcomputedに
 const isRangeSelected = ref(false);
@@ -552,6 +559,8 @@ const contextMenudata = ref<
   [
     MenuItemButton,
     MenuItemButton,
+    MenuItemButton,
+    MenuItemSeparator,
     MenuItemButton,
     MenuItemSeparator,
     MenuItemButton,
@@ -621,6 +630,20 @@ const contextMenudata = ref<
     },
     disableWhenUiLocked: true,
   },
+  { type: "separator" },
+  {
+    type: "button",
+    label: "辞書に登録",
+    onClick: () => {
+      const selectedSurface = textFieldSelection.getAsString();
+      if (selectedSurface.length === 0) return;
+
+      selectedSurfaceForDictionary.value = selectedSurface;
+      contextMenu.value?.hide();
+      isDictionaryRegistrationDialogOpen.value = true;
+    },
+    disableWhenUiLocked: true,
+  },
 ]);
 /**
  * コンテキストメニューの開閉によりFocusやBlurが発生する可能性のある間は`true`。
@@ -662,10 +685,12 @@ const readyForContextMenu = () => {
     isRangeSelected.value = false;
     getMenuItemButton("切り取り").disabled = true;
     getMenuItemButton("コピー").disabled = true;
+    getMenuItemButton("辞書に登録").disabled = true;
   } else {
     isRangeSelected.value = true;
     getMenuItemButton("切り取り").disabled = false;
     getMenuItemButton("コピー").disabled = false;
+    getMenuItemButton("辞書に登録").disabled = false;
   }
 };
 const endContextMenuOperation = async () => {

--- a/tests/e2e/browser/辞書ダイアログ.spec.ts
+++ b/tests/e2e/browser/辞書ダイアログ.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page, type Locator } from "@playwright/test";
 import { gotoHome, navigateToMain } from "../navigators";
-import { getNewestQuasarDialog } from "../locators";
+import { getNewestQuasarDialog, getQuasarMenu } from "../locators";
 
 test.beforeEach(gotoHome);
 
@@ -195,6 +195,44 @@ async function expectWarningDialog(
 test("辞書ダイアログを表示できる", async ({ page }) => {
   await navigateToMain(page);
   await openDictDialog(page);
+});
+
+test("台本で選択した単語を右クリックから辞書に登録できる", async ({ page }) => {
+  const surface = createSurface("右クリック登録");
+  const yomi = "テスト";
+
+  await navigateToMain(page);
+
+  const audioCellInput = page.getByRole("textbox", { name: "行目" }).last();
+  await audioCellInput.fill(surface);
+  await audioCellInput.press("Enter");
+  await audioCellInput.evaluate(
+    (element: HTMLInputElement, selectionLength: number) => {
+      element.setSelectionRange(0, selectionLength);
+    },
+    surface.length,
+  );
+  await audioCellInput.click({ button: "right" });
+
+  await test.step("選択した単語を辞書に登録する", async () => {
+    const dictionaryRegistrationMenu = getQuasarMenu(page, "辞書に登録");
+    await expect(dictionaryRegistrationMenu).toBeVisible();
+    await dictionaryRegistrationMenu.click();
+
+    const dialog = getNewestQuasarDialog(page);
+    await expect(dialog.getByText("新しい単語の追加")).toBeVisible();
+    await expect(getWordField(page, "単語")).toHaveText(surface);
+    await fillTextField(getWordField(page, "読み"), yomi);
+    await dialog
+      .locator("footer")
+      .getByRole("button", { name: "追加" })
+      .click();
+    await expect(dialog).toBeHidden();
+  });
+
+  await test.step("登録した単語が台本の読みに反映される", async () => {
+    expect(await getYomi(page, surface)).toBe(yomi);
+  });
 });
 
 test("単語を追加できる", async ({ page }) => {


### PR DESCRIPTION
## 内容

台本欄で選択した文字列を、右クリックメニューからユーザー辞書へ登録できるようにしました。

- 右クリックメニューに「辞書に登録」を追加
- 選択した文字列を辞書登録ダイアログの初期値として設定
- 既存の `WordEditor` を再利用して、読み・アクセント・優先度を設定可能に
- 右クリックから登録した単語が台本の読みに反映されることを確認する E2E を追加
- 登録処理中はダイアログを閉じられないように調整

## 関連 Issue

close #2139

## スクリーンショット・動画など

| コンテキストメニュー | 辞書登録ダイアログ |
| --- | --- |
| <img width="1286" height="786" alt="コンテキストメニュー" src="https://github.com/user-attachments/assets/e16d6a65-f52c-4261-bd51-997b36ced57b" /> | <img width="1286" height="786" alt="辞書登録ダイアログ" src="https://github.com/user-attachments/assets/a2947f81-9404-40c9-a01d-a62089a2524e" /> |

https://github.com/user-attachments/assets/d47a9f9c-5136-477a-8afe-ec56800bcc92

## その他

- 既存の辞書登録処理を再利用して実装しています。
- E2E、typecheck、lint の実行を確認済みです。
- 全 browser E2E の並列実行で既存テストが一度失敗しましたが、単独再実行では成功しています。