### PR TITLE
複数選択したテキスト欄をDeleteキーでまとめて削除する

### DIFF
--- a/src/components/Talk/TalkEditor.vue
+++ b/src/components/Talk/TalkEditor.vue
@@ -266,6 +266,19 @@ registerHotkeyWithCleanup({
 });
 registerHotkeyWithCleanup({
   editor: "talk",
+  name: "選択中のテキスト欄を削除",
+  callback: () => {
+    if (
+      !uiLocked.value &&
+      isMultiSelectEnabled.value &&
+      selectedAudioKeys.value.length >= 2
+    ) {
+      void removeAudioItem();
+    }
+  },
+});
+registerHotkeyWithCleanup({
+  editor: "talk",
   enableInTextbox: true,
   name: "テキスト欄からフォーカスを外す",
   callback: () => {

--- a/src/domain/hotkeyAction.ts
+++ b/src/domain/hotkeyAction.ts
@@ -21,6 +21,7 @@ export const hotkeyActionNameSchema = z.enum([
   "テキスト欄を追加",
   "テキスト欄を複製",
   "テキスト欄を削除",
+  "選択中のテキスト欄を削除",
   "テキスト欄からフォーカスを外す",
   "テキスト欄にフォーカスを戻す",
   "元に戻す",
@@ -111,6 +112,10 @@ export function getDefaultHotkeySettings({
     {
       action: "テキスト欄を削除",
       combination: HotkeyCombination("Shift Delete"),
+    },
+    {
+      action: "選択中のテキスト欄を削除",
+      combination: HotkeyCombination("Delete"),
     },
     {
       action: "テキスト欄からフォーカスを外す",

--- a/tests/e2e/browser/複数選択/選択.spec.ts
+++ b/tests/e2e/browser/複数選択/選択.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from "@playwright/test";
 import { navigateToMain, gotoHome } from "../../navigators";
+import { collectAllAudioCellContents, fillAudioCell } from "../utils";
 import { ctrlLike, addAudioCells } from "./utils";
 
 test.beforeEach(async ({ page }) => {
@@ -203,6 +204,35 @@ test("複数選択：キーボード", async ({ page }) => {
   selectedStatus = await getSelectedStatus(page);
   expect(selectedStatus.active).toBe(3);
   expect(selectedStatus.selected).toEqual([3]);
+});
+
+test("複数選択したAudioCellをDeleteキーで削除できる", async ({ page }) => {
+  await test.step("各AudioCellにテキストを入力する", async () => {
+    await fillAudioCell(page, 0, "一つ目のセルは削除されません。");
+    await fillAudioCell(page, 1, "二つ目のセルは削除されます。");
+    await fillAudioCell(page, 2, "三つ目のセルは削除されます。");
+    await fillAudioCell(page, 3, "四つ目のセルは削除されません。");
+  });
+
+  await test.step("中央のAudioCellを複数選択する", async () => {
+    await page.locator(".audio-cell:nth-child(2)").click();
+    await page.keyboard.down("Shift");
+    await page.locator(".audio-cell:nth-child(3)").click();
+    await page.keyboard.up("Shift");
+    await expect(page.locator(".audio-cell.selected")).toHaveCount(2);
+  });
+
+  await test.step("Deleteキーで選択したAudioCellを削除する", async () => {
+    await page.keyboard.press("Delete");
+  });
+
+  await test.step("選択していないAudioCellだけが残る", async () => {
+    await expect(page.locator(".audio-cell")).toHaveCount(2);
+    expect(await collectAllAudioCellContents(page)).toEqual([
+      "一つ目のセルは削除されません。",
+      "四つ目のセルは削除されません。",
+    ]);
+  });
 });
 
 test("複数選択：台本欄の余白クリックで解除", async ({ page }) => {

--- a/tests/e2e/browser/複数選択/選択.spec.ts
+++ b/tests/e2e/browser/複数選択/選択.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from "@playwright/test";
 import { navigateToMain, gotoHome } from "../../navigators";
+import { getQuasarMenu } from "../../locators";
 import { collectAllAudioCellContents, fillAudioCell } from "../utils";
 import { ctrlLike, addAudioCells } from "./utils";
 
@@ -230,6 +231,82 @@ test("複数選択したAudioCellをDeleteキーで削除できる", async ({ pa
     await expect(page.locator(".audio-cell")).toHaveCount(2);
     expect(await collectAllAudioCellContents(page)).toEqual([
       "一つ目のセルは削除されません。",
+      "四つ目のセルは削除されません。",
+    ]);
+  });
+});
+
+test("テキスト入力中のDeleteキーではAudioCellを削除しない", async ({
+  page,
+}) => {
+  const textField = page.getByRole("textbox", { name: "1行目" });
+
+  await test.step("テキストを入力する", async () => {
+    await textField.fill("テストです");
+  });
+
+  await test.step("入力中にDeleteキーで一文字を削除する", async () => {
+    await textField.press("Home");
+    await textField.press("ArrowRight");
+    await textField.press("Delete");
+  });
+
+  await test.step("AudioCellを維持してテキストだけを変更する", async () => {
+    await expect(page.locator(".audio-cell")).toHaveCount(4);
+    await expect(textField).toHaveValue("テトです");
+  });
+});
+
+test("単独選択したAudioCellをDeleteキーで削除しない", async ({ page }) => {
+  const audioCell = page.locator(".audio-cell").nth(1);
+
+  await test.step("AudioCellを単独選択してrootにフォーカスする", async () => {
+    await audioCell.click();
+    await audioCell.focus();
+    await expect(audioCell).toHaveClass(/active/);
+    await expect(page.locator(".audio-cell.selected")).toHaveCount(1);
+  });
+
+  await test.step("Deleteキーを押す", async () => {
+    await page.keyboard.press("Delete");
+  });
+
+  await test.step("AudioCellを維持する", async () => {
+    await expect(page.locator(".audio-cell")).toHaveCount(4);
+  });
+});
+
+test("複数削除を一回のUndoで復元できる", async ({ page }) => {
+  await test.step("各AudioCellにテキストを入力する", async () => {
+    await fillAudioCell(page, 0, "一つ目のセルは削除されません。");
+    await fillAudioCell(page, 1, "二つ目のセルは削除されます。");
+    await fillAudioCell(page, 2, "三つ目のセルは削除されます。");
+    await fillAudioCell(page, 3, "四つ目のセルは削除されません。");
+  });
+
+  await test.step("中央のAudioCellを複数選択する", async () => {
+    await page.locator(".audio-cell:nth-child(2)").click();
+    await page.keyboard.down("Shift");
+    await page.locator(".audio-cell:nth-child(3)").click();
+    await page.keyboard.up("Shift");
+  });
+
+  await test.step("Deleteキーで選択したAudioCellを削除する", async () => {
+    await page.keyboard.press("Delete");
+    await expect(page.locator(".audio-cell")).toHaveCount(2);
+  });
+
+  await test.step("元に戻す操作で削除前のAudioCellを復元する", async () => {
+    await page.getByRole("button", { name: "編集" }).click();
+    await getQuasarMenu(page, "元に戻す").click();
+  });
+
+  await test.step("全てのAudioCellを復元する", async () => {
+    await expect(page.locator(".audio-cell")).toHaveCount(4);
+    expect(await collectAllAudioCellContents(page)).toEqual([
+      "一つ目のセルは削除されません。",
+      "二つ目のセルは削除されます。",
+      "三つ目のセルは削除されます。",
       "四つ目のセルは削除されません。",
     ]);
   });

--- a/tests/unit/backend/common/__snapshots__/configManager.spec.ts.snap
+++ b/tests/unit/backend/common/__snapshots__/configManager.spec.ts.snap
@@ -79,6 +79,10 @@ exports[`0.13.0からマイグレーションできる 1`] = `
       "combination": "Shift Delete",
     },
     {
+      "action": "選択中のテキスト欄を削除",
+      "combination": "Delete",
+    },
+    {
       "action": "テキスト欄からフォーカスを外す",
       "combination": "Escape",
     },


### PR DESCRIPTION
## 内容

複数選択したテキスト欄を `Delete` キーでまとめて削除できるようにしました。

また、以下の挙動を E2E テストで確認しています。

- テキスト入力中の `Delete` は通常の文字削除として動作する
- 単独選択時の `Delete` ではテキスト欄を削除しない
- 複数削除は1回の Undo で復元できる

## 関連 Issue

close #2258

## スクリーンショット・動画など

https://github.com/user-attachments/assets/8367fff4-6161-4cbf-bee1-827fdb809523

## その他

- 既存の `Shift + Delete` による削除操作は変更していません。
- 検証時に複数選択→右クリックによるコンテキストメニューが使用できないことが不便かもと感じた。
- 特定のセルを選択して複製したい場合、削除したい場合にキーボードのみでしか操作できないかもしれない。