### PR TITLE
feat: アクセント句の右クリックメニューに調整結果のリセットを追加

### DIFF
--- a/src/components/Talk/AccentPhrase.vue
+++ b/src/components/Talk/AccentPhrase.vue
@@ -210,7 +210,7 @@
 import { computed, ref } from "vue";
 import AudioAccent from "./AudioAccent.vue";
 import AudioParameter from "./AudioParameter.vue";
-import type { MenuItemButton } from "@/components/Menu/type";
+import type { MenuItemButton, MenuItemSeparator } from "@/components/Menu/type";
 import ContextMenu from "@/components/Menu/ContextMenu/Container.vue";
 import { useStore } from "@/store";
 import type { AudioKey, MoraDataType } from "@/type/preload";
@@ -243,7 +243,28 @@ const store = useStore();
 
 const uiLocked = computed(() => store.getters.UI_LOCKED);
 
-const contextMenudata = ref<[MenuItemButton]>([
+const resetMenuItem = computed<MenuItemButton | undefined>(() => {
+  const type = props.selectedDetail;
+  if (type === "accent") return undefined;
+
+  return {
+    type: "button",
+    label: type === "pitch" ? "イントネーションをリセット" : "長さをリセット",
+    onClick: () => {
+      void store.actions.COMMAND_RESET_SELECTED_MORA_PITCH_AND_LENGTH({
+        audioKey: props.audioKey,
+        accentPhraseIndex: props.index,
+        type,
+      });
+    },
+    disableWhenUiLocked: true,
+  };
+});
+
+const contextMenudata = computed<(MenuItemButton | MenuItemSeparator)[]>(() => [
+  ...(resetMenuItem.value == undefined
+    ? []
+    : [resetMenuItem.value, { type: "separator" } as const]),
   {
     type: "button",
     label: "削除",

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -2520,7 +2520,7 @@ export const audioCommandStore = transformCommandStore(
     COMMAND_RESET_SELECTED_MORA_PITCH_AND_LENGTH: {
       async action(
         { state, actions, mutations },
-        { audioKey, accentPhraseIndex },
+        { audioKey, accentPhraseIndex, type },
       ) {
         const engineId = state.audioItems[audioKey].voice.engineId;
         const styleId = state.audioItems[audioKey].voice.styleId;
@@ -2528,12 +2528,38 @@ export const audioCommandStore = transformCommandStore(
         const query = state.audioItems[audioKey].query;
         if (query == undefined) throw new Error("query == undefined");
 
-        const newAccentPhrases = await actions.FETCH_AND_COPY_MORA_DATA({
-          accentPhrases: [...query.accentPhrases],
+        const fetchedAccentPhrases = await actions.FETCH_MORA_DATA({
+          accentPhrases: query.accentPhrases,
           engineId,
           styleId,
-          copyIndexes: [accentPhraseIndex],
         });
+        const newAccentPhrases = cloneWithUnwrapProxy(query.accentPhrases);
+
+        if (type == undefined) {
+          newAccentPhrases[accentPhraseIndex] =
+            fetchedAccentPhrases[accentPhraseIndex];
+        } else {
+          const newAccentPhrase = newAccentPhrases[accentPhraseIndex];
+          const fetchedAccentPhrase = fetchedAccentPhrases[accentPhraseIndex];
+
+          for (const [moraIndex, newMora] of newAccentPhrase.moras.entries()) {
+            const fetchedMora = fetchedAccentPhrase.moras[moraIndex];
+            if (type === "pitch") {
+              newMora.pitch = fetchedMora.pitch;
+            } else {
+              newMora.consonantLength = fetchedMora.consonantLength;
+              newMora.vowelLength = fetchedMora.vowelLength;
+            }
+          }
+          if (
+            type === "length" &&
+            newAccentPhrase.pauseMora != undefined &&
+            fetchedAccentPhrase.pauseMora != undefined
+          ) {
+            newAccentPhrase.pauseMora.vowelLength =
+              fetchedAccentPhrase.pauseMora.vowelLength;
+          }
+        }
 
         mutations.COMMAND_CHANGE_ACCENT({
           audioKey,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -588,7 +588,11 @@ export type AudioCommandStoreTypes = {
   };
 
   COMMAND_RESET_SELECTED_MORA_PITCH_AND_LENGTH: {
-    action(payload: { audioKey: AudioKey; accentPhraseIndex: number }): void;
+    action(payload: {
+      audioKey: AudioKey;
+      accentPhraseIndex: number;
+      type?: "pitch" | "length";
+    }): void;
   };
 
   COMMAND_SET_AUDIO_MORA_DATA: {

--- a/tests/e2e/browser/音声詳細.spec.ts
+++ b/tests/e2e/browser/音声詳細.spec.ts
@@ -60,6 +60,20 @@ test("詳細調整欄のコンテキストメニュー", async ({ page }) => {
     .getByRole("textbox", { name: "1行目" })
     .fill("あれもこれもそれもどれも");
   await page.getByRole("textbox", { name: "1行目" }).press("Enter");
+
+  // イントネーションと長さの各欄に対応するリセット項目が表示される
+  const firstAccentPhrase = page.locator(".accent-phrase").first();
+  await page.getByText("ｲﾝﾄﾈｰｼｮﾝ").click();
+  await firstAccentPhrase.click({ button: "right" });
+  await expect(page.getByText("イントネーションをリセット")).toBeVisible();
+  await page.getByText("イントネーションをリセット").click();
+
+  await page.getByText("長さ", { exact: true }).click();
+  await firstAccentPhrase.click({ button: "right" });
+  await expect(page.getByText("長さをリセット")).toBeVisible();
+  await page.getByText("長さをリセット").click();
+
+  await page.getByText("ｱｸｾﾝﾄ").click();
   await page.getByText("ソレモ").click({
     button: "right",
   });


### PR DESCRIPTION
## 内容

イントネーション欄・長さ欄のアクセント句コンテキストメニューから、調整結果をリセットできるようにしました。

- イントネーション欄に「イントネーションをリセット」を追加
- 長さ欄に「長さをリセット」を追加
- イントネーションのリセットでは pitch のみを再計算結果に戻す
- 長さのリセットでは母音長・子音長・ポーズ長のみを再計算結果に戻す
- 既存のショートカットによるリセット動作は変更しない
- 各タブのコンテキストメニューを確認するE2Eテストを追加

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

close #1645

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
